### PR TITLE
User operator: leverage CrdOperator and SecretOperator

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
@@ -506,4 +506,28 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
     public MixedOperation<T, L, R> client() {
         return operation();
     }
+
+    /**
+     * Returns a Kubernetes client {@linkplain Resource} of this resource
+     * operator's type T for the given resource namespace and name.
+     *
+     * @param namespace namespace of the resource
+     * @param name name of the resource
+     * @return Kubernetes client {@linkplain Resource}
+     */
+    public Resource<T> resource(String namespace, String name) {
+        return operation().inNamespace(namespace).withName(name);
+    }
+
+    /**
+     * Returns a Kubernetes client {@linkplain Resource} of this resource
+     * operator's type T for the given resource namespace and item.
+     *
+     * @param namespace namespace of the resource
+     * @param item instance of the resource
+     * @return Kubernetes client {@linkplain Resource}
+     */
+    public Resource<T> resource(String namespace, T item) {
+        return operation().inNamespace(namespace).resource(item);
+    }
 }

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -78,6 +78,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/user-operator/src/main/java/io/strimzi/operator/user/DESIGN.md
+++ b/user-operator/src/main/java/io/strimzi/operator/user/DESIGN.md
@@ -33,7 +33,7 @@ The metrics are handled from the Micrometer metrics and its Prometheus registry.
 
 The handlers for the different endpoints were originally based on `HttpServlet` classes.
 But this class implements `Serializable` and was causing issues when the servlet handlers were using non-serializable classes such as the `UserController` or `PrometheusMeterRegistry`.
-So instead, the code now uses the Jetty `AbstractHandler` which doe snot implement `Serializable` and does not have this kind od issues.
+So instead, the code now uses the Jetty `AbstractHandler` which does not implement `Serializable` and does not have this kind od issues.
 
 Another issue was that Jetty by default redirects the path without trailing `/` to the path with trailing `/`.
 So for example `/metrics` was always redirected to `/metrics/`.

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.user;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
@@ -14,6 +15,8 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.strimzi.api.kafka.KafkaUserList;
+import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
@@ -22,6 +25,8 @@ import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.http.HealthCheckAndMetricsServer;
+import io.strimzi.operator.common.operator.resource.concurrent.CrdOperator;
+import io.strimzi.operator.common.operator.resource.concurrent.SecretOperator;
 import io.strimzi.operator.user.operator.DisabledSimpleAclOperator;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
 import io.strimzi.operator.user.operator.QuotasOperator;
