### PR TITLE
Update Kaniko Container Builder to 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Update Kafka Exporter to [1.7.0](https://github.com/danielqsj/kafka_exporter/releases/tag/v1.7.0)
 * Improve Kafka rolling update to avoid rolling broker in log recovery
 * Added support for Kafka Exporter topic exclude and consumer group exclude parameters
-* Update Kaniko container builder to 1.12.0
+* Update Kaniko container builder to 1.12.1
 * Add support for _Kafka node pools_ according to [Strimzi Proposal #50](https://github.com/strimzi/proposals/blob/main/050-Kafka-Node-Pools.md)
 * Update OpenTelemetry 1.19.0
 * Fixed ordering of JVM performance options [#8579](https://github.com/strimzi/strimzi-kafka-operator/issues/8579)

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.12.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.12.1
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kaniko container builder used in Kafka Connect Build on Kubernetes to new version 1.12.0. Hopefully the last Kaniko update before Strimzi 0.36 🤦 

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md