### PR TITLE
Update Spotbugs and remove unneeded suppressions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -98,10 +98,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
             <scope>test</scope>

--- a/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/Kafka.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -81,7 +80,6 @@ import java.util.function.Predicate;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Namespaced, UnknownPropertyPreserving {
 
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnect.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -75,7 +74,6 @@ import java.util.function.Predicate;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaConnector.java
@@ -6,7 +6,6 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -82,7 +81,6 @@ import static java.util.Collections.emptyMap;
 @ToString
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -74,7 +73,6 @@ import java.util.function.Predicate;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaRebalance.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -90,7 +89,6 @@ import java.util.function.Predicate;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/StrimziPodSet.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -82,7 +81,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_CORE_GROUP_NAME)
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodSetStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -6,7 +6,6 @@
 package io.strimzi.operator.cluster.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.kafka.config.model.ConfigModel;
 import io.strimzi.kafka.config.model.ConfigModels;
@@ -107,7 +106,6 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param kafkaVersion The broker version.
      * @return The config model for that broker version.
      */
-    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"})
     public static Map<String, ConfigModel> readConfigModel(KafkaVersion kafkaVersion) {
         String name = "/kafka-" + kafkaVersion.version() + "-config-model.json";
         try {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -352,7 +352,6 @@ public class KafkaRoller {
      * @throws ForceableProblem         Some error. Not thrown when finalAttempt==true.
      * @throws UnforceableProblem       Some error, still thrown when finalAttempt==true.
      */
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     private void restartIfNecessary(NodeRef nodeRef, RestartContext restartContext)
             throws Exception {

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -174,10 +174,6 @@
             <artifactId>test</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.Vertx;
 import static java.util.Objects.requireNonNull;
 import org.apache.logging.log4j.LogManager;
@@ -19,7 +18,6 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * We add a fixed timeout because Vertx has none for stopping running Verticles.
  */
-@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
 public class ShutdownHook implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger(ShutdownHook.class);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common.operator.resource;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -28,8 +27,6 @@ import io.vertx.core.Vertx;
  * @param <T> The custom resource type.
  * @param <L> The list variant of the custom resource type.
  */
-@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-        justification = "Erroneous on Java 11: https://github.com/spotbugs/spotbugs/issues/756")
 public class CrdOperator<C extends KubernetesClient,
             T extends CustomResource,
             L extends DefaultKubernetesResourceList<T>>

--- a/pom.xml
+++ b/pom.xml
@@ -109,14 +109,14 @@
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <maven.jar.version>3.1.0</maven.jar.version>
         <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
-        <maven.spotbugs.version>4.5.3.0</maven.spotbugs.version>
+        <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
         <maven.jacoco.version>0.8.8</maven.jacoco.version>
         <maven.exec.version>3.1.0</maven.exec.version>
         <maven.resources.version>3.1.0</maven.resources.version>
 
         <!-- Build tools -->
         <checkstyle.version>9.2.1</checkstyle.version>
-        <spotbugs.version>4.7.2</spotbugs.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
         <sundrio.version>0.91.1</sundrio.version>
         <lombok.version>1.18.24</lombok.version>
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Spotbugs and its Maven plugin. It also removes the `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` suppressions which are not needed anymore.