### PR TITLE
Update the expected move of `StableConnectIdentities` feature gate to beta

### DIFF
--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -22,7 +22,7 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseStrimziPodSets` feature gate moved to GA stage in Strimzi 0.35 and the support for StatefulSets is completely removed. It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 * The `StableConnectIdentities` feature gate is in alpha stage and is disabled by default.
-  It is expected to move to beta phase and be enabled by default from Strimzi 0.36.
+  It is expected to move to beta phase and be enabled by default from Strimzi 0.37.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -57,7 +57,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 ¦`StableConnectIdentities`
 ¦0.34
-¦0.36 (planned)
+¦0.37 (planned)
 ¦ -
 
 |===


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Due to the recent issues with informers in some environments, we decided to postpone the move of the `StableConnectIdentities` feature gate to beta to Strimzi 0.37.0. This PR updates the documentation accordingly.

### Checklist

- [x] Update documentation