### PR TITLE
Added ZooKeeper ports binding on all interfaces

### DIFF
--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -9,7 +9,7 @@ ARG strimzi_version
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar bind-utils \
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install gettext nmap-ncat stunnel net-tools unzip hostname findutils tar \
     && microdnf clean all
 
 # Add kafka user with UID 1001

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -38,12 +38,15 @@ ${ZOOKEEPER_CONFIGURATION}
 # Zookeeper nodes configuration
 EOF
 
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
+
 # Setting self IP as 0.0.0.0 to workaround the slow DNS issue.
+# Also check that Kafka version is greater-equal 3.4.1, because binding to 0.0.0.0 doesn't seem to work with previous version.
 # For single node case, we cannot set to 0.0.0.0 since ZooKeeper will fail when looking for next candidate in case of issue.
 # See: https://issues.apache.org/jira/browse/ZOOKEEPER-4708
 NODE=1
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
-    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]]; then
+    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]] && [[ $(version $KAFKA_VERSION) -ge $(version "3.4.1") ]]; then
       echo "server.${NODE}=0.0.0.0:2888:3888:participant;127.0.0.1:12181"
     else
       echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888:participant;127.0.0.1:12181"

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -40,6 +40,10 @@ EOF
 
 NODE=1
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
-    echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888:participant;127.0.0.1:12181"
+    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]]; then
+      echo "server.${NODE}=0.0.0.0:2888:3888:participant;127.0.0.1:12181"
+    else
+      echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888:participant;127.0.0.1:12181"
+    fi
     (( NODE=NODE+1 ))
 done

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -38,6 +38,9 @@ ${ZOOKEEPER_CONFIGURATION}
 # Zookeeper nodes configuration
 EOF
 
+# Setting self IP as 0.0.0.0 to workaround the slow DNS issue.
+# For single node case, we cannot set to 0.0.0.0 since ZooKeeper will fail when looking for next candidate in case of issue.
+# See: https://issues.apache.org/jira/browse/ZOOKEEPER-4708
 NODE=1
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
     if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]]; then

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -46,7 +46,7 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 # See: https://issues.apache.org/jira/browse/ZOOKEEPER-4708
 NODE=1
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
-    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]] && [[ $(version $KAFKA_VERSION) -ge $(version "3.4.1") ]]; then
+    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]] && [[ $(version "$KAFKA_VERSION") -ge $(version "3.4.1") ]]; then
       echo "server.${NODE}=0.0.0.0:2888:3888:participant;127.0.0.1:12181"
     else
       echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888:participant;127.0.0.1:12181"

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -37,23 +37,6 @@ export CERTS_STORE_PASSWORD
 
 mkdir -p /tmp/zookeeper
 
-# If it should run a check on DNS name resolving before starting ZooKeeper
-# This is useful in environment (i.e. minikube) where DNS registration is slow
-# It is also related to https://issues.apache.org/jira/browse/ZOOKEEPER-4708
-if [ -z "$ZOOKEEPER_DNS_CHECKS_DISABLED" ] || [ "$ZOOKEEPER_DNS_CHECKS_DISABLED" = "false" ]; then
-  echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."
-  ipaddress=$(nslookup "${BASE_HOSTNAME}"-$((ZOOKEEPER_ID-1))."${BASE_FQDN}" | grep "Address" | awk '{print $2}' | sed -n 2p)
-
-  # check IP address is resolved and not 127.0.0.1, we want a "valid" Pod one
-  while [ -z "$ipaddress" ] || [ "$ipaddress" = "127.0.0.1" ]; do
-    sleep 1
-    echo "Trying to resolve ${BASE_HOSTNAME}-$((ZOOKEEPER_ID-1)).${BASE_FQDN} ..."
-    ipaddress=$(nslookup "${BASE_HOSTNAME}"-$((ZOOKEEPER_ID-1))."${BASE_FQDN}" | grep "Address" | awk '{print $2}' | sed -n 2p)
-  done
-fi
-
-echo "Resolved IP address $ipaddress"
-
 # Import certificates into keystore and truststore
 ./zookeeper_tls_prepare_certificates.sh
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfSharedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/dynamicconfiguration/DynamicConfSharedST.java
@@ -46,7 +46,7 @@ public class DynamicConfSharedST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(DynamicConfSharedST.class);
 
-    private final String dynamicConfigurationSharedClusterName = "dynamic-configuration-shared-cluster-name";
+    private final String dynamicConfigurationSharedClusterName = "dynamic-config-shared";
 
     private String scraperPodName;
 


### PR DESCRIPTION
After more tests, we decided to go with binding ZooKeeper quorum and followers ports (3888 and 2888) to all interfaces to overcome the issue we are seeing with slow DNS resolution (https://issues.apache.org/jira/browse/ZOOKEEPER-4708).
This PR other than adding such fix, also removes the previous one about a DNS check (waiting for resolution to be done) before starting ZooKeeper (which introduces some delays in different environments, i.e. minikube).