### PR TITLE
Fixed recovery of new CA certificate trusting phase on CO stopped

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -609,6 +609,16 @@ public class ModelUtils {
     }
 
     /**
+     * Extract the CA key generation from the CA
+     *
+     * @param ca CA from which the generation should be extracted
+     * @return CA key generation or the initial generation if no generation is set
+     */
+    public static int caKeyGeneration(Ca ca) {
+        return Annotations.intAnnotation(ca.caKeySecret(), Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, Ca.INIT_GENERATION);
+    }
+
+    /**
      * Generates all possible DNS names for a Kubernetes service:
      *     - service-name
      *     - service-name.namespace

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -64,11 +64,11 @@ import java.util.function.Function;
 public class CaReconciler {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(CaReconciler.class.getName());
 
-    private final Reconciliation reconciliation;
+    /* test */ final Reconciliation reconciliation;
     private final Vertx vertx;
     private final long operationTimeoutMs;
 
-    private final DeploymentOperator deploymentOperator;
+    /* test */ final DeploymentOperator deploymentOperator;
     private final StrimziPodSetOperator strimziPodSetOperator;
     private final SecretOperator secretOperator;
     private final PodOperator podOperator;
@@ -92,6 +92,9 @@ public class CaReconciler {
     private ClusterCa clusterCa;
     private ClientsCa clientsCa;
     private Secret oldCoSecret;
+
+    /* test */ boolean isClusterCaNeedFullTrust;
+    /* test */ boolean isClusterCaFullyUsed;
 
     /**
      * Constructs the CA reconciler which reconciles the Cluster and Client CAs
@@ -196,6 +199,7 @@ public class CaReconciler {
      */
     public Future<CaReconciliationResult> reconcile(Clock clock)    {
         return reconcileCas(clock)
+                .compose(i -> verifyClusterCaFullyTrustedAndUsed())
                 .compose(i -> clusterOperatorSecret(clock))
                 .compose(i -> rollingUpdateForNewCaKey())
                 .compose(i -> maybeRemoveOldClusterCaCertificates())
@@ -328,6 +332,10 @@ public class CaReconciler {
 
     Future<Void> clusterOperatorSecret(Clock clock) {
         oldCoSecret = clusterCa.clusterOperatorSecret();
+        if (oldCoSecret != null && this.isClusterCaNeedFullTrust) {
+            LOGGER.warnCr(reconciliation, "Cluster CA needs to be fully trusted across the cluster, keeping current CO secret and certs");
+            return Future.succeededFuture();
+        }
         Secret secret = ModelUtils.buildSecret(
                 reconciliation,
                 clusterCa,
@@ -353,7 +361,9 @@ public class CaReconciler {
     Future<Void> rollingUpdateForNewCaKey() {
         RestartReasons podRollReasons = RestartReasons.empty();
 
-        if (clusterCa.keyReplaced()) {
+        // cluster CA needs to be fully trusted
+        // it is coming from a cluster CA key replacement which didn't end successfully (i.e. CO stopped) and we need to continue from there
+        if (clusterCa.keyReplaced() || isClusterCaNeedFullTrust) {
             podRollReasons.add(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED);
         }
 
@@ -375,6 +385,77 @@ public class CaReconciler {
     }
 
     /**
+     * Gather the Kafka related components pods for checking CA key trust and CA certificate usage to sign servers certificate.
+     *
+     * Verify that all the pods are already trusting the new CA certificate signed by a new CA key.
+     * It checks each pod's CA key generation, compared with the new CA key generation.
+     * When the trusting phase is not completed (i.e. because CO stopped), it needs to be recovered from where it was left.
+     *
+     * Verify that all pods are already using the new CA certificate to sign server certificates.
+     * It checks each pod's CA certificate generation, compared with the new CA certificate generation.
+     * When the new CA certificate is used everywhere, the old CA certificate can be removed.
+     */
+    /* test */ Future<Void> verifyClusterCaFullyTrustedAndUsed() {
+        isClusterCaNeedFullTrust = false;
+        isClusterCaFullyUsed = true;
+
+        // Building the selector for Kafka related components
+        Labels labels =  Labels.forStrimziCluster(reconciliation.name()).withStrimziKind(Kafka.RESOURCE_KIND);
+
+        return podOperator.listAsync(reconciliation.namespace(), labels)
+                .compose(pods -> {
+
+                    // still no Pods, a new Kafka cluster is under creation
+                    if (pods.isEmpty()) {
+                        isClusterCaFullyUsed = false;
+                        return Future.succeededFuture();
+                    }
+
+                    int clusterCaCertGeneration = clusterCa.certGeneration();
+                    int clusterCaKeyGeneration = clusterCa.keyGeneration();
+
+                    LOGGER.debugCr(reconciliation, "Current cluster CA cert generation {}", clusterCaCertGeneration);
+                    LOGGER.debugCr(reconciliation, "Current cluster CA key generation {}", clusterCaKeyGeneration);
+
+
+                    for (Pod pod : pods) {
+                        // with "RollingUpdate" strategy on Deployment(s) (i.e. the Cruise Control one),
+                        // while the Deployment is reported to be ready, the old pod is still alive but terminating
+                        // this condition is for skipping "Terminating" pods for checks on the CA key and old certificates
+                        if (pod.getMetadata().getDeletionTimestamp() == null) {
+                            int podClusterCaCertGeneration = Annotations.intAnnotation(pod, Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, clusterCaCertGeneration);
+                            LOGGER.debugCr(reconciliation, "Pod {} has cluster CA cert generation {}", pod.getMetadata().getName(), podClusterCaCertGeneration);
+
+                            int podClusterCaKeyGeneration = Annotations.intAnnotation(pod, Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, clusterCaKeyGeneration);
+                            LOGGER.debugCr(reconciliation, "Pod {} has cluster CA key generation {} compared to the Secret CA key generation {}",
+                                    pod.getMetadata().getName(), podClusterCaKeyGeneration, clusterCaKeyGeneration);
+
+                            // only if all Kafka related components pods are updated to the new cluster CA cert generation,
+                            // there is the possibility that we should remove the older cluster CA from the Secret and stores
+                            if (clusterCaCertGeneration != podClusterCaCertGeneration) {
+                                this.isClusterCaFullyUsed = false;
+                            }
+
+                            if (clusterCaKeyGeneration != podClusterCaKeyGeneration) {
+                                this.isClusterCaNeedFullTrust = true;
+                            }
+
+                        } else {
+                            LOGGER.debugCr(reconciliation, "Skipping CA key generation check on pod {}, it's terminating", pod.getMetadata().getName());
+                        }
+
+                        if (isClusterCaNeedFullTrust) {
+                            LOGGER.debugCr(reconciliation, "The new Cluster CA is not yet trusted by all pods");
+                        }
+                        if (!isClusterCaFullyUsed) {
+                            LOGGER.debugCr(reconciliation, "The old Cluster CA is still used by some server certificates and cannot be removed");
+                        }
+                    }
+                    return Future.succeededFuture();
+                });
+    }
+
+    /**
      * If we need to roll the ZooKeeper cluster to roll out the trust to a new CA certificate when a CA private key is
      * being replaced, we need to know what the current number of ZooKeeper nodes is. Getting it from the Kafka custom
      * resource might not be good enough if a scale-up /scale-down is happening at the same time. So we get the
@@ -382,7 +463,7 @@ public class CaReconciler {
      *
      * @return  Current number of ZooKeeper replicas
      */
-    private Future<Integer> getZooKeeperReplicas() {
+    /* test */ Future<Integer> getZooKeeperReplicas() {
         return strimziPodSetOperator.getAsync(reconciliation.namespace(), KafkaResources.zookeeperStatefulSetName(reconciliation.name()))
                 .compose(podSet -> {
                     if (podSet != null
@@ -405,7 +486,7 @@ public class CaReconciler {
      * @return  Future which completes when this step is done either by rolling the ZooKeeper cluster or by deciding
      *          that no rolling is needed.
      */
-    private Future<Void> maybeRollZookeeper(int replicas, RestartReasons podRestartReasons) {
+    /* test */ Future<Void> maybeRollZookeeper(int replicas, RestartReasons podRestartReasons) {
         if (podRestartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED)) {
             Labels zkSelectorLabels = Labels.EMPTY
                     .withStrimziKind(reconciliation.kind())
@@ -424,7 +505,7 @@ public class CaReconciler {
         }
     }
 
-    private Future<Set<NodeRef>> getKafkaReplicas() {
+    /* test */ Future<Set<NodeRef>> getKafkaReplicas() {
         Labels selectorLabels = Labels.EMPTY
                 .withStrimziKind(reconciliation.kind())
                 .withStrimziCluster(reconciliation.name())
@@ -444,7 +525,7 @@ public class CaReconciler {
                 });
     }
 
-    private Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons) {
+    /* test */ Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons) {
         return new KafkaRoller(
                 reconciliation,
                 vertx,
@@ -484,7 +565,7 @@ public class CaReconciler {
      *
      * @return  Succeeded future if it succeeded, failed otherwise.
      */
-    private Future<Void> rollDeploymentIfExists(String deploymentName, String reason)  {
+    Future<Void> rollDeploymentIfExists(String deploymentName, String reason)  {
         return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                 .compose(dep -> {
                     if (dep != null) {
@@ -501,44 +582,20 @@ public class CaReconciler {
      * corresponding CA private key.
      */
     Future<Void> maybeRemoveOldClusterCaCertificates() {
-        // Building the selector for Kafka related components
-        Labels labels =  Labels.forStrimziCluster(reconciliation.name()).withStrimziKind(Kafka.RESOURCE_KIND);
+        // if the new CA certificate is used to sign all server certificates
+        if (isClusterCaFullyUsed) {
+            LOGGER.debugCr(reconciliation, "Maybe there are old cluster CA certificates to remove");
+            clusterCa.maybeDeleteOldCerts();
 
-        return podOperator.listAsync(reconciliation.namespace(), labels)
-                .compose(pods -> {
-                    // still no Pods, a new Kafka cluster is under creation
-                    if (pods.isEmpty()) {
-                        return Future.succeededFuture();
-                    }
-
-                    int clusterCaCertGeneration = clusterCa.certGeneration();
-
-                    LOGGER.debugCr(reconciliation, "Current cluster CA cert generation {}", clusterCaCertGeneration);
-
-                    // only if all Kafka related components pods are updated to the new cluster CA cert generation,
-                    // there is the possibility that we should remove the older cluster CA from the Secret and stores
-                    for (Pod pod : pods) {
-                        int podClusterCaCertGeneration = Annotations.intAnnotation(pod, Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, clusterCaCertGeneration);
-                        LOGGER.debugCr(reconciliation, "Pod {} cluster CA cert generation {}", pod.getMetadata().getName(), podClusterCaCertGeneration);
-
-                        if (clusterCaCertGeneration != podClusterCaCertGeneration) {
-                            return Future.succeededFuture();
-                        }
-                    }
-
-                    LOGGER.debugCr(reconciliation, "Maybe there are old cluster CA certificates to remove");
-                    clusterCa.maybeDeleteOldCerts();
-
-                    return Future.succeededFuture(clusterCa);
-                })
-                .compose(ca -> {
-                    if (ca != null && ca.certsRemoved()) {
-                        return secretOperator.reconcile(reconciliation, reconciliation.namespace(), AbstractModel.clusterCaCertSecretName(reconciliation.name()), ca.caCertSecret())
-                                .map((Void) null);
-                    } else {
-                        return Future.succeededFuture();
-                    }
-                });
+            if (clusterCa.certsRemoved()) {
+                return secretOperator.reconcile(reconciliation, reconciliation.namespace(), AbstractModel.clusterCaCertSecretName(reconciliation.name()), clusterCa.caCertSecret())
+                        .map((Void) null);
+            } else {
+                return Future.succeededFuture();
+            }
+        } else {
+            return Future.succeededFuture();
+        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -276,6 +276,9 @@ public class CruiseControlReconciler {
             int caCertGeneration = ModelUtils.caCertGeneration(clusterCa);
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            Annotations.annotations(deployment.getSpec().getTemplate()).put(
+                    Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.deploymentName(reconciliation.name()), deployment)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -424,6 +424,8 @@ public class EntityOperatorReconciler {
             Deployment deployment = entityOperator.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
             int caCertGeneration = ModelUtils.caCertGeneration(clusterCa);
             Annotations.annotations(deployment.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            Annotations.annotations(deployment.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), deployment)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -183,6 +183,9 @@ public class KafkaExporterReconciler {
             int caCertGeneration = ModelUtils.caCertGeneration(this.clusterCa);
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
+            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            Annotations.annotations(deployment.getSpec().getTemplate()).put(
+                    Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.deploymentName(reconciliation.name()), deployment)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -732,6 +732,7 @@ public class KafkaReconciler {
     private Map<String, String> podSetPodAnnotations(int nodeId) {
         Map<String, String> podAnnotations = new LinkedHashMap<>(9);
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clusterCa)));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(ModelUtils.caKeyGeneration(this.clusterCa)));
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clientsCa)));
         podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, loggingHash);
         podAnnotations.put(KafkaCluster.ANNO_STRIMZI_BROKER_CONFIGURATION_HASH, brokerConfigurationHash.get(nodeId));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -513,6 +513,7 @@ public class ZooKeeperReconciler {
     public Map<String, String> zkPodSetPodAnnotations(int podNum) {
         Map<String, String> podAnnotations = new LinkedHashMap<>((int) Math.ceil(podNum / 0.75));
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clusterCa)));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(ModelUtils.caKeyGeneration(this.clusterCa)));
         podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, loggingHash);
         podAnnotations.put(ANNO_STRIMZI_SERVER_CERT_HASH, zkCertificateHash.get(podNum));
         return podAnnotations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/TestUtils.java
@@ -66,21 +66,21 @@ public class TestUtils {
     public static void maybeAddHttpProxyEnvVars(List<EnvVar> envVars) {
         if (System.getenv(ClusterOperatorConfig.HTTP_PROXY) != null) {
             envVars.add(new EnvVarBuilder()
-                .withName(ClusterOperatorConfig.HTTP_PROXY)
-                .withValue(System.getenv(ClusterOperatorConfig.NO_PROXY))
-                .build());
+                    .withName(ClusterOperatorConfig.HTTP_PROXY)
+                    .withValue(System.getenv(ClusterOperatorConfig.NO_PROXY))
+                    .build());
         }
         if (System.getenv(ClusterOperatorConfig.HTTPS_PROXY) != null) {
             envVars.add(new EnvVarBuilder()
-                .withName(ClusterOperatorConfig.HTTPS_PROXY)
-                .withValue(System.getenv(ClusterOperatorConfig.HTTPS_PROXY))
-                .build());
+                    .withName(ClusterOperatorConfig.HTTPS_PROXY)
+                    .withValue(System.getenv(ClusterOperatorConfig.HTTPS_PROXY))
+                    .build());
         }
         if (System.getenv(ClusterOperatorConfig.NO_PROXY) != null) {
             envVars.add(new EnvVarBuilder()
-                .withName(ClusterOperatorConfig.NO_PROXY)
-                .withValue(System.getenv(ClusterOperatorConfig.NO_PROXY))
-                .build());
+                    .withName(ClusterOperatorConfig.NO_PROXY)
+                    .withValue(System.getenv(ClusterOperatorConfig.NO_PROXY))
+                    .build());
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -6,7 +6,11 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.CertificateAuthorityBuilder;
 import io.strimzi.api.kafka.model.CertificateExpirationPolicy;
@@ -14,6 +18,7 @@ import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.ClusterOperator;
@@ -24,6 +29,9 @@ import io.strimzi.operator.cluster.model.AbstractModel;
 import io.strimzi.operator.cluster.model.Ca;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.ModelUtils;
+import io.strimzi.operator.cluster.model.NodeRef;
+import io.strimzi.operator.cluster.model.RestartReason;
+import io.strimzi.operator.cluster.model.RestartReasons;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
@@ -62,10 +70,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.cluster.model.Ca.CA_CRT;
@@ -86,6 +97,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerTest {
     public static final String NAMESPACE = "test";
@@ -1451,5 +1463,260 @@ public class CaReconcilerTest {
 
                     async.flag();
                 })));
+    }
+
+    @Test
+    public void testClusterCAKeyNotTrusted(Vertx vertx, VertxTestContext context) {
+
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                .endSpec()
+                .build();
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        SecretOperator secretOps = supplier.secretOperations;
+        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture())).thenAnswer(i -> {
+            Secret s = clusterCaCert.getValue();
+            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+            return Future.succeededFuture(ReconcileResult.created(s));
+        });
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture())).thenAnswer(i -> {
+            Secret s = clusterCaKey.getValue();
+            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+            return Future.succeededFuture(ReconcileResult.created(s));
+        });
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(ClusterOperator.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenAnswer(i -> {
+            List<Pod> pods = new ArrayList<>();
+            // adding a terminating Cruise Control pod to test that it's skipped during the key generation check
+            Pod ccPod = podWithNameAndAnnotations("my-kafka-cruise-control", generationAnnotations);
+            ccPod.getMetadata().setDeletionTimestamp("2023-06-08T16:23:18Z");
+            pods.add(ccPod);
+            // adding ZooKeeper and Kafka pods with old CA cert and key generation
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-0", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-1", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-2", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-0", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-1", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-2", generationAnnotations));
+            return Future.succeededFuture(pods);
+        });
+
+        Checkpoint async = context.checkpoint();
+
+        CaReconciler caReconciler = new CaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, certManager, passwordGenerator);
+        caReconciler
+                .reconcileCas(Clock.systemUTC())
+                .compose(i -> caReconciler.verifyClusterCaFullyTrustedAndUsed())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat(caReconciler.isClusterCaNeedFullTrust, is(true));
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testRollingReasonsWithClusterCAKeyNotTrusted(Vertx vertx, VertxTestContext context) {
+
+        Kafka kafka = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endKafka()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewEntityOperator()
+                    .endEntityOperator()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                    .withNewKafkaExporter()
+                    .endKafkaExporter()
+                .endSpec()
+                .build();
+
+        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        SecretOperator secretOps = supplier.secretOperations;
+        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
+        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture())).thenAnswer(i -> {
+            Secret s = clusterCaCert.getValue();
+            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
+            return Future.succeededFuture(ReconcileResult.created(s));
+        });
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture())).thenAnswer(i -> {
+            Secret s = clusterCaKey.getValue();
+            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
+            return Future.succeededFuture(ReconcileResult.created(s));
+        });
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(ClusterOperator.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+
+        Map<String, String> generationAnnotations =
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenAnswer(i -> {
+            List<Pod> pods = new ArrayList<>();
+            // adding a terminating Cruise Control pod to test that it's skipped during the key generation check
+            Pod ccPod = podWithNameAndAnnotations("my-kafka-cruise-control", generationAnnotations);
+            ccPod.getMetadata().setDeletionTimestamp("2023-06-08T16:23:18Z");
+            pods.add(ccPod);
+            // adding ZooKeeper and Kafka pods with old CA cert and key generation
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-0", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-1", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-2", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-0", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-1", generationAnnotations));
+            pods.add(podWithNameAndAnnotations("my-kafka-kafka-2", generationAnnotations));
+            return Future.succeededFuture(pods);
+        });
+
+        Map<String, Deployment> deps = new HashMap<>();
+        deps.put("my-kafka-entity-operator", deploymentWithName("my-kafka-entity-operator"));
+        deps.put("my-kafka-cruise-control", deploymentWithName("my-kafka-cruise-control"));
+        deps.put("my-kafka-kafka-exporter", deploymentWithName("my-kafka-kafka-exporter"));
+        DeploymentOperator depsOperator = supplier.deploymentOperations;
+        when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1))));
+
+        Checkpoint async = context.checkpoint();
+
+        MockCaReconciler mockCaReconciler = new MockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
+                supplier, vertx, certManager, passwordGenerator);
+        mockCaReconciler
+                .reconcile(Clock.systemUTC())
+                .onComplete(context.succeeding(c -> context.verify(() -> {
+                    assertThat(mockCaReconciler.isClusterCaNeedFullTrust, is(true));
+                    assertThat(mockCaReconciler.zkPodRestartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                    assertThat(mockCaReconciler.kPodRollReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                    assertThat(mockCaReconciler.deploymentRollReason.size() == 3, is(true));
+                    for (String reason: mockCaReconciler.deploymentRollReason) {
+                        assertThat(reason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true));
+                    }
+                    async.flag();
+                })));
+    }
+
+    static class MockCaReconciler extends CaReconciler {
+
+        RestartReasons zkPodRestartReasons;
+        RestartReasons kPodRollReasons;
+        List<String> deploymentRollReason = new ArrayList<>();
+
+        public MockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
+            super(reconciliation, kafkaCr, config, supplier, vertx, certManager, passwordGenerator);
+        }
+
+        @Override
+        Future<Void> verifyClusterCaFullyTrustedAndUsed() {
+            // assuming the CA key is not trusted
+            this.isClusterCaNeedFullTrust = true;
+            this.isClusterCaFullyUsed = false;
+            return Future.succeededFuture();
+        }
+
+        @Override
+        Future<Integer> getZooKeeperReplicas() {
+            return Future.succeededFuture(3);
+        }
+
+        @Override
+        Future<Void> maybeRollZookeeper(int replicas, RestartReasons podRestartReasons) {
+            this.zkPodRestartReasons = podRestartReasons;
+            return Future.succeededFuture();
+        }
+
+        @Override
+        Future<Set<NodeRef>> getKafkaReplicas() {
+            Set<NodeRef> nodes = new HashSet<>();
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-0")));
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-1")));
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-2")));
+            return Future.succeededFuture(nodes);
+        }
+
+        @Override
+        Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons) {
+            this.kPodRollReasons = podRollReasons;
+            return Future.succeededFuture();
+        }
+
+        @Override
+        Future<Void> rollDeploymentIfExists(String deploymentName, String reason) {
+            return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
+                    .compose(dep -> {
+                        if (dep != null) {
+                            this.deploymentRollReason.add(reason);
+                        }
+                        return Future.succeededFuture();
+                    });
+        }
+
+        @Override
+        Future<Void> maybeRemoveOldClusterCaCertificates() {
+            return Future.succeededFuture();
+        }
+    }
+
+    public static Pod podWithName(String name) {
+        return podWithNameAndAnnotations(name, Collections.emptyMap());
+    }
+
+    public static Pod podWithNameAndAnnotations(String name, Map<String, String> annotations) {
+        return new PodBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withAnnotations(annotations)
+                    .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME))
+                .endMetadata()
+                .build();
+    }
+
+    public static Deployment deploymentWithName(String name) {
+        return new DeploymentBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                .endMetadata()
+                .build();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -195,6 +195,7 @@ public class KafkaAssemblyOperatorMockTest {
                 sps.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0"));
                     var brokersSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
                             CertUtils.getCertificateThumbprint(brokersSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))
@@ -204,6 +205,7 @@ public class KafkaAssemblyOperatorMockTest {
                 StrimziPodSet zkSps = supplier.strimziPodSetOperator.client().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperStatefulSetName(CLUSTER_NAME)).get();
                 zkSps.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
+                    assertThat(pod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0"));
                     var zooKeeperSecret = client.secrets().inNamespace(NAMESPACE).withName(KafkaResources.zookeeperSecretName(CLUSTER_NAME)).get();
                     assertThat(pod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH,
                             CertUtils.getCertificateThumbprint(zooKeeperSecret, ClusterCa.secretEntryNameForPod(pod.getMetadata().getName(), Ca.SecretEntry.CRT))

--- a/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/cluster/model/Ca.java
@@ -175,6 +175,11 @@ public abstract class Ca {
     public static final String ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION = Annotations.STRIMZI_DOMAIN + "clients-ca-cert-generation";
 
     /**
+     * Annotation for tracking the Cluster CA key generation used by Kubernetes resources
+     */
+    public static final String ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION = Annotations.STRIMZI_DOMAIN + "cluster-ca-key-generation";
+
+    /**
      * Initial generation used for the CAs
      */
     public static final int INIT_GENERATION = 0;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #8402.
As discussed in the issue, it works by adding a new `strimzi.io/cluster-ca-key-trusted-generation` annotation on the pods which has to match the `strimzi.io/strimzi.io/cluster-ca-key-generation` in order to consider the "trusting" phase to be completed.
This is done as the first step in the `CaReconciler` to check such annotation on all the pods. If it's not consistent with the new CA key generation, pods should continue to roll for the "trusting" phase. During it, even the CO Secret doesn't have to be updated otherwise if something goes wrong it will already get the new signed certs and won't be able to connect to Kafka and ZooKeeper pods anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Reference relevant issue(s) and close them after merging