### PR TITLE
[ST] Multiple cluster operators ST, adding cluster operator metric checks

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -111,6 +111,11 @@ public interface Constants {
     String DRAIN_CLEANER_NAMESPACE = "strimzi-drain-cleaner";
 
     /**
+     * Deployment labels related constants
+     */
+    String APP_POD_LABEL = "app";
+
+    /**
      * Constants for specific ports
      */
     int COMPONENTS_METRICS_PORT = 9404;

--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ComponentType;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -178,7 +177,7 @@ public class MetricsCollector {
             case TopicOperator:
                 return kubeClient(namespaceName).getDeploymentSelectors(KafkaResources.entityOperatorDeploymentName(componentName));
             case ClusterOperator:
-                return kubeClient(namespaceName).getDeploymentSelectors(ResourceManager.getCoDeploymentName());
+                return kubeClient(namespaceName).getDeploymentSelectors(componentName);
             case KafkaBridge:
                 return kubeClient(namespaceName).getDeploymentSelectors(KafkaBridgeResources.deploymentName(componentName));
             default:

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -60,10 +60,10 @@ public class MetricsUtils {
 
     public static MetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace, String coScraperName) {
 
-        var scraperDeploymentPodLabel = new LabelSelector(null, Map.of(Constants.APP_POD_LABEL, coScraperName));
+        LabelSelector scraperDeploymentPodLabel = new LabelSelector(null, Map.of(Constants.APP_POD_LABEL, coScraperName));
         String coScraperPodName = ResourceManager.kubeClient().listPods(coNamespace, scraperDeploymentPodLabel).get(0).getMetadata().getName();
 
-        return  new MetricsCollector.Builder()
+        return new MetricsCollector.Builder()
             .withScraperPodName(coScraperPodName)
             .withNamespaceName(coNamespace)
             .withComponentType(ComponentType.ClusterOperator)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -14,8 +14,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -783,7 +783,7 @@ public class MetricsIsolatedST extends AbstractST {
             .withScraperPodName(coScraperPodName)
             .withNamespaceName(clusterOperator.getDeploymentNamespace())
             .withComponentType(ComponentType.ClusterOperator)
-            .withComponentName("")
+            .withComponentName(clusterOperator.getClusterOperatorName())
             .build();
 
         kafkaCollector.collectMetricsFromPods();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -329,23 +329,6 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(secondCoMetricsCollector, Kafka.RESOURCE_KIND, 1);
     }
 
-//    private MetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace) {
-//        // necessary for finding correct deployment when building metric collector.
-//        ResourceManager.setCoDeploymentName(coName);
-//
-//        String coScraperName = coNamespace + "-" + Constants.SCRAPER_NAME;
-//        String coScraperPodName = ResourceManager.kubeClient().listPodsByPrefixInName(coNamespace, coScraperName).get(0).getMetadata().getName();
-//
-//        MetricsCollector clusterOperatorCollector = new MetricsCollector.Builder()
-//            .withScraperPodName(coScraperPodName)
-//            .withNamespaceName(coNamespace)
-//            .withComponentType(ComponentType.ClusterOperator)
-//            .withComponentName("")
-//            .build();
-//
-//        return clusterOperatorCollector;
-//    }
-
     void deployCOInNamespace(ExtensionContext extensionContext, String coName, String coNamespace, List<EnvVar> extraEnvs, boolean multipleNamespaces) {
         String namespace = multipleNamespaces ? Constants.WATCH_ALL_NAMESPACES : coNamespace;
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsIsolatedST.java
@@ -29,6 +29,7 @@ import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaRebalanceTemplates;
@@ -88,6 +89,40 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
     public static final Map<String, String> FIRST_CO_SELECTOR = Collections.singletonMap("app.kubernetes.io/operator", FIRST_CO_NAME);
     public static final Map<String, String> SECOND_CO_SELECTOR = Collections.singletonMap("app.kubernetes.io/operator", SECOND_CO_NAME);
 
+    /**
+     * @description This test case checks how two Cluster Operators operates operands deployed in namespace watched by both of these operators, and transition
+     * of operand from one Cluster Operator to another.
+     *
+     * @steps
+     *  1. - Deploy all namespace watching first Cluster Operator to the first namespace and second Cluster Operator to the second namespace.
+     *     - Cluster Operators are successfully deployed.
+     *  2. - Set up scrapers and metric collectors for both of Cluster Operators.
+     *     - Mentioned resources are successfully set up.
+     *  3. - Create and Set namespace 'multiple-co-cluster-test' as default, because all resources from now on will be deployed here.
+     *     - Namespace is created and set as default.
+     *  4. - Deploy Kafka operand in default namespace without label 'app.kubernetes.io/operator'.
+     *     - Kafka is not deployed.
+     *  5. - Verify state of metric 'strimzi_resource' for Kafka, which holds number of operated Kafka operands.
+     *     - Metric 'strimzi_resource' exposed by Cluster Operators is not present indicating no Kafka resource is being operated.
+     *  6. - Modify Kafka custom resource, by changing its label 'app.kubernetes.io/operator' to point to the first Cluster Operator
+     *     - Kafka is deployed and operated by the first Cluster Operator.
+     *  7. - Deploy Kafka Connect (with label 'app.kubernetes.io/operator' pointing the first Cluster Operator) and  Kafka Connector
+     *     - Both Operands are successfully deployed, and managed by the first Cluster Operator.
+     *  8. - Produce messages into the kafka Topic and consume with Sink Connector.
+     *     - Messages are produced and later handled correctly by the Connector.
+     *  9. - Management of Kafka is switched to the second Cluster Operator by modifying value of label 'app.kubernetes.io/operator'.
+     *     - Management is modified, later confirmed by the expected change in the value of metric 'strimzi_resource' for kind Kafka on both Cluster Operators.
+     *  10. - Verify 'strimzi_resource' of each Cluster Operator for all deployed operands.
+     *      - Metric 'strimzi_resource' indicates expected number of operated resources for both Cluster Operators.
+     *
+     * @usecase
+     *  - cluster-operator-metrics
+     *  - cluster-operator-watcher
+     *  - connect
+     *  - kafka
+     *  - labels
+     *  - metrics
+     */
     @IsolatedTest
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
@@ -95,11 +130,7 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         // Strimzi is deployed with cluster-wide access in this class STRIMZI_RBAC_SCOPE=NAMESPACE won't work
         assumeFalse(Environment.isNamespaceRbacScope());
 
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        String topicName = mapWithTestTopics.get(extensionContext.getDisplayName());
-
-        String producerName = "hello-world-producer";
-        String consumerName = "hello-world-consumer";
+        TestStorage testStorage = new TestStorage(extensionContext, DEFAULT_NAMESPACE);
 
         String firstCOScraperName = FIRST_NAMESPACE + "-" + Constants.SCRAPER_NAME;
         String secondCOScraperName = SECOND_NAMESPACE + "-" + Constants.SCRAPER_NAME;
@@ -118,87 +149,181 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
         MetricsCollector firstCoMetricsCollector = setupCOMetricsCollectorInNamespace(FIRST_CO_NAME, FIRST_NAMESPACE);
         MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE);
 
-        LOGGER.info("Deploying Namespace: {} to host all additional operands", DEFAULT_NAMESPACE);
-        cluster.createNamespace(DEFAULT_NAMESPACE);
-        StUtils.copyImagePullSecrets(DEFAULT_NAMESPACE);
-        cluster.setNamespace(DEFAULT_NAMESPACE);
+        LOGGER.info("Deploying Namespace: {} to host all additional operands", testStorage.getNamespaceName());
+        cluster.createNamespace(testStorage.getNamespaceName());
+        StUtils.copyImagePullSecrets(testStorage.getNamespaceName());
 
-        LOGGER.info("Deploying Kafka: {}/{} without CR selector", DEFAULT_NAMESPACE, clusterName);
-        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3)
-            .editMetadata()
-                .withNamespace(DEFAULT_NAMESPACE)
-            .endMetadata()
-            .build());
+        LOGGER.info("Set cluster namespace to {}, as all operands will be from now on deployd here", testStorage.getNamespaceName());
+        cluster.setNamespace(testStorage.getNamespaceName());
+
+        LOGGER.info("Deploying Kafka: {}/{} without CR selector", testStorage.getNamespaceName(), testStorage.getClusterName());
+        resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaEphemeral(testStorage.getClusterName(), 3, 3).build());
 
         // checking that no pods with prefix 'clusterName' will be created in some time
