### PR TITLE
Add Roadmap link and ArtifactHub badge to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub release](https://img.shields.io/github/release/strimzi/strimzi-kafka-operator.svg)](https://github.com/strimzi/strimzi-kafka-operator/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio?style=social)](https://twitter.com/strimziio)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/strimzi-kafka-operator)](https://artifacthub.io/packages/search?repo=strimzi-kafka-operator)
 
 Strimzi provides a way to run an [Apache Kafka®][kafka] cluster on 
 [Kubernetes][k8s] or [OpenShift][os] in various deployment configurations.
@@ -18,6 +19,10 @@ To get up and running quickly, check our [Quick Start for Minikube, OKD (OpenShi
 ## Documentation
 
 Documentation to the current _main_ branch as well as all releases can be found on our [website][strimzi].
+
+## Roadmap
+
+The roadmap of the Strimzi Operator project is maintained as [GitHub Project](https://github.com/orgs/strimzi/projects/1).
 
 ## Getting help
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds a link to the Roadmap which we maintain in the GitHub Projects and an ArtifactHub badge to the README.md file. (this is based on some of the missing points raised by clomonitor.io).