### PR TITLE
[systemtest] Two small fixes for flaky tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectIsolatedST.java
@@ -1059,6 +1059,7 @@ class ConnectIsolatedST extends AbstractST {
 
         KafkaConnectUtils.waitForConnectReady(namespaceName, clusterName);
         PodUtils.waitForPodsReady(namespaceName, labelSelector, 0, true);
+        KafkaConnectorUtils.waitForConnectorNotReady(namespaceName, clusterName);
 
         connectPods = kubeClient(namespaceName).listPods(Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.deploymentName(clusterName));
         KafkaConnectStatus connectStatus = KafkaConnectResource.kafkaConnectClient().inNamespace(namespaceName).withName(clusterName).get().getStatus();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthScopeIsolatedST.java
@@ -26,8 +26,6 @@ import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.k8s.KubeClusterResource;
-import org.apache.logging.log4j.Level;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -134,7 +132,7 @@ public class OauthScopeIsolatedST extends OauthAbstractST {
         // explicitly verifying also logs
         String kafkaPodName = kubeClient().listPodsByPrefixInName(clusterOperator.getDeploymentNamespace(), KafkaResources.kafkaPodName(oauthClusterName, 0)).get(0).getMetadata().getName();
 
-        String kafkaLog = KubeClusterResource.cmdKubeClient(clusterOperator.getDeploymentNamespace()).execInCurrentNamespace(Level.DEBUG, "logs", kafkaPodName, "--tail", "50").out();
+        String kafkaLog = kubeClient().logsInSpecificNamespace(clusterOperator.getDeploymentNamespace(), kafkaPodName);
         assertThat(kafkaLog, CoreMatchers.containsString("Access token expires at"));
         assertThat(kafkaLog, CoreMatchers.containsString("Evaluating path: $[*][?]"));
         assertThat(kafkaLog, CoreMatchers.containsString("Evaluating path: @['scope']"));


### PR DESCRIPTION
### Type of change

- Test fixes

### Description

This small PR fixes two flaky tests:

`ConnectIsolatedST#testScaleConnectWithConnectorToZero` - problem with KafkaConnector and its status - we are checking that the status is `NotReady`, but there was race condition, when from time to time the status of the connector wasn't switched and the test failed

`OauthScopeIsolatedST#testScopeKafkaConnectSetCorrectly` - because the logs of Kafka pods contain many things, the last 30 lines could be filled up with different logs than the needed one.

### Checklist

- [ ] Make sure all tests pass
