### PR TITLE
Improved ignored annotations in PvcOperator

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -23,7 +23,9 @@ public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesCl
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(PvcOperator.class);
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
-                    "|/metadata/annotations/pv.kubernetes.io~1bind-completed" +
+                    "|/metadata/annotations/pv.kubernetes.io~1.*" +
+                    "|/metadata/annotations/volume.beta.kubernetes.io~1.*" +
+                    "|/metadata/annotations/volume.kubernetes.io~1.*" +
                     "|/metadata/finalizers" +
                     "|/metadata/creationTimestamp" +
                     "|/metadata/resourceVersion" +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `PvcOperator` class already ignores some Kubernetes annotations. But as discussed in #8667, there are some more that we should ignore as well and not patch them. This PR expands the range of ignored annotations.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging