### PR TITLE
Log a warning when a KafkaTopic has no spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add support for _Kafka node pools_ according to [Strimzi Proposal #50](https://github.com/strimzi/proposals/blob/main/050-Kafka-Node-Pools.md)
 * Update OpenTelemetry 1.19.0
 * Fixed ordering of JVM performance options [#8579](https://github.com/strimzi/strimzi-kafka-operator/issues/8579)
+* Log a warning when a KafkaTopic has no spec [#8465](https://github.com/strimzi/strimzi-kafka-operator/issues/8465)
 
 ### Changes, deprecations and removals
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -49,8 +49,8 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
     public void eventReceived(Action action, KafkaTopic kafkaTopic) {
         ObjectMeta metadata = kafkaTopic.getMetadata();
         Map<String, String> labels = metadata.getLabels();
+        LogContext logContext = LogContext.kubeWatch(action, kafkaTopic).withKubeTopic(kafkaTopic);
         if (kafkaTopic.getSpec() != null) {
-            LogContext logContext = LogContext.kubeWatch(action, kafkaTopic).withKubeTopic(kafkaTopic);
             String name = metadata.getName();
             String kind = kafkaTopic.getKind();
             if (!initReconcileFuture.isComplete()) {
@@ -91,6 +91,8 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                     LOGGER.debugCr(logContext.toReconciliation(), "Ignoring {} to {} {} because metadata.generation==status.observedGeneration", action, kind, name);
                 }
             }
+        } else {
+            LOGGER.warnCr(logContext.toReconciliation(), "Topic {}/{} has no spec", kafkaTopic.getMetadata().getNamespace(), kafkaTopic.getMetadata().getName());
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sTopicWatcher.java
@@ -92,7 +92,7 @@ class K8sTopicWatcher implements Watcher<KafkaTopic> {
                 }
             }
         } else {
-            LOGGER.warnCr(logContext.toReconciliation(), "Topic {}/{} has no spec", kafkaTopic.getMetadata().getNamespace(), kafkaTopic.getMetadata().getName());
+            LOGGER.warnCr(logContext.toReconciliation(), "Topic has no spec");
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicName.java
@@ -39,7 +39,7 @@ class TopicName {
      * @param kafkaTopic  The Kafka Topic
      */
     public TopicName(KafkaTopic kafkaTopic) {
-        this(kafkaTopic.getSpec().getTopicName() != null ? kafkaTopic.getSpec().getTopicName() : kafkaTopic.getMetadata().getName());
+        this(kafkaTopic.getSpec() != null && kafkaTopic.getSpec().getTopicName() != null ? kafkaTopic.getSpec().getTopicName() : kafkaTopic.getMetadata().getName());
     }
 
     /**

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -37,15 +37,8 @@ import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.StringLayout;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.jupiter.api.TestInstance;
 
-import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -624,31 +617,6 @@ public abstract class TopicOperatorBaseIT {
                 .editOrNewSpec().addToConfig(key, newValue).endSpec().build();
         operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
         return newValue;
-    }
-
-    /**
-     * Adds a WriterAppender which writes to a CharArrayWriter to be used for output validation purposes
-     *
-     * @param appenderName
-     * @param outContent
-     * @return
-     */
-    protected LoggerConfig addAppenderForSTDOUTLogger(String appenderName, CharArrayWriter outContent) {
-        StringLayout layout = PatternLayout.newBuilder().withPattern("%msg").build();
-        WriterAppender appender = WriterAppender.newBuilder()
-                .setTarget(outContent)
-                .setLayout(layout)
-                .setName(appenderName).build();
-        appender.start();
-
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        Configuration config = ctx.getConfiguration();
-        config.addAppender(appender);
-
-        LoggerConfig loggerConfig = config.getLoggerConfig("STDOUT");
-        loggerConfig.addAppender(appender, null, null);
-
-        return loggerConfig;
     }
 }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -37,8 +37,15 @@ import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.StringLayout;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.jupiter.api.TestInstance;
 
+import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -617,6 +624,31 @@ public abstract class TopicOperatorBaseIT {
                 .editOrNewSpec().addToConfig(key, newValue).endSpec().build();
         operation().inNamespace(NAMESPACE).withName(resourceName).replace(changedTopic);
         return newValue;
+    }
+
+    /**
+     * Adds a WriterAppender which writes to a CharArrayWriter to be used for output validation purposes
+     *
+     * @param appenderName
+     * @param outContent
+     * @return
+     */
+    protected LoggerConfig addAppenderForSTDOUTLogger(String appenderName, CharArrayWriter outContent){
+        StringLayout layout = PatternLayout.newBuilder().withPattern("%msg").build();
+        WriterAppender appender = WriterAppender.newBuilder()
+                .setTarget(outContent)
+                .setLayout(layout)
+                .setName(appenderName).build();
+        appender.start();
+
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        config.addAppender(appender);
+
+        LoggerConfig loggerConfig = config.getLoggerConfig("STDOUT") ;
+        loggerConfig.addAppender(appender, null, null);
+
+        return loggerConfig;
     }
 }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorBaseIT.java
@@ -633,7 +633,7 @@ public abstract class TopicOperatorBaseIT {
      * @param outContent
      * @return
      */
-    protected LoggerConfig addAppenderForSTDOUTLogger(String appenderName, CharArrayWriter outContent){
+    protected LoggerConfig addAppenderForSTDOUTLogger(String appenderName, CharArrayWriter outContent) {
         StringLayout layout = PatternLayout.newBuilder().withPattern("%msg").build();
         WriterAppender appender = WriterAppender.newBuilder()
                 .setTarget(outContent)
@@ -645,7 +645,7 @@ public abstract class TopicOperatorBaseIT {
         Configuration config = ctx.getConfiguration();
         config.addAppender(appender);
 
-        LoggerConfig loggerConfig = config.getLoggerConfig("STDOUT") ;
+        LoggerConfig loggerConfig = config.getLoggerConfig("STDOUT");
         loggerConfig.addAppender(appender, null, null);
 
         return loggerConfig;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -4,7 +4,21 @@
  */
 package io.strimzi.operator.topic;
 
-import io.fabric8.kubernetes.api.model.*;
+import java.io.CharArrayWriter;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.api.kafka.model.KafkaTopic;
@@ -22,19 +36,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.io.CharArrayWriter;
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import static java.util.Collections.*;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TopicOperatorIT extends TopicOperatorBaseIT {
     private static final Logger LOGGER = LogManager.getLogger(TopicOperatorIT.class);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.topic;
 
-import java.io.CharArrayWriter;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -30,7 +29,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -227,11 +225,6 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
     @Test
     public void testKafkaTopicAddedWithNoSpec() throws InterruptedException, TimeoutException {
-        final String logAppenderName = "WRITER";
-        CharArrayWriter logContent = new CharArrayWriter();
-
-        LoggerConfig loggerConfig = addAppenderForSTDOUTLogger(logAppenderName, logContent);
-
         String topicName = "test-resource-created-with-no-spec";
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
 
@@ -251,10 +244,6 @@ public class TopicOperatorIT extends TopicOperatorBaseIT {
 
             return createdTopicResource != null;
         }, "Expected the kafkatopic to have been created by now");
-
-        assertThat(logContent.toString().contains("Topic " + NAMESPACE + "/" + topicName + " has no spec"), is(true));
-
-        loggerConfig.removeAppender(logAppenderName);
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -151,6 +151,22 @@ public class TopicOperatorTest {
         context.completeNow();
     }
 
+    /** Test what happens when a KafkaTopic with no spec gets created in kubernetes */
+    @Test
+    public void testOnKafkaTopicAdded_nospec(VertxTestContext context) {
+        KafkaTopic kafkaTopic = new KafkaTopicBuilder()
+                .withMetadata(new ObjectMetaBuilder().withName("nospec")
+                        .withNamespace("my-namespace")
+                        .withLabels(labels.labels()).build())
+                .build();
+        K8sTopicWatcher watcher = new K8sTopicWatcher(topicOperator, Future.succeededFuture(), () -> { });
+        watcher.eventReceived(ADDED, kafkaTopic);
+
+        mockKafka.assertEmpty(context);
+        mockTopicStore.assertEmpty(context);
+        context.completeNow();
+    }
+
     /** Test what happens when a non-topic KafkaTopic gets created in kubernetes */
     @Test
     public void testOnKafkaTopicAdded_invalidResource(VertxTestContext context) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -153,7 +153,7 @@ public class TopicOperatorTest {
 
     /** Test what happens when a KafkaTopic with no spec gets created in kubernetes */
     @Test
-    public void testOnKafkaTopicAdded_nospec(VertxTestContext context) {
+    public void testOnKafkaTopicAdded_noSpec(VertxTestContext context) {
         KafkaTopic kafkaTopic = new KafkaTopicBuilder()
                 .withMetadata(new ObjectMetaBuilder().withName("nospec")
                         .withNamespace("my-namespace")


### PR DESCRIPTION
### Type of change

Bugfix

Fixes #8465 

### Description

Please see the related issue: https://github.com/strimzi/strimzi-kafka-operator/issues/8465
Also related discussion: https://github.com/orgs/strimzi/discussions/8463

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
~~- [ ] Update documentation~~
~~- [ ] Check RBAC rights for Kubernetes / OpenShift roles~~
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
~~- [ ] Supply screenshots for visual changes, such as Grafana dashboards~~

### Notes

**NOTE TO REVIEWER:** 
It is not possible to handle the log output in the test context to validate without any problems, so I did the validation manually. I found a few ways which made me create a WriterAppender to write the logs to a Writer, but the maven verification complained this time by saying "dependency problems found" without any detail. This worked, but it could not pass the verification of maven-dependency-plugin

Here is that commit if you are interested, and further discussion if needed: https://github.com/strimzi/strimzi-kafka-operator/pull/8738/commits/8eb23803dcfd2f5867a179360679fa374ac778c2

Here is the complaining maven verification log: https://dev.azure.com/cncf/strimzi/_build/results?buildId=141431&view=logs&j=78df3800-942a-5b94-093f-0e36f8f8252f&t=1166645e-b435-5805-cc4c-2efe8ac57bb6&l=6323

