### PR TITLE
[systemtest] Fix `FeatureGatesIsolatedST#testSwitchingConnectStabilityIdentifiesFeatureGateOnAndOff`

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -60,7 +60,8 @@ public class KafkaConnectUtils {
     public static void waitForMessagesInKafkaConnectFileSink(String namespaceName, String kafkaConnectPodName, String sinkFileName, String message) {
         LOGGER.info("Waiting for messages in file sink on {}", kafkaConnectPodName);
         TestUtils.waitFor("messages in file sink", Constants.GLOBAL_POLL_INTERVAL, Constants.TIMEOUT_FOR_SEND_RECEIVE_MSG,
-            () -> cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message));
+            () -> cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message),
+            () -> LOGGER.warn(cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out()));
         LOGGER.info("Expected messages are in file sink on {}", kafkaConnectPodName);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -162,7 +162,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         final TestStorage testStorage = new TestStorage(extensionContext);
         final int connectReplicas = 1;
-        final int messageCount = 500;
+        final int messageCount = 1000;
         List<EnvVar> coEnvVars = new ArrayList<>();
 
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "-StableConnectIdentities", null));
@@ -180,7 +180,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
 
         resourceManager.createResource(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 1).build());
         resourceManager.createResource(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName()).build());
-        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getClusterName(), testStorage.getNamespaceName(), connectReplicas)
+        resourceManager.createResource(extensionContext, KafkaConnectTemplates.kafkaConnectWithFilePlugin(testStorage.getClusterName(), clusterOperator.getDeploymentNamespace(), connectReplicas)
                 .editMetadata()
                     .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
                 .endMetadata()
@@ -205,19 +205,25 @@ public class FeatureGatesIsolatedST extends AbstractST {
         Map<String, String> coPod = DeploymentUtils.depSnapshot(clusterOperator.getDeploymentNamespace(), ResourceManager.getCoDeploymentName());
 
         final LabelSelector connectLabelSelector = KafkaConnectResource.getLabelSelector(testStorage.getClusterName(), KafkaConnectResources.deploymentName(testStorage.getClusterName()));
-        Map<String, String> connectPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), connectLabelSelector);
+        Map<String, String> connectPods = PodUtils.podSnapshot(clusterOperator.getDeploymentNamespace(), connectLabelSelector);
 
         KafkaClients clients = new KafkaClientsBuilder()
-                .withProducerName(testStorage.getProducerName())
-                .withConsumerName(testStorage.getConsumerName())
-                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-                .withTopicName(testStorage.getTopicName())
-                .withMessageCount(messageCount)
-                .withDelayMs(500)
-                .withNamespaceName(clusterOperator.getDeploymentNamespace())
-                .build();
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(messageCount)
+            .withDelayMs(500)
+            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .build();
 
+        String connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), testStorage.getClusterName() + "-connect").get(0).getMetadata().getName();
+
+        // we are sending messages continuously throughout the test to check that connector is working
         resourceManager.createResource(extensionContext, clients.producerStrimzi());
+
+        LOGGER.info("Verifying that KafkaConnector is able to sink the messages to the file-sink file");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world");
 
         LOGGER.info("Changing FG env variable to enable Stable Connect Identities");
         coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -231,6 +237,11 @@ public class FeatureGatesIsolatedST extends AbstractST {
         connectPods = RollingUpdateUtils.waitTillComponentHasRolled(clusterOperator.getDeploymentNamespace(), connectLabelSelector, connectReplicas, connectPods);
         KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), testStorage.getClusterName());
 
+        connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), testStorage.getClusterName() + "-connect").get(0).getMetadata().getName();
+
+        LOGGER.info("Verifying that KafkaConnector is able to sink the messages to the file-sink file");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world");
+
         LOGGER.info("Changing FG env variable to disable again Stable Connect Identities");
         coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-StableConnectIdentities");
 
@@ -242,8 +253,9 @@ public class FeatureGatesIsolatedST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(clusterOperator.getDeploymentNamespace(), connectLabelSelector, connectReplicas, connectPods);
         KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), testStorage.getClusterName());
 
-        final String connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), testStorage.getClusterName() + "-connect").get(0).getMetadata().getName();
+        connectorPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), testStorage.getClusterName() + "-connect").get(0).getMetadata().getName();
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
+        LOGGER.info("Verifying that KafkaConnector is able to sink the messages to the file-sink file");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, Constants.DEFAULT_SINK_FILE_PATH, "Hello-world");
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This small PR fixes a flaky check inside the `testSwitchingConnectStabilityIdentifiesFeatureGateOnAndOff` that we are hitting in AZP and Jenkins.
The problem is that when we are continuously sending messages to the KafkaTopic, from where the FileSink connector sinks the messages to the specified file, we can hit situations when all messages were already sent and the offset was committed before last RU of the Connect Pod, thus losing all the records.

This PR adds checks between the RUs if the Connector is working and file (which "collects" the messages) contains a record from the sent message.
Also, I added the `warn` log when the `waitForMessagesInKafkaConnectFileSink` fails, so we know exactly what records the file-sink file contains.

Note: we are not waiting for all messages to be sent, as we are testing that the connector is working after the RUs, not if it consumes all the messages.

### Checklist

- [ ] Make sure all tests pass
