### PR TITLE
[ST]  rack awareness system tests improvement.

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -9,15 +9,18 @@ import io.fabric8.kubernetes.api.model.NodeAffinity;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
+import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.Rack;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 
+import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.annotations.ParallelSuite;
@@ -25,18 +28,22 @@ import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
-import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaMirrorMaker2Templates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+
+import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,12 +55,30 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Tag(REGRESSION)
 @ParallelSuite
 class RackAwarenessST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(RackAwarenessST.class);
     private static final String TOPOLOGY_KEY = "kubernetes.io/hostname";
 
+    /**
+     * @description This test case verifies that Rack awareness configuration works as expected in Kafka Cluster.
+     *
+     * @steps
+     *  1. - Deploy Kafka Clusters with rack topology key and also 'replica.selector.class' configured to rack aware value.
+     *     - Kafka Clusters is deployed with according configuration in pod affinity, consumer client rack, and additional expected labels.
+     *  2. - Make sure Kafka works as expected by producing and consuming data.
+     *     - Data are successfully produced and consumed from Kafka Clusters.
+     *
+     * @usecase
+     *  - rack-awareness
+     *  - configuration
+     *  - kafka
+     *  - labels
+     */
     @ParallelNamespaceTest
     void testKafkaRackAwareness(ExtensionContext extensionContext) {
         Assumptions.assumeFalse(Environment.isNamespaceRbacScope());
@@ -100,34 +125,80 @@ class RackAwarenessST extends AbstractST {
                 "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack").out().trim();
         assertThat(rackIdOut.trim(), is(hostname));
         assertThat(brokerRackOut.contains("broker.rack=" + hostname), is(true));
+
+        LOGGER.info("Producing and Consuming data in the Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
+        KafkaClients kafkaClients = new KafkaClientsBuilder()
+            .withTopicName(testStorage.getTopicName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withMessageCount(testStorage.getMessageCount())
+            .build();
+
+        resourceManager.createResource(extensionContext,
+            kafkaClients.producerStrimzi(),
+            kafkaClients.consumerStrimzi()
+        );
+        ClientUtils.waitForClientsSuccess(testStorage);
     }
 
+    /**
+     * @description This test case verifies that Rack awareness configuration works as expected in KafkaConnect. This is done by trying to deploy 2 Kafka Connect
+     * Clusters; First one with valid topology key configuration, which will be scheduled and eventually progress into ready state, while invalid configuration
+     * of the second Kafka Connect will render second Cluster unschedulable.
+     *
+     * @steps
+     *  1. - Deploy Kafka Clusters, with 1 replica.
+     *     - Kafka Clusters and its components are deployed.
+     *  2. - Deploy Kafka Connect cluster, with rack topology key set to invalid value.
+     *     - Kafka Connect is not scheduled.
+     *  3. - Deploy Kafka Connect cluster, with rack topology key set to valid value.
+     *     - Kafka Connect cluster is scheduled and eventually becomes ready, with its pod having all expected configuration in place.
+     *  4. - Deploy Sink Kafka Connector and Produce 100 messages into the observed topic.
+     *     - Messages are handled by Sink Connector successfully, thereby confirming Connect Cluster and Connector work correctly.
+     *
+     * @usecase
+     *  - rack-awareness
+     *  - configuration
+     *  - connect
+     */
     @Tag(CONNECT)
     @ParallelNamespaceTest
     void testConnectRackAwareness(ExtensionContext extensionContext) {
         Assumptions.assumeFalse(Environment.isNamespaceRbacScope());
 
-        TestStorage testStorage = storageMap.get(extensionContext);
-        String invalidTopologyKey = "invalid-topology-key";
+        final TestStorage testStorage = storageMap.get(extensionContext);
+        final String invalidTopologyKey = "invalid-topology-key";
+        final String invalidConnectClusterName = testStorage.getClusterName() + "-invalid";
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 1, 1).build());
 
-        LOGGER.info("Deploy KafkaConnect with an invalid topology key: {}", invalidTopologyKey);
-        resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnect(testStorage.getClusterName(), testStorage.getNamespaceName(), 1)
+        LOGGER.info("Deploy unschedulable KafkaConnect: {}/{} with an invalid topology key: {}", testStorage.getNamespaceName(), invalidConnectClusterName, invalidTopologyKey);
+        resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnect(invalidConnectClusterName, testStorage.getNamespaceName(), testStorage.getClusterName(), 1)
                 .editSpec()
                     .withNewRack(invalidTopologyKey)
                 .endSpec()
                 .build());
 
-        LOGGER.info("Check that KafkaConnect pod is unschedulable");
-        KafkaConnectUtils.waitForConnectPodCondition("Unschedulable", testStorage.getNamespaceName(), testStorage.getClusterName(), 30_000);
+        LOGGER.info("Deploy KafkaConnect: {}/{} with a valid topology key: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), TOPOLOGY_KEY);
+        resourceManager.createResource(extensionContext, false, KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getClusterName(), testStorage.getNamespaceName(), 1)
+                .editMetadata()
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .editSpec()
+                    .withNewRack(TOPOLOGY_KEY)
+                .endSpec()
+                .build());
 
