### PR TITLE
[DOC] Add StrimziPodSet to the API reference

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -252,6 +252,7 @@
                                 <argument>io.strimzi.api.kafka.model.KafkaMirrorMaker2</argument>
                                 <argument>io.strimzi.api.kafka.model.KafkaRebalance</argument>
                                 <argument>io.strimzi.api.kafka.model.nodepool.KafkaNodePool</argument>
+                                <argument>io.strimzi.api.kafka.model.StrimziPodSet</argument>
                             </arguments>
                             <workingDirectory>${project.basedir}${file.separator}..${file.separator}documentation</workingDirectory>
                         </configuration>

--- a/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSet.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 import io.strimzi.api.kafka.model.status.StrimziPodSetStatus;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
@@ -78,6 +79,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
+@DescriptionFile
 @EqualsAndHashCode(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_CORE_GROUP_NAME)

--- a/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSetSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSetSpec.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.crdgenerator.annotations.Description;
-import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -17,7 +16,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 import java.util.Map;
 
-@DescriptionFile
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/StrimziPodSetStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/StrimziPodSetStatus.java
@@ -30,7 +30,7 @@ public class StrimziPodSetStatus extends Status {
     private int readyPods;
     private int currentPods;
 
-    @Description("Number of pods managed by the StrimziPodSet controller.")
+    @Description("Number of pods managed by this StrimziPodSet resource.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getPods() {
         return pods;
@@ -40,7 +40,7 @@ public class StrimziPodSetStatus extends Status {
         this.pods = pods;
     }
 
-    @Description("Number of pods managed by the StrimziPodSet controller that are ready.")
+    @Description("Number of pods managed by this StrimziPodSet resource that are ready.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getReadyPods() {
         return readyPods;
@@ -50,7 +50,7 @@ public class StrimziPodSetStatus extends Status {
         this.readyPods = readyPods;
     }
 
-    @Description("Number of pods managed by the StrimziPodSet controller that have the current revision.")
+    @Description("Number of pods managed by this StrimziPodSet resource that have the current revision.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getCurrentPods() {
         return currentPods;

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/StrimziPodSetStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/StrimziPodSetStatus.java
@@ -30,7 +30,7 @@ public class StrimziPodSetStatus extends Status {
     private int readyPods;
     private int currentPods;
 
-    @Description("Number of pods managed by this StrimziPodSet resource.")
+    @Description("Number of pods managed by this `StrimziPodSet` resource.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getPods() {
         return pods;
@@ -40,7 +40,7 @@ public class StrimziPodSetStatus extends Status {
         this.pods = pods;
     }
 
-    @Description("Number of pods managed by this StrimziPodSet resource that are ready.")
+    @Description("Number of pods managed by this `StrimziPodSet` resource that are ready.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getReadyPods() {
         return readyPods;
@@ -50,7 +50,7 @@ public class StrimziPodSetStatus extends Status {
         this.readyPods = readyPods;
     }
 
-    @Description("Number of pods managed by this StrimziPodSet resource that have the current revision.")
+    @Description("Number of pods managed by this `StrimziPodSet` resource that have the current revision.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public int getCurrentPods() {
         return currentPods;

--- a/documentation/api/io.strimzi.api.kafka.model.StrimziPodSet.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.StrimziPodSet.adoc
@@ -1,2 +1,3 @@
 IMPORTANT: `StrimziPodSet` is an internal Strimzi resource.
-Strimzi users are not expected to create, modify or delete `StrimziPodSet` resources.
+Information is provided for reference only.
+Do not create, modify or delete `StrimziPodSet` resources as this might cause errors.

--- a/documentation/api/io.strimzi.api.kafka.model.StrimziPodSet.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.StrimziPodSet.adoc
@@ -1,0 +1,2 @@
+IMPORTANT: `StrimziPodSet` is an internal Strimzi resource.
+Strimzi users are not expected to create, modify or delete `StrimziPodSet` resources.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3525,11 +3525,11 @@ Used in: xref:type-StrimziPodSet-{context}[`StrimziPodSet`]
 |xref:type-Condition-{context}[`Condition`] array
 |observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|pods                1.2+<.<a|Number of pods managed by this StrimziPodSet resource.
+|pods                1.2+<.<a|Number of pods managed by this `StrimziPodSet` resource.
 |integer
-|readyPods           1.2+<.<a|Number of pods managed by this StrimziPodSet resource that are ready.
+|readyPods           1.2+<.<a|Number of pods managed by this `StrimziPodSet` resource that are ready.
 |integer
-|currentPods         1.2+<.<a|Number of pods managed by this StrimziPodSet resource that have the current revision.
+|currentPods         1.2+<.<a|Number of pods managed by this `StrimziPodSet` resource that have the current revision.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1615,7 +1615,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 [id='type-Condition-{context}']
 = `Condition` schema reference
 
-Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaNodePoolStatus-{context}[`KafkaNodePoolStatus`], xref:type-KafkaRebalanceStatus-{context}[`KafkaRebalanceStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`]
+Used in: xref:type-KafkaBridgeStatus-{context}[`KafkaBridgeStatus`], xref:type-KafkaConnectorStatus-{context}[`KafkaConnectorStatus`], xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type-KafkaMirrorMaker2Status-{context}[`KafkaMirrorMaker2Status`], xref:type-KafkaMirrorMakerStatus-{context}[`KafkaMirrorMakerStatus`], xref:type-KafkaNodePoolStatus-{context}[`KafkaNodePoolStatus`], xref:type-KafkaRebalanceStatus-{context}[`KafkaRebalanceStatus`], xref:type-KafkaStatus-{context}[`KafkaStatus`], xref:type-KafkaTopicStatus-{context}[`KafkaTopicStatus`], xref:type-KafkaUserStatus-{context}[`KafkaUserStatus`], xref:type-StrimziPodSetStatus-{context}[`StrimziPodSetStatus`]
 
 
 [options="header"]
@@ -3471,5 +3471,65 @@ Used in: xref:type-KafkaNodePool-{context}[`KafkaNodePool`]
 |integer
 |labelSelector       1.2+<.<a|Label selector for pods providing this resource.
 |string
+|====
+
+[id='type-StrimziPodSet-{context}']
+= `StrimziPodSet` schema reference
+
+xref:type-StrimziPodSet-schema-{context}[Full list of `StrimziPodSet` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.StrimziPodSet.adoc[leveloffset=+1]
+
+[id='type-StrimziPodSet-schema-{context}']
+== `StrimziPodSet` schema properties
+
+
+[options="header"]
+|====
+|Property       |Description
+|spec    1.2+<.<a|The specification of the StrimziPodSet.
+|xref:type-StrimziPodSetSpec-{context}[`StrimziPodSetSpec`]
+|status  1.2+<.<a|The status of the StrimziPodSet.
+|xref:type-StrimziPodSetStatus-{context}[`StrimziPodSetStatus`]
+|====
+
+[id='type-StrimziPodSetSpec-{context}']
+= `StrimziPodSetSpec` schema reference
+
+Used in: xref:type-StrimziPodSet-{context}[`StrimziPodSet`]
+
+
+[options="header"]
+|====
+|Property         |Description
+|selector  1.2+<.<a|Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#labelselector-v1-meta[external documentation for meta/v1 labelselector].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#labelselector-v1-meta[LabelSelector]
+|pods      1.2+<.<a|The Pods managed by this StrimziPodSet. For more information, see the https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pods-v1-core[external documentation for core/v1 pods].
+
+
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pods-v1-core[Map] array
+|====
+
+[id='type-StrimziPodSetStatus-{context}']
+= `StrimziPodSetStatus` schema reference
+
+Used in: xref:type-StrimziPodSet-{context}[`StrimziPodSet`]
+
+
+[options="header"]
+|====
+|Property                   |Description
+|conditions          1.2+<.<a|List of status conditions.
+|xref:type-Condition-{context}[`Condition`] array
+|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
+|integer
+|pods                1.2+<.<a|Number of pods managed by this StrimziPodSet resource.
+|integer
+|readyPods           1.2+<.<a|Number of pods managed by this StrimziPodSet resource that are ready.
+|integer
+|currentPods         1.2+<.<a|Number of pods managed by this StrimziPodSet resource that have the current revision.
+|integer
 |====
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -109,11 +109,11 @@ spec:
                   description: The generation of the CRD that was last reconciled by the operator.
                 pods:
                   type: integer
-                  description: Number of pods managed by this StrimziPodSet resource.
+                  description: Number of pods managed by this `StrimziPodSet` resource.
                 readyPods:
                   type: integer
-                  description: Number of pods managed by this StrimziPodSet resource that are ready.
+                  description: Number of pods managed by this `StrimziPodSet` resource that are ready.
                 currentPods:
                   type: integer
-                  description: Number of pods managed by this StrimziPodSet resource that have the current revision.
+                  description: Number of pods managed by this `StrimziPodSet` resource that have the current revision.
               description: The status of the StrimziPodSet.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -109,11 +109,11 @@ spec:
                   description: The generation of the CRD that was last reconciled by the operator.
                 pods:
                   type: integer
-                  description: Number of pods managed by the StrimziPodSet controller.
+                  description: Number of pods managed by this StrimziPodSet resource.
                 readyPods:
                   type: integer
-                  description: Number of pods managed by the StrimziPodSet controller that are ready.
+                  description: Number of pods managed by this StrimziPodSet resource that are ready.
                 currentPods:
                   type: integer
-                  description: Number of pods managed by the StrimziPodSet controller that have the current revision.
+                  description: Number of pods managed by this StrimziPodSet resource that have the current revision.
               description: The status of the StrimziPodSet.

--- a/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -108,11 +108,11 @@ spec:
                 description: The generation of the CRD that was last reconciled by the operator.
               pods:
                 type: integer
-                description: Number of pods managed by the StrimziPodSet controller.
+                description: Number of pods managed by this StrimziPodSet resource.
               readyPods:
                 type: integer
-                description: Number of pods managed by the StrimziPodSet controller that are ready.
+                description: Number of pods managed by this StrimziPodSet resource that are ready.
               currentPods:
                 type: integer
-                description: Number of pods managed by the StrimziPodSet controller that have the current revision.
+                description: Number of pods managed by this StrimziPodSet resource that have the current revision.
             description: The status of the StrimziPodSet.

--- a/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -108,11 +108,11 @@ spec:
                 description: The generation of the CRD that was last reconciled by the operator.
               pods:
                 type: integer
-                description: Number of pods managed by this StrimziPodSet resource.
+                description: Number of pods managed by this `StrimziPodSet` resource.
               readyPods:
                 type: integer
-                description: Number of pods managed by this StrimziPodSet resource that are ready.
+                description: Number of pods managed by this `StrimziPodSet` resource that are ready.
               currentPods:
                 type: integer
-                description: Number of pods managed by this StrimziPodSet resource that have the current revision.
+                description: Number of pods managed by this `StrimziPodSet` resource that have the current revision.
             description: The status of the StrimziPodSet.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Originally, we did not include the `StrimziPodSet` specification into the API reference guide as it is only an internal resource. But since people are noticing it anyway and often reading it, it makes sense to have it there to make it easier for them to understand the structure. This PR includes it there with a warning that it is an internal resource and users are not expected to create, modify or delete it.

### Checklist

- [x] Update documentation