### PR TITLE
[systemtest] Update CO version to 0.35.1 in tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -215,7 +215,7 @@ public class Environment {
     public static final String OLM_SOURCE_NAME = getOrDefault(OLM_SOURCE_NAME_ENV, OLM_SOURCE_NAME_DEFAULT);
     public static final String OLM_SOURCE_NAMESPACE = getOrDefault(OLM_SOURCE_NAMESPACE_ENV, OpenShift.OLM_SOURCE_NAMESPACE);
     public static final String OLM_APP_BUNDLE_PREFIX = getOrDefault(OLM_APP_BUNDLE_PREFIX_ENV, OLM_APP_BUNDLE_PREFIX_DEFAULT);
-    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, "0.35.0");
+    public static final String OLM_OPERATOR_LATEST_RELEASE_VERSION = getOrDefault(OLM_OPERATOR_VERSION_ENV, "0.35.1");
     // NetworkPolicy variable
     public static final boolean DEFAULT_TO_DENY_NETWORK_POLICIES = getOrDefault(DEFAULT_TO_DENY_NETWORK_POLICIES_ENV, Boolean::parseBoolean, DEFAULT_TO_DENY_NETWORK_POLICIES_DEFAULT);
     // ClusterOperator installation type variable

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -26,18 +26,18 @@
 # --- Structure ---
   
 - fromVersion: HEAD
-  toVersion: 0.35.0
+  toVersion: 0.35.1
   fromExamples: HEAD
-  toExamples: strimzi-0.35.0
+  toExamples: strimzi-0.35.1
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.0/strimzi-0.35.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.1/strimzi-0.35.1.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.35.0-kafka-3.4.0
-    kafka: strimzi/kafka:0.35.0-kafka-3.4.0
-    topicOperator: strimzi/operator:0.35.0
-    userOperator: strimzi/operator:0.35.0
+    zookeeper: strimzi/kafka:0.35.1-kafka-3.4.0
+    kafka: strimzi/kafka:0.35.1-kafka-3.4.0
+    topicOperator: strimzi/operator:0.35.1
+    userOperator: strimzi/operator:0.35.1
   deployKafkaVersion: 3.4.0
   client:
     continuousClientsMessages: 500
@@ -49,18 +49,18 @@
   featureGatesBefore: "+StableConnectIdentities"
   featureGatesAfter: ""
 - fromVersion: HEAD
-  toVersion: 0.35.0
+  toVersion: 0.35.1
   fromExamples: HEAD
-  toExamples: strimzi-0.35.0
+  toExamples: strimzi-0.35.1
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.0/strimzi-0.35.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.1/strimzi-0.35.1.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.35.0-kafka-3.4.0
-    kafka: strimzi/kafka:0.35.0-kafka-3.4.0
-    topicOperator: strimzi/operator:0.35.0
-    userOperator: strimzi/operator:0.35.0
+    zookeeper: strimzi/kafka:0.35.1-kafka-3.4.0
+    kafka: strimzi/kafka:0.35.1-kafka-3.4.0
+    topicOperator: strimzi/operator:0.35.1
+    userOperator: strimzi/operator:0.35.1
   deployKafkaVersion: 3.4.0
   client:
     continuousClientsMessages: 500

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -24,11 +24,11 @@
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
 #  --- Structure ---
 
-- fromVersion: 0.35.0
-  fromExamples: strimzi-0.35.0
+- fromVersion: 0.35.1
+  fromExamples: strimzi-0.35.1
   oldestKafka: 3.3.1
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.0/strimzi-0.35.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.0/kafka-versions.yaml
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.1/strimzi-0.35.1.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.1/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.4.1
@@ -44,11 +44,11 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: ""
   featureGatesAfter: ""
-- fromVersion: 0.35.0
-  fromExamples: strimzi-0.35.0
+- fromVersion: 0.35.1
+  fromExamples: strimzi-0.35.1
   oldestKafka: 3.3.1
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.0/strimzi-0.35.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.0/kafka-versions.yaml
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.1/strimzi-0.35.1.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.1/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.4.1

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -13,8 +13,8 @@
 #  Kubernetes cluster.
 #  --- Prerequisites ---
 
-fromVersion: 0.35.0
+fromVersion: 0.35.1
 fromOlmChannelName: strimzi-0.35.x
-fromExamples: strimzi-0.35.0
-fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.0/strimzi-0.35.0.zip
-fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.0/kafka-versions.yaml
+fromExamples: strimzi-0.35.1
+fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.35.1/strimzi-0.35.1.zip
+fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.35.1/kafka-versions.yaml


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates the version of CO used in upgrade/downgrade tests and for OLM to `0.35.1` after the release.

### Checklist

- [x] Make sure all tests pass
