### PR TITLE
Update otel 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update Kafka Exporter to [1.7.0](https://github.com/danielqsj/kafka_exporter/releases/tag/v1.7.0)
 * Update Kaniko container builder to 1.11.0
 * Add support for _Kafka node pools_ according to [Strimzi Proposal #50](https://github.com/strimzi/proposals/blob/main/050-Kafka-Node-Pools.md)
+* Update OpenTelemetry 1.19.0
 
 ### Changes, deprecations and removals
 

--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
         <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
-        <opentelemetry.version>1.18.0</opentelemetry.version>
-        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.19.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.12.0</strimzi-oauth.version>


### PR DESCRIPTION
Trivial PR to update OpenTelemetry to 1.19.0 (aligning with what we use in the Strimzi HTTP bridge as well).