### PR TITLE
Make sure MM2 examples work regardless the `min.insync.replicas` setting on the Kafka cluster

### DIFF
--- a/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
+++ b/packaging/examples/metrics/kafka-mirror-maker-2-metrics.yaml
@@ -14,23 +14,27 @@ spec:
     - alias: "my-cluster-target"
       bootstrapServers: my-cluster-target-kafka-bootstrap:9092
       config:
-        config.storage.replication.factor: 1
-        offset.storage.replication.factor: 1
-        status.storage.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        config.storage.replication.factor: -1
+        offset.storage.replication.factor: -1
+        status.storage.replication.factor: -1
   mirrors:
     - sourceCluster: "my-cluster-source"
       targetCluster: "my-cluster-target"
       sourceConnector:
         config:
-          replication.factor: 1
-          offset-syncs.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          replication.factor: -1
+          offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
       heartbeatConnector:
         config:
-          heartbeats.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          heartbeats.topic.replication.factor: -1
       checkpointConnector:
         config:
-          checkpoints.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          checkpoints.topic.replication.factor: -1
       topicsPattern: ".*"
       groupsPattern: ".*"
   metricsConfig:

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -22,14 +22,16 @@ spec:
     sourceConnector:
       tasksMax: 1
       config:
-        replication.factor: 1
-        offset-syncs.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        replication.factor: -1
+        offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
     checkpointConnector:
       tasksMax: 1
       config:
-        checkpoints.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        checkpoints.topic.replication.factor: -1
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -22,13 +22,14 @@ spec:
     sourceConnector:
       tasksMax: 1
       config:
-        replication.factor: 1
-        offset-syncs.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        replication.factor: -1
+        offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
     checkpointConnector:
       tasksMax: 1
       config:
-        checkpoints.topic.replication.factor: 1
+        checkpoints.topic.replication.factor: -1
         sync.group.offsets.enabled: "true"
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -30,12 +30,13 @@ spec:
     sourceConnector:
       tasksMax: 1
       config:
-        replication.factor: 1
-        offset-syncs.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        replication.factor: -1
+        offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
     checkpointConnector:
       tasksMax: 1
       config:
-        checkpoints.topic.replication.factor: 1
+        checkpoints.topic.replication.factor: -1
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
@@ -22,12 +22,14 @@ spec:
     sourceConnector:
       tasksMax: 1
       config:
-        replication.factor: 1
-        offset-syncs.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        replication.factor: -1
+        offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
     checkpointConnector:
       tasksMax: 1
       config:
-        checkpoints.topic.replication.factor: 1
+        # -1 means it will use the default replication factor configured in the broker
+        checkpoints.topic.replication.factor: -1
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -257,13 +257,15 @@ spec:
       sourceConnector:
         tasksMax: 1
         config:
-          replication.factor: 1
-          offset-syncs.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          replication.factor: -1
+          offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
       checkpointConnector:
         tasksMax: 1
         config:
-          checkpoints.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
       topicsPattern: ".*"
       groupsPattern: ".*"

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -248,13 +248,15 @@ spec:
       sourceConnector:
         tasksMax: 1
         config:
-          replication.factor: 1
-          offset-syncs.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          replication.factor: -1
+          offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
       checkpointConnector:
         tasksMax: 1
         config:
-          checkpoints.topic.replication.factor: 1
+          # -1 means it will use the default replication factor configured in the broker
+          checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
       topicsPattern: ".*"
       groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In our Mirror Maker 2 examples, we currently set the number of replicas for the Connect part to `-1` to use the default replication factor from the Kafka cluster:

```
      config.storage.replication.factor: -1
      offset.storage.replication.factor: -1
      status.storage.replication.factor: -1
```

But at the same time, we set the `replication.factor` in the connector configurations to simply `1`. So when a user tries the example against the Kafka cluster which has `default.replication.factor: 3` and `min.insync.replicas: 2`, the topics will be created with RF=1 and the minimum number of in-sync replicas of 2. Such a topic will never work.

This PR updates the examples to use `-1` in the connector configurations as well to use the default replication factor of the Kafka cluster. That should make it work even in such situations.

After the release, this should be also updated in the OLM examples which are part of the CSV submission.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally