### PR TITLE
[systemtest] Remove YAML desc from upgrade tests log on INFO level

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -415,6 +415,8 @@ public class AbstractUpgradeST extends AbstractST {
 
     protected void deployCoWithWaitForReadiness(final ExtensionContext extensionContext, final BundleVersionModificationData upgradeData,
                                                 final String namespaceName) throws IOException {
+        LOGGER.info("Deploying CO: {} in namespace: {}", ResourceManager.getCoDeploymentName(), namespaceName);
+
         if (upgradeData.getFromVersion().equals("HEAD")) {
             coDir = new File(TestUtils.USER_PATH + "/../packaging/install/cluster-operator");
         } else {
@@ -434,6 +436,8 @@ public class AbstractUpgradeST extends AbstractST {
 
     protected void deployKafkaClusterWithWaitForReadiness(final ExtensionContext extensionContext, final BundleVersionModificationData upgradeData,
                                                           final UpgradeKafkaVersion upgradeKafkaVersion) {
+        LOGGER.info("Deploying Kafka: {} in namespace: {}", clusterName, kubeClient().getNamespace());
+
         if (!cmdKubeClient().getResources(getResourceApiVersion(Kafka.RESOURCE_PLURAL, upgradeData.getFromVersion())).contains(clusterName)) {
             // Deploy a Kafka cluster
             if (upgradeData.getFromExamples().equals("HEAD")) {
@@ -463,6 +467,8 @@ public class AbstractUpgradeST extends AbstractST {
 
     protected void deployKafkaUserWithWaitForReadiness(final ExtensionContext extensionContext, final BundleVersionModificationData upgradeData,
                                                        final String namespaceName) {
+        LOGGER.info("Deploying KafkaUser: {} in namespace: {}", userName, kubeClient().getNamespace());
+
         if (!cmdKubeClient().getResources(getResourceApiVersion(KafkaUser.RESOURCE_PLURAL, upgradeData.getFromVersion())).contains(userName)) {
             if (upgradeData.getFromVersion().equals("HEAD")) {
                 resourceManager.createResource(extensionContext, KafkaUserTemplates.tlsUser(namespaceName, clusterName, userName).build());
@@ -476,6 +482,8 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     protected void deployKafkaTopicWithWaitForReadiness(final BundleVersionModificationData upgradeData) {
+        LOGGER.info("Deploying KafkaTopic: {} in namespace: {}", topicName, kubeClient().getNamespace());
+
         if (!cmdKubeClient().getResources(getResourceApiVersion(KafkaTopic.RESOURCE_PLURAL, upgradeData.getFromVersion())).contains(topicName)) {
             if (upgradeData.getFromVersion().equals("HEAD")) {
                 kafkaTopicYaml = new File(dir, PATH_TO_PACKAGING_EXAMPLES + "/topic/kafka-topic.yaml");

--- a/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cmdClient/BaseCmdKubeClient.java
@@ -220,7 +220,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K applyContent(String yamlContent) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(APPLY, "-f", "-"), 0, Level.INFO);
+            Exec.exec(yamlContent, namespacedCommand(APPLY, "-f", "-"), 0, Level.DEBUG);
             return (K) this;
         }
     }
@@ -229,7 +229,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K createContent(String yamlContent) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(CREATE, "-f", "-"), 0, Level.INFO);
+            Exec.exec(yamlContent, namespacedCommand(CREATE, "-f", "-"), 0, Level.DEBUG);
             return (K) this;
         }
     }
@@ -241,7 +241,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
             try {
                 createContent(yamlContent);
             } catch (KubeClusterException.AlreadyExists e) {
-                Exec.exec(yamlContent, namespacedCommand(REPLACE, "-f", "-"), 0, Level.INFO);
+                Exec.exec(yamlContent, namespacedCommand(REPLACE, "-f", "-"), 0, Level.DEBUG);
             }
 
             return (K) this;
@@ -252,7 +252,7 @@ public abstract class BaseCmdKubeClient<K extends BaseCmdKubeClient<K>> implemen
     @SuppressWarnings("unchecked")
     public K deleteContent(String yamlContent) {
         try (Context context = defaultContext()) {
-            Exec.exec(yamlContent, namespacedCommand(DELETE, "-f", "-"), 0, Level.INFO, false);
+            Exec.exec(yamlContent, namespacedCommand(DELETE, "-f", "-"), 0, Level.DEBUG, false);
             return (K) this;
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR changes the log level for methods used in upgrade/downgrade tests to `DEBUG` level from `INFO` level. It will remove the unnecessary description of all YAMLs applied inside the test run.

Also, it adds few lines about resource creation to make the log more clear.

### Checklist

- [ ] Make sure all tests pass

