### PR TITLE
Update Kaniko container builder to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for Apache Kafka 3.4.1
 * Update Kafka Exporter to [1.7.0](https://github.com/danielqsj/kafka_exporter/releases/tag/v1.7.0)
+* Update Kaniko container builder to 1.11.0
 
 ### Changes, deprecations and removals
 

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.10.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.11.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Kaniko container builder used in Kafka Connect Build to 1.11.0-

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md