-        PodUtils.waitUntilPodStabilityReplicasCount(DEFAULT_NAMESPACE, clusterName, 0);
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), testStorage.getClusterName(), 0);
 
         // verify that metric signalizing managing of kafka is not present in either of cluster operators
-        MetricsUtils.assertCoMetricResourcesNullOrZero(firstCoMetricsCollector, Kafka.RESOURCE_KIND, DEFAULT_NAMESPACE);
-        MetricsUtils.assertCoMetricResourcesNullOrZero(secondCoMetricsCollector, Kafka.RESOURCE_KIND, DEFAULT_NAMESPACE);
+        MetricsUtils.assertCoMetricResourcesNullOrZero(firstCoMetricsCollector, Kafka.RESOURCE_KIND, testStorage.getNamespaceName());
+        MetricsUtils.assertCoMetricResourcesNullOrZero(secondCoMetricsCollector, Kafka.RESOURCE_KIND, testStorage.getNamespaceName());
 
-        LOGGER.info("Adding {} selector of {} into Kafka: {} CR", FIRST_CO_SELECTOR, FIRST_CO_NAME, clusterName);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> kafka.getMetadata().setLabels(FIRST_CO_SELECTOR), DEFAULT_NAMESPACE);
-        KafkaUtils.waitForKafkaReady(DEFAULT_NAMESPACE, clusterName);
+        LOGGER.info("Adding {} selector of {} into Kafka: {} CR", FIRST_CO_SELECTOR, FIRST_CO_NAME, testStorage.getClusterName());
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> kafka.getMetadata().setLabels(FIRST_CO_SELECTOR), testStorage.getNamespaceName());
+        KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         resourceManager.createResource(extensionContext,
-            KafkaTopicTemplates.topic(clusterName, topicName)
-                .editMetadata()
-                    .withNamespace(DEFAULT_NAMESPACE)
-                .endMetadata()
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName())
                 .build(),
