### PR TITLE
Updated Kafka node pools examples with 3.4.1 version

### DIFF
--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -26,7 +26,7 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.4.1
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -44,7 +44,7 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.4.1
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3

--- a/packaging/examples/kafka/nodepools/kafka.yaml
+++ b/packaging/examples/kafka/nodepools/kafka.yaml
@@ -44,7 +44,7 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.4.1
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3


### PR DESCRIPTION
Trivial PR to use the Kafka version 3.4.1 in the node pools examples as it is already used in the others (non node pools based).