@@ -34,13 +39,16 @@ import org.apache.logging.log4j.Logger;
 import java.security.Security;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * The main class of the Strimzi User Operator
  */
 public class Main {
-    private final static Logger LOGGER = LogManager.getLogger(Main.class);
+    private static final Logger LOGGER = LogManager.getLogger(Main.class);
 
     /**
      * Main method which starts the webserver with healthchecks and metrics and the UserController which is responsible
@@ -63,18 +71,19 @@ public class Main {
         LOGGER.info("Cluster Operator configuration is {}", config);
 
         // Create KubernetesClient, AdminClient and KafkaUserOperator classes
+        ExecutorService kafkaUserOperatorExecutor = Executors.newFixedThreadPool(config.getUserOperationsThreadPoolSize(), new OperatorWorkThreadFactory());
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-user-operator", Main.class.getPackage().getImplementationVersion()).build();
-        Admin adminClient = createAdminClient(config, client, new DefaultAdminClientProvider());
-        AtomicInteger kafkaUserOperatorExecutorThreadCounter = new AtomicInteger(0);
-        ExecutorService kafkaUserOperatorExecutor = Executors.newFixedThreadPool(config.getUserOperationsThreadPoolSize(), r -> new Thread(r, "operator-thread-pool-" + kafkaUserOperatorExecutorThreadCounter.getAndIncrement()));
+        SecretOperator secretOperator = new SecretOperator(kafkaUserOperatorExecutor, client);
+        Admin adminClient = createAdminClient(config, secretOperator, new DefaultAdminClientProvider());
+
         KafkaUserOperator kafkaUserOperator = new KafkaUserOperator(
                 config,
-                client,
                 new OpenSslCertManager(),
+                secretOperator,
+                new CrdOperator<>(kafkaUserOperatorExecutor, client, KafkaUser.class, KafkaUserList.class, "KafkaUser"),
                 new ScramCredentialsOperator(adminClient, config, kafkaUserOperatorExecutor),
                 new QuotasOperator(adminClient, config, kafkaUserOperatorExecutor),
-                config.isAclsAdminApiSupported() ? new SimpleAclOperator(adminClient, config, kafkaUserOperatorExecutor) : new DisabledSimpleAclOperator(),
-                kafkaUserOperatorExecutor
+                config.isAclsAdminApiSupported() ? new SimpleAclOperator(adminClient, config, kafkaUserOperatorExecutor) : new DisabledSimpleAclOperator()
         );
 
         MetricsProvider metricsProvider = createMetricsProvider();
@@ -82,7 +91,7 @@ public class Main {
         // Create the User controller
         UserController controller = new UserController(
                 config,
-                client,
+                secretOperator,
                 kafkaUserOperator,
                 metricsProvider
         );
@@ -127,16 +136,9 @@ public class Main {
      *
      * @return  An instance of the Admin API client
      */
-    private static Admin createAdminClient(UserOperatorConfig config, KubernetesClient client, AdminClientProvider adminClientProvider)    {
-        Secret clusterCaCert = null;
-        if (config.getClusterCaCertSecretName() != null && !config.getClusterCaCertSecretName().isEmpty()) {
-            clusterCaCert = client.secrets().inNamespace(config.getCaNamespaceOrNamespace()).withName(config.getClusterCaCertSecretName()).get();
-        }
-
-        Secret uoKeyAndCert = null;
-        if (config.getEuoKeySecretName() != null && !config.getEuoKeySecretName().isEmpty()) {
-            uoKeyAndCert = client.secrets().inNamespace(config.getCaNamespaceOrNamespace()).withName(config.getEuoKeySecretName()).get();
-        }
+    private static Admin createAdminClient(UserOperatorConfig config, SecretOperator secretOperator, AdminClientProvider adminClientProvider)    {
+        Secret clusterCaCert = getSecret(secretOperator, config.getCaNamespaceOrNamespace(), config.getClusterCaCertSecretName());
+        Secret uoKeyAndCert = getSecret(secretOperator, config.getCaNamespaceOrNamespace(), config.getEuoKeySecretName());
 
         return adminClientProvider.createAdminClient(
                 config.getKafkaBootstrapServers(),
@@ -147,6 +149,22 @@ public class Main {
     }
 
     /**
+     * Fetch a secret with the given name and namespace using the secretOperator if
+     * the name is present.
+     *
+     * @param secretOperator secret operator to retrieve the secret
+     * @param namespace      namespace of the secret
+     * @param name           name of the secret
+     * @return the secret or null if not found or the name is not given
+     */
+    private static Secret getSecret(SecretOperator secretOperator, String namespace, String name) {
+        if (name != null && !name.isEmpty()) {
+            return secretOperator.get(namespace, name);
+        }
+        return null;
+    }
+
+    /**
      * Creates the MetricsProvider instance based on a PrometheusMeterRegistry and binds the JVM metrics to it
      *
      * @return  MetricsProvider instance
@@ -154,13 +172,30 @@ public class Main {
     private static MetricsProvider createMetricsProvider()  {
         MeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
-        // Bind JVM metrics
-        new ClassLoaderMetrics().bindTo(registry);
-        new JvmMemoryMetrics().bindTo(registry);
-        new JvmGcMetrics().bindTo(registry);
-        new ProcessorMetrics().bindTo(registry);
-        new JvmThreadMetrics().bindTo(registry);
+        /*
+         * Bind JVM metrics. Handled as stream of Suppliers to circumvent checkstyle
+         * error for Class Data Abstraction Coupling by limiting direct instantiations.
+         *
+         * See https://checkstyle.sourceforge.io/checks/metrics/classdataabstractioncoupling.html
+         */
+        Stream.<Supplier<MeterBinder>>of(
+                ClassLoaderMetrics::new,
+                JvmMemoryMetrics::new,
+                JvmGcMetrics::new,
+                ProcessorMetrics::new,
+                JvmThreadMetrics::new)
+            .forEach(binder -> binder.get().bindTo(registry));
 
         return new MicrometerMetricsProvider(registry);
+    }
+
+    private static class OperatorWorkThreadFactory implements ThreadFactory {
+
+        private final AtomicInteger threadCounter = new AtomicInteger(0);
+
+        @Override
+        public Thread newThread(Runnable r) {
+            return new Thread(r, "operator-thread-pool-" + threadCounter.getAndIncrement());
+        }
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
@@ -5,9 +5,11 @@
 package io.strimzi.operator.user;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
+import io.strimzi.api.kafka.KafkaUserList;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InformerUtils;
@@ -22,6 +24,7 @@ import io.strimzi.operator.common.http.Readiness;
 import io.strimzi.operator.common.metrics.ControllerMetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
+import io.strimzi.operator.common.operator.resource.concurrent.CrdOperator;
 import io.strimzi.operator.common.operator.resource.concurrent.SecretOperator;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
 
@@ -63,14 +66,23 @@ public class UserController implements Liveness, Readiness {
     private final ScheduledExecutorService scheduledExecutor;
 
     /**
-     * Creates the User controller responsible for controlling users in a single namespace
+     * Creates the User controller responsible for controlling users in a single
+     * namespace
      *
      * @param config          User Operator configuration
      * @param secretOperator  For operating on secrets
-     * @param userOperator    The User Operator which encapsulates the logic for updating the users
+     * @param userCrdOperator For operating on KafkaUser resources
+     * @param userOperator    The User Operator which encapsulates the logic for
+     *                        updating the users
      * @param metricsProvider Metrics provider for handling metrics
      */
-    public UserController(UserOperatorConfig config, SecretOperator secretOperator, KafkaUserOperator userOperator, MetricsProvider metricsProvider) {
+    public UserController(
+            UserOperatorConfig config,
+            SecretOperator secretOperator,
+            CrdOperator<KubernetesClient, KafkaUser, KafkaUserList> userCrdOperator,
+            KafkaUserOperator userOperator,
+            MetricsProvider metricsProvider) {
+
         this.userOperator = userOperator;
 
         // Store some useful settings into local fields
@@ -98,7 +110,7 @@ public class UserController implements Liveness, Readiness {
         Lister<Secret> secretLister = new Lister<>(secretInformer.getIndexer());
 
         // KafkaUser informer and lister is used to get events about Users and get Users quickly
-        this.userInformer = userOperator.informer(watchedNamespace, userSelector, DEFAULT_RESYNC_PERIOD_MS);
+        this.userInformer = userCrdOperator.informer(watchedNamespace, userSelector, DEFAULT_RESYNC_PERIOD_MS);
         Lister<KafkaUser> userLister = new Lister<>(userInformer.getIndexer());
 
         // Creates the scheduled executor service used for periodical reconciliations and progress warnings
@@ -110,7 +122,7 @@ public class UserController implements Liveness, Readiness {
         // Create a thread pool for the reconciliation loops and add the reconciliation loops
         this.threadPool = new ArrayList<>(config.getControllerThreadPoolSize());
         for (int i = 0; i < config.getControllerThreadPoolSize(); i++)  {
-            threadPool.add(new UserControllerLoop(RESOURCE_KIND + "-ControllerLoop-" + i, workQueue, lockManager, scheduledExecutor, userLister, secretLister, userOperator, metrics, config));
+            threadPool.add(new UserControllerLoop(RESOURCE_KIND + "-ControllerLoop-" + i, workQueue, lockManager, scheduledExecutor, userLister, secretLister, userCrdOperator, userOperator, metrics, config));
         }
     }
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserController.java
@@ -5,11 +5,9 @@
 package io.strimzi.operator.user;
 
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Lister;
-import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaUser;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InformerUtils;
@@ -24,6 +22,7 @@ import io.strimzi.operator.common.http.Readiness;
 import io.strimzi.operator.common.metrics.ControllerMetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
+import io.strimzi.operator.common.operator.resource.concurrent.SecretOperator;
 import io.strimzi.operator.user.operator.KafkaUserOperator;
 
 import java.util.ArrayList;
@@ -67,11 +66,11 @@ public class UserController implements Liveness, Readiness {
      * Creates the User controller responsible for controlling users in a single namespace
      *
      * @param config          User Operator configuration
-     * @param client          Kubernetes client
+     * @param secretOperator  For operating on secrets
      * @param userOperator    The User Operator which encapsulates the logic for updating the users
      * @param metricsProvider Metrics provider for handling metrics
      */
-    public UserController(UserOperatorConfig config, KubernetesClient client, KafkaUserOperator userOperator, MetricsProvider metricsProvider) {
+    public UserController(UserOperatorConfig config, SecretOperator secretOperator, KafkaUserOperator userOperator, MetricsProvider metricsProvider) {
         this.userOperator = userOperator;
 
         // Store some useful settings into local fields
@@ -95,11 +94,11 @@ public class UserController implements Liveness, Readiness {
         this.workQueue = new ControllerQueue(config.getWorkQueueSize(), this.metrics);
 
         // Secret informer and lister is used to get events about Secrets and get Secrets quickly
-        this.secretInformer = client.secrets().inNamespace(watchedNamespace).withLabels(secretSelector).runnableInformer(DEFAULT_RESYNC_PERIOD_MS);
+        this.secretInformer = secretOperator.informer(watchedNamespace, secretSelector, DEFAULT_RESYNC_PERIOD_MS);
         Lister<Secret> secretLister = new Lister<>(secretInformer.getIndexer());
 
         // KafkaUser informer and lister is used to get events about Users and get Users quickly
-        this.userInformer = Crds.kafkaUserOperation(client).inNamespace(watchedNamespace).withLabels(userSelector).runnableInformer(DEFAULT_RESYNC_PERIOD_MS);
+        this.userInformer = userOperator.informer(watchedNamespace, userSelector, DEFAULT_RESYNC_PERIOD_MS);
         Lister<KafkaUser> userLister = new Lister<>(userInformer.getIndexer());
 
         // Creates the scheduled executor service used for periodical reconciliations and progress warnings
@@ -111,7 +110,7 @@ public class UserController implements Liveness, Readiness {
         // Create a thread pool for the reconciliation loops and add the reconciliation loops
         this.threadPool = new ArrayList<>(config.getControllerThreadPoolSize());
         for (int i = 0; i < config.getControllerThreadPoolSize(); i++)  {
-            threadPool.add(new UserControllerLoop(RESOURCE_KIND + "-ControllerLoop-" + i, workQueue, lockManager, scheduledExecutor, client, userLister, secretLister, userOperator, metrics, config));
+            threadPool.add(new UserControllerLoop(RESOURCE_KIND + "-ControllerLoop-" + i, workQueue, lockManager, scheduledExecutor, userLister, secretLister, userOperator, metrics, config));
         }
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.nio.charset.StandardCharsets;
@@ -1497,11 +1497,8 @@ public class KafkaUserOperatorMockTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        ResourceUtils.CA_CERT_NAME + ", CA certificate",
-        ResourceUtils.CA_KEY_NAME + ", CA key",
-    })
-    public void testReconciliationFailsWithMissingCaSecrets(String missingSecretName, String missingContentDescription) {
+    @ValueSource(strings = { ResourceUtils.CA_CERT_NAME, ResourceUtils.CA_KEY_NAME })
+    void testReconciliationFailsWithMissingCaSecrets(String missingSecretName) {
         KafkaUser user = ResourceUtils.createKafkaUserTls();
         KafkaUserOperator op = new KafkaUserOperator(ResourceUtils.createUserOperatorConfig(), mockCertManager, secretOps, kafkaUserOps, scramOps, quotasOps, new DisabledSimpleAclOperator());
         secretOps.resource(ResourceUtils.NAMESPACE, missingSecretName).delete();
@@ -1510,6 +1507,6 @@ public class KafkaUserOperatorMockTest {
         ExecutionException thrown = assertThrows(ExecutionException.class, futureResult.toCompletableFuture()::get);
         Throwable rootCause = Util.unwrap(thrown.getCause());
         assertTrue(rootCause instanceof InvalidConfigurationException);
-        assertThat(rootCause.getMessage(), containsString(missingContentDescription));
+        assertThat(rootCause.getMessage(), containsString(missingSecretName));
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- ~~Bugfix~~
- ~~Enhancement / new feature~~
- Refactoring
- ~~Documentation~~

### Description

Migrate User Operator to use new `CrdOperator` and `SecretOperator` resource classes and reduce direct interaction with the K8s client.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

