### PR TITLE
Fixed Log4j config refernce from ConfigMap in the doc

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -181,7 +181,7 @@ spec:
 ----
 <1> The number of replica nodes.
 <2> Kafka version, which can be changed to a supported version by following the upgrade procedure.
-<3> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom ConfigMap must be placed under the `log4j.properties` key. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<3> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` key in the ConfigMap. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <4> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <5> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
 <6> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The `log4j.properties` under the ConfigMap for external logging is not ... a ConfigMap as the doc says.
It's a valid Log4j configuration which usually is provided as a properties file. 

### Checklist

- [x] Update documentation