### PR TITLE
[ST] RackAwarenessST fix timeout error by  removal of wait on connect deployment

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -37,7 +37,6 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -197,7 +196,6 @@ class RackAwarenessST extends AbstractST {
 
         LOGGER.info("KafkaConnect cluster deployed successfully");
         String deployName = KafkaConnectResources.deploymentName(testStorage.getClusterName());
-        DeploymentUtils.waitForDeploymentReady(testStorage.getNamespaceName(), deployName);
         String podName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), deployName);
         Pod pod = kubeClient().getPod(testStorage.getNamespaceName(), podName);
 


### PR DESCRIPTION


### Type of change

- Refactoring

### Description

removal of wait causing timeout exception while waiting for deployment (while there is none) ready, with feature gate  `StableConnectPodIdentties`.

wait (which is now removed) was added only as precaution measure in case when running tests on older clusters, which once resulted in unexpected failure (only observed once when running localy)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles

runs on with/without mentioned feature gate in kubernetes and openstack.  

