### PR TITLE
Fix tmt plan stage naming due to new version of testing-farm

### DIFF
--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -47,7 +47,7 @@ prepare:
       if [[ $ARCH == "aarch64" ]]; then ARCH="arm64"; fi
       ./.azure/scripts/install_yq.sh ${ARCH}
 
-  - name: Install oc/kubectl
+  - name: Install oc kubectl client
     how: shell
     script: |
       PLATFORM=$(uname -m)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After new version of TF release with new TMT we hit a regression where naming of steps in tmt plan like `foo/bar`is not allowed. This fix remove `/` from step name.
 

