### PR TITLE
Fixed s390x specific local registry push error

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -89,7 +89,14 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
       set -ex
     fi
 
-    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
+    if [ "$ARCH" = "s390x" ]; then
+        git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git
+        sed -i 's/:1.11/:1.22.1/' kubernetes/cluster/addons/registry/images/Dockerfile
+        docker build --pull -t gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH} kubernetes/cluster/addons/registry/images/
+        minikube image load ${ARCH}/registry:2.8.0-beta.1 gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}
+        minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.0-beta.1,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
+        rm -rf kubernetes
+    elif [[ "$ARCH" = "ppc64le" ]]; then
         git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git
         sed -i 's/:1.11//' kubernetes/cluster/addons/registry/images/Dockerfile
         docker build --pull -t gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH} kubernetes/cluster/addons/registry/images/

--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -93,8 +93,8 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git
         sed -i 's/:1.11/:1.22.1/' kubernetes/cluster/addons/registry/images/Dockerfile
         docker build --pull -t gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH} kubernetes/cluster/addons/registry/images/
-        minikube image load ${ARCH}/registry:2.8.0-beta.1 gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}
-        minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.0-beta.1,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
+        minikube image load ${ARCH}/registry:2.8.2 gcr.io/google_containers/kube-registry-proxy:0.4-${ARCH}
+        minikube addons enable registry --images="Registry=${ARCH}/registry:2.8.2,KubeRegistryProxy=google_containers/kube-registry-proxy:0.4-${ARCH}"
         rm -rf kubernetes
     elif [[ "$ARCH" = "ppc64le" ]]; then
         git clone -b v1.9.11 --depth 1 https://github.com/kubernetes/kubernetes.git


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

When building docker image as follows
`docker buildx build  --platform linux/s390x --load --build-arg strimzi_version=0.36.0-SNAPSHOT -t strimzi/operator:latest ./`
Below docker registry push error observed

` Also tag with jenkins-strimzi-kafka-operator-Strimzi_Kafka_Operator_ST-519
docker tag strimzi/operator:latest strimzi/operator:jenkins-strimzi-kafka-operator-Strimzi_Kafka_Operator_ST-519
 Pull dependencies first
 Tag the jenkins-strimzi-kafka-operator-Strimzi_Kafka_Operator_ST-519 image we built with the given pr tag
docker tag strimzi/operator:jenkins-strimzi-kafka-operator-Strimzi_Kafka_Operator_ST-519 localhost:5000/strimzi/operator:pr
 Push the pr-tagged image to the registry
docker push localhost:5000/strimzi/operator:pr
The push refers to repository [localhost:5000/strimzi/operator]
Get "http://localhost:5000/v2/": EOF
make[1]: *** [../../Makefile.docker:41: docker_push_default] Error 1
make[1]: Leaving directory '/home/jenkins/workspace/strimzi-kafka-operator/Strimzi_Kafka_Operator_ST/docker-images/operator'
make: *** [Makefile:180: docker-images/operator] Error 2`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

