### PR TITLE
[ST] assertNoCoErrorsLogged call in abstractST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -335,7 +335,7 @@ public class ResourceManager {
     }
 
     @SafeVarargs
-    public final <T extends HasMetadata> void updateResource(ExtensionContext testContext, T... resources) {
+    public final <T extends HasMetadata> void updateResource(T... resources) {
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
             type.update(resource);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -87,6 +87,9 @@ public abstract class AbstractST implements TestSeparator {
     protected static Map<String, String> mapWithTestTopics = new HashMap<>();
     protected static Map<String, String> mapWithTestUsers = new HashMap<>();
     protected static Map<String, String> mapWithScraperNames = new HashMap<>();
+
+    // This variable makes sure the assertNoCoErrorsLogged performed as afterEach
+    // does not take all the Cluster Operator logs from the beginning, but only from the time when the test execution started
     protected static Map<String, Long> mapWithTestExecutionStartTimes = new HashMap<>();
     protected static ConcurrentHashMap<ExtensionContext, TestStorage> storageMap = new ConcurrentHashMap<>();
     protected static final String CLUSTER_NAME_PREFIX = "my-cluster-";

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -450,7 +450,7 @@ public abstract class AbstractST implements TestSeparator {
 
     protected void assertNoCoErrorsLogged(String namespaceName, long sinceSeconds) {
         LOGGER.info("Search in strimzi-cluster-operator log for errors in last {} second(s)", sinceSeconds);
-        String clusterOperatorLog = cmdKubeClient(namespaceName).searchInLog("deploy", ResourceManager.getCoDeploymentName(), sinceSeconds, "Exception", "Error", "Throwable");
+        String clusterOperatorLog = cmdKubeClient(namespaceName).searchInLog(Constants.DEPLOYMENT, ResourceManager.getCoDeploymentName(), sinceSeconds, "Exception", "Error", "Throwable", "OOM");
         assertThat(clusterOperatorLog, logHasNoUnexpectedErrors());
     }
 
@@ -620,6 +620,7 @@ public abstract class AbstractST implements TestSeparator {
         // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
         // it will always execute the second method.
         try {
+            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
             afterEachMayOverride(extensionContext);
         } finally {
             afterEachMustExecute(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -87,6 +87,7 @@ public abstract class AbstractST implements TestSeparator {
     protected static Map<String, String> mapWithTestTopics = new HashMap<>();
     protected static Map<String, String> mapWithTestUsers = new HashMap<>();
     protected static Map<String, String> mapWithScraperNames = new HashMap<>();
+    protected static Map<String, Long> mapWithTestExecutionStartTimes = new HashMap<>();
     protected static ConcurrentHashMap<ExtensionContext, TestStorage> storageMap = new ConcurrentHashMap<>();
     protected static final String CLUSTER_NAME_PREFIX = "my-cluster-";
     protected static final String KAFKA_IMAGE_MAP = "STRIMZI_KAFKA_IMAGES";
@@ -558,6 +559,7 @@ public abstract class AbstractST implements TestSeparator {
             mapWithTestTopics.put(testName, KafkaTopicUtils.generateRandomNameOfTopic());
             mapWithTestUsers.put(testName, KafkaUserUtils.generateRandomNameOfKafkaUser());
             mapWithScraperNames.put(testName, clusterName + "-" + Constants.SCRAPER_NAME);
+            mapWithTestExecutionStartTimes.put(testName, System.currentTimeMillis());
 
             LOGGER.trace("CLUSTER_NAMES_MAP: {}", mapWithClusterNames);
             LOGGER.trace("USERS_NAME_MAP: {}", mapWithTestUsers);
@@ -620,8 +622,9 @@ public abstract class AbstractST implements TestSeparator {
         // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
         // it will always execute the second method.
         try {
-            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
+            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), mapWithTestExecutionStartTimes.get(extensionContext.getTestMethod().get().getName()));
             afterEachMayOverride(extensionContext);
+            mapWithTestExecutionStartTimes.remove(extensionContext.getTestMethod().get().getName());
         } finally {
             afterEachMustExecute(extensionContext);
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
@@ -121,7 +121,7 @@ public class UserScalabilityIsolatedST extends AbstractST {
         // get one user spec as the template for wait
         KafkaUserSpec kafkaUserSpec = listOfUsers.stream().findFirst().get().getSpec();
 
-        resourceManager.updateResource(extensionContext, listOfUsers.toArray(new KafkaUser[listOfUsers.size()]));
+        resourceManager.updateResource(listOfUsers.toArray(new KafkaUser[listOfUsers.size()]));
         KafkaUserUtils.waitForConfigToBeChangedInAllUsersWithPrefix(clusterOperator.getDeploymentNamespace(), usersPrefix, kafkaUserSpec);
         KafkaUserUtils.waitForAllUsersWithPrefixReady(clusterOperator.getDeploymentNamespace(), usersPrefix);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -623,7 +623,5 @@ public class AbstractUpgradeST extends AbstractST {
 
         // Verify that pods are stable
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);
-        // Check errors in CO log
-        assertNoCoErrorsLogged(testStorage.getNamespaceName(), 0);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeIsolatedST.java
@@ -145,9 +145,6 @@ public class OlmUpgradeIsolatedST extends AbstractUpgradeST {
 
         // Wait for messages of previously created clients
         ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace(), testStorage.getMessageCount());
-
-        // Check for errors in Cluster Operator log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeIsolatedST.java
@@ -79,8 +79,6 @@ public class StrimziDowngradeIsolatedST extends AbstractUpgradeST {
         checkAllImages(downgradeData, clusterOperator.getDeploymentNamespace());
         // Verify upgrade
         verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
-        // Check errors in CO log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeIsolatedST.java
@@ -94,8 +94,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
         assertThat(KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0)), containsString(acrossUpgradeData.getProcedures().getVersion()));
-        // Check errors in CO log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @Test
@@ -120,8 +118,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(clusterOperator.getDeploymentNamespace(), clusterName);
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
-        // Check errors in CO log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @Test
@@ -146,9 +142,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(clusterOperator.getDeploymentNamespace(), clusterName);
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
-
-        // Check errors in CO log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @Test
@@ -185,9 +178,6 @@ public class StrimziUpgradeIsolatedST extends AbstractUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(clusterOperator.getDeploymentNamespace(), clusterName);
         // Verify upgrade
         verifyProcedure(upgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), clusterOperator.getDeploymentNamespace());
-
-        // Check errors in CO log
-        assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), 0);
     }
 
     @BeforeEach


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We want to check every test that operator does not contain unwanted (non-expected) errors in the log. Currently the assertNoCoErrorsLogged check is performed only as part of several test cases. This PR changes this situation and checks afterEach test in the abstractST. I utilized variable mapWithTestExecutionStartTImes to make sure that in this check the errors do not stack on top of each other and each test has its own logs provided only since the time of test execution start. (Basically the error from one test does not get propagated into every check and thus does not fail any other tests)

### Checklist


- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

