### PR TITLE
Update Fabric8 Kubernetes Client to 6.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.7.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.7.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.7.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.7.2</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.7.2</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.7.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.14.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.14.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to a new version 6.7.2 which contains several bug fixes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally