### PR TITLE
Fixed doc about Prometheus JMX exporter rules

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -201,7 +201,7 @@ spec:
 <20> Persistent storage has additional configuration options, such as a storage `id` and `class` for dynamic volume provisioning.
 <21> Rack awareness configuration to spread replicas across different racks, data centers, or availability zones. The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label.
 <22> Prometheus metrics enabled. In this example, metrics are configured for the Prometheus JMX Exporter (the default metrics exporter).
-<23> Prometheus rules for exporting metrics to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<23> Rules for exporting metrics in Prometheus format to a Grafana dashboard through the Prometheus JMX Exporter, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
 <24> ZooKeeper-specific configuration, which contains properties similar to the Kafka configuration.
 <25> The number of ZooKeeper nodes. ZooKeeper clusters or ensembles usually run with an odd number of nodes, typically three, five, or seven. The majority of nodes must be available in order to maintain an effective quorum.
 If the ZooKeeper cluster loses its quorum, it will stop responding to clients and the Kafka brokers will stop working.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The rules provided in the configuration are not technically Prometheus rules. They are JMX Exporter rules which has its own language to map metrics from JMX to Prometheus as described here https://github.com/prometheus/jmx_exporter
Talking about Prometheus rules can be misleading with the recording rules in Prometheus here https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/


### Checklist

- [x] Update documentation