### PR TITLE
Add alternate non-Vertx resource operators to the common module

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -966,7 +966,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         conditions.addAll(unknownAndDeprecatedConditions);
 
         if (!Annotations.isReconciliationPausedWithAnnotation(connector)) {
-            StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? Future.failedFuture(error) : connectorReadiness);
+            StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? error : connectorReadiness.cause());
             status.setConnectorStatus(statusResult);
             status.setTasksMax(getActualTaskCount(connector, statusResult));
             status.setTopics(topics);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -55,6 +55,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.model.ResourceVisitor;
@@ -209,7 +210,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                                      String watchNamespaceOrWildcard, Labels selectorLabels) {
         Optional<LabelSelector> selector = (selectorLabels == null || selectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, selectorLabels.toMap()));
 
-        return Util.async(connectOperator.vertx, () -> {
+        return VertxUtil.async(connectOperator.vertx, () -> {
             Watch watch = connectOperator.connectorOperator.watch(watchNamespaceOrWildcard, new Watcher<>() {
                 @Override
                 public void eventReceived(Action action, KafkaConnector kafkaConnector) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -64,7 +64,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
-import static io.strimzi.operator.common.Util.async;
+import static io.strimzi.operator.common.VertxUtil.async;
 
 /**
  * Assembly operator for the Kafka custom resource. It manages the following components:

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperator.java
@@ -23,11 +23,11 @@ import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -99,7 +99,7 @@ public class KafkaBridgeAssemblyOperator extends AbstractAssemblyOperator<Kubern
             .compose(i -> MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, bridge.logging(), null))
             .compose(metricsAndLogging -> configMapOperations.reconcile(reconciliation, namespace, KafkaBridgeResources.metricsAndLogConfigMapName(reconciliation.name()), bridge.generateMetricsAndLogConfigMap(metricsAndLogging)))
             .compose(i -> podDisruptionBudgetOperator.reconcile(reconciliation, namespace, bridge.getComponentName(), bridge.generatePodDisruptionBudget()))
-            .compose(i -> Util.authTlsHash(secretOperations, namespace, auth, trustedCertificates))
+            .compose(i -> VertxUtil.authTlsHash(secretOperations, namespace, auth, trustedCertificates))
             .compose(hash -> deploymentOperations.reconcile(reconciliation, namespace, bridge.getComponentName(), bridge.generateDeployment(Collections.singletonMap(Annotations.ANNO_STRIMZI_AUTH_HASH, Integer.toString(hash)), pfa.isOpenshift(), imagePullPolicy, imagePullSecrets)))
             .compose(i -> deploymentOperations.scaleUp(reconciliation, namespace, bridge.getComponentName(), bridge.getReplicas(), operationTimeoutMs))
             .compose(i -> deploymentOperations.waitForObserved(reconciliation, namespace, bridge.getComponentName(), 1_000, operationTimeoutMs))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -353,7 +354,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
     Future<Integer> generateAuthHash(String namespace, KafkaConnectSpec kafkaConnectSpec) {
         KafkaClientAuthentication auth = kafkaConnectSpec.getAuthentication();
         List<CertSecretSource> trustedCertificates = kafkaConnectSpec.getTls() == null ? Collections.emptyList() : kafkaConnectSpec.getTls().getTrustedCertificates();
-        return Util.authTlsHash(secretOperations, namespace, auth, trustedCertificates);
+        return VertxUtil.authTlsHash(secretOperations, namespace, auth, trustedCertificates);
     }
 
     private boolean isPaused(KafkaConnectorStatus status) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -139,7 +139,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             build = KafkaConnectBuild.fromCrd(reconciliation, kafkaConnect, versions, sharedEnvironmentProvider);
         } catch (Exception e) {
             LOGGER.warnCr(reconciliation, e);
-            StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, Future.failedFuture(e));
+            StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, e);
             return Future.failedFuture(new ReconciliationException(kafkaConnectStatus, e));
         }
 
@@ -220,7 +220,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 })
                 .compose(i -> reconcileConnectors(reconciliation, kafkaConnect, kafkaConnectStatus, hasZeroReplicas, desiredLogging.get(), connect.defaultLogConfig()))
                 .onComplete(reconciliationResult -> {
-                    StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult);
+                    StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnect, kafkaConnectStatus, reconciliationResult.cause());
 
                     if (!hasZeroReplicas) {
                         kafkaConnectStatus.setUrl(KafkaConnectResources.url(connect.getCluster(), namespace, KafkaConnectCluster.REST_API_PORT));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -46,6 +46,7 @@ import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -308,7 +309,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                             .stream()
                             .map(cluster -> {
                                 List<CertSecretSource> trustedCertificates = cluster.getTls() == null ? Collections.emptyList() : cluster.getTls().getTrustedCertificates();
-                                return Util.authTlsHash(secretOperations, namespace, cluster.getAuthentication(), trustedCertificates);
+                                return VertxUtil.authTlsHash(secretOperations, namespace, cluster.getAuthentication(), trustedCertificates);
                             }).collect(Collectors.toList())
                     )
                     .onSuccess(hashes -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -24,11 +24,11 @@ import io.strimzi.operator.cluster.model.MetricsAndLoggingUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
@@ -111,8 +111,8 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                     return configMapOperations.reconcile(reconciliation, namespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(reconciliation.name()), logAndMetricsConfigMap);
                 })
                 .compose(i -> podDisruptionBudgetOperator.reconcile(reconciliation, namespace, mirror.getComponentName(), mirror.generatePodDisruptionBudget()))
-                .compose(i -> CompositeFuture.join(Util.authTlsHash(secretOperations, namespace, authConsumer, trustedCertificatesConsumer),
-                        Util.authTlsHash(secretOperations, namespace, authProducer, trustedCertificatesProducer)))
+                .compose(i -> CompositeFuture.join(VertxUtil.authTlsHash(secretOperations, namespace, authConsumer, trustedCertificatesConsumer),
+                        VertxUtil.authTlsHash(secretOperations, namespace, authProducer, trustedCertificatesProducer)))
                 .compose(hashFut -> {
                     if (hashFut != null) {
                         annotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, Integer.toString((int) hashFut.resultAt(0) + (int) hashFut.resultAt(1)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -86,7 +86,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
             mirror = KafkaMirrorMakerCluster.fromCrd(reconciliation, assemblyResource, versions, sharedEnvironmentProvider);
         } catch (Exception e) {
             LOGGER.warnCr(reconciliation, e);
-            StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, Future.failedFuture(e));
+            StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, e);
             return Future.failedFuture(new ReconciliationException(kafkaMirrorMakerStatus, e));
         }
 
@@ -124,7 +124,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> deploymentOperations.waitForObserved(reconciliation, namespace, mirror.getComponentName(), 1_000, operationTimeoutMs))
                 .compose(i -> mirrorHasZeroReplicas ? Future.succeededFuture() : deploymentOperations.readiness(reconciliation, namespace, mirror.getComponentName(), 1_000, operationTimeoutMs))
                 .onComplete(reconciliationResult -> {
-                        StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult);
+                        StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult.cause());
 
                         kafkaMirrorMakerStatus.setReplicas(mirror.getReplicas());
                         kafkaMirrorMakerStatus.setLabelSelector(mirror.getSelectorLabels().toSelectorString());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -51,6 +51,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableStatusedNamespacedResourceOperator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
@@ -216,7 +217,7 @@ public class KafkaRebalanceAssemblyOperator
      */
     public Future<Void> createRebalanceWatch(String watchNamespaceOrWildcard) {
 
-        return Util.async(this.vertx, () -> {
+        return VertxUtil.async(this.vertx, () -> {
             kafkaRebalanceOperator.watch(watchNamespaceOrWildcard, selector(), new Watcher<>() {
                 @Override
                 public void eventReceived(Action action, KafkaRebalance kafkaRebalance) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -570,7 +571,7 @@ public class KafkaRoller {
      */
     protected Config brokerConfig(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
         ConfigResource resource = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(nodeRef.nodeId()));
-        return await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
+        return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
             30, TimeUnit.SECONDS,
             error -> new ForceableProblem("Error getting broker config", error)
         );
@@ -583,7 +584,7 @@ public class KafkaRoller {
      */
     protected Config brokerLogging(int brokerId) throws ForceableProblem, InterruptedException {
         ConfigResource resource = Util.getBrokersLogging(brokerId);
-        return await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
+        return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, allClient.describeConfigs(singletonList(resource)).values().get(resource)),
                 30, TimeUnit.SECONDS,
             error -> new ForceableProblem("Error getting broker logging", error)
         );
@@ -602,12 +603,12 @@ public class KafkaRoller {
         AlterConfigsResult alterConfigResult = ac.incrementalAlterConfigs(updatedConfig);
         KafkaFuture<Void> brokerConfigFuture = alterConfigResult.values().get(Util.getBrokersConfig(podId));
         KafkaFuture<Void> brokerLoggingConfigFuture = alterConfigResult.values().get(Util.getBrokersLogging(podId));
-        await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, brokerConfigFuture), 30, TimeUnit.SECONDS,
+        await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerConfigFuture), 30, TimeUnit.SECONDS,
             error -> {
                 LOGGER.errorCr(reconciliation, "Error updating broker configuration for pod {}", nodeRef, error);
                 return new ForceableProblem("Error updating broker configuration for pod " + nodeRef, error);
             });
-        await(Util.kafkaFutureToVertxFuture(reconciliation, vertx, brokerLoggingConfigFuture), 30, TimeUnit.SECONDS,
+        await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerLoggingConfigFuture), 30, TimeUnit.SECONDS,
             error -> {
                 LOGGER.errorCr(reconciliation, "Error updating broker logging configuration pod {}", nodeRef, error);
                 return new ForceableProblem("Error updating broker logging configuration pod " + nodeRef, error);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -11,6 +11,7 @@ import io.strimzi.operator.common.PasswordGenerator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -159,7 +160,7 @@ public class ZookeeperScaler implements AutoCloseable {
                 watchedEvent -> LOGGER.debugCr(reconciliation, "Received event {} from ZooKeeperAdmin client connected to {}", watchedEvent, zookeeperConnectionString),
                 clientConfig);
 
-            Util.waitFor(reconciliation, vertx,
+            VertxUtil.waitFor(reconciliation, vertx,
                 String.format("ZooKeeperAdmin connection to %s", zookeeperConnectionString),
                 "connected",
                 1_000,

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -102,6 +102,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
@@ -188,6 +189,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-micrometer-metrics</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -41,8 +41,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.common.Util.async;
-
 /**
  * A base implementation of {@link Operator}.
  *
@@ -474,7 +472,7 @@ public abstract class AbstractOperator<
      * @return A future which completes when the watcher has been created.
      */
     public Future<Watch> createWatch(String namespace, Consumer<WatcherException> onClose) {
-        return async(vertx, () -> resourceOperator.watch(namespace, selector(), new OperatorWatcher<>(this, namespace, onClose)));
+        return VertxUtil.async(vertx, () -> resourceOperator.watch(namespace, selector(), new OperatorWatcher<>(this, namespace, onClose)));
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -7,25 +7,10 @@ package io.strimzi.operator.common;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.strimzi.api.kafka.model.CertSecretSource;
-import io.strimzi.api.kafka.model.GenericSecretSource;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScram;
-import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls;
-import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.strimzi.operator.common.operator.resource.SecretOperator;
-import io.strimzi.operator.common.operator.resource.TimeoutException;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import org.apache.kafka.common.KafkaFuture;
+
 import org.apache.kafka.common.config.ConfigResource;
 import org.quartz.CronExpression;
 
@@ -46,7 +31,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -61,9 +45,6 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -77,50 +58,6 @@ public class Util {
      * Length of a hash stub. One example usage is when generating an annotation with a certificate short thumbprint.
      */
     public static final int HASH_STUB_LENGTH = 8;
-
-    /**
-     * Executes blocking code asynchronously
-     *
-     * @param vertx     Vert.x instance
-     * @param supplier  Supplier with the blocking code
-     *
-     * @return  Future for returning the result
-     *
-     * @param <T>   Type of the result
-     */
-    public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
-        Promise<T> result = Promise.promise();
-        vertx.executeBlocking(
-            future -> {
-                try {
-                    future.complete(supplier.get());
-                } catch (Throwable t) {
-                    future.fail(t);
-                }
-            }, result
-        );
-        return result.future();
-    }
-
-    /**
-     * Converts a standard Java {@link CompletionStage} to a Vert.x {@link Future}.
-     *
-     * @param <T>   type of the asynchronous result
-     * @param stage {@link CompletionStage} to convert
-     * @return a Vert.x {@link Future} with the result or error of the
-     *         {@link CompletionStage}
-     */
-    public static <T> Future<T> toFuture(CompletionStage<T> stage) {
-        Promise<T> promise = Promise.promise();
-        stage.whenComplete(unwrap((value, error) -> {
-            if (error != null) {
-                promise.fail(error);
-            } else {
-                promise.complete(value);
-            }
-        }));
-        return promise.future();
-    }
 
     /**
      * Wrap the given action with a BiConsumer that {@link #unwrap(Throwable)
@@ -149,89 +86,6 @@ public class Util {
             return wrapped.getCause();
         }
         return error;
-    }
-
-    /**
-     * Invoke the given {@code completed} supplier on a pooled thread approximately every {@code pollIntervalMs}
-     * milliseconds until it returns true or {@code timeoutMs} milliseconds have elapsed.
-     * @param reconciliation The reconciliation
-     * @param vertx The vertx instance.
-     * @param logContext A string used for context in logging.
-     * @param logState The state we are waiting for use in log messages
-     * @param pollIntervalMs The poll interval in milliseconds.
-     * @param timeoutMs The timeout, in milliseconds.
-     * @param completed Determines when the wait is complete by returning true.
-     * @return A future that completes when the given {@code completed} indicates readiness.
-     */
-    public static Future<Void> waitFor(Reconciliation reconciliation, Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed) {
-        return waitFor(reconciliation, vertx, logContext, logState, pollIntervalMs, timeoutMs, completed, error -> false);
-    }
-
-    /**
-     * Invoke the given {@code completed} supplier on a pooled thread approximately every {@code pollIntervalMs}
-     * milliseconds until it returns true or {@code timeoutMs} milliseconds have elapsed.
-     * @param reconciliation The reconciliation
-     * @param vertx The vertx instance.
-     * @param logContext A string used for context in logging.
-     * @param logState The state we are waiting for use in log messages
-     * @param pollIntervalMs The poll interval in milliseconds.
-     * @param timeoutMs The timeout, in milliseconds.
-     * @param completed Determines when the wait is complete by returning true.
-     * @param failOnError Determine whether a given error thrown by {@code completed},
-     *                    should result in the immediate completion of the returned Future.
-     * @return A future that completes when the given {@code completed} indicates readiness.
-     */
-    public static Future<Void> waitFor(Reconciliation reconciliation, Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed,
-                                       Predicate<Throwable> failOnError) {
-        Promise<Void> promise = Promise.promise();
-        LOGGER.debugCr(reconciliation, "Waiting for {} to get {}", logContext, logState);
-        long deadline = System.currentTimeMillis() + timeoutMs;
-        Handler<Long> handler = new Handler<>() {
-            @Override
-            public void handle(Long timerId) {
-                vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                    future -> {
-                        try {
-                            if (completed.getAsBoolean())   {
-                                future.complete();
-                            } else {
-                                LOGGER.traceCr(reconciliation, "{} is not {}", logContext, logState);
-                                future.fail("Not " + logState + " yet");
-                            }
-                        } catch (Throwable e) {
-                            LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
-                            future.fail(e);
-                        }
-                    },
-                    true,
-                    res -> {
-                        if (res.succeeded()) {
-                            LOGGER.debugCr(reconciliation, "{} is {}", logContext, logState);
-                            promise.complete();
-                        } else {
-                            if (failOnError.test(res.cause())) {
-                                promise.fail(res.cause());
-                            } else {
-                                long timeLeft = deadline - System.currentTimeMillis();
-                                if (timeLeft <= 0) {
-                                    String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
-                                    LOGGER.errorCr(reconciliation, exceptionMessage);
-                                    promise.fail(new TimeoutException(exceptionMessage));
-                                } else {
-                                    // Schedule ourselves to run again
-                                    vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
-                                }
-                            }
-                        }
-                    }
-                );
-            }
-        };
-
-        // Call the handler ourselves the first time
-        handler.handle(null);
-
-        return promise.future();
     }
 
     /**
@@ -434,41 +288,6 @@ public class Util {
     }
 
     /**
-     * Converts Kafka Future to VErt.x future
-     *
-     * @param reconciliation    Reconciliation marker
-     * @param vertx             Vert.x instance
-     * @param kf                Kafka future
-     *
-     * @return  Vert.x future based on the Kafka future
-     *
-     * @param <T>   Return type of the future
-     */
-    public static <T> Future<T> kafkaFutureToVertxFuture(Reconciliation reconciliation, Vertx vertx, KafkaFuture<T> kf) {
-        Promise<T> promise = Promise.promise();
-        if (kf != null) {
-            kf.whenComplete((result, error) -> {
-                vertx.runOnContext(ignored -> {
-                    if (error != null) {
-                        promise.fail(error);
-                    } else {
-                        promise.complete(result);
-                    }
-                });
-            });
-            return promise.future();
-        } else {
-            if (reconciliation != null) {
-                LOGGER.traceCr(reconciliation, "KafkaFuture is null");
-            } else {
-                LOGGER.traceOp("KafkaFuture is null");
-            }
-
-            return Future.succeededFuture();
-        }
-    }
-
-    /**
      * Created config resource instance
      *
      * @param podId Pod ID
@@ -614,77 +433,6 @@ public class Util {
     }
 
     /**
-     * When TLS certificate or Auth certificate (or password) is changed, the has is computed.
-     * It is used for rolling updates.
-     * @param secretOperations Secret operator
-     * @param namespace namespace to get Secrets in
-     * @param auth Authentication object to compute hash from
-     * @param certSecretSources TLS trusted certificates whose hashes are joined to result
-     * @return Future computing hash from TLS + Auth
-     */
-    public static Future<Integer> authTlsHash(SecretOperator secretOperations, String namespace, KafkaClientAuthentication auth, List<CertSecretSource> certSecretSources) {
-        Future<Integer> tlsFuture;
-        if (certSecretSources == null || certSecretSources.isEmpty()) {
-            tlsFuture = Future.succeededFuture(0);
-        } else {
-            // get all TLS trusted certs, compute hash from each of them, sum hashes
-            tlsFuture = CompositeFuture.join(certSecretSources.stream().map(certSecretSource ->
-                    getCertificateAsync(secretOperations, namespace, certSecretSource)
-                    .compose(cert -> Future.succeededFuture(cert.hashCode()))).collect(Collectors.toList()))
-                .compose(hashes -> Future.succeededFuture(hashes.list().stream().mapToInt(e -> (int) e).sum()));
-        }
-
-        if (auth == null) {
-            return tlsFuture;
-        } else {
-            // compute hash from Auth
-            if (auth instanceof KafkaClientAuthenticationScram) {
-                // only passwordSecret can be changed
-                return tlsFuture.compose(tlsHash -> getPasswordAsync(secretOperations, namespace, auth)
-                        .compose(password -> Future.succeededFuture(password.hashCode() + tlsHash)));
-            } else if (auth instanceof KafkaClientAuthenticationPlain) {
-                // only passwordSecret can be changed
-                return tlsFuture.compose(tlsHash -> getPasswordAsync(secretOperations, namespace, auth)
-                        .compose(password -> Future.succeededFuture(password.hashCode() + tlsHash)));
-            } else if (auth instanceof KafkaClientAuthenticationTls) {
-                // custom cert can be used (and changed)
-                return ((KafkaClientAuthenticationTls) auth).getCertificateAndKey() == null ? tlsFuture :
-                        tlsFuture.compose(tlsHash -> getCertificateAndKeyAsync(secretOperations, namespace, (KafkaClientAuthenticationTls) auth)
-                        .compose(crtAndKey -> Future.succeededFuture(crtAndKey.certAsBase64String().hashCode() + crtAndKey.keyAsBase64String().hashCode() + tlsHash)));
-            } else if (auth instanceof KafkaClientAuthenticationOAuth) {
-                @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
-                List<Future> futureList = ((KafkaClientAuthenticationOAuth) auth).getTlsTrustedCertificates() == null ?
-                        new ArrayList<>() : ((KafkaClientAuthenticationOAuth) auth).getTlsTrustedCertificates().stream().map(certSecretSource ->
-                        getCertificateAsync(secretOperations, namespace, certSecretSource)
-                                .compose(cert -> Future.succeededFuture(cert.hashCode()))).collect(Collectors.toList());
-                futureList.add(tlsFuture);
-                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getAccessToken()));
-                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getClientSecret()));
-                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getRefreshToken()));
-                return CompositeFuture.join(futureList)
-                        .compose(hashes -> Future.succeededFuture(hashes.list().stream().mapToInt(e -> (int) e).sum()));
-            } else {
-                // unknown Auth type
-                return tlsFuture;
-            }
-        }
-    }
-
-    private static Future<Integer> addSecretHash(SecretOperator secretOperations, String namespace, GenericSecretSource genericSecretSource) {
-        if (genericSecretSource != null) {
-            return secretOperations.getAsync(namespace, genericSecretSource.getSecretName())
-                    .compose(secret -> {
-                        if (secret == null) {
-                            return Future.failedFuture("Secret " + genericSecretSource.getSecretName() + " not found");
-                        } else {
-                            return Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode());
-                        }
-                    });
-        }
-        return Future.succeededFuture(0);
-    }
-
-    /**
      * Checks if the Kubernetes resource matches LabelSelector. This is useful when you use get/getAsync to retrieve a
      * resource and want to check if it matches the labels from the selector (since get/getAsync is using name and not
      * labels to identify the resource). This method currently supports only the matchLabels object. matchExpressions
@@ -719,64 +467,6 @@ public class Util {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-        }
-    }
-
-    /**
-     * Utility method which gets the secret and validates that the required fields are present in it
-     *
-     * @param secretOperator    Secret operator to get the secret from the Kubernetes API
-     * @param namespace         Namespace where the Secret exist
-     * @param name              Name of the Secret
-     * @param items             List of items which should be present in the Secret
-     *
-     * @return      Future with the Secret if is exits and has the required items. Failed future with an error message otherwise.
-     */
-    /* test */ static Future<Secret> getValidatedSecret(SecretOperator secretOperator, String namespace, String name, String... items)  {
-        return secretOperator.getAsync(namespace, name)
-                .compose(secret -> {
-                    if (secret == null) {
-                        return Future.failedFuture(new InvalidConfigurationException("Secret " + name + " not found"));
-                    } else {
-                        List<String> errors = new ArrayList<>(0);
-
-                        for (String item : items)   {
-                            if (!secret.getData().containsKey(item))    {
-                                // Item not found => error will be raised
-                                errors.add(item);
-                            }
-                        }
-
-                        if (errors.isEmpty()) {
-                            return Future.succeededFuture(secret);
-                        } else {
-                            return Future.failedFuture(new InvalidConfigurationException(String.format("Items with key(s) %s are missing in Secret %s", errors, name)));
-                        }
-                    }
-                });
-    }
-
-    private static Future<String> getCertificateAsync(SecretOperator secretOperator, String namespace, CertSecretSource certSecretSource) {
-        return getValidatedSecret(secretOperator, namespace, certSecretSource.getSecretName(), certSecretSource.getCertificate())
-                .compose(secret -> Future.succeededFuture(secret.getData().get(certSecretSource.getCertificate())));
-    }
-
-    private static Future<CertAndKey> getCertificateAndKeyAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthenticationTls auth) {
-        return getValidatedSecret(secretOperator, namespace, auth.getCertificateAndKey().getSecretName(), auth.getCertificateAndKey().getCertificate(), auth.getCertificateAndKey().getKey())
-                .compose(secret -> Future.succeededFuture(new CertAndKey(secret.getData().get(auth.getCertificateAndKey().getKey()).getBytes(StandardCharsets.UTF_8), secret.getData().get(auth.getCertificateAndKey().getCertificate()).getBytes(StandardCharsets.UTF_8))));
-    }
-
-    private static Future<String> getPasswordAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthentication auth) {
-        if (auth instanceof KafkaClientAuthenticationPlain plainAuth) {
-
-            return getValidatedSecret(secretOperator, namespace, plainAuth.getPasswordSecret().getSecretName(), plainAuth.getPasswordSecret().getPassword())
-                    .compose(secret -> Future.succeededFuture(secret.getData().get(plainAuth.getPasswordSecret().getPassword())));
-        } else if (auth instanceof KafkaClientAuthenticationScram scramAuth) {
-
-            return getValidatedSecret(secretOperator, namespace, scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword())
-                    .compose(secret -> Future.succeededFuture(secret.getData().get(scramAuth.getPasswordSecret().getPassword())));
-        } else {
-            return Future.failedFuture("Auth type " + auth.getType() + " does not have a password property");
         }
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.KafkaFuture;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.GenericSecretSource;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuth;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScram;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationTls;
+import io.strimzi.certs.CertAndKey;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.strimzi.operator.common.operator.resource.TimeoutException;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * Class with various utility methods that use or depend on Vert.x core.
+ */
+public final class VertxUtil {
+
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(VertxUtil.class);
+
+    private VertxUtil() {
+        // Not used
+    }
+
+    /**
+     * Executes blocking code asynchronously
+     *
+     * @param vertx     Vert.x instance
+     * @param supplier  Supplier with the blocking code
+     *
+     * @return  Future for returning the result
+     *
+     * @param <T>   Type of the result
+     */
+    public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
+        Promise<T> result = Promise.promise();
+        vertx.executeBlocking(
+            future -> {
+                try {
+                    future.complete(supplier.get());
+                } catch (Throwable t) {
+                    future.fail(t);
+                }
+            }, result
+        );
+        return result.future();
+    }
+
+    /**
+     * Converts a standard Java {@link CompletionStage} to a Vert.x {@link Future}.
+     *
+     * @param <T>   type of the asynchronous result
+     * @param stage {@link CompletionStage} to convert
+     * @return a Vert.x {@link Future} with the result or error of the
+     *         {@link CompletionStage}
+     */
+    public static <T> Future<T> toFuture(CompletionStage<T> stage) {
+        Promise<T> promise = Promise.promise();
+        stage.whenComplete(Util.unwrap((value, error) -> {
+            if (error != null) {
+                promise.fail(error);
+            } else {
+                promise.complete(value);
+            }
+        }));
+        return promise.future();
+    }
+
+    /**
+     * Invoke the given {@code completed} supplier on a pooled thread approximately every {@code pollIntervalMs}
+     * milliseconds until it returns true or {@code timeoutMs} milliseconds have elapsed.
+     * @param reconciliation The reconciliation
+     * @param vertx The vertx instance.
+     * @param logContext A string used for context in logging.
+     * @param logState The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param completed Determines when the wait is complete by returning true.
+     * @return A future that completes when the given {@code completed} indicates readiness.
+     */
+    public static Future<Void> waitFor(Reconciliation reconciliation, Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed) {
+        return waitFor(reconciliation, vertx, logContext, logState, pollIntervalMs, timeoutMs, completed, error -> false);
+    }
+
+    /**
+     * Invoke the given {@code completed} supplier on a pooled thread approximately every {@code pollIntervalMs}
+     * milliseconds until it returns true or {@code timeoutMs} milliseconds have elapsed.
+     * @param reconciliation The reconciliation
+     * @param vertx The vertx instance.
+     * @param logContext A string used for context in logging.
+     * @param logState The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
+     * @param completed Determines when the wait is complete by returning true.
+     * @param failOnError Determine whether a given error thrown by {@code completed},
+     *                    should result in the immediate completion of the returned Future.
+     * @return A future that completes when the given {@code completed} indicates readiness.
+     */
+    public static Future<Void> waitFor(Reconciliation reconciliation, Vertx vertx, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed,
+                                       Predicate<Throwable> failOnError) {
+        Promise<Void> promise = Promise.promise();
+        LOGGER.debugCr(reconciliation, "Waiting for {} to get {}", logContext, logState);
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        Handler<Long> handler = new Handler<>() {
+            @Override
+            public void handle(Long timerId) {
+                vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+                    future -> {
+                        try {
+                            if (completed.getAsBoolean())   {
+                                future.complete();
+                            } else {
+                                LOGGER.traceCr(reconciliation, "{} is not {}", logContext, logState);
+                                future.fail("Not " + logState + " yet");
+                            }
+                        } catch (Throwable e) {
+                            LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                            future.fail(e);
+                        }
+                    },
+                    true,
+                    res -> {
+                        if (res.succeeded()) {
+                            LOGGER.debugCr(reconciliation, "{} is {}", logContext, logState);
+                            promise.complete();
+                        } else {
+                            if (failOnError.test(res.cause())) {
+                                promise.fail(res.cause());
+                            } else {
+                                long timeLeft = deadline - System.currentTimeMillis();
+                                if (timeLeft <= 0) {
+                                    String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
+                                    LOGGER.errorCr(reconciliation, exceptionMessage);
+                                    promise.fail(new TimeoutException(exceptionMessage));
+                                } else {
+                                    // Schedule ourselves to run again
+                                    vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
+                                }
+                            }
+                        }
+                    }
+                );
+            }
+        };
+
+        // Call the handler ourselves the first time
+        handler.handle(null);
+
+        return promise.future();
+    }
+
+    /**
+     * Converts Kafka Future to VErt.x future
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param vertx             Vert.x instance
+     * @param kf                Kafka future
+     *
+     * @return  Vert.x future based on the Kafka future
+     *
+     * @param <T>   Return type of the future
+     */
+    public static <T> Future<T> kafkaFutureToVertxFuture(Reconciliation reconciliation, Vertx vertx, KafkaFuture<T> kf) {
+        Promise<T> promise = Promise.promise();
+        if (kf != null) {
+            kf.whenComplete((result, error) -> {
+                vertx.runOnContext(ignored -> {
+                    if (error != null) {
+                        promise.fail(error);
+                    } else {
+                        promise.complete(result);
+                    }
+                });
+            });
+            return promise.future();
+        } else {
+            if (reconciliation != null) {
+                LOGGER.traceCr(reconciliation, "KafkaFuture is null");
+            } else {
+                LOGGER.traceOp("KafkaFuture is null");
+            }
+
+            return Future.succeededFuture();
+        }
+    }
+
+    /**
+     * When TLS certificate or Auth certificate (or password) is changed, the has is computed.
+     * It is used for rolling updates.
+     * @param secretOperations Secret operator
+     * @param namespace namespace to get Secrets in
+     * @param auth Authentication object to compute hash from
+     * @param certSecretSources TLS trusted certificates whose hashes are joined to result
+     * @return Future computing hash from TLS + Auth
+     */
+    public static Future<Integer> authTlsHash(SecretOperator secretOperations, String namespace, KafkaClientAuthentication auth, List<CertSecretSource> certSecretSources) {
+        Future<Integer> tlsFuture;
+        if (certSecretSources == null || certSecretSources.isEmpty()) {
+            tlsFuture = Future.succeededFuture(0);
+        } else {
+            // get all TLS trusted certs, compute hash from each of them, sum hashes
+            tlsFuture = CompositeFuture.join(certSecretSources.stream().map(certSecretSource ->
+                    getCertificateAsync(secretOperations, namespace, certSecretSource)
+                    .compose(cert -> Future.succeededFuture(cert.hashCode()))).collect(Collectors.toList()))
+                .compose(hashes -> Future.succeededFuture(hashes.list().stream().mapToInt(e -> (int) e).sum()));
+        }
+
+        if (auth == null) {
+            return tlsFuture;
+        } else {
+            // compute hash from Auth
+            if (auth instanceof KafkaClientAuthenticationScram) {
+                // only passwordSecret can be changed
+                return tlsFuture.compose(tlsHash -> getPasswordAsync(secretOperations, namespace, auth)
+                        .compose(password -> Future.succeededFuture(password.hashCode() + tlsHash)));
+            } else if (auth instanceof KafkaClientAuthenticationPlain) {
+                // only passwordSecret can be changed
+                return tlsFuture.compose(tlsHash -> getPasswordAsync(secretOperations, namespace, auth)
+                        .compose(password -> Future.succeededFuture(password.hashCode() + tlsHash)));
+            } else if (auth instanceof KafkaClientAuthenticationTls) {
+                // custom cert can be used (and changed)
+                return ((KafkaClientAuthenticationTls) auth).getCertificateAndKey() == null ? tlsFuture :
+                        tlsFuture.compose(tlsHash -> getCertificateAndKeyAsync(secretOperations, namespace, (KafkaClientAuthenticationTls) auth)
+                        .compose(crtAndKey -> Future.succeededFuture(crtAndKey.certAsBase64String().hashCode() + crtAndKey.keyAsBase64String().hashCode() + tlsHash)));
+            } else if (auth instanceof KafkaClientAuthenticationOAuth) {
+                @SuppressWarnings({ "rawtypes" }) // Has to use Raw type because of the CompositeFuture
+                List<Future> futureList = ((KafkaClientAuthenticationOAuth) auth).getTlsTrustedCertificates() == null ?
+                        new ArrayList<>() : ((KafkaClientAuthenticationOAuth) auth).getTlsTrustedCertificates().stream().map(certSecretSource ->
+                        getCertificateAsync(secretOperations, namespace, certSecretSource)
+                                .compose(cert -> Future.succeededFuture(cert.hashCode()))).collect(Collectors.toList());
+                futureList.add(tlsFuture);
+                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getAccessToken()));
+                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getClientSecret()));
+                futureList.add(addSecretHash(secretOperations, namespace, ((KafkaClientAuthenticationOAuth) auth).getRefreshToken()));
+                return CompositeFuture.join(futureList)
+                        .compose(hashes -> Future.succeededFuture(hashes.list().stream().mapToInt(e -> (int) e).sum()));
+            } else {
+                // unknown Auth type
+                return tlsFuture;
+            }
+        }
+    }
+
+    private static Future<Integer> addSecretHash(SecretOperator secretOperations, String namespace, GenericSecretSource genericSecretSource) {
+        if (genericSecretSource != null) {
+            return secretOperations.getAsync(namespace, genericSecretSource.getSecretName())
+                    .compose(secret -> {
+                        if (secret == null) {
+                            return Future.failedFuture("Secret " + genericSecretSource.getSecretName() + " not found");
+                        } else {
+                            return Future.succeededFuture(secret.getData().get(genericSecretSource.getKey()).hashCode());
+                        }
+                    });
+        }
+        return Future.succeededFuture(0);
+    }
+
+    /**
+     * Utility method which gets the secret and validates that the required fields are present in it
+     *
+     * @param secretOperator    Secret operator to get the secret from the Kubernetes API
+     * @param namespace         Namespace where the Secret exist
+     * @param name              Name of the Secret
+     * @param items             List of items which should be present in the Secret
+     *
+     * @return      Future with the Secret if is exits and has the required items. Failed future with an error message otherwise.
+     */
+    /* test */ static Future<Secret> getValidatedSecret(SecretOperator secretOperator, String namespace, String name, String... items) {
+        return secretOperator.getAsync(namespace, name)
+                .compose(secret -> {
+                    if (secret == null) {
+                        return Future.failedFuture(new InvalidConfigurationException("Secret " + name + " not found"));
+                    } else {
+                        List<String> errors = new ArrayList<>(0);
+
+                        for (String item : items)   {
+                            if (!secret.getData().containsKey(item))    {
+                                // Item not found => error will be raised
+                                errors.add(item);
+                            }
+                        }
+
+                        if (errors.isEmpty()) {
+                            return Future.succeededFuture(secret);
+                        } else {
+                            return Future.failedFuture(new InvalidConfigurationException(String.format("Items with key(s) %s are missing in Secret %s", errors, name)));
+                        }
+                    }
+                });
+    }
+
+    private static Future<String> getCertificateAsync(SecretOperator secretOperator, String namespace, CertSecretSource certSecretSource) {
+        return getValidatedSecret(secretOperator, namespace, certSecretSource.getSecretName(), certSecretSource.getCertificate())
+                .compose(secret -> Future.succeededFuture(secret.getData().get(certSecretSource.getCertificate())));
+    }
+
+    private static Future<CertAndKey> getCertificateAndKeyAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthenticationTls auth) {
+        return getValidatedSecret(secretOperator, namespace, auth.getCertificateAndKey().getSecretName(), auth.getCertificateAndKey().getCertificate(), auth.getCertificateAndKey().getKey())
+                .compose(secret -> Future.succeededFuture(new CertAndKey(secret.getData().get(auth.getCertificateAndKey().getKey()).getBytes(StandardCharsets.UTF_8), secret.getData().get(auth.getCertificateAndKey().getCertificate()).getBytes(StandardCharsets.UTF_8))));
+    }
+
+    private static Future<String> getPasswordAsync(SecretOperator secretOperator, String namespace, KafkaClientAuthentication auth) {
+        if (auth instanceof KafkaClientAuthenticationPlain plainAuth) {
+
+            return getValidatedSecret(secretOperator, namespace, plainAuth.getPasswordSecret().getSecretName(), plainAuth.getPasswordSecret().getPassword())
+                    .compose(secret -> Future.succeededFuture(secret.getData().get(plainAuth.getPasswordSecret().getPassword())));
+        } else if (auth instanceof KafkaClientAuthenticationScram scramAuth) {
+
+            return getValidatedSecret(secretOperator, namespace, scramAuth.getPasswordSecret().getSecretName(), scramAuth.getPasswordSecret().getPassword())
+                    .compose(secret -> Future.succeededFuture(secret.getData().get(scramAuth.getPasswordSecret().getPassword())));
+        } else {
+            return Future.failedFuture("Auth type " + auth.getType() + " does not have a password property");
+        }
+    }
+
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
@@ -171,7 +171,7 @@ public final class VertxUtil {
     }
 
     /**
-     * Converts Kafka Future to VErt.x future
+     * Converts Kafka Future to Vert.x future
      *
      * @param reconciliation    Reconciliation marker
      * @param vertx             Vert.x instance
@@ -206,7 +206,7 @@ public final class VertxUtil {
     }
 
     /**
-     * When TLS certificate or Auth certificate (or password) is changed, the has is computed.
+     * When TLS certificate or Auth certificate (or password) is changed, the hash is computed.
      * It is used for rolling updates.
      * @param secretOperations Secret operator
      * @param namespace namespace to get Secrets in

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -19,7 +19,7 @@ import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -394,7 +394,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * is ready.
      */
     public Future<Void> waitFor(Reconciliation reconciliation, String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
-        return Util.waitFor(reconciliation, vertx,
+        return VertxUtil.waitFor(reconciliation, vertx,
             String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
             logState,
             pollIntervalMs,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -14,7 +14,7 @@ import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -71,7 +71,7 @@ public class CrdOperator<C extends KubernetesClient,
     protected Future<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
         Resource<T> resourceOp = operation().inNamespace(namespace).withName(name);
 
-        Future<Void> watchForDeleteFuture = Util.waitFor(reconciliation, vertx,
+        Future<Void> watchForDeleteFuture = VertxUtil.waitFor(reconciliation, vertx,
             String.format("%s resource %s", resourceKind, name),
             "deleted",
             1_000,

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/StatusUtils.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.ResourceVisitor;
 import io.strimzi.operator.common.model.ValidationVisitor;
-import io.vertx.core.AsyncResult;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -158,21 +157,6 @@ public class StatusUtils {
                 .withType(type)
                 .withStatus("True")
                 .build();
-    }
-
-    /**
-     * Sets a status with conditions and observed generation in a resource
-     *
-     * @param resource  Current custom resource
-     * @param status    Desired status
-     * @param result    Reconciliation result to add to the status
-     *
-     * @param <R>   Type of the custom resource
-     * @param <P>   Type of the custom resource spec
-     * @param <S>   Type of the custom resource status
-     */
-    public static <R extends CustomResource<P, S>, P extends Spec, S extends Status> void setStatusConditionAndObservedGeneration(R resource, S status, AsyncResult<Void> result) {
-        setStatusConditionAndObservedGeneration(resource, status, result.cause());
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.Informable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+
+/**
+ * Abstract resource creation, for a generic resource type {@code R}.
+ * This class applies the template method pattern, first checking whether the resource exists,
+ * and creating it if it does not. It is not an error if the resource did already exist.
+ * @param <C> The type of client used to interact with kubernetes.
+ * @param <T> The Kubernetes resource type.
+ * @param <L> The list variant of the Kubernetes resource type.
+ * @param <R> The resource operations.
+ */
+public abstract class AbstractNamespacedResourceOperator<C extends KubernetesClient,
+            T extends HasMetadata,
+            L extends KubernetesResourceList<T>,
+            R extends Resource<T>>
+        extends AbstractResourceOperator<C, T, L, R> {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractNamespacedResourceOperator.class);
+
+    /**
+     * Marker for indication "all namespaces" => this is used for example when creating watches to create a cluster
+     * wide watch.
+     */
+    public static final String ANY_NAMESPACE = "*";
+
+    /**
+     * Constructor.
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client        The kubernetes client.
+     * @param resourceKind  The mind of Kubernetes resource (used for logging).
+     */
+    protected AbstractNamespacedResourceOperator(Executor asyncExecutor, C client, String resourceKind) {
+        super(asyncExecutor, client, resourceKind);
+    }
+
+    protected abstract MixedOperation<T, L, R> operation();
+
+    /**
+     * Asynchronously create or update the given {@code resource} depending on whether it already exists,
+     * returning a CompletionStage for the outcome.
+     * If the resource with that name already exists the future completes successfully.
+     * @param reconciliation The reconciliation
+     * @param resource The resource to create.
+     * @return A CompletionStage which completes with the outcome.
+     */
+    public CompletionStage<ReconcileResult<T>> createOrUpdate(Reconciliation reconciliation, T resource) {
+        if (resource == null) {
+            throw new NullPointerException();
+        }
+        return reconcile(reconciliation, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource);
+    }
+
+    /**
+     * Asynchronously reconciles the resource with the given namespace and name to
+     * match the given desired resource, returning a CompletionStage for the result.
+     *
+     * @param reconciliation Reconciliation object
+     * @param namespace      The namespace of the resource to reconcile
+     * @param name           The name of the resource to reconcile
+     * @param desired        The desired state of the resource.
+     * @return A CompletionStage which completes when the resource has been updated.
+     */
+    public CompletionStage<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T desired) {
+        if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
+            return CompletableFuture.failedStage(new IllegalArgumentException("Given namespace " + namespace + " incompatible with desired namespace " + desired.getMetadata().getNamespace()));
+        } else if (desired != null && !name.equals(desired.getMetadata().getName())) {
+            return CompletableFuture.failedStage(new IllegalArgumentException("Given name " + name + " incompatible with desired name " + desired.getMetadata().getName()));
+        }
+
+        return CompletableFuture.supplyAsync(() -> operation().inNamespace(namespace).withName(name).get(), asyncExecutor)
+            .thenCompose(current -> this.reconcile(reconciliation, namespace, name, current, desired));
+    }
+
+    /**
+     * Asynchronously reconciles the given current resource to match the given
+     * desired resource, returning a CompletionStage for the result.
+     *
+     * @param reconciliation Reconciliation object
+     * @param namespace      The namespace of the resource to reconcile
+     * @param name           The name of the resource to reconcile
+     * @param current        The current state of the resource.
+     * @param desired        The desired state of the resource.
+     * @return A CompletionStage which completes when the resource has been updated.
+     */
+    public CompletionStage<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T current, T desired) {
+        if (desired != null) {
+            if (current == null) {
+                LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, creating it", resourceKind, namespace, name);
+                return internalCreate(reconciliation, namespace, name, desired);
+            } else {
+                LOGGER.debugCr(reconciliation, "{} {}/{} already exists, updating it", resourceKind, namespace, name);
+                return internalUpdate(reconciliation, namespace, name, current, desired);
+            }
+        } else {
+            if (current != null) {
+                // Deletion is desired
+                LOGGER.debugCr(reconciliation, "{} {}/{} exist, deleting it", resourceKind, namespace, name);
+                return internalDelete(reconciliation, namespace, name);
+            } else {
+                LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, noop", resourceKind, namespace, name);
+                return CompletableFuture.completedStage(ReconcileResult.noop(null));
+            }
+        }
+    }
+
+    /**
+     * Does a batch reconciliation of resources. It takes a list with desired resources and a selector for getting all
+     * resources. It will compare the desired resources against the actual resources based on the selector and decides
+     * which need to be created, modified or deleted. This is useful in situations when we need to manage list of
+     * resources per operand and not just single resource which either exists or not. The reconciliation of the
+     * individual resources delegates to the regular reconcile(...) methods for a single resource.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param namespace         Namespace where the resources should be reconciled
+     * @param desired           List of desired resources
+     * @param selector          Selector for getting a list of current resource
+     *
+     * @return CompletionStage which completes when the lists are reconciled
+     */
+    public CompletionStage<Void> batchReconcile(Reconciliation reconciliation, String namespace, List<T> desired, Labels selector)  {
+        return listAsync(namespace, selector)
+                .thenCompose(current -> {
+                    List<CompletionStage<?>> futures = new ArrayList<>(desired.size());
+                    List<String> currentNames = current.stream().map(ingress -> ingress.getMetadata().getName()).collect(Collectors.toList());
+
+                    LOGGER.debugCr(reconciliation, "Reconciling existing {} resources {} against the desired {} resources", resourceKind, currentNames, resourceKind);
+
+                    // Update desired resources which should be created or already exist and are still desired
+                    for (T desiredResource : desired) {
+                        String name = desiredResource.getMetadata().getName();
+                        currentNames.remove(name);
+                        futures.add(reconcile(reconciliation, namespace, name, desiredResource));
+                    }
+
+                    LOGGER.debugCr(reconciliation, "{} {}/{} should be deleted", resourceKind, namespace, currentNames);
+
+                    // Delete resources which match our selector but are not desired anymore
+                    for (String name : currentNames) {
+                        futures.add(reconcile(reconciliation, namespace, name, null));
+                    }
+
+                    return CompletableFuture.allOf(futures.stream().map(CompletionStage::toCompletableFuture).toArray(CompletableFuture[]::new));
+                });
+    }
+
+    /**
+     * Deletes the resource with the given namespace and name and completes the
+     * given CompletionStage accordingly. This method will do a cascading delete.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace      Namespace of the resource which should be deleted
+     * @param name           Name of the resource which should be deleted
+     *
+     * @return A CompletionStage which will be completed on the context thread once
+     *         the resource has been deleted.
+     */
+    protected CompletionStage<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name) {
+        return internalDelete(reconciliation, namespace, name, true);
+    }
+
+    /**
+     * Asynchronously deletes the resource in the given {@code namespace} with the
+     * given {@code name}, returning a CompletionStage which completes once the
+     * resource is observed to have been deleted.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace      Namespace of the resource which should be deleted
+     * @param name           Name of the resource which should be deleted
+     * @param cascading      Defines whether the deletion should be cascading or not
+     *                       (e.g. whether an STS deletion should delete pods etc.)
+     *
+     * @return A CompletionStage which will be completed on the context thread once
+     *         the resource has been deleted.
+     */
+    protected CompletionStage<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
+        R resourceOp = operation().inNamespace(namespace).withName(name);
+
+        CompletableFuture<?> watchForDeleteFuture = resourceSupport.selfClosingWatch(
+            reconciliation,
+            resourceOp,
+            resourceOp,
+            deleteTimeoutMs(),
+            "observe deletion of " + resourceKind + " " + namespace + "/" + name,
+            (action, resource) -> {
+                if (action == Watcher.Action.DELETED) {
+                    LOGGER.debugCr(reconciliation, "{} {}/{} has been deleted", resourceKind, namespace, name);
+                    return ReconcileResult.deleted();
+                } else {
+                    return null;
+                }
+            },
+            resource -> {
+                if (resource == null) {
+                    LOGGER.debugCr(reconciliation, "{} {}/{} has been already deleted in pre-check", resourceKind, namespace, name);
+                    return ReconcileResult.deleted();
+                } else {
+                    return null;
+                }
+            })
+            .toCompletableFuture();
+
+        CompletableFuture<?> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L))
+                .toCompletableFuture();
+
+        return CompletableFuture.allOf(watchForDeleteFuture, deleteFuture)
+            .thenApply(nothing -> ReconcileResult.deleted());
+    }
+
+    /**
+     * Patches the resource with the given namespace and name to match the given desired resource
+     * and completes the given future accordingly.
+     */
+    protected CompletionStage<ReconcileResult<T>> internalUpdate(Reconciliation reconciliation, String namespace, String name, T current, T desired) {
+        if (needsPatching(reconciliation, name, current, desired)) {
+            return patchOrReplace(namespace, name, desired)
+                .thenApply(result -> wasChanged(current, result) ? ReconcileResult.patched(result) : ReconcileResult.noop(result))
+                .whenComplete((result, error) -> {
+                    if (error == null) {
+                        LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, error);
+                    }
+                });
+        } else {
+            LOGGER.debugCr(reconciliation, "{} {} in namespace {} did not changed and doesn't need patching", resourceKind, name, namespace);
+            return CompletableFuture.completedStage(ReconcileResult.noop(current));
+        }
+    }
+
+    /**
+     * Method for patching or replacing a resource. By default, is using JSON-type patch. Overriding this method can be
+     * used to use replace instead of patch or different patch strategies.
+     *
+     * @param namespace     Namespace of the resource
+     * @param name          Name of the resource
+     * @param desired       Desired resource
+     *
+     * @return  The patched or replaced resource
+     */
+    protected CompletionStage<T> patchOrReplace(String namespace, String name, T desired) {
+        return CompletableFuture.supplyAsync(
+                () -> operation().inNamespace(namespace).withName(name).patch(PatchContext.of(PatchType.JSON), desired),
+                asyncExecutor);
+    }
+
+    /**
+     * Creates a resource with the given namespace and name with the given desired state
+     * and completes the given future accordingly.
+     */
+    protected CompletionStage<ReconcileResult<T>> internalCreate(Reconciliation reconciliation, String namespace, String name, T desired) {
+        return CompletableFuture.supplyAsync(operation().inNamespace(namespace).resource(desired)::update, asyncExecutor)
+            .thenApply(ReconcileResult::created)
+            .whenComplete((result, error) -> {
+                if (error == null) {
+                    LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been created", resourceKind, name, namespace);
+                } else {
+                    LOGGER.debugCr(reconciliation, "Caught exception while creating {} {} in namespace {}", resourceKind, name, namespace, error);
+                }
+            });
+    }
+
+    /**
+     * Synchronously gets the resource with the given {@code name} in the given {@code namespace}.
+     * @param namespace The namespace.
+     * @param name The name.
+     * @return The resource, or null if it doesn't exist.
+     */
+    public T get(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
+        return operation().inNamespace(namespace).withName(name).get();
+    }
+
+    /**
+     * Asynchronously gets the resource with the given {@code name} in the given
+     * {@code namespace}.
+     *
+     * @param namespace The namespace.
+     * @param name      The name.
+     * @return A CompletionStage for the result.
+     */
+    public CompletionStage<T> getAsync(String namespace, String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
+        }
+        return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
+    }
+
+    /**
+     * Synchronously list the resources in the given {@code namespace} with the given {@code selector}.
+     * @param namespace The namespace.
+     * @param selector The selector.
+     * @return A list of matching resources.
+     */
+    public List<T> list(String namespace, Labels selector) {
+        return list(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Applies the namespace on the operation. Depending on the value of the namespace parameter, it returns either
+     * operation for working in all namespaces or in the selected namespace.
+     *
+     * @param namespace     Namespace which should be applied or * for all namespaces
+     *
+     * @return  Operation with applied namespace
+     */
+    private FilterWatchListDeletable<T, L, R> applyNamespace(String namespace) {
+        if (ANY_NAMESPACE.equals(namespace)) {
+            return operation().inAnyNamespace();
+        } else {
+            return operation().inNamespace(namespace);
+        }
+    }
+
+    /**
+     * Asynchronously lists the resource with the given {@code selector} in the
+     * given {@code namespace}.
+     *
+     * @param namespace The namespace.
+     * @param selector  The selector.
+     * @return A CompletionStage with a list of matching resources.
+     */
+    public CompletionStage<List<T>> listAsync(String namespace, Labels selector) {
+        return listAsync(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Asynchronously lists the resource with the given {@code selector} in the
+     * given {@code namespace}.
+     *
+     * @param namespace Namespace where the resources should be listed
+     * @param selector  Label selector for selecting only some of the resources
+     *
+     * @return A CompletionStage with a list of matching resources.
+     */
+    public CompletionStage<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
+        return listAsync(applySelector(applyNamespace(namespace), selector));
+    }
+
+    /**
+     * Returns a CompletionStage that completes when the resource identified by the
+     * given {@code namespace} and {@code name} is ready.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace      The namespace.
+     * @param name           The resource name.
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs      The timeout, in milliseconds.
+     * @param predicate      The predicate.
+     * @return A CompletionStage that completes when the resource identified by the
+     *         given {@code namespace} and {@code name} is ready.
+     */
+    public CompletionStage<Void> waitFor(Reconciliation reconciliation, String namespace, String name, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        return waitFor(reconciliation, namespace, name, "ready", pollIntervalMs, timeoutMs, predicate);
+    }
+
+    /**
+     * Returns a CompletionStage that completes when the resource identified by the
+     * given {@code namespace} and {@code name} is ready.
+     *
+     * @param reconciliation The reconciliation
+     * @param namespace      The namespace.
+     * @param name           The resource name.
+     * @param logState       The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs      The timeout, in milliseconds.
+     * @param predicate      The predicate.
+     * @return A CompletionStage that completes when the resource identified by the
+     *         given {@code namespace} and {@code name} is ready.
+     */
+    public CompletionStage<Void> waitFor(Reconciliation reconciliation, String namespace, String name, String logState, long pollIntervalMs, final long timeoutMs, BiPredicate<String, String> predicate) {
+        return resourceSupport.waitFor(reconciliation,
+            String.format("%s resource %s in namespace %s", resourceKind, name, namespace),
+            logState,
+            pollIntervalMs,
+            timeoutMs,
+            () -> predicate.test(namespace, name));
+    }
+
+    /**
+     * Asynchronously deletes the resource with the given {@code name} in the given {@code namespace}.
+     *
+     * @param reconciliation    The reconciliation
+     * @param namespace         Namespace of the resource which should be deleted
+     * @param name              Name of the resource which should be deleted
+     * @param cascading         Defines whether the deletion should be cascading or not
+     *
+     * @return                  A Future with True if the deletion succeeded and False when it failed.
+     */
+    public CompletionStage<Void> deleteAsync(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
+        return internalDelete(reconciliation, namespace, name, cascading).thenRun(ResourceSupport.NOOP);
+    }
+
+    /**
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
+     * informer returned by this method is not running and has to be started by the code using it.
+     *
+     * @param namespace         Namespace on which to inform
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+     *
+     * @return          Informer instance
+     */
+    public SharedIndexInformer<T> informer(String namespace, long resyncIntervalMs) {
+        return runnableInformer(applyNamespace(namespace), resyncIntervalMs);
+    }
+
+    /**
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
+     * matching the selector. The informer returned by this method is not running and has to be started by the code
+     * using it.
+     *
+     * @param namespace         Namespace on which to inform
+     * @param selectorLabels    Selector which should be matched by the resources
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+     *
+     * @return                  Informer instance
+     */
+    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs) {
+        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs);
+    }
+
+    /**
+     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
+     * matching the selector. The informer returned by this method is not running and has to be started by the code
+     * using it.
+     *
+     * @param namespace         Namespace on which to inform
+     * @param labelSelector     Labels Selector which should be matched by the resources
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+     *
+     * @return                  Informer instance
+     */
+    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncIntervalMs) {
+        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncIntervalMs);
+    }
+
+    /**
+     * Creates a runnable informer. Runnable informer is not running yet and need to be started by the code using it.
+     *
+     * @param informable        Instance of the Informable interface for creating informers
+     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+     *
+     * @return  Runnable informer
+     */
+    private SharedIndexInformer<T> runnableInformer(Informable<T> informable, long resyncIntervalMs) {
+        return informable.runnableInformer(resyncIntervalMs);
+    }
+
+    /**
+     * Returns the Kubernetes client for given resource type
+     *
+     * @return  Kubernetes client instance for given resource
+     */
+    public MixedOperation<T, L, R> client() {
+        return operation();
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractResourceOperator.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.regex.Pattern;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.Listable;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.ResourceDiff;
+
+/**
+ * Abstract resource creation, for a generic resource type {@code R}. This class
+ * applies the template method pattern, first checking whether the resource
+ * exists, and creating it if it does not. It is not an error if the resource
+ * did already exist.
+ *
+ * @param <C> The type of client used to interact with kubernetes.
+ * @param <T> The Kubernetes resource type.
+ * @param <L> The list variant of the Kubernetes resource type.
+ * @param <R> The resource operations.
+ */
+public abstract class AbstractResourceOperator<C extends KubernetesClient,
+        T extends HasMetadata,
+        L extends KubernetesResourceList<T>,
+        R extends Resource<T>> {
+    /**
+     * Default reconciliation timeout
+     */
+    private static final long DEFAULT_TIMEOUT_MS = 300_000;
+
+    protected final Executor asyncExecutor;
+    protected final C client;
+    protected final String resourceKind;
+    protected final ResourceSupport resourceSupport;
+
+    /**
+     * Constructor.
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client The kubernetes client.
+     * @param resourceKind The mind of Kubernetes resource (used for logging).
+     */
+    protected AbstractResourceOperator(Executor asyncExecutor, C client, String resourceKind) {
+        this.asyncExecutor = asyncExecutor;
+        this.resourceSupport = new ResourceSupport(asyncExecutor);
+        this.client = client;
+        this.resourceKind = resourceKind;
+    }
+
+    /**
+     * @return  Default timeout for deleting resources
+     */
+    protected long deleteTimeoutMs() {
+        return DEFAULT_TIMEOUT_MS;
+    }
+
+    /**
+     * @return  Returns the Pattern for matching paths which can be ignored in the resource diff
+     */
+    protected Pattern ignorablePaths() {
+        return ResourceDiff.DEFAULT_IGNORABLE_PATHS;
+    }
+
+    /**
+     * Returns the diff of the current and desired resources
+     *
+     * @param reconciliation The reconciliation
+     * @param resourceName  Name of the resource used for logging
+     * @param current       Current resource
+     * @param desired       Desired resource
+     *
+     * @return              The ResourceDiff instance
+     */
+    protected ResourceDiff<T> diff(Reconciliation reconciliation, String resourceName, T current, T desired)  {
+        return new ResourceDiff<>(reconciliation, resourceKind, resourceName, current, desired, ignorablePaths());
+    }
+
+    /**
+     * Checks whether the current and desired resources differ and need to be patched in the Kubernetes API server.
+     *
+     * @param reconciliation The reconciliation
+     * @param name      Name of the resource used for logging
+     * @param current   Current resource
+     * @param desired   Desired resource
+     *
+     * @return          True if the resources differ and need patching
+     */
+    protected boolean needsPatching(Reconciliation reconciliation, String name, T current, T desired)   {
+        return !diff(reconciliation, name, current, desired).isEmpty();
+    }
+
+    /**
+     * Compares two resources and decides whether they changed or not based on their resource versions form metadata.
+     *
+     * @param oldVersion    Old resource
+     * @param newVersion    New resource
+     *
+     * @return  True if the resource changed. False otherwise.
+     */
+    protected boolean wasChanged(T oldVersion, T newVersion) {
+        if (oldVersion != null
+                && oldVersion.getMetadata() != null
+                && newVersion != null
+                && newVersion.getMetadata() != null) {
+            return !Objects.equals(oldVersion.getMetadata().getResourceVersion(), newVersion.getMetadata().getResourceVersion());
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Applies the selector to the operation. If the selector is specified, it will return an operation with the applied
+     * selector. If it is not specified, it will return the original operation.
+     *
+     * @param filterable    Filterable operation on which we can apply the selector
+     * @param selector      Selector
+     *
+     * @return  Filtered operation
+     */
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Labels selector)  {
+        if (selector != null) {
+            return filterable.withLabels(selector.toMap());
+        } else {
+            return filterable;
+        }
+    }
+
+    /**
+     * Applies the selector to the operation. If the selector is specified, it will return an operation with the applied
+     * selector. If it is not specified, it will return the original operation.
+     *
+     * @param filterable    Filterable operation on which we can apply the selector
+     * @param selector      Selector
+     *
+     * @return  Filtered operation
+     */
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Optional<LabelSelector> selector)  {
+        if (selector.isPresent()) {
+            return filterable.withLabelSelector(selector.get());
+        } else {
+            return filterable;
+        }
+    }
+
+    /**
+     * List the resources and returns Java list with all found resources.
+     *
+     * @param listable  Listable operation
+     *
+     * @return  List of resources
+     */
+    protected List<T> list(Listable<L> listable) {
+        return listable.list(new ListOptionsBuilder().withResourceVersion("0").build()).getItems();
+    }
+
+    /**
+     * List the resources and returns Java list with all found resources in
+     * asynchronous way.
+     *
+     * @param listable Listable operation
+     *
+     * @return CompletionStage with the list of resources
+     */
+    protected CompletionStage<List<T>> listAsync(Listable<L> listable) {
+        return resourceSupport.listAsync(listable);
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableNamespacedResourceOperator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+/**
+ * Abstract class for resources which can be watched.
+ *
+ * @param <C> The type of client used to interact with kubernetes.
+ * @param <T> The Kubernetes resource type.
+ * @param <L> The list variant of the Kubernetes resource type.
+ * @param <R> The resource operations.
+ */
+public abstract class AbstractWatchableNamespacedResourceOperator<
+        C extends KubernetesClient,
+        T extends HasMetadata,
+        L extends KubernetesResourceList<T>,
+        R extends Resource<T>>
+        extends AbstractNamespacedResourceOperator<C, T, L, R> {
+    /**
+     * Constructor.
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client        The kubernetes client.
+     * @param resourceKind  The mind of Kubernetes resource (used for logging).
+     */
+    protected AbstractWatchableNamespacedResourceOperator(Executor asyncExecutor, C client, String resourceKind) {
+        super(asyncExecutor, client, resourceKind);
+    }
+
+    protected Watch watchInAnyNamespace(Watcher<T> watcher) {
+        return operation().inAnyNamespace().watch(watcher);
+    }
+
+    protected Watch watchInNamespace(String namespace, Watcher<T> watcher) {
+        return operation().inNamespace(namespace).watch(watcher);
+    }
+
+    /**
+     * Creates a resource watch
+     *
+     * @param namespace     Namespace which should be watched
+     * @param watcher       The Watcher object which will handle the events from the watch
+     *
+     * @return  A Kubernetes watch instance
+     */
+    public Watch watch(String namespace, Watcher<T> watcher) {
+        if (ANY_NAMESPACE.equals(namespace))    {
+            return watchInAnyNamespace(watcher);
+        } else {
+            return watchInNamespace(namespace, watcher);
+        }
+    }
+
+    /**
+     * Creates a resource watch using a label selector
+     *
+     * @param namespace     Namespace which should be watched
+     * @param selector      Label selector for watching only some resources
+     * @param watcher       The Watcher object which will handle the events from the watch
+     *
+     * @return  A Kubernetes watch instance
+     */
+    public Watch watch(String namespace, Optional<LabelSelector> selector, Watcher<T> watcher) {
+        FilterWatchListDeletable<T, L, R> operation
+                = ANY_NAMESPACE.equals(namespace) ? operation().inAnyNamespace() : operation().inNamespace(namespace);
+        if (selector.isPresent()) {
+            operation = operation.withLabelSelector(selector.get());
+        }
+        return operation.watch(watcher);
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableStatusedNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableStatusedNamespacedResourceOperator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Reconciliation;
+
+/**
+ * Class used for managing Kubernetes resources which can be watched and have Status. This is used by the assembly
+ * operator for access to Custom Resources which have all the status sections.
+ *
+ * @param <C>   Kubernetes client
+ * @param <T>   Kubernetes resource
+ * @param <L>   Kubernetes resource list
+ * @param <R>   Kubernetes Reasource
+ */
+public abstract class AbstractWatchableStatusedNamespacedResourceOperator<
+        C extends KubernetesClient,
+        T extends HasMetadata,
+        L extends KubernetesResourceList<T>,
+        R extends Resource<T>>
+        extends AbstractWatchableNamespacedResourceOperator<C, T, L, R> {
+    /**
+     * Constructor.
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client        The kubernetes client.
+     * @param resourceKind  The mind of Kubernetes resource (used for logging).
+     */
+    protected AbstractWatchableStatusedNamespacedResourceOperator(Executor asyncExecutor, C client, String resourceKind) {
+        super(asyncExecutor, client, resourceKind);
+    }
+
+    /**
+     * Updates status of the resource
+     *
+     * @param reconciliation Reconciliation object
+     * @param resource  Resource with the status which should be updated in the Kube API server
+     * @return          Future with the updated resource
+     */
+    public abstract CompletionStage<T> updateStatusAsync(Reconciliation reconciliation, T resource);
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
@@ -8,7 +8,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -28,8 +27,6 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
  * @param <T> The custom resource type.
  * @param <L> The list variant of the custom resource type.
  */
-@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-        justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
 public class CrdOperator<C extends KubernetesClient,
             T extends CustomResource<?, ?>,
             L extends DefaultKubernetesResourceList<T>>

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.operator.resource.ReconcileResult;
+
+/**
+ * Operator for managing CRD resources
+ *
+ * @param <C> The type of client used to interact with kubernetes.
+ * @param <T> The custom resource type.
+ * @param <L> The list variant of the custom resource type.
+ */
+@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+        justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
+public class CrdOperator<C extends KubernetesClient,
+            T extends CustomResource<?, ?>,
+            L extends DefaultKubernetesResourceList<T>>
+        extends AbstractWatchableStatusedNamespacedResourceOperator<C, T, L, Resource<T>> {
+
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(CrdOperator.class);
+
+    private final Class<T> cls;
+    private final Class<L> listCls;
+
+    /**
+     * Constructor
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client        The Kubernetes client
+     * @param cls           The class of the CR
+     * @param listCls       The class of the list.
+     * @param kind          The Kind of the CR for which this operator should be
+     *                      used
+     */
+    public CrdOperator(Executor asyncExecutor, C client, Class<T> cls, Class<L> listCls, String kind) {
+        super(asyncExecutor, client, kind);
+        this.cls = cls;
+        this.listCls = listCls;
+    }
+
+    @Override
+    protected MixedOperation<T, L, Resource<T>> operation() {
+        return client.resources(cls, listCls);
+    }
+
+    /**
+     * The selfClosingWatch does not work for Custom Resources. Therefore we override the method and delete custom
+     * resources without it.
+     *
+     * @param namespace Namespace of the resource which should be deleted
+     * @param name Name of the resource which should be deleted
+     * @param cascading Defines whether the delete should be cascading or not (e.g. whether a STS deletion should delete pods etc.)
+     *
+     * @return A future which will be completed on the context thread
+     *         once the resource has been deleted.
+     */
+    @Override
+    protected CompletionStage<ReconcileResult<T>> internalDelete(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
+        Resource<T> resourceOp = operation().inNamespace(namespace).withName(name);
+
+        CompletableFuture<Void> watchForDeleteFuture = resourceSupport.waitFor(reconciliation,
+            String.format("%s resource %s", resourceKind, name),
+            "deleted",
+            1_000,
+            deleteTimeoutMs(),
+            () -> resourceOp.get() != null)
+            .toCompletableFuture();
+
+        CompletableFuture<Void> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L))
+                .toCompletableFuture();
+
+        return CompletableFuture.allOf(watchForDeleteFuture, deleteFuture)
+                .thenApply(nothing -> ReconcileResult.deleted());
+    }
+
+    /**
+     * Patches custom resource asynchronously
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          Desired resource
+     *
+     * @return  Future which completes when the resource is patched
+     */
+    public CompletionStage<T> patchAsync(Reconciliation reconciliation, T resource) {
+        String namespace = resource.getMetadata().getNamespace();
+        String name = resource.getMetadata().getName();
+
+        return CompletableFuture.supplyAsync(
+                () -> operation()
+                    .inNamespace(namespace)
+                    .withName(name)
+                    .patch(PatchContext.of(PatchType.JSON), resource),
+                asyncExecutor)
+            .whenComplete((result, error) -> {
+                if (error == null) {
+                    LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
+                } else {
+                    LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, error);
+                }
+            });
+    }
+
+    /**
+     * Updates custom resource status asynchronously
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          Desired resource with the updated statis
+     *
+     * @return  Future which completes when the status is patched
+     */
+    public CompletionStage<T> updateStatusAsync(Reconciliation reconciliation, T resource) {
+        String namespace = resource.getMetadata().getNamespace();
+        String name = resource.getMetadata().getName();
+
+        return CompletableFuture.supplyAsync(
+                operation().inNamespace(namespace).resource(resource)::updateStatus,
+                asyncExecutor)
+            .whenComplete((result, error) -> {
+                if (error == null) {
+                    LOGGER.infoCr(reconciliation, "Status of {} {} in namespace {} has been updated", resourceKind, name, namespace);
+                } else {
+                    LOGGER.debugCr(reconciliation, "Caught exception while updating status of {} {} in namespace {}", resourceKind, name, namespace, error);
+                }
+            });
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/ResourceSupport.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.Deletable;
+import io.fabric8.kubernetes.client.dsl.Gettable;
+import io.fabric8.kubernetes.client.dsl.Listable;
+import io.fabric8.kubernetes.client.dsl.Watchable;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.operator.resource.TimeoutException;
+
+/**
+ * Utility method for working with Kubernetes resources
+ */
+public class ResourceSupport {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ResourceSupport.class);
+    static final Runnable NOOP = () -> { /* Empty */ };
+
+    private final Executor asyncExecutor;
+
+    /**
+     * Constructor
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     */
+    public ResourceSupport(Executor asyncExecutor) {
+        this.asyncExecutor = asyncExecutor;
+    }
+
+    /**
+     * Asynchronously close the given {@code closeable} on a worker thread,
+     * returning a CompletionStage which completes with the outcome.
+     *
+     * @param closeable The closeable
+     * @return The CompletionStage
+     */
+    public CompletionStage<Void> closeOnWorkerThread(Closeable closeable) {
+        return CompletableFuture.runAsync(() -> {
+            LOGGER.debugOp("Closing {}", closeable);
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        }, asyncExecutor);
+    }
+
+    <T> CompletionStage<T> executeBlocking(Supplier<T> blockingCodeHandler) {
+        return CompletableFuture.supplyAsync(blockingCodeHandler, asyncExecutor);
+    }
+
+    /**
+     * Combines two possible Throwables, returning a single cause Throwable,
+     * possibly with suppressed exception. If both Throwable are present,
+     * {@code primary} will be the main cause of failure and {@code secondary} will
+     * be a suppressed exception.
+     *
+     * @param primary   The primary failure.
+     * @param secondary The secondary failure.
+     * @return The cause.
+     */
+    private Throwable collectCauses(Throwable primary, Throwable secondary) {
+        Throwable cause = primary;
+        if (cause == null) {
+            cause = secondary;
+        } else {
+            if (secondary != null) {
+                cause.addSuppressed(secondary);
+            }
+        }
+        return cause;
+    }
+
+    /**
+     * Watches the given {@code watchable} using the given {@code watchFn},
+     * returning a CompletionStage which completes when {@code watchFn} returns non-null to
+     * some event on the watchable, or after a timeout.
+     *
+     * The given {@code watchFn} will be invoked on a worker thread when the
+     * Kubernetes resources changes, so may block. When the {@code watchFn} returns
+     * non-null the watch will be closed and then the future returned from this
+     * method will be completed on the context thread.
+     *
+     * In some cases such as resource deletion, it might happen that the resource is
+     * deleted already before the watch is started and as a result the watch never
+     * completes. The {@code preCheckFn} will be invoked on a worker thread after
+     * the watch has been created. It is expected to double check if we still need
+     * to wait for the watch to fire. When the {@code preCheckFn} returns non-null
+     * the watch will be closed and the future returned from this method will be
+     * completed with the result of the {@code preCheckFn} on the context thread. In
+     * the deletion example described above, the {@code preCheckFn} can check if the
+     * resource still exists and close the watch in case it was already deleted.
+     *
+     * @param reconciliation     Reconciliation marker used for logging
+     * @param watchable          The watchable - used to watch the resource.
+     * @param gettable           The Gettable - used to get the resource in the
+     *                           pre-check.
+     * @param operationTimeoutMs The timeout in ms.
+     * @param watchFnDescription A description of what {@code watchFn} is watching
+     *                           for. E.g. "observe ${condition} of ${kind}
+     *                           ${namespace}/${name}".
+     * @param watchFn            The function to determine if the event occured
+     * @param preCheckFn         Pre-check function to avoid situation when the
+     *                           watch is never fired because ot was started too
+     *                           late.
+     * @param <T>                The type of watched resource.
+     * @param <U>                The result type of the {@code watchFn}.
+     *
+     * @return A CompletionStage which completes when the {@code watchFn} returns
+     *         non-null in response to some Kubernetes even on the watched
+     *         resource(s).
+     */
+    <T, U> CompletionStage<U> selfClosingWatch(Reconciliation reconciliation,
+                                               Watchable<T> watchable,
+                                               Gettable<T> gettable,
+                                               long operationTimeoutMs,
+                                               String watchFnDescription,
+                                               BiFunction<Watcher.Action, T, U> watchFn,
+                                               Function<T, U> preCheckFn) {
+
+        return new Watcher<T>() {
+            private final CompletableFuture<Watch> watchPromise;
+            private final CompletableFuture<U> donePromise;
+            private final CompletableFuture<U> resultPromise;
+
+            /* init */
+            {
+                this.watchPromise = new CompletableFuture<>();
+                this.donePromise = new CompletableFuture<U>().orTimeout(operationTimeoutMs, TimeUnit.MILLISECONDS);
+                this.resultPromise = new CompletableFuture<>();
+
+                CompletableFuture.allOf(watchPromise, donePromise).whenComplete((nothing, thrown) -> {
+                    CompletionStage<Void> closeFuture;
+
+                    if (succeeded(watchPromise)) {
+                        closeFuture = closeOnWorkerThread(watchPromise.join());
+                    } else {
+                        closeFuture = CompletableFuture.completedFuture(null);
+                    }
+
+                    closeFuture.whenComplete((closeResult, closeThrown) -> {
+                        LOGGER.debugCr(reconciliation, "Completing watch future");
+                        if (thrown == null && closeThrown == null) {
+                            resultPromise.complete(donePromise.join());
+                        } else {
+                            Throwable primary;
+
+                            if (Util.unwrap(thrown) instanceof java.util.concurrent.TimeoutException) {
+                                primary = new TimeoutException("\"" + watchFnDescription + "\" timed out after " + operationTimeoutMs + "ms");
+                            } else {
+                                primary = thrown;
+                            }
+
+                            resultPromise.completeExceptionally(collectCauses(primary, closeThrown));
+                        }
+                    });
+                });
+
+                try {
+                    Watch watch = watchable.watch(this);
+                    LOGGER.debugCr(reconciliation, "Opened watch {} for evaluation of {}", watch, watchFnDescription);
+                    // Pre-check is done after the watch is open to make sure we did not missed the event. In the worst
+                    // case, both pre-check and watch complete the future. But at least one should always complete it.
+                    U apply = preCheckFn.apply(gettable.get());
+                    if (apply != null) {
+                        LOGGER.debugCr(reconciliation, "Pre-check is already complete, no need to wait for the watch: {}", watchFnDescription);
+                        donePromise.complete(apply);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Pre-check is not complete yet, let's wait for the watch: {}", watchFnDescription);
+                    }
+
+                    watchPromise.complete(watch);
+                } catch (Throwable t) {
+                    watchPromise.completeExceptionally(t);
+                }
+            }
+
+            @Override
+            public void eventReceived(Action action, T resource) {
+                CompletableFuture.runAsync(() -> {
+                    try {
+                        U apply = watchFn.apply(action, resource);
+                        if (apply != null) {
+                            LOGGER.debugCr(reconciliation, "Satisfied: {}", watchFnDescription);
+                            donePromise.complete(apply);
+                        } else {
+                            LOGGER.debugCr(reconciliation, "Not yet satisfied: {}", watchFnDescription);
+                        }
+                    } catch (Throwable t) {
+                        if (!donePromise.completeExceptionally(t)) {
+                            LOGGER.debugCr(reconciliation, "Ignoring exception thrown while " +
+                                    "evaluating watch {} because the future was already completed", watchFnDescription, t);
+                        }
+                    }
+                }, asyncExecutor);
+            }
+
+            @Override
+            public void onClose(WatcherException cause) {
+
+            }
+
+        }.resultPromise;
+    }
+
+    static boolean succeeded(CompletableFuture<?> future) {
+        return future.isDone() && !future.isCompletedExceptionally();
+    }
+
+    /**
+     * Asynchronously deletes the given resource(s), returning a CompletionStage which completes on the context thread.
+     * <strong>Note: The API server can return asynchronously, meaning the resource is still accessible from the API server
+     * after the returned Future completes. Use {@link #selfClosingWatch(Reconciliation, Watchable, Gettable, long, String, BiFunction, Function)}
+     * to provide server-synchronous semantics.</strong>
+     *
+     * @param resource The resource(s) to delete.
+     * @return A CompletionStage which completes on the context thread.
+     */
+    CompletionStage<Void> deleteAsync(Deletable resource) {
+        return CompletableFuture.supplyAsync(resource::delete, asyncExecutor).thenRun(NOOP);
+    }
+
+    /**
+     * Asynchronously gets the given resource, returning a CompletionStage which completes on the context thread.
+     *
+     * @param resource The resource(s) to get.
+     * @return A CompletionStage which completes on the context thread.
+     */
+    <T> CompletionStage<T> getAsync(Gettable<T> resource) {
+        return CompletableFuture.supplyAsync(resource::get, asyncExecutor);
+    }
+
+    /**
+     * Asynchronously lists the matching resources, returning a CompletionStage which completes on the context thread.
+     *
+     * @param resource The resources to list.
+     * @return A CompletionStage which completes on the context thread.
+     */
+    <T extends HasMetadata, L extends KubernetesResourceList<T>> CompletionStage<List<T>> listAsync(Listable<L> resource) {
+        var options = new ListOptionsBuilder().withResourceVersion("0").build();
+
+        return CompletableFuture.supplyAsync(() -> resource.list(options), asyncExecutor)
+                .thenApply(KubernetesResourceList::getItems);
+    }
+
+    /**
+     * Invoke the given {@code completed} supplier on a pooled thread approximately
+     * every {@code pollIntervalMs} milliseconds until it returns true or
+     * {@code timeoutMs} milliseconds have elapsed.
+     *
+     * @param reconciliation The reconciliation
+     * @param logContext     A string used for context in logging.
+     * @param logState       The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs      The timeout, in milliseconds.
+     * @param completed      Determines when the wait is complete by returning true.
+     * @param failOnError    Determine whether a given error thrown by
+     *                       {@code completed}, should result in the immediate
+     *                       completion of the returned Future.
+     * @return A CompletionStage that completes when the given {@code completed}
+     *         indicates readiness.
+     */
+    public CompletionStage<Void> waitFor(Reconciliation reconciliation, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed,
+                Predicate<Throwable> failOnError) {
+
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        LOGGER.debugCr(reconciliation, "Waiting for {} to get {}", logContext, logState);
+        long deadline = System.currentTimeMillis() + timeoutMs;
+
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                Throwable failure = null;
+                boolean complete = false;
+
+                try {
+                    complete = completed.getAsBoolean();
+                } catch (Throwable e) {
+                    LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                    failure = e;
+                }
+
+                if (complete) {
+                    LOGGER.debugCr(reconciliation, "{} is {}", logContext, logState);
+                    promise.complete(null);
+                } else if (failure != null && failOnError.test(failure)) {
+                    promise.completeExceptionally(failure);
+                } else {
+                    LOGGER.traceCr(reconciliation, "{} is not {}", logContext, logState);
+                    long timeLeft = deadline - System.currentTimeMillis();
+
+                    if (timeLeft <= 0) {
+                        String exceptionMessage = String.format(
+                                "Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext,
+                                logState);
+                        LOGGER.errorCr(reconciliation, exceptionMessage);
+                        promise.completeExceptionally(new TimeoutException(exceptionMessage));
+                    } else {
+                        // Schedule ourselves to run again
+                        CompletableFuture.delayedExecutor(
+                                Math.min(pollIntervalMs, timeLeft),
+                                TimeUnit.MILLISECONDS,
+                                asyncExecutor)
+                            .execute(this);
+                    }
+                }
+            }
+        };
+
+        // Call the handler ourselves the first time
+        task.run();
+
+        return promise;
+    }
+
+    /**
+     * Invoke the given {@code completed} supplier on a pooled thread approximately
+     * every {@code pollIntervalMs} milliseconds until it returns true or
+     * {@code timeoutMs} milliseconds have elapsed.
+     *
+     * @param reconciliation The reconciliation
+     * @param logContext     A string used for context in logging.
+     * @param logState       The state we are waiting for use in log messages
+     * @param pollIntervalMs The poll interval in milliseconds.
+     * @param timeoutMs      The timeout, in milliseconds.
+     * @param completed      Determines when the wait is complete by returning true.
+     * @return A CompletionStage that completes when the given {@code completed}
+     *         indicates readiness.
+     */
+    public CompletionStage<Void> waitFor(Reconciliation reconciliation, String logContext, String logState, long pollIntervalMs, long timeoutMs, BooleanSupplier completed) {
+        return waitFor(reconciliation, logContext, logState, pollIntervalMs, timeoutMs, completed, error -> false);
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.concurrent.Executor;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+/**
+ * Operations for {@code Secret}s.
+ */
+public class SecretOperator extends AbstractNamespacedResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> {
+
+    /**
+     * Constructor
+     *
+     * @param asyncExecutor Executor to use for asynchronous subroutines
+     * @param client        The Kubernetes client
+     */
+    public SecretOperator(Executor asyncExecutor, KubernetesClient client) {
+        super(asyncExecutor, client, "Secret");
+    }
+
+    @Override
+    protected MixedOperation<Secret, SecretList, Resource<Secret>> operation() {
+        return client.secrets();
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/VertxUtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/VertxUtilTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.strimzi.api.kafka.model.CertSecretSource;
+import io.strimzi.api.kafka.model.CertSecretSourceBuilder;
+import io.strimzi.api.kafka.model.GenericSecretSource;
+import io.strimzi.api.kafka.model.GenericSecretSourceBuilder;
+import io.strimzi.api.kafka.model.PasswordSecretSource;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthentication;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationOAuthBuilder;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationPlain;
+import io.strimzi.api.kafka.model.authentication.KafkaClientAuthenticationScramSha512;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+
+class VertxUtilTest {
+
+    @Test
+    void getHashOk() {
+        String namespace = "ns";
+
+        GenericSecretSource at = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-at")
+                .withKey("key")
+                .build();
+
+        GenericSecretSource cs = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-cs")
+                .withKey("key")
+                .build();
+
+        GenericSecretSource rt = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-rt")
+                .withKey("key")
+                .build();
+        KafkaClientAuthentication kcu = new KafkaClientAuthenticationOAuthBuilder()
+                .withAccessToken(at)
+                .withRefreshToken(rt)
+                .withClientSecret(cs)
+                .build();
+
+        CertSecretSource css = new CertSecretSourceBuilder()
+                .withCertificate("key")
+                .withSecretName("css-secret")
+                .build();
+
+        Secret secret = new SecretBuilder()
+                .withData(Map.of("key", "value"))
+                .build();
+
+        SecretOperator secretOps = mock(SecretOperator.class);
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-at"))).thenReturn(Future.succeededFuture(secret));
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-rt"))).thenReturn(Future.succeededFuture(secret));
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-cs"))).thenReturn(Future.succeededFuture(secret));
+        when(secretOps.getAsync(eq(namespace), eq("css-secret"))).thenReturn(Future.succeededFuture(secret));
+        Future<Integer> res = VertxUtil.authTlsHash(secretOps, "ns", kcu, singletonList(css));
+        res.onComplete(v -> {
+            assertThat(v.succeeded(), is(true));
+            // we are summing "value" hash four times
+            assertThat(v.result(), is("value".hashCode() * 4));
+        });
+    }
+
+    @Test
+    void getHashFailure() {
+        String namespace = "ns";
+
+        GenericSecretSource at = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-at")
+                .withKey("key")
+                .build();
+
+        GenericSecretSource cs = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-cs")
+                .withKey("key")
+                .build();
+
+        GenericSecretSource rt = new GenericSecretSourceBuilder()
+                .withSecretName("top-secret-rt")
+                .withKey("key")
+                .build();
+        KafkaClientAuthentication kcu = new KafkaClientAuthenticationOAuthBuilder()
+                .withAccessToken(at)
+                .withRefreshToken(rt)
+                .withClientSecret(cs)
+                .build();
+
+        CertSecretSource css = new CertSecretSourceBuilder()
+                .withCertificate("key")
+                .withSecretName("css-secret")
+                .build();
+
+        Secret secret = new SecretBuilder()
+                .withData(Map.of("key", "value"))
+                .build();
+
+        SecretOperator secretOps = mock(SecretOperator.class);
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-at"))).thenReturn(Future.succeededFuture(secret));
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-rt"))).thenReturn(Future.succeededFuture(secret));
+        when(secretOps.getAsync(eq(namespace), eq("top-secret-cs"))).thenReturn(Future.succeededFuture(null));
+        when(secretOps.getAsync(eq(namespace), eq("css-secret"))).thenReturn(Future.succeededFuture(secret));
+        Future<Integer> res = VertxUtil.authTlsHash(secretOps, "ns", kcu, singletonList(css));
+        res.onComplete(v -> {
+            assertThat(v.succeeded(), is(false));
+            assertThat(v.cause().getMessage(), is("Secret top-secret-cs not found"));
+        });
+    }
+
+    @Test
+    void testAuthTlsHashScramSha512SecretFoundAndPasswordNotFound() {
+        SecretOperator secretOpertator = mock(SecretOperator.class);
+        Map<String, String> data = new HashMap<>();
+        data.put("passwordKey", "my-password");
+        Secret secret = new Secret();
+        secret.setData(data);
+        CompletionStage<Secret> cf = CompletableFuture.supplyAsync(() ->  secret);
+        when(secretOpertator.getAsync(anyString(), anyString())).thenReturn(Future.fromCompletionStage(cf));
+        KafkaClientAuthenticationScramSha512 auth = new KafkaClientAuthenticationScramSha512();
+        PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
+        passwordSecretSource.setSecretName("my-secret");
+        passwordSecretSource.setPassword("password1");
+        auth.setPasswordSecret(passwordSecretSource);
+        Future<Integer> result = VertxUtil.authTlsHash(secretOpertator, "anyNamespace", auth, List.of());
+        result.onComplete(handler -> {
+            assertTrue(handler.failed());
+            assertEquals("Items with key(s) [password1] are missing in Secret my-secret", handler.cause().getMessage());
+        });
+    }
+
+    @Test
+    void testAuthTlsHashScramSha512SecretAndPasswordFound() {
+        SecretOperator secretOpertator = mock(SecretOperator.class);
+        Map<String, String> data = new HashMap<>();
+        data.put("passwordKey", "my-password");
+        Secret secret = new Secret();
+        secret.setData(data);
+        CompletionStage<Secret> cf = CompletableFuture.supplyAsync(() ->  secret);
+        when(secretOpertator.getAsync(anyString(), anyString())).thenReturn(Future.fromCompletionStage(cf));
+        KafkaClientAuthenticationScramSha512 auth = new KafkaClientAuthenticationScramSha512();
+        PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
+        passwordSecretSource.setSecretName("my-secret");
+        passwordSecretSource.setPassword("passwordKey");
+        auth.setPasswordSecret(passwordSecretSource);
+        Future<Integer> result = VertxUtil.authTlsHash(secretOpertator, "anyNamespace", auth, List.of());
+        result.onComplete(handler -> {
+            assertTrue(handler.succeeded());
+            assertEquals("my-password".hashCode(), handler.result());
+        });
+    }
+
+    @Test
+    void testAuthTlsPlainSecretFoundAndPasswordNotFound() {
+        SecretOperator secretOpertator = mock(SecretOperator.class);
+        Map<String, String> data = new HashMap<>();
+        data.put("passwordKey", "my-password");
+        Secret secret = new Secret();
+        secret.setData(data);
+        CompletionStage<Secret> cf = CompletableFuture.supplyAsync(() ->  secret);
+        when(secretOpertator.getAsync(anyString(), anyString())).thenReturn(Future.fromCompletionStage(cf));
+        KafkaClientAuthenticationPlain auth = new KafkaClientAuthenticationPlain();
+        PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
+        passwordSecretSource.setSecretName("my-secret");
+        passwordSecretSource.setPassword("password1");
+        auth.setPasswordSecret(passwordSecretSource);
+        Future<Integer> result = VertxUtil.authTlsHash(secretOpertator, "anyNamespace", auth, List.of());
+        result.onComplete(handler -> {
+            assertTrue(handler.failed());
+            assertEquals("Items with key(s) [password1] are missing in Secret my-secret", handler.cause().getMessage());
+        });
+    }
+
+    @Test
+    void testAuthTlsPlainSecretAndPasswordFound() {
+        SecretOperator secretOpertator = mock(SecretOperator.class);
+        Map<String, String> data = new HashMap<>();
+        data.put("passwordKey", "my-password");
+        Secret secret = new Secret();
+        secret.setData(data);
+        CompletionStage<Secret> cf = CompletableFuture.supplyAsync(() ->  secret);
+        when(secretOpertator.getAsync(anyString(), anyString())).thenReturn(Future.fromCompletionStage(cf));
+        KafkaClientAuthenticationPlain auth = new KafkaClientAuthenticationPlain();
+        PasswordSecretSource passwordSecretSource = new PasswordSecretSource();
+        passwordSecretSource.setSecretName("my-secret");
+        passwordSecretSource.setPassword("passwordKey");
+        auth.setPasswordSecret(passwordSecretSource);
+        Future<Integer> result = VertxUtil.authTlsHash(secretOpertator, "anyNamespace", auth, List.of());
+        result.onComplete(handler -> {
+            assertTrue(handler.succeeded());
+            assertEquals("my-password".hashCode(), handler.result());
+        });
+    }
+
+    @Test
+    void testGetValidateSecret() {
+        String namespace = "ns";
+        String secretName = "my-secret";
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withData(Map.of("key1", "value", "key2", "value", "key3", "value"))
+                .build();
+
+        SecretOperator secretOps = mock(SecretOperator.class);
+        when(secretOps.getAsync(eq(namespace), eq(secretName))).thenReturn(Future.succeededFuture(secret));
+
+        VertxUtil.getValidatedSecret(secretOps, namespace, secretName, "key1", "key2")
+                .onComplete(r -> {
+                    assertThat(r.succeeded(), is(true));
+                    assertThat(r.result(), is(secret));
+                });
+    }
+
+    @Test
+    void testGetValidateSecretMissingSecret() {
+        String namespace = "ns";
+        String secretName = "my-secret";
+
+        SecretOperator secretOps = mock(SecretOperator.class);
+        when(secretOps.getAsync(eq(namespace), eq(secretName))).thenReturn(Future.succeededFuture(null));
+
+        VertxUtil.getValidatedSecret(secretOps, namespace, secretName, "key1", "key2")
+                .onComplete(r -> {
+                    assertThat(r.succeeded(), is(false));
+                    assertThat(r.cause().getMessage(), is("Secret my-secret not found"));
+                });
+    }
+
+    @Test
+    void testGetValidateSecretMissingKeys() {
+        String namespace = "ns";
+        String secretName = "my-secret";
+
+        Secret secret = new SecretBuilder()
+                .withNewMetadata()
+                    .withName(secretName)
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withData(Map.of("key1", "value", "key2", "value", "key3", "value"))
+                .build();
+
+        SecretOperator secretOps = mock(SecretOperator.class);
+        when(secretOps.getAsync(eq(namespace), eq(secretName))).thenReturn(Future.succeededFuture(secret));
+
+        VertxUtil.getValidatedSecret(secretOps, namespace, secretName, "key1", "key4", "key5")
+                .onComplete(r -> {
+                    assertThat(r.succeeded(), is(false));
+                    assertThat(r.cause().getMessage(), is("Items with key(s) [key4, key5] are missing in Secret my-secret"));
+                });
+    }
+
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorIT.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.vertx.core.Vertx;
@@ -125,7 +125,7 @@ public abstract class AbstractNamespacedResourceOperatorIT<C extends KubernetesC
             .onComplete(context.succeeding(rrDeleted -> {
                 // it seems the resource is cached for some time so we need wait for it to be null
                 context.verify(() -> {
-                        Util.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
+                        VertxUtil.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
                                 30_000, () -> op.get(namespace, resourceName) == null)
                                 .onComplete(del -> {
                                     assertThat(op.get(namespace, resourceName), is(nullValue()));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperatorIT.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -98,7 +98,7 @@ public abstract class AbstractNonNamespacedResourceOperatorIT<C extends Kubernet
             .onComplete(context.succeeding(rrDelete -> context.verify(() -> {
                 // it seems the resource is cached for some time so we need wait for it to be null
                 context.verify(() -> {
-                        Util.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
+                        VertxUtil.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
                                 30_000, () -> op.get(resourceName) == null)
                                 .onComplete(del -> {
                                     assertThat(op.get(resourceName), is(nullValue()));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceAccountOperatorIT.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -79,7 +79,7 @@ public class ServiceAccountOperatorIT extends AbstractNamespacedResourceOperator
                 .compose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null))
                 .onComplete(context.succeeding(rrDeleted -> {
                     // it seems the resource is cached for some time so we need wait for it to be null
-                    context.verify(() -> Util.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
+                    context.verify(() -> VertxUtil.waitFor(Reconciliation.DUMMY_RECONCILIATION, vertx, "resource deletion " + resourceName, "deleted", 1000,
                             30_000, () -> op.get(namespace, resourceName) == null)
                             .onComplete(del -> {
                                 assertThat(op.get(namespace, resourceName), Matchers.is(nullValue()));

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.strimzi.api.kafka.model.status.Condition;
+import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
+import io.strimzi.test.k8s.cluster.KubeCluster;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
+ * Real Kubernetes cluster has often some quirks such as some fields being immutable, some fields in the spec section
+ * being created by the Kubernetes API etc. These things are hard to test with mocks. These IT tests make it easy to
+ * test them against real clusters.
+ */
+// TestInstance lifecycle set to per class so that @BeforeAll and @AfterAll methods are non-static.
+// Methods must be non-static as they make a non-static call to getCrd()
+// to correctly set up the test environment before the tests.
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractCustomResourceOperatorIT<
+            C extends KubernetesClient,
+            T extends CustomResource<?, ?>,
+            L extends DefaultKubernetesResourceList<T>> {
+
+    protected static final Logger LOGGER = LogManager.getLogger(AbstractCustomResourceOperatorIT.class);
+    protected static final String RESOURCE_NAME = "my-test-resource";
+    protected static final Condition READY_CONDITION = new ConditionBuilder()
+            .withType("Ready")
+            .withStatus("True")
+            .build();
+
+    protected static Executor asyncExecutor = ForkJoinPool.commonPool();
+    protected static KubernetesClient client;
+
+    protected abstract CrdOperator<C, T, L> operator();
+    protected abstract String getCrd();
+    protected abstract String getCrdName();
+    protected abstract String getNamespace();
+    protected abstract T getResource(String name);
+    protected abstract T getResourceWithModifications(T resourceInCluster);
+    protected abstract T getResourceWithNewReadyStatus(T resourceInCluster);
+    protected abstract void assertReady(T modifiedCustomResource);
+
+    @BeforeAll
+    public void before() {
+        String namespace = getNamespace();
+        KubeClusterResource cluster = KubeClusterResource.getInstance();
+        cluster.setNamespace(namespace);
+
+        assertDoesNotThrow(KubeCluster::bootstrap, "Could not bootstrap server");
+        client = new KubernetesClientBuilder().build();
+
+        if (cluster.getNamespace() != null && System.getenv("SKIP_TEARDOWN") == null) {
+            LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
+            kubeClient().deleteNamespace(namespace);
+            cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
+        }
+
+        LOGGER.info("Creating namespace: {}", namespace);
+        kubeClient().createNamespace(namespace);
+        cmdKubeClient().waitForResourceCreation("Namespace", namespace);
+
+        LOGGER.info("Creating CRD");
+        cluster.createCustomResources(getCrd());
+        cluster.waitForCustomResourceDefinition(getCrdName());
+        LOGGER.info("Created CRD");
+    }
+
+    @AfterAll
+    public void after() {
+        String namespace = getNamespace();
+        if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {
+            LOGGER.warn("Deleting namespace {} after tests run", namespace);
+            kubeClient().deleteNamespace(namespace);
+            cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
+        }
+    }
+
+    @Test
+    public void testUpdateStatus() {
+        String resourceName = getResourceName(RESOURCE_NAME);
+        String namespace = getNamespace();
+        CrdOperator<C, T, L> op = operator();
+        LOGGER.info("Creating resource");
+
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, getResource(resourceName))
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenCompose(rrCreated -> {
+                T newStatus = getResourceWithNewReadyStatus(rrCreated.resource());
+
+                LOGGER.info("Updating resource status");
+                return op.updateStatusAsync(Reconciliation.DUMMY_RECONCILIATION, newStatus);
+            })
+            .thenCompose(rrModified -> op.getAsync(namespace, resourceName))
+            .whenComplete((modifiedCustomResource, error) -> assertReady(modifiedCustomResource))
+            .thenCompose(rrModified -> {
+                LOGGER.info("Deleting resource");
+                return op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null);
+            }));
+    }
+
+    /**
+     * Tests what happens when the resource is deleted while updating the status
+     *
+     * @param context   Test context
+     */
+    @Test
+    public void testUpdateStatusAfterResourceDeletedThrowsKubernetesClientException() {
+        String resourceName = getResourceName(RESOURCE_NAME);
+        String namespace = getNamespace();
+        CrdOperator<C, T, L> op = operator();
+        AtomicReference<T> newStatus = new AtomicReference<>();
+
+        LOGGER.info("Creating resource");
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, getResource(resourceName))
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenCompose(rr -> {
+                LOGGER.info("Saving resource with status change prior to deletion");
+                newStatus.set(getResourceWithNewReadyStatus(op.get(namespace, resourceName)));
+                LOGGER.info("Deleting resource");
+                return op.deleteAsync(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, false);
+            })
+            .thenCompose(i -> {
+                LOGGER.info("Wait for confirmed deletion");
+                return op.waitFor(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, 100L, 10_000L, (n, ns) -> operator().get(namespace, resourceName) == null);
+            })
+            .thenCompose(i -> {
+                LOGGER.info("Updating resource with new status - should fail");
+                return op.updateStatusAsync(Reconciliation.DUMMY_RECONCILIATION, newStatus.get());
+            })
+            .<Void>handle((i, error) -> {
+                assertThat(Util.unwrap(error), instanceOf(KubernetesClientException.class));
+                return null;
+            }));
+    }
+
+    /**
+     * Tests what happens when the resource is modified while updating the status
+     *
+     * @param context   Test context
+     */
+    @Test
+    public void testUpdateStatusAfterResourceUpdated() {
+        String resourceName = getResourceName(RESOURCE_NAME);
+        String namespace = getNamespace();
+        CrdOperator<C, T, L> op = operator();
+
+        LOGGER.info("Creating resource");
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, getResource(resourceName))
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenCompose(rrCreated -> {
+                T updated = getResourceWithModifications(rrCreated.resource());
+                T newStatus = getResourceWithNewReadyStatus(rrCreated.resource());
+
+                LOGGER.info("Updating resource (mocking an update due to some other reason)");
+                op.operation().inNamespace(namespace).withName(resourceName).patch(updated);
+
+                LOGGER.info("Updating resource status after underlying resource has changed");
+                return op.updateStatusAsync(Reconciliation.DUMMY_RECONCILIATION, newStatus);
+            })
+            .<Void>handle((unused, error) -> {
+                assertNotNull(error);
+                LOGGER.info("Failed as expected");
+                Throwable cause = Util.unwrap(error);
+                assertThat(cause, instanceOf(KubernetesClientException.class));
+                assertThat(((KubernetesClientException) cause).getCode(), is(409));
+                return null;
+            })
+            .thenCompose(v -> {
+                LOGGER.info("Deleting resource");
+                return op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null);
+            }));
+    }
+
+    protected String getResourceName(String name) {
+        return name + "-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+}
+

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
+import io.strimzi.test.k8s.cluster.KubeCluster;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The main purpose of the Integration Tests for the operators is to test them against a real Kubernetes cluster.
+ * Real Kubernetes cluster has often some quirks such as some fields being immutable, some fields in the spec section
+ * being created by the Kubernetes API etc. These things are hard to test with mocks. These IT tests make it easy to
+ * test them against real clusters.
+ */
+public abstract class AbstractNamespacedResourceOperatorIT<
+        C extends KubernetesClient,
+        T extends HasMetadata,
+        L extends KubernetesResourceList<T>,
+        R extends Resource<T>> {
+
+    protected static final Logger LOGGER = LogManager.getLogger(AbstractNamespacedResourceOperatorIT.class);
+    public static final String RESOURCE_NAME = "my-test-resource";
+
+    protected String resourceName;
+    protected static KubernetesClient client;
+    protected static String namespace = "resource-operator-it-namespace";
+
+    private static KubeClusterResource cluster;
+    protected static Executor asyncExecutor;
+    protected static ResourceSupport resourceSupport;
+
+    @BeforeEach
+    public void renameResource() {
+        this.resourceName = getResourceName(RESOURCE_NAME);
+    }
+
+    @BeforeAll
+    public static void before() {
+        cluster = KubeClusterResource.getInstance();
+        cluster.setNamespace(namespace);
+        asyncExecutor = ForkJoinPool.commonPool();
+        resourceSupport = new ResourceSupport(asyncExecutor);
+
+        assertDoesNotThrow(() -> KubeCluster.bootstrap(), "Could not bootstrap server");
+        client = new KubernetesClientBuilder().build();
+
+        if (cluster.getNamespace() != null && System.getenv("SKIP_TEARDOWN") == null) {
+            LOGGER.warn("Namespace {} is already created, going to delete it", namespace);
+            kubeClient().deleteNamespace(namespace);
+            cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
+        }
+
+        LOGGER.info("Creating namespace: {}", namespace);
+        kubeClient().createNamespace(namespace);
+        cmdKubeClient().waitForResourceCreation("Namespace", namespace);
+    }
+
+    @AfterAll
+    public static void after() {
+        if (kubeClient().getNamespace(namespace) != null && System.getenv("SKIP_TEARDOWN") == null) {
+            LOGGER.warn("Deleting namespace {} after tests run", namespace);
+            kubeClient().deleteNamespace(namespace);
+            cmdKubeClient().waitForResourceDeletion("Namespace", namespace);
+        }
+    }
+
+    abstract AbstractNamespacedResourceOperator<C, T, L, R> operator();
+    abstract T getOriginal();
+    abstract T getModified();
+    abstract void assertResources(T expected, T actual);
+
+    @Test
+    public void testCreateModifyDelete() {
+        AbstractNamespacedResourceOperator<C, T, L, R> op = operator();
+        T newResource = getOriginal();
+        T modResource = getModified();
+
+        op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, newResource)
+            .whenComplete((rrCreated, error) -> {
+                assertNull(error);
+                T created = op.get(namespace, resourceName);
+                assertThat(created, is(notNullValue()));
+                assertResources(newResource, created);
+            })
+            .thenCompose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, modResource))
+            .whenComplete((rrModified, error) -> {
+                assertNull(error);
+                T modified = op.get(namespace, resourceName);
+                assertThat(modified, is(notNullValue()));
+                assertResources(modResource, modified);
+            })
+            .thenCompose(rr -> op.reconcile(Reconciliation.DUMMY_RECONCILIATION, namespace, resourceName, null))
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenCompose(rr -> resourceSupport.waitFor(
+                    Reconciliation.DUMMY_RECONCILIATION,
+                    "resource deletion " + resourceName,
+                    "deleted",
+                    1000,
+                    30_000,
+                    () -> op.get(namespace, resourceName) == null))
+            .thenRun(() -> {
+                assertThat(op.get(namespace, resourceName), is(nullValue()));
+            });
+    }
+
+    protected String getResourceName(String name) {
+        return name + "-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorTest.java
@@ -1,0 +1,589 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.GracePeriodConfigurable;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Deletable;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.TestUtils;
+
+public abstract class AbstractNamespacedResourceOperatorTest<C extends KubernetesClient, T extends HasMetadata,
+        L extends KubernetesResourceList<T>, R extends Resource<T>> {
+
+    public static final String RESOURCE_NAME = "my-resource";
+    public static final String NAMESPACE = "test";
+    protected static Executor asyncExecutor;
+
+    @BeforeAll
+    public static void before() {
+        asyncExecutor = ForkJoinPool.commonPool();
+    }
+
+    /**
+     * The type of kubernetes client to be mocked
+     */
+    protected abstract Class<C> clientType();
+
+    /**
+     * The type of the resource being tested
+     */
+    protected abstract Class<? extends Resource> resourceType();
+
+    /**
+     * @return  New resource with the default name
+     */
+    protected T resource()  {
+        return resource(RESOURCE_NAME);
+    }
+
+    /**
+     * Create a resource which will be used for the tests
+     *
+     * @param name  Name of the resource
+     *
+     * @return  New resource with the name
+     */
+    protected abstract T resource(String name);
+
+    /**
+     * @return  Modified resource with the default name
+     */
+    protected T modifiedResource()  {
+        return modifiedResource(RESOURCE_NAME);
+    }
+
+    /**
+     * Create a modified resource which will be used for the tests
+     *
+     * @param name Name of the resource
+     * @return Modified resource with the name
+     */
+    protected abstract T modifiedResource(String name);
+
+    /**
+     * Configure the given {@code mockClient} to return the given {@code op}
+     * that's appropriate for the kind of resource being tests.
+     */
+    protected abstract void mocker(C mockClient, MixedOperation<T, L, R> op);
+
+    /** Create the subclass of ResourceOperation to be tested */
+    protected abstract AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperations(C mockClient);
+
+    /** Create the subclass of ResourceOperation to be tested with mocked readiness checks*/
+    protected AbstractNamespacedResourceOperator<C, T, L, R> createResourceOperationsWithMockedReadiness(C mockClient) {
+        return createResourceOperations(mockClient);
+    }
+
+    @Test
+    public void testCreateWhenExistsWithChangeIsAPatch() {
+        testCreateWhenExistsWithChangeIsAPatch(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreateWhenExistsWithChangeIsAPatch(boolean cascade) {
+        T resource = resource();
+        R mockResource =  (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+
+        when(mockResource.patch(any(), (T) any())).thenReturn(resource);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, modifiedResource())
+            .<Void>handle((rr, error) -> {
+                assertNull(error);
+                verify(mockResource).get();
+                verify(mockResource).patch(any(), (T) any());
+                verify(mockResource, never()).create();
+                return null;
+            }));
+    }
+
+    @Test
+    public void testCreateWhenExistsWithoutChangeIsNotAPatch() {
+        testCreateWhenExistsWithoutChangeIsNotAPatch(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCreateWhenExistsWithoutChangeIsNotAPatch(boolean cascade) {
+        T resource = resource();
+        @SuppressWarnings("rawtypes")
+        Resource mockResource = mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withPropagationPolicy(cascade ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN)).thenReturn(mockResource);
+        when(mockResource.patch(any(), (T) any())).thenReturn(resource);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn((R) mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource())
+            .<Void>handle((rr, error) -> {
+                verify(mockResource).get();
+                verify(mockResource, never()).patch(any(), (T) any());
+                verify(mockResource, never()).create();
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testExistenceCheckThrows() {
+        T resource = resource();
+        RuntimeException ex = new RuntimeException();
+
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenThrow(ex);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
+            .<Void>handle((rr, error) -> {
+                assertSame(Util.unwrap(error), ex);
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSuccessfulCreation() {
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+
+        when(mockResource.get()).thenReturn(null);
+        when(mockResource.create()).thenReturn(resource);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+        when(mockNameable.resource(resource)).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperationsWithMockedReadiness(mockClient);
+
+        TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
+            .<Void>handle((rr, error) -> {
+                assertNull(error);
+                verify(mockResource).get();
+                verify(mockResource).create();
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateOrUpdateThrowsWhenCreateThrows() {
+        T resource = resource();
+        RuntimeException ex = new RuntimeException("Testing this exception is handled correctly");
+
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(null);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(resource.getMetadata().getName()))).thenReturn(mockResource);
+        when(mockNameable.resource(resource)).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
+        when(mockResource.create()).thenThrow(ex);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+        TestUtils.await(op.createOrUpdate(Reconciliation.DUMMY_RECONCILIATION, resource)
+            .<Void>handle((rr, error) -> {
+                assertSame(Util.unwrap(error), ex);
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDeleteWhenResourceDoesNotExistIsANop() {
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .<Void>handle((rr, error) -> {
+                assertNull(error);
+                verify(mockResource).get();
+                verify(mockResource, never()).delete();
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeleteWhenResourceExistsStillDeletes() {
+        Deletable mockDeletable = mock(Deletable.class);
+        when(mockDeletable.delete()).thenReturn(List.of());
+        var mockDeletableGrace = mock(GracePeriodConfigurable.class);
+        when(mockDeletableGrace.delete()).thenReturn(List.of());
+
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            Watcher<T> watcher = invocation.getArgument(0);
+            watcher.eventReceived(Watcher.Action.DELETED, resource);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .<Void>handle((rr, error) -> {
+                assertNull(error);
+                verify(mockDeletable).delete();
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeletionSuccessfullyDeletes() {
+        Deletable mockDeletable = mock(Deletable.class);
+        when(mockDeletable.delete()).thenReturn(List.of());
+        var mockDeletableGrace = mock(GracePeriodConfigurable.class);
+        when(mockDeletableGrace.delete()).thenReturn(List.of());
+
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            Watcher<T> watcher = invocation.getArgument(0);
+            watcher.eventReceived(Watcher.Action.DELETED, resource);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .whenComplete(TestUtils::assertSuccessful)
+            .<Void>handle((rr, error) -> {
+                verify(mockDeletable).delete();
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeleteThrowsWhenDeletionThrows() {
+        RuntimeException ex = new RuntimeException("Testing this exception is handled correctly");
+        Deletable mockDeletable = mock(Deletable.class);
+        var mockDeletableGrace = mock(GracePeriodConfigurable.class);
+        when(mockDeletable.delete()).thenThrow(ex);
+
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            Watcher<T> watcher = invocation.getArgument(0);
+            watcher.eventReceived(Watcher.Action.DELETED, resource);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .<Void>handle((rr, error) -> {
+                assertThat(Util.unwrap(error), is(ex));
+                return null;
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeleteDoesNotThrowWhenDeletionReturnsFalse() {
+        Deletable mockDeletable = mock(Deletable.class);
+        when(mockDeletable.delete()).thenReturn(List.of());
+        var mockDeletableGrace = mock(GracePeriodConfigurable.class);
+        when(mockDeletableGrace.delete()).thenReturn(List.of());
+
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            Watcher<T> watcher = invocation.getArgument(0);
+            watcher.eventReceived(Watcher.Action.DELETED, resource);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenRun(() -> {
+                verify(mockDeletable).delete();
+            }));
+    }
+
+    // This tests the pre-check which should stop the self-closing-watch in case the resource is deleted before the
+    // watch is opened.
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReconcileDeleteDoesNotTimeoutWhenResourceIsAlreadyDeleted() {
+        Deletable mockDeletable = mock(Deletable.class);
+        when(mockDeletable.delete()).thenReturn(List.of());
+        var mockDeletableGrace = mock(GracePeriodConfigurable.class);
+        when(mockDeletableGrace.delete()).thenReturn(List.of());
+
+        T resource = resource();
+        R mockResource = (R) mock(resourceType());
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        AtomicBoolean watchCreated = new AtomicBoolean(false);
+
+        when(mockResource.get()).thenAnswer(invocation -> {
+            // First get needs to return the resource to trigger deletion
+            // Next gets return null since the resource was already deleted
+            if (watchCreated.get()) {
+                return null;
+            } else {
+                return resource;
+            }
+        });
+        when(mockResource.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace);
+        when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
+
+        when(mockResource.watch(any())).thenAnswer(invocation -> {
+            watchCreated.set(true);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withName(matches(RESOURCE_NAME))).thenReturn(mockResource);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(matches(NAMESPACE))).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.reconcile(Reconciliation.DUMMY_RECONCILIATION, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), null)
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenRun(() -> {
+                verify(mockDeletable).delete();
+            }));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBatchReconciliation() {
+        Map<String, String> selector = Map.of("labelA", "a", "labelB", "b");
+
+        T resource1 = resource("resource-1");
+        T resource2 = resource("resource-2");
+        T resource2Mod = modifiedResource("resource-2");
+        T resource3 = resource("resource-3");
+
+        // For resource1 we need to mock the async deletion process as well
+        Deletable mockDeletable1 = mock(Deletable.class);
+        when(mockDeletable1.delete()).thenReturn(List.of());
+        var mockDeletableGrace1 = mock(GracePeriodConfigurable.class);
+        when(mockDeletableGrace1.withGracePeriod(anyLong())).thenReturn(mockDeletable1);
+        R mockResource1 = (R) mock(resourceType());
+        AtomicBoolean watchClosed = new AtomicBoolean(false);
+        AtomicBoolean watchCreated = new AtomicBoolean(false);
+        when(mockResource1.get()).thenAnswer(invocation -> {
+            // First get needs to return the resource to trigger deletion
+            // Next gets return null since the resource was already deleted
+            if (watchCreated.get()) {
+                return null;
+            } else {
+                return resource1;
+            }
+        });
+        when(mockResource1.withPropagationPolicy(DeletionPropagation.FOREGROUND)).thenReturn(mockDeletableGrace1);
+        when(mockResource1.watch(any())).thenAnswer(invocation -> {
+            watchCreated.set(true);
+            return (Watch) () -> {
+                watchClosed.set(true);
+            };
+        });
+
+        R mockResource2 = (R) mock(resourceType());
+        when(mockResource2.get()).thenReturn(resource2);
+        when(mockResource2.patch(any(), eq(resource2Mod))).thenReturn(resource2Mod);
+
+        R mockResource3 = (R) mock(resourceType());
+        when(mockResource3.get()).thenReturn(null);
+        when(mockResource3.create()).thenReturn(resource3);
+
+        KubernetesResourceList<T> mockResourceList = mock(KubernetesResourceList.class);
+        when(mockResourceList.getItems()).thenReturn(List.of(resource1, resource2));
+
+        FilterWatchListDeletable<T, L, R> mockListable = mock(FilterWatchListDeletable.class);
+        when(mockListable.list(any())).thenReturn((L) mockResourceList);
+
+        NonNamespaceOperation<T, L, R> mockNameable = mock(NonNamespaceOperation.class);
+        when(mockNameable.withLabels(selector)).thenReturn(mockListable);
+        when(mockNameable.withName("resource-1")).thenReturn(mockResource1);
+        when(mockNameable.withName("resource-2")).thenReturn(mockResource2);
+        when(mockNameable.withName("resource-3")).thenReturn(mockResource3);
+        when(mockNameable.resource(resource3)).thenReturn(mockResource3);
+
+        MixedOperation<T, L, R> mockCms = mock(MixedOperation.class);
+        when(mockCms.inNamespace(anyString())).thenReturn(mockNameable);
+
+        C mockClient = mock(clientType());
+        mocker(mockClient, mockCms);
+
+        AbstractNamespacedResourceOperator<C, T, L, R> op = createResourceOperations(mockClient);
+
+        TestUtils.await(op.batchReconcile(Reconciliation.DUMMY_RECONCILIATION, NAMESPACE, List.of(resource2Mod, resource3), Labels.fromMap(selector))
+            .whenComplete(TestUtils::assertSuccessful)
+            .thenRun(() -> {
+                verify(mockResource1, atLeast(1)).get();
+                verify(mockResource1, never()).patch(any(), (T) any());
+                verify(mockResource1, never()).create();
+                verify(mockDeletable1, times(1)).delete();
+
+                verify(mockResource2, times(1)).get();
+                verify(mockResource2, times(1)).patch(any(), eq(resource2Mod));
+                verify(mockResource2, never()).create();
+                verify(mockResource2, never()).delete();
+
+                verify(mockResource3, times(1)).get();
+                verify(mockResource3, never()).patch(any(), (T) any());
+                verify(mockResource3, times(1)).create();
+                verify(mockResource3, never()).delete();
+            }));
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperatorIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SecretOperatorIT extends AbstractNamespacedResourceOperatorIT<KubernetesClient, Secret, SecretList, Resource<Secret>> {
+
+    @Override
+    Secret getOriginal() {
+        return new SecretBuilder()
+                .withNewMetadata()
+                    .withName(resourceName)
+                    .withNamespace(namespace)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withData(singletonMap("FOO", "BAR"))
+                .build();
+    }
+
+    @Override
+    Secret getModified() {
+        return new SecretBuilder()
+                .withNewMetadata()
+                    .withName(resourceName)
+                    .withNamespace(namespace)
+                    .withLabels(singletonMap("foo", "baz"))
+                .endMetadata()
+                .withData(singletonMap("FOO", "BAZ"))
+                .build();
+    }
+
+    @Override
+    void assertResources(Secret expected, Secret actual) {
+        assertThat(actual.getMetadata().getLabels(), is(expected.getMetadata().getLabels()));
+        assertThat(actual.getData(), is(expected.getData()));
+    }
+
+    @Override
+    AbstractNamespacedResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> operator() {
+        return new SecretOperator(asyncExecutor, client);
+    }
+}

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/SecretOperatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.when;
+
+public class SecretOperatorTest extends AbstractNamespacedResourceOperatorTest<KubernetesClient, Secret, SecretList, Resource<Secret>> {
+
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<? extends Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Secret resource(String name) {
+        return new SecretBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(NAMESPACE)
+                    .withLabels(singletonMap("foo", "bar"))
+                .endMetadata()
+                .withData(singletonMap("FOO", "BAR"))
+                .build();
+    }
+
+    @Override
+    protected Secret modifiedResource(String name) {
+        return new SecretBuilder(resource(name))
+                .withData(singletonMap("FOO2", "BAR2"))
+                .build();
+    }
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation<Secret, SecretList, Resource<Secret>> op) {
+        when(mockClient.secrets()).thenReturn(op);
+    }
+
+    @Override
+    protected AbstractNamespacedResourceOperator<KubernetesClient, Secret, SecretList, Resource<Secret>> createResourceOperations(KubernetesClient mockClient) {
+        return new SecretOperator(asyncExecutor, mockClient);
+    }
+}

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -15,7 +15,7 @@ import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import io.strimzi.api.kafka.KafkaTopicList;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -129,7 +129,7 @@ public class K8sImpl implements K8s {
                 // Delete the resource by the topic name, because neither ZK nor Kafka know the resource name
                 operation().inNamespace(namespace).withName(resourceName.toString()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
 
-                Util.waitFor(reconciliation, vertx, "sync resource deletion " + resourceName, "deleted", 1000, Long.MAX_VALUE, () -> {
+                VertxUtil.waitFor(reconciliation, vertx, "sync resource deletion " + resourceName, "deleted", 1000, Long.MAX_VALUE, () -> {
                     KafkaTopic kafkaTopic = operation().inNamespace(namespace).withName(resourceName.toString()).get();
                     boolean notExists = kafkaTopic == null;
                     LOGGER.debug("KafkaTopic {} deleted {}", resourceName.toString(), notExists);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -22,7 +22,7 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.MaxAttemptsExceededException;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.operator.resource.StatusUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -956,7 +956,7 @@ class TopicOperator {
     private Future<Void> awaitExistential(LogContext logContext, TopicName topicName, boolean checkExists) {
         String logState = "confirmed " + (checkExists ? "" : "non-") + "existence";
         AtomicReference<Future<Boolean>> ref = new AtomicReference<>(kafka.topicExists(logContext.toReconciliation(), topicName));
-        return Util.waitFor(logContext.toReconciliation(), vertx, logContext.toString(), logState, 1_000, 60_000,
+        return VertxUtil.waitFor(logContext.toReconciliation(), vertx, logContext.toString(), logState, 1_000, 60_000,
             () -> {
                 Future<Boolean> existsFuture = ref.get();
                 if (existsFuture.isComplete()) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperator.java
@@ -116,7 +116,7 @@ class TopicOperator {
         public void handle(Void v) {
             EventBuilder evtb = new EventBuilder();
             final String eventTime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
-            
+
             if (involvedObject != null) {
                 evtb.withNewInvolvedObject()
                         .withKind(involvedObject.getKind())
@@ -1166,7 +1166,7 @@ class TopicOperator {
                             topic.getMetadata().getResourceVersion(),
                             topic.getMetadata().getGeneration());
                     KafkaTopicStatus kts = new KafkaTopicStatus();
-                    StatusUtils.setStatusConditionAndObservedGeneration(topic, kts, result);
+                    StatusUtils.setStatusConditionAndObservedGeneration(topic, kts, result.cause());
 
                     if (topic.getStatus() == null || topic.getStatus().getTopicName() == null) {
                         String specTopicName = new TopicName(topic).toString();

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/KafkaUserOperator.java
@@ -4,10 +4,8 @@
  */
 package io.strimzi.operator.user.operator;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.Crds;
@@ -425,9 +423,7 @@ public class KafkaUserOperator {
             .reconcile(reconciliation, reconciliation.namespace(), user.getSecretName(), currentSecret, user.generateSecret())
             .whenComplete((result, error) -> {
                 if (error == null) {
-                    result.resourceOpt()
-                        .map(HasMetadata::getMetadata)
-                        .map(ObjectMeta::getName)
+                    result.resourceOpt().map(secret -> secret.getMetadata().getName())
                         .ifPresent(userStatus::setSecret);
                 }
             });


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- ~~Bugfix~~
- ~~Enhancement / new feature~~
- Refactoring
- ~~Documentation~~

### Description

- Add several alternate/parallel non-Vertx resource operators to the common module. Note that the abstract create method includes 409/Conflict handling to replace an existing resource if it already exists, but the operator does not see it. For example if the labels used for selection have changed and the operator thinks it needs to be created.
- Remove `AsyncResult` variant of `StatusUtils#setStatusConditionAndObservedGeneration` and split Vertx utilities to separate class, allowing Vertx dependencies to be made optional.
- Update the UO to leverage the new `SecretOperator` for the user secret reconcile processing.

Relates to #7594 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