-            KafkaConnectTemplates.kafkaConnectWithFilePlugin(clusterName, DEFAULT_NAMESPACE, 1)
+            KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getClusterName(), testStorage.getNamespaceName(), 1)
                 .editOrNewMetadata()
                     .addToLabels(FIRST_CO_SELECTOR)
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
-                    .withNamespace(DEFAULT_NAMESPACE)
                 .endMetadata()
                 .build());
 
-        String kafkaConnectPodName = kubeClient(DEFAULT_NAMESPACE).listPods(DEFAULT_NAMESPACE, clusterName, Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
+        String kafkaConnectPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
 
         LOGGER.info("Deploying KafkaConnector with file sink and CR selector - {} - different than selector in Kafka", SECOND_CO_SELECTOR);
-        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(clusterName)
-            .editOrNewMetadata()
-                .addToLabels(SECOND_CO_SELECTOR)
-                .withNamespace(DEFAULT_NAMESPACE)
-            .endMetadata()
+        resourceManager.createResource(extensionContext, KafkaConnectorTemplates.kafkaConnector(testStorage.getClusterName())
             .editSpec()
                 .withClassName("org.apache.kafka.connect.file.FileStreamSinkConnector")
                 .addToConfig("file", Constants.DEFAULT_SINK_FILE_PATH)
                 .addToConfig("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
-                .addToConfig("topics", topicName)
+                .addToConfig("topics", testStorage.getTopicName())
             .endSpec()
             .build());
 
         KafkaClients basicClients = new KafkaClientsBuilder()
-            .withNamespaceName(DEFAULT_NAMESPACE)
-            .withProducerName(producerName)
-            .withConsumerName(consumerName)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
-            .withTopicName(topicName)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
             .withMessageCount(MESSAGE_COUNT)
             .build();
 
         resourceManager.createResource(extensionContext, basicClients.producerStrimzi());
-        ClientUtils.waitForClientSuccess(producerName, DEFAULT_NAMESPACE, MESSAGE_COUNT);
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), MESSAGE_COUNT);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(DEFAULT_NAMESPACE, kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world - 99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world - 99");
 
-        LOGGER.info("Verifying that all operands in Namespace: {} are managed by Cluster Operator: {}", DEFAULT_NAMESPACE, FIRST_CO_NAME);
+        LOGGER.info("Verifying that all operands in Namespace: {} are managed by Cluster Operator: {}", testStorage.getNamespaceName(), FIRST_CO_NAME);
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(firstCoMetricsCollector, Kafka.RESOURCE_KIND, 1);
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(firstCoMetricsCollector, KafkaConnect.RESOURCE_KIND, 1);
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(firstCoMetricsCollector, KafkaConnector.RESOURCE_KIND, 1);
 
-        LOGGER.info("Switch management of Kafka Cluster: {}/{} operand from CO: {} to CO: {}", DEFAULT_NAMESPACE, clusterName, FIRST_CO_NAME, SECOND_CO_NAME);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+        LOGGER.info("Switch management of Kafka Cluster: {}/{} operand from CO: {} to CO: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), FIRST_CO_NAME, SECOND_CO_NAME);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getMetadata().getLabels().replace("app.kubernetes.io/operator", SECOND_CO_NAME);
-        }, DEFAULT_NAMESPACE);
+        }, testStorage.getNamespaceName());
 
         LOGGER.info("Verifying that number of managed Kafka resources in increased in CO: {} and decreased om CO: {}", SECOND_CO_NAME, FIRST_CO_NAME);
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(secondCoMetricsCollector, Kafka.RESOURCE_KIND, 1);
         MetricsUtils.assertMetricResourcesLowerThanOrEqualTo(firstCoMetricsCollector, Kafka.RESOURCE_KIND, 0);
