### PR TITLE
Correct CRD operator delete predicate, increase test timeout

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -306,7 +306,8 @@ public class Main {
             Future.all(futures).onComplete(res -> {
                 if (res.succeeded())    {
                     returnPromise.complete();
-                } else  {
+                } else {
+                    LOGGER.error("Failed to create Cluster Roles.", res.cause());
                     returnPromise.fail("Failed to create Cluster Roles.");
                 }
             });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -319,11 +319,16 @@ public class StrimziPodSetControllerIT {
             // Delete the PodSet
             podSetOp().inNamespace(NAMESPACE).withName(podSetName).delete();
 
-            // Check that pod is deleted after pod set deletion
+            /*
+             * Check that pod is deleted after pod set deletion
+             *
+             * The CR finalizer removal does not complete in a consistent amount of time,
+             * therefore the timeout for waiting on the deletion is increased to 1 minute.
+             */
             TestUtils.waitFor(
                     "Wait for Pod to be deleted",
                     100,
-                    10_000,
+                    60_000,
                     () -> client.pods().inNamespace(NAMESPACE).withName(podName).get() == null,
                     () -> context.failNow("Test timed out waiting for pod deletion!"));
 
@@ -655,11 +660,16 @@ public class StrimziPodSetControllerIT {
             // Delete the PodSet in non-cascading way
             podSetOp().inNamespace(NAMESPACE).withName(podSetName).withPropagationPolicy(DeletionPropagation.ORPHAN).delete();
 
-            // Check that the PodSet is deleted
+            /*
+             * Check that the PodSet is deleted
+             *
+             * The CR finalizer removal does not complete in a consistent amount of time,
+             * therefore the timeout for waiting on the deletion is increased to 1 minute.
+             */
             TestUtils.waitFor(
                     "Wait for StrimziPodSet deletion",
                     100,
-                    10_000,
+                    60_000,
                     () -> {
                         StrimziPodSet podSet = podSetOp().inNamespace(NAMESPACE).withName(podSetName).get();
                         return podSet == null;

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -74,11 +74,11 @@ public class CrdOperator<C extends KubernetesClient,
             "deleted",
             1_000,
             deleteTimeoutMs(),
-            () -> resourceOp.get() != null);
+            () -> resourceOp.get() == null);
 
         Future<Void> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L));
 
-        return Future.join(watchForDeleteFuture, deleteFuture).map(ReconcileResult.deleted());
+        return Future.all(watchForDeleteFuture, deleteFuture).map(ReconcileResult.deleted());
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/CrdOperator.java
@@ -78,7 +78,7 @@ public class CrdOperator<C extends KubernetesClient,
             "deleted",
             1_000,
             deleteTimeoutMs(),
-            () -> resourceOp.get() != null)
+            () -> resourceOp.get() == null)
             .toCompletableFuture();
 
         CompletableFuture<Void> deleteFuture = resourceSupport.deleteAsync(resourceOp.withPropagationPolicy(cascading ? DeletionPropagation.FOREGROUND : DeletionPropagation.ORPHAN).withGracePeriod(-1L))

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperatorTest.java
@@ -296,13 +296,17 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
     @Test
     public void testReconcileDeleteWhenResourceExistsStillDeletes(VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
-        when(mockDeletable.delete()).thenReturn(List.of());
+        AtomicBoolean resourceDeleted = new AtomicBoolean(false);
+        when(mockDeletable.delete()).thenAnswer(args -> {
+            resourceDeleted.set(true);
+            return List.of();
+        });
         GracePeriodConfigurable mockDeletableGrace = mock(GracePeriodConfigurable.class);
         when(mockDeletableGrace.delete()).thenReturn(List.of());
 
         T resource = resource();
         Resource mockResource = mock(resourceType());
-        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.get()).thenAnswer(args -> resourceDeleted.get() ? null : resource);
         when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
         when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
         AtomicBoolean watchClosed = new AtomicBoolean(false);
