### PR TITLE
update prometheus operation doc

### DIFF
--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
@@ -32,7 +32,7 @@ The following resources are defined on deployment:
 
 .Procedure
 
-. Update the `alert-manager-config.yaml` file in the `examples/metrics/prometheus-alertmanager-config` directory to replace the:
+. Update the `alert-manager-config.yaml` file in the `examples/metrics/prometheus-alertmanager-config` directory to replace the following:
 +
 * `slack_api_url` property with the actual value of the Slack API URL related to the application for the Slack workspace
 * `channel` property with the actual Slack channel on which to send notifications

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-alertmanager.adoc
@@ -32,15 +32,15 @@ The following resources are defined on deployment:
 
 .Procedure
 
-. Create a `Secret` resource from the Alertmanager configuration file (`alert-manager-config.yaml` in the `examples/metrics/prometheus-alertmanager-config` directory):
-+
-[source,shell,subs="+quotes,attributes"]
-kubectl apply -f alert-manager-config.yaml
-
-. Update the `alert-manager-config.yaml` file to replace the:
+. Update the `alert-manager-config.yaml` file in the `examples/metrics/prometheus-alertmanager-config` directory to replace the:
 +
 * `slack_api_url` property with the actual value of the Slack API URL related to the application for the Slack workspace
 * `channel` property with the actual Slack channel on which to send notifications
+
+. Create a `Secret` resource from the Alertmanager configuration file:
++
+[source,shell,subs="+quotes,attributes"]
+kubectl apply -f alert-manager-config.yaml
 
 . Deploy Alertmanager:
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -12,22 +12,25 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 
 . Download the `bundle.yaml` resources file from the repository.
 +
+[source,shell,subs="+quotes,attributes+"]
+curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml > prometheus-operator-deployment.yaml
++
+ifdef::Downloading[]
+** Use the latest `master` release as shown, or choose a release that is compatible with your version of Kubernetes (see the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix]).
+The `master` release of the Prometheus Operator works with Kubernetes 1.18+.
+endif::Downloading[]
++
+** Update the namespace by replacing the example `my-namespace` with your own
++
 On Linux, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
+sed -E -i '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' prometheus-operator-deployment.yaml
 +
 On MacOS, use:
 +
 [source,shell,subs="+quotes,attributes+"]
-curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml | sed -e '' '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' > prometheus-operator-deployment.yaml
-+
-** Replace the example `namespace` with your own.
-+
-ifdef::Downloading[]
-** Use the latest `master` release as shown, or choose a release that is compatible with your version of Kubernetes (see the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix]). 
-The `master` release of the Prometheus Operator works with Kubernetes 1.18+.
-endif::Downloading[]
+sed -i '' -e '/[[:space:]]\*namespace: [a-zA-Z0-9-]*$/s/namespace:[[:space:]]\*[a-zA-Z0-9-]*$/namespace: _my-namespace_/' prometheus-operator-deployment.yaml
 +
 NOTE: If using OpenShift, specify a release of the link:https://github.com/openshift/prometheus-operator[OpenShift fork^] of the Prometheus Operator repository.
 

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus-operator.adoc
@@ -10,17 +10,15 @@ To deploy the Prometheus Operator to your Kafka cluster, apply the YAML bundle r
 
 .Procedure
 
-. Download the `bundle.yaml` resources file from the repository.
+. Download the `bundle.yaml` resources file from the repository:
 +
 [source,shell,subs="+quotes,attributes+"]
 curl -s https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml > prometheus-operator-deployment.yaml
 +
-ifdef::Downloading[]
 ** Use the latest `master` release as shown, or choose a release that is compatible with your version of Kubernetes (see the https://github.com/coreos/kube-prometheus#kubernetes-compatibility-matrix[Kubernetes compatibility matrix]).
 The `master` release of the Prometheus Operator works with Kubernetes 1.18+.
-endif::Downloading[]
 +
-** Update the namespace by replacing the example `my-namespace` with your own
+** Update the namespace by replacing the example `my-namespace` with your own.
 +
 On Linux, use:
 +

--- a/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
+++ b/documentation/modules/metrics/proc_metrics-deploying-prometheus.adoc
@@ -57,7 +57,7 @@ The Prometheus Operator does not have a monitoring resource like `PodMonitor` fo
 [source,shell,subs="+quotes,attributes"]
 kubectl apply -f prometheus-additional.yaml
 
-.. Edit the `additionalScrapeConfigs` property in the `prometheus.yaml` file to include the name of the `Secret` and the `prometheus-additional.yaml` file.
+.. Edit the `additionalScrapeConfigs` property in the `prometheus.yaml` file to include the name of the `Secret` in the `prometheus-additional.yaml` file.
 
 . Deploy the Prometheus resources:
 +


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

1. We asked users to apply the `alert-manager-config.yaml` and then update the content, which is not correct
2. In macOS, The Prometheus installation command with `sed` command to update the namespace won't work. Update it
3. fix typo

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

