### PR TITLE
Fixed what TLS enabled by default means on OpenShift Route on doc

### DIFF
--- a/documentation/modules/configuring/proc-config-kafka.adoc
+++ b/documentation/modules/configuring/proc-config-kafka.adoc
@@ -190,7 +190,7 @@ spec:
 <9> Name to identify the listener. Must be unique within the Kafka cluster.
 <10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <11> Listener type specified as `internal` or `cluster-ip` (to expose Kafka using per-broker `ClusterIP` services), or for external listeners, as `route` (OpenShift only), `loadbalancer`, `nodeport` or `ingress` (Kubernetes only).
-<12> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners.
+<12> Enables TLS encryption for each listener. Default is `false`. TLS encryption is not required for `route` listeners, because it is enabled by default by the OpenShift Route itself.
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0.
 <15> External listener configuration specifies how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Saying that "TLS encryption is not required for `route` listeners" sounded weird and not clear to me.
With this PR I would try to explain that it's not required to be configured in the CR just because TLS encryption is provided by default by the OpenShift Route itself.

### Checklist

- [x] Update documentation