@@ -336,13 +340,17 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
     @Test
     public void testReconcileDeletionSuccessfullyDeletes(VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
-        when(mockDeletable.delete()).thenReturn(List.of());
+        AtomicBoolean resourceDeleted = new AtomicBoolean(false);
+        when(mockDeletable.delete()).thenAnswer(args -> {
+            resourceDeleted.set(true);
+            return List.of();
+        });
         GracePeriodConfigurable mockDeletableGrace = mock(GracePeriodConfigurable.class);
         when(mockDeletableGrace.delete()).thenReturn(List.of());
 
         T resource = resource();
         Resource mockResource = mock(resourceType());
-        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.get()).thenAnswer(args -> resourceDeleted.get() ? null : resource);
         when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
         when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
         AtomicBoolean watchClosed = new AtomicBoolean(false);
@@ -417,13 +425,17 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
     @SuppressWarnings("unchecked")
     public void testReconcileDeleteDoesNotThrowWhenDeletionReturnsFalse(VertxTestContext context) {
         Deletable mockDeletable = mock(Deletable.class);
-        when(mockDeletable.delete()).thenReturn(List.of());
+        AtomicBoolean resourceDeleted = new AtomicBoolean(false);
+        when(mockDeletable.delete()).thenAnswer(args -> {
+            resourceDeleted.set(true);
+            return List.of();
+        });
         GracePeriodConfigurable mockDeletableGrace = mock(GracePeriodConfigurable.class);
         when(mockDeletableGrace.delete()).thenReturn(List.of());
 
         T resource = resource();
         Resource mockResource = mock(resourceType());
-        when(mockResource.get()).thenReturn(resource);
+        when(mockResource.get()).thenAnswer(args -> resourceDeleted.get() ? null : resource);
         when(mockResource.withPropagationPolicy(eq(DeletionPropagation.FOREGROUND))).thenReturn(mockDeletableGrace);
         when(mockDeletableGrace.withGracePeriod(anyLong())).thenReturn(mockDeletable);
         AtomicBoolean watchClosed = new AtomicBoolean(false);
@@ -518,7 +530,11 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
 
         // For resource1 we need to mock the async deletion process as well
         Deletable mockDeletable1 = mock(Deletable.class);
-        when(mockDeletable1.delete()).thenReturn(List.of());
+        AtomicBoolean resource1Deleted = new AtomicBoolean(false);
+        when(mockDeletable1.delete()).thenAnswer(args -> {
+            resource1Deleted.set(true);
+            return List.of();
+        });
         GracePeriodConfigurable mockDeletableGrace1 = mock(GracePeriodConfigurable.class);
         when(mockDeletableGrace1.withGracePeriod(anyLong())).thenReturn(mockDeletable1);
         Resource mockResource1 = mock(resourceType());
@@ -527,7 +543,7 @@ public abstract class AbstractNamespacedResourceOperatorTest<C extends Kubernete
         when(mockResource1.get()).thenAnswer(invocation -> {
             // First get needs to return the resource to trigger deletion
             // Next gets return null since the resource was already deleted
-            if (watchCreated.get()) {
+            if (watchCreated.get() || resource1Deleted.get()) {
                 return null;
             } else {
                 return resource1;

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperatorIT.java
@@ -123,7 +123,7 @@ public abstract class AbstractNamespacedResourceOperatorIT<
                     "resource deletion " + resourceName,
                     "deleted",
                     1000,
-                    30_000,
+                    60_000,
                     () -> op.get(namespace, resourceName) == null))
             .thenRun(() -> {
                 assertThat(op.get(namespace, resourceName), is(nullValue()));


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~
- ~~Documentation~~

### Description

Fixes #8526 

I am unable to confirm the fix with MacOS/aarch64 myself, however.

- Correct the CRD operator's delete `waitFor` predicate to complete when the resource being deleted is missing. 
- Adjust test mocks to account for the above change.
- Increase the timeout for a test dealing with updates to a CR following it being deleted. The amount of time for the `orphan` finalizer to be handled and the resource fully deleted seems to vary significantly between runs. Increasing the timeout to 1 minute appears to be sufficient to allow it to succeed consistently.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

