### PR TITLE
docs(headings): changes heading levels in overview

### DIFF
--- a/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
+++ b/documentation/modules/overview/con-configuration-points-mirrormaker.adoc
@@ -17,19 +17,19 @@ As a consequence, the Strimzi `KafkaMirrorMaker` custom resource which is used t
 The `KafkaMirrorMaker` resource will be removed from Strimzi when Kafka 4.0.0 is adopted.
 
 [discrete]
-=== Key Consumer configuration
+== Key Consumer configuration
 
 Consumer group identifier:: The consumer group ID for a MirrorMaker consumer so that messages consumed are assigned to a consumer group.
 Number of consumer streams:: A value to determine the number of consumers in a consumer group that consume a message in parallel.
 Offset commit interval:: An offset commit interval to set the time between consuming and committing a message.
 
 [discrete]
-=== Key Producer configuration
+== Key Producer configuration
 
 Cancel option for send failure:: You can define whether a message send failure is ignored or MirrorMaker is terminated and recreated.
 
 [discrete]
-=== Example YAML showing MirrorMaker configuration
+== Example YAML showing MirrorMaker configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: {KafkaMirrorMakerApiVersion}

--- a/documentation/modules/overview/con-configuration-points-mirrormaker2.adoc
+++ b/documentation/modules/overview/con-configuration-points-mirrormaker2.adoc
@@ -24,7 +24,7 @@ MirrorMaker 2 uses source and target cluster configuration as follows:
 Topic and consumer group replication is specified as comma-separated lists or regular expression patterns.
 
 [discrete]
-=== Example YAML showing MirrorMaker 2 configuration
+== Example YAML showing MirrorMaker 2 configuration
 
 [source,yaml,subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
Documentation

A couple of headings in the overview skipped a level.
This PR fixes them

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