-        LOGGER.info("Fix KafkaConnect with a valid topology key: {}", TOPOLOGY_KEY);
-        KafkaConnectResource.replaceKafkaConnectResourceInSpecificNamespace(testStorage.getClusterName(), kc -> kc.getSpec().setRack(new Rack(TOPOLOGY_KEY)), testStorage.getNamespaceName());
+        LOGGER.info("Check that KafkaConnect pod is unschedulable");
+        KafkaConnectUtils.waitForConnectPodCondition("Unschedulable", testStorage.getNamespaceName(), invalidConnectClusterName, 30_000);
+
         KafkaConnectUtils.waitForConnectReady(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         LOGGER.info("KafkaConnect cluster deployed successfully");
         String deployName = KafkaConnectResources.deploymentName(testStorage.getClusterName());
+        DeploymentUtils.waitForDeploymentReady(testStorage.getNamespaceName(), deployName);
         String podName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), deployName);
         Pod pod = kubeClient().getPod(testStorage.getNamespaceName(), podName);
 
@@ -146,8 +217,27 @@ class RackAwarenessST extends AbstractST {
         String commandOut = cmdKubeClient(testStorage.getNamespaceName()).execInPod(podName,
                 "/bin/bash", "-c", "cat /tmp/strimzi-connect.properties | grep consumer.client.rack").out().trim();
         assertThat(commandOut.equals("consumer.client.rack=" + hostname), is(true));
+
+        LOGGER.info("Deploy Sink connector in Kafka Connect Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
+        produceConsumeDataWithSinkConnector(extensionContext, testStorage);
     }
 
+    /**
+     * @description This test case verifies that Rack awareness configuration works as expected in KafkaMirrorMaker2 by configuring it and also using given CLuster.
+     *
+     * @steps
+     *  1. - Deploy target and source Kafka Clusters, both with 1 Kafka and 1 Zookeeper replica.
+     *     - Kafka Clusters and its components are deployed.
+     *  2. - Deploy KafkaMirrorMaker2 Cluster with rack configuration set to 'kubernetes.io/hostname'.
+     *     - KafkaMirrorMaker2 Cluster is deployed with according configuration in pod affinity, and consumer client rack on a given node.
+     *  3. - Produce messages in the source Kafka Cluster and Consuming from mirrored KafkaTopic in the target Kafka Cluster, thus making sure KafkaMirrorMaker2 works as expected.
+     *     - Data are produced and consumed from respective Kafka Clusters successfully.
+     *
+     * @usecase
+     *  - rack-awareness
+     *  - configuration
+     *  - mirror-maker-2
+     */
     @Tag(MIRROR_MAKER2)
     @ParallelNamespaceTest
     void testMirrorMaker2RackAwareness(ExtensionContext extensionContext) {
@@ -218,6 +308,46 @@ class RackAwarenessST extends AbstractST {
             .build();
         resourceManager.createResource(extensionContext, clients.consumerStrimzi());
         ClientUtils.waitForConsumerClientSuccess(testStorage);
+    }
+
+    private void produceConsumeDataWithSinkConnector(ExtensionContext extensionContext, TestStorage testStorage) {
+
+        // Deploy Kafka Connector
+        Map<String, Object> connectorConfig = new HashMap<>();
+        connectorConfig.put("topics", testStorage.getTopicName());
+        connectorConfig.put("file", Constants.DEFAULT_SINK_FILE_PATH);
+        connectorConfig.put("key.converter", "org.apache.kafka.connect.storage.StringConverter");
+        connectorConfig.put("value.converter", "org.apache.kafka.connect.storage.StringConverter");
+
+        LOGGER.info("Creating KafkaConnector: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
+        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(testStorage.getClusterName())
+            .editMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .editSpec()
+                .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
+                .withConfig(connectorConfig)
+            .endSpec()
+            .build());
+        KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        String kafkaConnectPodName = KubeClusterResource.kubeClient(testStorage.getNamespaceName()).listPods(testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        LOGGER.info("Kafka Connect Pod: {}/{}", testStorage.getNamespaceName(), kafkaConnectPodName);
+        KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(testStorage.getNamespaceName(), kafkaConnectPodName);
+
+        KafkaClients kafkaClients = new KafkaClientsBuilder()
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withNamespaceName(testStorage.getNamespaceName())
+            .build();
+
+        resourceManager.createResource(extensionContext, kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
+        ClientUtils.waitForClientsSuccess(testStorage);
+
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "99");
     }
 
     @BeforeEach


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

- addition of producing and consuming data into each of tests (only small increment in time duration)
- documentation of all tests
- changing of logic of connect test so it would not last so long (~8minutes) due to long waits, causing test to be unnecessarily long. Instead creating 2 connects clusters (one of them is expected to be not deployed)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
