### PR TITLE
Fix nslookup resolving ZooKeeper pod IP address as 127.0.0.1

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -44,7 +44,7 @@ if [ -z "$ZOOKEEPER_DNS_CHECKS_DISABLED" ] || [ "$ZOOKEEPER_DNS_CHECKS_DISABLED"
   echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."
   ipaddress=$(nslookup "${BASE_HOSTNAME}"-$((ZOOKEEPER_ID-1))."${BASE_FQDN}" | grep "Address" | awk '{print $2}' | sed -n 2p)
 
-  # check IP address is resolved and not 127.0.0.1, we want a Cluster IP one
+  # check IP address is resolved and not 127.0.0.1, we want a "valid" Pod one
   while [ -z "$ipaddress" ] || [ "$ipaddress" = "127.0.0.1" ]; do
     sleep 1
     echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -44,7 +44,8 @@ if [ -z "$ZOOKEEPER_DNS_CHECKS_DISABLED" ] || [ "$ZOOKEEPER_DNS_CHECKS_DISABLED"
   echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."
   ipaddress=$(nslookup "${BASE_HOSTNAME}"-$((ZOOKEEPER_ID-1))."${BASE_FQDN}" | grep "Address" | awk '{print $2}' | sed -n 2p)
 
-  while [ -z "$ipaddress" ]; do
+  # check IP address is resolved and not 127.0.0.1, we want a Cluster IP one
+  while [ -z "$ipaddress" ] || [ "$ipaddress" = "127.0.0.1" ]; do
     sleep 1
     echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."
     ipaddress=$(nslookup "${BASE_HOSTNAME}"-$((ZOOKEEPER_ID-1))."${BASE_FQDN}" | grep "Address" | awk '{print $2}' | sed -n 2p)


### PR DESCRIPTION
After adding the DNS name resolution check on the ZooKeeper pods via `nslookup`, I noticed that it can return `127.0.0.1` as an early resolution. It takes more time to get a "valid" Pod IP.
This would unlock the ZooKeeper application to start but then trying to bind the quorum port to 127.0.0.1 which, of course, makes the ensamble not working.
This PR adds an additional check that during `nslookup` DNS name resolution, the IP address has to be different from `127.0.0.1`.