### PR TITLE
Removed legacy clientPort configuration on ZooKeeper

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -10,8 +10,6 @@ dataDir=${ZOOKEEPER_DATA_DIR}
 4lw.commands.whitelist=*
 standaloneEnabled=false
 reconfigEnabled=true
-clientPort=12181
-clientPortAddress=127.0.0.1
 
 # TLS options
 serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory


### PR DESCRIPTION
As per ZooKeeper documentation here https://github.com/apache/zookeeper/blob/release-3.6.4/zookeeper-docs/src/main/resources/markdown/zookeeperReconfig.md#specifying-the-client-port, `clientPort` and `clientPortAddress` should no longer be used.
We already have this information in the `server.` configuration as `127.0.0.1:12181`.
This PR removes such legacy parameters.