### PR TITLE
Bump up test container to 0.104.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <opentest4j.version>1.2.0</opentest4j.version>
         <jupiter.version>5.8.2</jupiter.version>
-        <strimzi-test-container.version>0.103.0</strimzi-test-container.version>
+        <strimzi-test-container.version>0.104.0</strimzi-test-container.version>
         <mockserver.version>5.13.2</mockserver.version>
         <mockwebserver.version>3.14.7</mockwebserver.version>
         <valid4j.version>1.1</valid4j.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates the version of the test container to the recently released (i.e., 0.104.0), which brings Kafka 3.5.0 and 3.4.1. 

### Checklist

- [x] Make sure all tests pass