+    }
+
+    /**
+     * @description This test case checks how two Cluster Operators deployed in the same namespace operates operands including rebalances and transition
+     * of operand from one Cluster Operator to another.
+     *
+     * @steps
+     *  1. - Deploy 2 Cluster Operators in the same namespace, with additional env variable 'STRIMZI_LEADER_ELECTION_LEASE_NAME'.
+     *     - Cluster Operators are successfully deployed.
+     *  2. - Set up scrapers and metric collectors for first Cluster Operators.
+     *     - Mentioned resources are successfully set up.
+     *  3. - Deploy Kafka Cluster with 3 kafka replicas and label 'app.kubernetes.io/operator' pointing to the first Cluster Operator.
+     *     - Kafka is deployed.
+     *  4. - Modify Kafka custom resource, by removing its 'app.kubernetes.io/operator' and changing number of replicas to 4
+     *     - Kafka is not scaled to 4 replicas.
+     *  5. - Deploy Kafka Rebalance without 'app.kubernetes.io/operator' label.
+     *     - For a stable period of time, Kafka Rebalance is ignored as well.
+     *  6. - Modify Kafka Rebalance labels 'second-strimzi-cluster-operator' to point to Cluster Operator and
+     *     - Messages are produced and later handled correctly by the Connector.
+     *  7. - Management of Kafka is switched to the second Cluster Operator by modifying value of label 'app.kubernetes.io/operator'.
+     *     - Management is modified, and reballance finally takes place.
+     *  8. - Verify that Operators operate expected operands.
+     *     - Operators operate expected operands.
+     *
+     * @usecase
+     *  - cluster-operator-metrics
+     *  - cluster-operator-watcher
+     *  - connect
+     *  - kafka
+     *  - labels
+     *  - metrics
+     *  - rebalance
+     */
+    @IsolatedTest
+    @Tag(CRUISE_CONTROL)
+    @KRaftNotSupported("The scaling of the Kafka pods is not working properly at the moment")
+    void testKafkaCCAndRebalanceWithMultipleCOs(ExtensionContext extensionContext) {
+        TestStorage testStorage = new TestStorage(extensionContext, DEFAULT_NAMESPACE);
+        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(testStorage.getClusterName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
+
+        int scaleTo = 4;
+
+        LOGGER.info("Deploying 2 Cluster Operators: {}, {} in the same namespace: {}", FIRST_CO_NAME, SECOND_CO_NAME, testStorage.getNamespaceName());
+        deployCOInNamespace(extensionContext, FIRST_CO_NAME, testStorage.getNamespaceName(), List.of(FIRST_CO_SELECTOR_ENV, FIRST_CO_LEASE_NAME_ENV), false);
+        deployCOInNamespace(extensionContext, SECOND_CO_NAME, testStorage.getNamespaceName(), List.of(SECOND_CO_SELECTOR_ENV, SECOND_CO_LEASE_NAME_ENV), false);
+
+        String secondCOScraperName = testStorage.getNamespaceName() + "-" + Constants.SCRAPER_NAME;
+
+        LOGGER.info("Deploying scraper Pod: {}, for later metrics retrieval", secondCOScraperName);
+        resourceManager.createResource(extensionContext, true, ScraperTemplates.scraperPod(testStorage.getNamespaceName(), secondCOScraperName).build());
+
+        LOGGER.info("Setting up metric collectors targeting Cluster Operator: {}", SECOND_CO_NAME);
+        MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, testStorage.getNamespaceName());
+
+        LOGGER.info("Deploying Kafka with {} selector of {}", FIRST_CO_NAME, FIRST_CO_SELECTOR);
+        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(testStorage.getClusterName(), 3, 3)
+            .editOrNewMetadata()
+                .addToLabels(FIRST_CO_SELECTOR)
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .build());
+
+        LOGGER.info("Removing CR selector from Kafka and increasing number of replicas to 4, new pod should not appear");
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
+            kafka.getMetadata().getLabels().clear();
+            kafka.getSpec().getKafka().setReplicas(scaleTo);
+        }, testStorage.getNamespaceName());
+
+        // because KafkaRebalance is pointing to Kafka with CC cluster, we need to create KR before adding the label back
+        // to test if KR will be ignored
+        LOGGER.info("Creating KafkaRebalance when CC doesn't have label for CO, the KR should be ignored");
+        resourceManager.createResource(extensionContext, false, KafkaRebalanceTemplates.kafkaRebalance(testStorage.getClusterName())
+            .editMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .editSpec()
+                .withGoals("DiskCapacityGoal", "CpuCapacityGoal",
+                    "NetworkInboundCapacityGoal", "MinTopicLeadersPerBrokerGoal",
+                    "NetworkOutboundCapacityGoal", "ReplicaCapacityGoal")
+                .withSkipHardGoalCheck(true)
+                // skip sanity check: because of removal 'RackAwareGoal'
+            .endSpec()
+            .build());
+
+        KafkaUtils.waitForClusterStability(testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        LOGGER.info("Checking if KafkaRebalance is still ignored, after the cluster stability wait");
+
+        // because KR is ignored, it shouldn't contain any status
+        assertNull(KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus());
+
+        LOGGER.info("Adding {} selector of {} to Kafka", SECOND_CO_SELECTOR, SECOND_CO_NAME);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> kafka.getMetadata().setLabels(SECOND_CO_SELECTOR), testStorage.getNamespaceName());
+
+        LOGGER.info("Waiting for Kafka to scales pods to {}", scaleTo);
+        RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), kafkaSelector, scaleTo);
+
+        assertThat(PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaSelector).size(), is(scaleTo));
+
+        KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND, testStorage.getNamespaceName(), testStorage.getClusterName()), testStorage.getNamespaceName(), testStorage.getClusterName());
+
+        LOGGER.info("Verifying that operands are operated by expected Cluster Operator {}", FIRST_CO_NAME);
+        MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(secondCoMetricsCollector, KafkaRebalance.RESOURCE_KIND, 1);
+        MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(secondCoMetricsCollector, Kafka.RESOURCE_KIND, 1);
     }
 
     private MetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace) {
@@ -216,67 +341,6 @@ public class MultipleClusterOperatorsIsolatedST extends AbstractST {
             .build();
 
         return clusterOperatorCollector;
-    }
-
-    @IsolatedTest
-    @Tag(CRUISE_CONTROL)
-    @KRaftNotSupported("The scaling of the Kafka pods is not working properly at the moment")
-    void testKafkaCCAndRebalanceWithMultipleCOs(ExtensionContext extensionContext) {
-        String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
-        LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
-
-        int scaleTo = 4;
-
-        deployCOInNamespace(extensionContext, FIRST_CO_NAME, DEFAULT_NAMESPACE, List.of(FIRST_CO_SELECTOR_ENV, FIRST_CO_LEASE_NAME_ENV), false);
-        deployCOInNamespace(extensionContext, SECOND_CO_NAME, DEFAULT_NAMESPACE, List.of(SECOND_CO_SELECTOR_ENV, SECOND_CO_LEASE_NAME_ENV), false);
-
-        LOGGER.info("Deploying Kafka with {} selector of {}", FIRST_CO_SELECTOR, FIRST_CO_NAME);
-
-        resourceManager.createResource(extensionContext, KafkaTemplates.kafkaWithCruiseControl(clusterName, 3, 3)
-            .editOrNewMetadata()
-                .addToLabels(FIRST_CO_SELECTOR)
-                .withNamespace(DEFAULT_NAMESPACE)
-            .endMetadata()
-            .build());
-
-        LOGGER.info("Removing CR selector from Kafka and increasing number of replicas to 4, new pod should not appear");
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
-            kafka.getMetadata().getLabels().clear();
-            kafka.getSpec().getKafka().setReplicas(scaleTo);
-        }, DEFAULT_NAMESPACE);
-
-        // because KafkaRebalance is pointing to Kafka with CC cluster, we need to create KR before adding the label back
-        // to test if KR will be ignored
-        LOGGER.info("Creating KafkaRebalance when CC doesn't have label for CO, the KR should be ignored");
-        resourceManager.createResource(extensionContext, false, KafkaRebalanceTemplates.kafkaRebalance(clusterName)
-            .editMetadata()
-                .withNamespace(DEFAULT_NAMESPACE)
-            .endMetadata()
-            .editSpec()
-                .withGoals("DiskCapacityGoal", "CpuCapacityGoal",
-                    "NetworkInboundCapacityGoal", "MinTopicLeadersPerBrokerGoal",
-                    "NetworkOutboundCapacityGoal", "ReplicaCapacityGoal")
-                .withSkipHardGoalCheck(true)
-                // skip sanity check: because of removal 'RackAwareGoal'
-            .endSpec()
-            .build());
-
-        KafkaUtils.waitForClusterStability(DEFAULT_NAMESPACE, clusterName);
-
-        LOGGER.info("Checking if KafkaRebalance is still ignored, after the cluster stability wait");
-
-        // because KR is ignored, it shouldn't contain any status
-        assertNull(KafkaRebalanceResource.kafkaRebalanceClient().inNamespace(DEFAULT_NAMESPACE).withName(clusterName).get().getStatus());
-
-        LOGGER.info("Adding {} selector of {} to Kafka", SECOND_CO_SELECTOR, SECOND_CO_NAME);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> kafka.getMetadata().setLabels(SECOND_CO_SELECTOR), DEFAULT_NAMESPACE);
-
-        LOGGER.info("Waiting for Kafka to scales pods to {}", scaleTo);
-        RollingUpdateUtils.waitForComponentAndPodsReady(DEFAULT_NAMESPACE, kafkaSelector, scaleTo);
-
-        assertThat(PodUtils.podSnapshot(DEFAULT_NAMESPACE, kafkaSelector).size(), is(scaleTo));
-
-        KafkaRebalanceUtils.doRebalancingProcess(new Reconciliation("test", KafkaRebalance.RESOURCE_KIND, DEFAULT_NAMESPACE, clusterName), DEFAULT_NAMESPACE, clusterName);
     }
 
     void deployCOInNamespace(ExtensionContext extensionContext, String coName, String coNamespace, List<EnvVar> extraEnvs, boolean multipleNamespaces) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Documentation of tests
Addition of metric scrapers and extra asserts regarding which operator operates which operand. 
Refactor to use TestStorage instead of local variables with names.  

### Checklist
Test sometimes fails on diffent problem connected to Cruise Control (but this happens even without this refactor). 

running correctly with FeatureGates (kraft and StableConnectIdentities) and without both Minikube and Openstack.   

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles


