### PR TITLE
Add warning conditions tot he Kafka CR if PVCs cannot be resized because of Storage Class

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -257,7 +257,7 @@ public class KafkaReconciler {
                 .compose(i -> manualPodCleaning())
                 .compose(i -> networkPolicy())
                 .compose(i -> manualRollingUpdate())
-                .compose(i -> pvcs())
+                .compose(i -> pvcs(kafkaStatus))
                 .compose(i -> serviceAccount())
                 .compose(i -> initClusterRoleBinding())
                 .compose(i -> scaleDown())
@@ -460,13 +460,15 @@ public class KafkaReconciler {
      * Manages the PVCs needed by the Kafka cluster. This method only creates or updates the PVCs. Deletion of PVCs
      * after scale-down happens only at the end of the reconciliation when they are not used anymore.
      *
+     * @param kafkaStatus   Status of the Kafka custom resource where warnings about any issues with resizing will be added
+     *
      * @return  Completes when the PVCs were successfully created or updated
      */
-    protected Future<Void> pvcs() {
+    protected Future<Void> pvcs(KafkaStatus kafkaStatus) {
         List<PersistentVolumeClaim> pvcs = kafka.generatePersistentVolumeClaims();
 
         return new PvcReconciler(reconciliation, pvcOperator, storageClassOperator)
-                .resizeAndReconcilePvcs(podIndex -> KafkaResources.kafkaPodName(reconciliation.name(), podIndex), pvcs)
+                .resizeAndReconcilePvcs(kafkaStatus, podIndex -> KafkaResources.kafkaPodName(reconciliation.name(), podIndex), pvcs)
                 .compose(podsToRestart -> {
                     fsResizingRestartRequest.addAll(podsToRestart);
                     return Future.succeededFuture();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When a user tries to resize the storage but it is not supported due to a storage class (e.g. missing Storage Class or Storage Class which does not support resizing), we issue warnings into logs. But those might be easy to miss for the users. So this PR adds in addition warning conditions to the Kafka CR:

```
    - lastTransitionTime: "2023-06-24T14:49:35.098095357Z"
      message: Storage Class standard does not support resizing of volumes. PVC data-0-my-cluster-kafka-0
        cannot be resized.
      reason: PvcResizingWarning
      status: "True"
      type: Warning
```

This should help to make sure users are aware of the issue.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally