### PR TITLE
Add support for configuring node IDs for Kafka Node Pools

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignor.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignor.java
@@ -261,8 +261,8 @@ public class NodeIdAssignor {
     }
 
     /**
-     * Finds the next node ID from a range which is not in use. The IDs are found from range specified in the Node Pool
-     * annotation strimzi.io/next-node-ids.
+     * Finds the next node ID which should be removed from the existing node IDs. The IDs are found from range specified
+     * in the Node Pool annotation strimzi.io/remove-node-ids.
      *
      * @param desired           Set with currently used IDs
      * @param removeIdRange     The NodeIdRange which will pick up the next node ID
@@ -299,7 +299,7 @@ public class NodeIdAssignor {
         try {
             return removeNodeIds == null ? null : new NodeIdRange(removeNodeIds);
         } catch (NodeIdRange.InvalidNodeIdRangeException e) {
-            LOGGER.warnCr(reconciliation, "Failed to use " + Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS + " " + removeNodeIds + ". Nodes will be scaled down from the highest node ID.", e);
+            LOGGER.warnCr(reconciliation, "Failed to use " + Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS + " " + removeNodeIds + ". Nodes will be scaled down from the highest node ID.", e);
             return null;
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignor.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignor.java
@@ -5,35 +5,43 @@
 package io.strimzi.operator.cluster.model.nodepools;
 
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.TreeSet;
 
 /**
  * Generates the Node ID assignments from / for node pools
  */
 public class NodeIdAssignor {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(NodePoolUtils.class.getName());
+
     private final Map<String, NodeIdAssignment> assignments = new HashMap<>();
 
     /**
      * Constructs the NodeIdAssignor instance.
      *
-     * @param nodePools     List of KafkaNodePool resources including their statuses
+     * @param reconciliation    Reconciliation marker
+     * @param nodePools         List of KafkaNodePool resources including their statuses
      */
-    /* test */ NodeIdAssignor(KafkaNodePool... nodePools) {
-        this(Arrays.asList(nodePools));
+    /* test */ NodeIdAssignor(Reconciliation reconciliation, KafkaNodePool... nodePools) {
+        this(reconciliation, Arrays.asList(nodePools));
     }
 
     /**
      * Constructs the NodeIdAssignor instance
      *
-     * @param nodePools     List of KafkaNodePool resources including their statuses
+     * @param reconciliation    Reconciliation marker
+     * @param nodePools         List of KafkaNodePool resources including their statuses
      */
-    public NodeIdAssignor(List<KafkaNodePool> nodePools) {
+    public NodeIdAssignor(Reconciliation reconciliation, List<KafkaNodePool> nodePools) {
         // Collect the existing assigned IDs
         TreeSet<Integer> idsInUse = new TreeSet<>();
 
@@ -63,15 +71,21 @@ public class NodeIdAssignor {
                     // We have a scale-down
                     desired = new TreeSet<>(current);
 
+                    // Provides the node IDs which the user would like to remove first
+                    NodeIdRange removeIdRange = removeIdRange(reconciliation, pool);
+
                     for (int i = 0; i < (current.size() - pool.getSpec().getReplicas()); i++)   {
-                        toBeRemoved.add(desired.pollLast());
+                        toBeRemoved.add(nextRemoveId(desired, removeIdRange));
                     }
                 } else if (pool.getSpec().getReplicas() > pool.getStatus().getNodeIds().size())    {
                     // We have a scale-up
                     desired = new TreeSet<>(current);
 
+                    // Provides the node IDs which the user would like to assign to the next broker(s)
+                    NodeIdRange nextIdRange = nextIdRange(reconciliation, pool);
+
                     for (int i = 0; i < (pool.getSpec().getReplicas() - current.size()); i++)   {
-                        Integer nextId = provideNextId(idsInUse);
+                        Integer nextId = provideNextId(idsInUse, nextIdRange);
                         toBeAdded.add(nextId);
                         desired.add(nextId);
                     }
@@ -84,8 +98,11 @@ public class NodeIdAssignor {
                 current = new TreeSet<>();
                 desired = new TreeSet<>();
 
+                // Provides the node IDs which the user would like to assign to the next broker(s)
+                NodeIdRange nextIdRange = nextIdRange(reconciliation, pool);
+
                 for (int i = 0; i < pool.getSpec().getReplicas(); i++)   {
-                    Integer nextId = provideNextId(idsInUse);
+                    Integer nextId = provideNextId(idsInUse, nextIdRange);
                     toBeAdded.add(nextId);
                     desired.add(nextId);
                 }
@@ -116,32 +133,175 @@ public class NodeIdAssignor {
     /**
      * Generates the next node ID based on the already used IDs
      *
-     * @param idsInUse  TreeSet with already used IDs. This should contain all IDs currently used (including those which
-     *                  will be scaled done) or those already generated. The newly generated ID is automatically added
-     *                  to this set by this method.
+     * @param idsInUse      TreeSet with already used IDs. This should contain all IDs currently used (including those which
+     *                      will be scaled done) or those already generated. The newly generated ID is automatically added
+     *                      to this set by this method.
+     * @param nextIdRange   The NodeIdRange which will pick up the next node ID
      *
      * @return  The next node ID
      */
-    private int provideNextId(TreeSet<Integer> idsInUse) {
-        int nextId;
+    private int provideNextId(TreeSet<Integer> idsInUse, NodeIdRange nextIdRange) {
+        // We try to first get the Node ID from range first
+        Integer nextId = nextUnusedIdFromRange(idsInUse, nextIdRange);
 
-        // TODO: We should provide more advanced strategies for assigning the node IDs. For example
-        //           * Search for gaps
-        //           * Use annotations to control the next ID
-        //           * Assigning various node ID ranges to different node pools
-        //           * Configuring the next IDs which should be used for a new broker
-        //           * Configuring which broker should be removed at scale down
-        //           * (more situations are described in the proposal)
-        //       This is tracked by https://github.com/strimzi/strimzi-kafka-operator/issues/8590
-
-        if (idsInUse.isEmpty()) {
-            nextId = 0;
-        } else {
-            nextId = idsInUse.last() + 1;
+        // We did not get an ID from the ID range. So we get the next ID only
+        if (nextId == null) {
+            nextId = nextUnusedId(idsInUse);
         }
 
+        // We add the new ID to used IDs
         idsInUse.add(nextId);
+
         return nextId;
+    }
+
+    /**
+     * Finds the next unused ID sequentially. It will take the highest used ID and increment is by 1.
+     *
+     * @param idsInUse  Set with currently used IDs
+     *
+     * @return  The next unused Node ID
+     */
+    private Integer nextUnusedId(TreeSet<Integer> idsInUse) {
+        if (idsInUse.isEmpty()) {
+            // Its empty -> we start with 0
+            return 0;
+        } else if (idsInUse.size() == idsInUse.last() + 1)    {
+            // Size is the same as the last index -> no gaps
+            return idsInUse.last() + 1;
+        } else {
+            // There are some IDs but also gaps. Let's try to find a gap
+            return findNextUnusedIdFromGap(idsInUse);
+        }
+    }
+
+    /**
+     * Finds the lowest available number from a gap inside the set. It starts from 0 and increments by one until it
+     * finds a used ID. Algorithm based on binary search was considered, but for the expected numbers of node IDs
+     * (== nodes of a Kafka cluster) it did not seem worth it (increased complexity over marginally faster execution).
+     *
+     * @param setWithGaps   Set with some gaps
+     *
+     * @return  The lowest available ID
+     */
+    /* test */ static Integer findNextUnusedIdFromGap(NavigableSet<Integer> setWithGaps)  {
+        int next = 0;
+
+        while (setWithGaps.contains(next))  {
+            next++;
+        }
+
+        return next;
+    }
+
+    /**
+     * Finds the next node ID from a range which is not in use. The IDs are found from range specified in the Node Pool
+     * annotation strimzi.io/next-node-ids.
+     *
+     * @param idsInUse      Set with currently used IDs
+     * @param nextIdRange   The NodeIdRange which will pick up the next node ID
+     *
+     * @return  Next unused node ID from the range or null if no such ID was found
+     */
+    private Integer nextUnusedIdFromRange(TreeSet<Integer> idsInUse, NodeIdRange nextIdRange)   {
+        Integer nextId = null;
+
+        if (nextIdRange != null)    {
+            while ((nextId = nextIdRange.getNextNodeId()) != null)  {
+                // If the next ID is not in use, we can break the while loop
+                // If it is already used, we continue wth the next ID
+                if (!idsInUse.contains(nextId)) {
+                    break;
+                }
+            }
+        }
+
+        return nextId;
+    }
+
+    /**
+     * Creates the Node ID range based on the strimzi.io/next-node-ids annotation on the Node Pool.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param pool              NodePool instance
+     *
+     * @return  The NodeIdRange based on the annotation or null when the annotation is not set or is invalid.
+     */
+    private NodeIdRange nextIdRange(Reconciliation reconciliation, KafkaNodePool pool)   {
+        String nextNodeIds = Annotations.stringAnnotation(pool, Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, null);
+
+        try {
+            return nextNodeIds == null ? null : new NodeIdRange(nextNodeIds);
+        } catch (NodeIdRange.InvalidNodeIdRangeException e) {
+            LOGGER.warnCr(reconciliation, "Failed to use " + Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS + " " + nextNodeIds + ". New node IDs will be assigned sequentially.", e);
+            return null;
+        }
+    }
+
+    /**
+     * Generates the next node ID which should be removed based on the already used Node IDs and the user preferred range.
+     *
+     * @param desired           TreeSet with already used IDs. This should contain all IDs currently used (including those which
+     *                          will be scaled done) or those already generated. The newly generated ID is automatically added
+     *                          to this set by this method.
+     * @param removeIdRange     The NodeIdRange which will pick up the next node ID
+     *
+     * @return  The next node ID to remove in scale down
+     */
+    private int nextRemoveId(TreeSet<Integer> desired, NodeIdRange removeIdRange) {
+        // We try to first get the Node ID from range first
+        Integer removeId = removeUsedIdFromRange(desired, removeIdRange);
+
+        // We did not get an ID from the ID range. So we get the next ID only
+        if (removeId == null) {
+            removeId = desired.pollLast();
+        }
+
+        return removeId;
+    }
+
+    /**
+     * Finds the next node ID from a range which is not in use. The IDs are found from range specified in the Node Pool
+     * annotation strimzi.io/next-node-ids.
+     *
+     * @param desired           Set with currently used IDs
+     * @param removeIdRange     The NodeIdRange which will pick up the next node ID
+     *
+     * @return  Next unused node ID from the range or null if no such ID was found
+     */
+    private Integer removeUsedIdFromRange(TreeSet<Integer> desired, NodeIdRange removeIdRange)   {
+        Integer removeId = null;
+
+        if (removeIdRange != null)    {
+            while ((removeId = removeIdRange.getNextNodeId()) != null)  {
+                // If the next ID is in use (remove returns true), we can break the while loop
+                // If it is not used, we continue with the next ID
+                if (desired.remove(removeId)) {
+                    break;
+                }
+            }
+        }
+
+        return removeId;
+    }
+
+    /**
+     * Creates the Node ID range based on the strimzi.io/remove-node-ids annotation on the Node Pool.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param pool              NodePool instance
+     *
+     * @return  The NodeIdRange based on the annotation or null when the annotation is not set or is invalid.
+     */
+    private NodeIdRange removeIdRange(Reconciliation reconciliation, KafkaNodePool pool)   {
+        String removeNodeIds = Annotations.stringAnnotation(pool, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, null);
+
+        try {
+            return removeNodeIds == null ? null : new NodeIdRange(removeNodeIds);
+        } catch (NodeIdRange.InvalidNodeIdRangeException e) {
+            LOGGER.warnCr(reconciliation, "Failed to use " + Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS + " " + removeNodeIds + ". Nodes will be scaled down from the highest node ID.", e);
+            return null;
+        }
     }
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRange.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRange.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.nodepools;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Holds a range of Node IDs configured by the user. The range can be defined in the Node Pools as annotation in the
+ * form such as [0, 1, 10-15, 100-110, 200] which is used to assign new IDs or scale down nodes.
+ */
+public class NodeIdRange {
+    /**
+     * Pattern for validating the range of Node IDs preferred by the user for scale-up or scale-down
+     */
+    private static final String SINGLE_NODE_ID = "([0-9]+)";
+    private static final Pattern SINGLE_NODE_ID_PATTERN = Pattern.compile(SINGLE_NODE_ID);
+
+    private static final String RANGE_OF_NODE_IDS = "([0-9]+\\s*-\\s*[0-9]+)";
+    private static final Pattern RANGE_OF_NODE_IDS_PATTERN = Pattern.compile(RANGE_OF_NODE_IDS);
+
+    private final static String SINGLE_OR_RANGE = "(" + SINGLE_NODE_ID + "|" + RANGE_OF_NODE_IDS + ")";
+    private static final Pattern NODE_ID_RANGE_PATTERN = Pattern.compile("^\\s*\\[(\\s*" + SINGLE_OR_RANGE + "\\s*,)*\\s*" + SINGLE_OR_RANGE + "\\s*]\\s*$");
+    private static final Pattern EMPTY_RANGE_PATTERN = Pattern.compile("^\\s*\\[\\s*]\\s*$");
+
+    private final Queue<IdRange> ranges;
+
+    /**
+     * Constructs the Node ID Range which can be used to provide
+     *
+     * @param range     The array with Node ID ranges from Node Pool annotations
+     *
+     * @throws InvalidNodeIdRangeException  Throws InvalidNodeIdRangeException if the range is invalid
+     */
+    public NodeIdRange(String range) throws InvalidNodeIdRangeException {
+        if (range.isBlank()
+                || EMPTY_RANGE_PATTERN.matcher(range).matches())    {
+            // The value is completely empty or an empty array
+            ranges = new ArrayDeque<>(0);
+        } else if (isValidNodeIdRange(range))   {
+            ranges = parseRanges(range);
+        } else {
+            throw new InvalidNodeIdRangeException("Invalid Node ID range: " + range);
+        }
+    }
+
+    /**
+     * Returns the next node ID
+     *
+     * @return  The next node ID or null if this range was already depleted
+     */
+    public Integer getNextNodeId()  {
+        while (!ranges.isEmpty())   {
+            IdRange nextRange = ranges.peek();
+
+            Integer nextNodeId = nextRange.getNextNodeId();
+            if (nextNodeId == null) {
+                ranges.poll();
+            } else {
+                return nextNodeId;
+            }
+        }
+
+        // No more ranges
+        return null;
+    }
+
+    /**
+     * Validates a range definition from a Node Pool annotation
+     *
+     * @param range The full range as defined in the Node Pool annotation
+     *
+     * @return  True if the range is valid. False otherwise.
+     */
+    /* test */ static boolean isValidNodeIdRange(String range) {
+        return NODE_ID_RANGE_PATTERN.matcher(range).matches();
+    }
+
+    /**
+     * Parses Node ID range from the Node Pool annotation into the individual sections
+     *
+     * @param range The full range as defined in the Node Pool annotation
+     *
+     * @return  Queue with the individual range sections
+     */
+    /* test */ static Queue<IdRange> parseRanges(String range)    {
+        // Remove the starting and closing brackets together with whitespaces
+        range = range.replaceAll("^\\s*\\[\\s*", "");
+        range = range.replaceAll("\\s*]\\s*$", "");
+
+        return Arrays.stream(range.split("\\s*,\\s*")).map(IdRange::new).collect(Collectors.toCollection(ArrayDeque::new));
+    }
+
+    /**
+     * Internal class to hold a single node ID or a single range
+     */
+    /* test */ static class IdRange   {
+        private Integer start;
+        private Integer end;
+
+        /**
+         * Constructs new IdRange
+         *
+         * @param rangeItem     A single node ID or range
+         *
+         * @throws InvalidNodeIdRangeException  Throws InvalidNodeIdRangeException when the range is not valid
+         */
+        public IdRange(String rangeItem) throws InvalidNodeIdRangeException {
+            if (SINGLE_NODE_ID_PATTERN.matcher(rangeItem).matches())    {
+                try {
+                    start = Integer.parseInt(rangeItem);
+                    end = null;
+                } catch (NumberFormatException e)   {
+                    throw new InvalidNodeIdRangeException("Invalid Node ID (not an integer): " + rangeItem, e);
+                }
+            } else if (RANGE_OF_NODE_IDS_PATTERN.matcher(rangeItem).matches())  {
+                String[] startAndEnd = rangeItem.split("\\s*-\\s*");
+
+                if (startAndEnd.length != 2)    {
+                    throw new InvalidNodeIdRangeException("Invalid Node ID range (exactly 2 items must be found): " + rangeItem);
+                }
+
+                try {
+                    start = Integer.parseInt(startAndEnd[0]);
+                    end = Integer.parseInt(startAndEnd[1]);
+                } catch (NumberFormatException e)   {
+                    throw new InvalidNodeIdRangeException("Invalid Node ID (not an integer): " + rangeItem, e);
+                }
+            } else {
+                throw new InvalidNodeIdRangeException("Invalid Node ID range (does not match a single node ID or node ID range): " + rangeItem);
+            }
+        }
+
+        /**
+         * Returns the next node ID
+         *
+         * @return  The next ID or null if this range was already depleted
+         */
+        public Integer getNextNodeId()   {
+            if (start == null)  {
+                // Starts is null => this range is empty -> return null to indicate that this range was exhausted and should be removed
+                return null;
+            } else if (end == null)    {
+                // Start is not null but end is null => this is a single node id -> return start and set it to null since we are empty now
+                Integer returnValue = start;
+                start = null;
+                return returnValue;
+            } else {
+                // we have a non-empty range
+                if (start.equals(end))   {
+                    // Start is the end => return start and set it to null since we will be empty soon
+                    Integer returnValue = start;
+                    start = null;
+                    end = null;
+                    return returnValue;
+                } else if (start > end) {
+                    // Start is bigger than end => return start and decrement it (the range is going down)
+                    Integer returnValue = start;
+                    start--;
+                    return returnValue;
+                } else {
+                    // Start is smaller then end => return start and increment it (the range is going up)
+                    Integer returnValue = start;
+                    start++;
+                    return returnValue;
+                }
+            }
+        }
+    }
+
+    /**
+     * This exception is thrown when the Node ID range is invalid.
+     */
+    public static class InvalidNodeIdRangeException extends RuntimeException    {
+        /**
+         * Constructor
+         *
+         * @param message   Exception message
+         */
+        public InvalidNodeIdRangeException(String message) {
+            super(message);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param message   Exception message
+         * @param cause     Cause exception
+         */
+        public InvalidNodeIdRangeException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRange.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRange.java
@@ -60,7 +60,8 @@ public class NodeIdRange {
 
             Integer nextNodeId = nextRange.getNextNodeId();
             if (nextNodeId == null) {
-                ranges.poll();
+                // The range is empty. We remove it.
+                ranges.remove();
             } else {
                 return nextNodeId;
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/NodeIdAssignorTest.java
@@ -6,11 +6,17 @@ package io.strimzi.operator.cluster.model.nodepools;
 
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Reconciliation;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class NodeIdAssignorTest {
     @Test
     public void testNewSinglePoolCluster()  {
-        NodeIdAssignor assignor = new NodeIdAssignor(createPool("my-pool", 3));
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null));
 
         assertThat(assignor.assignments().size(), is(1));
 
@@ -31,8 +37,34 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testNewSinglePoolClusterWithNextIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999]")));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of()));
+        assertThat(assignment.desired(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeAdded(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
+    public void testNewSinglePoolClusterWithNextIdsForSomeNodes()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1002]")));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of()));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 1000, 1001, 1002)));
+        assertThat(assignment.toBeAdded(), is(Set.of(0, 1, 1000, 1001, 1002)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
     public void testExistingSinglePoolClusterWithoutChange()  {
-        NodeIdAssignor assignor = new NodeIdAssignor(createPool("my-pool", 3, List.of(0, 1, 2)));
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2)));
 
         assertThat(assignor.assignments().size(), is(1));
 
@@ -45,7 +77,7 @@ public class NodeIdAssignorTest {
 
     @Test
     public void testExistingSinglePoolClusterOutOfSequenceWithoutChange()  {
-        NodeIdAssignor assignor = new NodeIdAssignor(createPool("my-pool", 3, List.of(2, 3, 5)));
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(2, 3, 5)));
 
         assertThat(assignor.assignments().size(), is(1));
 
@@ -57,8 +89,34 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testNewSinglePoolClusterWithNextIdsWithoutChange()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[2000-2999]"), List.of(1000, 1001, 1002)));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.desired(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
+    public void testNewSinglePoolClusterWithRemoveIdsWithoutChange()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[2000-2999]"), List.of(1000, 1001, 1002)));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.desired(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
     public void testExistingSinglePoolClusterScaleDown()  {
-        NodeIdAssignor assignor = new NodeIdAssignor(createPool("my-pool", 3, List.of(0, 1, 2, 3, 4)));
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2, 3, 4)));
 
         assertThat(assignor.assignments().size(), is(1));
 
@@ -70,8 +128,57 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testExistingSinglePoolClusterScaleDownWithRemoveIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[1-3]"), List.of(0, 1, 2, 3, 4)));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2, 3, 4)));
+        assertThat(assignment.desired(), is(Set.of(0, 3, 4)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of(1, 2)));
+    }
+
+    @Test
+    public void testExistingSinglePoolClusterScaleDownWithUnusedRemoveIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[1000-1999]"), List.of(0, 1, 2, 3, 4)));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2, 3, 4)));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 2)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of(3, 4)));
+    }
+
+    @Test
+    public void testExistingSinglePoolClusterScaleDownBigClusterWithRemoveIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5000, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[10000-19999, 4613, 1919, 1874]"), IntStream.range(0, 5002).boxed().collect(Collectors.toList())));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.toBeRemoved(), is(Set.of(4613, 1919)));
+    }
+
+    @Test
     public void testExistingSinglePoolClusterScaleUp()  {
-        NodeIdAssignor assignor = new NodeIdAssignor(createPool("my-pool", 5, List.of(0, 1, 2)));
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999]"), List.of(0, 1, 2)));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2)));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 2, 1000, 1001)));
+        assertThat(assignment.toBeAdded(), is(Set.of(1000, 1001)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
+    public void testExistingSinglePoolClusterScaleUpWithNextIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, null, List.of(0, 1, 2)));
 
         assertThat(assignor.assignments().size(), is(1));
 
@@ -83,10 +190,21 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testExistingSinglePoolBigClusterScaleUpWithNextIds()  {
+        // We scale cluster from 5000 nodes to 5003 nodes
+        NodeIdAssignor assignor = new NodeIdAssignor(Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5003, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999, 6000, 7000, 8000]"), IntStream.range(0, 5000).boxed().collect(Collectors.toList())));
+
+        assertThat(assignor.assignments().size(), is(1));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.toBeAdded(), is(Set.of(6000, 7000, 8000)));
+    }
+
+    @Test
     public void testNewMultiPoolCluster()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 3),
-                createPool("my-pool2", 3)
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null),
+                createPool("my-pool2", 3, null)
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -105,10 +223,32 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testNewMultiPoolClusterWithNextIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999]")),
+                createPool("my-pool2", 3, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[2000-2999]"))
+        );
+
+        assertThat(assignor.assignments().size(), is(2));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of()));
+        assertThat(assignment.desired(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeAdded(), is(Set.of(1000, 1001, 1002)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+
+        assignment = assignor.assignmentForPool("my-pool2");
+        assertThat(assignment.current(), is(Set.of()));
+        assertThat(assignment.desired(), is(Set.of(2000, 2001, 2002)));
+        assertThat(assignment.toBeAdded(), is(Set.of(2000, 2001, 2002)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
     public void testExistingMultiPoolCluster()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 3, List.of(0, 1, 2)),
-                createPool("my-pool2", 3, List.of(3, 4, 5))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2)),
+                createPool("my-pool2", 3, null, List.of(3, 4, 5))
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -129,8 +269,8 @@ public class NodeIdAssignorTest {
     @Test
     public void testExistingMultiPoolClusterScaleUp()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 5, List.of(0, 1, 2)),
-                createPool("my-pool2", 5, List.of(3, 4, 5))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, null, List.of(0, 1, 2)),
+                createPool("my-pool2", 5, null, List.of(3, 4, 5))
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -149,10 +289,32 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testExistingMultiPoolClusterScaleUpWithNextIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999]"), List.of(0, 1, 2)),
+                createPool("my-pool2", 5, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[2000-2999]"), List.of(3, 4, 5))
+        );
+
+        assertThat(assignor.assignments().size(), is(2));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2)));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 2, 1000, 1001)));
+        assertThat(assignment.toBeAdded(), is(Set.of(1000, 1001)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+
+        assignment = assignor.assignmentForPool("my-pool2");
+        assertThat(assignment.current(), is(Set.of(3, 4, 5)));
+        assertThat(assignment.desired(), is(Set.of(3, 4, 5, 2000, 2001)));
+        assertThat(assignment.toBeAdded(), is(Set.of(2000, 2001)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+    }
+
+    @Test
     public void testExistingMultiPoolClusterScaleDown()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 3, List.of(0, 1, 2, 3, 4)),
-                createPool("my-pool2", 3, List.of(5, 6, 7, 8, 9))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2, 3, 4)),
+                createPool("my-pool2", 3, null, List.of(5, 6, 7, 8, 9))
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -171,10 +333,32 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testExistingMultiPoolClusterScaleDownWithRemoveIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[3, 2, 1]"), List.of(0, 1, 2, 3, 4)),
+                createPool("my-pool2", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[6-8]"), List.of(5, 6, 7, 8, 9))
+        );
+
+        assertThat(assignor.assignments().size(), is(2));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2, 3, 4)));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 4)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of(3, 2)));
+
+        assignment = assignor.assignmentForPool("my-pool2");
+        assertThat(assignment.current(), is(Set.of(5, 6, 7, 8, 9)));
+        assertThat(assignment.desired(), is(Set.of(5, 8, 9)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of(6, 7)));
+    }
+
+    @Test
     public void testExistingMultiPoolClusterScaleDownUp()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 3, List.of(0, 1, 2, 3, 4)),
-                createPool("my-pool2", 5, List.of(5, 6, 7))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2, 3, 4)),
+                createPool("my-pool2", 5, null, List.of(5, 6, 7))
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -195,8 +379,8 @@ public class NodeIdAssignorTest {
     @Test
     public void testExistingMultiPoolClusterScaleUpDown()  {
         NodeIdAssignor assignor = new NodeIdAssignor(
-                createPool("my-pool", 5, List.of(0, 1, 2)),
-                createPool("my-pool2", 3, List.of(3, 4, 5, 6, 7))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, null, List.of(0, 1, 2)),
+                createPool("my-pool2", 3, null, List.of(3, 4, 5, 6, 7))
         );
 
         assertThat(assignor.assignments().size(), is(2));
@@ -215,23 +399,58 @@ public class NodeIdAssignorTest {
     }
 
     @Test
+    public void testExistingMultiPoolClusterScaleUpDownWithNodeIds()  {
+        NodeIdAssignor assignor = new NodeIdAssignor(
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 5, Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[1000-1999]"), List.of(0, 1, 2)),
+                createPool("my-pool2", 3, Map.of(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[5-8]"), List.of(3, 4, 5, 6, 7))
+        );
+
+        assertThat(assignor.assignments().size(), is(2));
+
+        NodeIdAssignment assignment = assignor.assignmentForPool("my-pool");
+        assertThat(assignment.current(), is(Set.of(0, 1, 2)));
+        assertThat(assignment.desired(), is(Set.of(0, 1, 2, 1000, 1001)));
+        assertThat(assignment.toBeAdded(), is(Set.of(1000, 1001)));
+        assertThat(assignment.toBeRemoved(), is(Set.of()));
+
+        assignment = assignor.assignmentForPool("my-pool2");
+        assertThat(assignment.current(), is(Set.of(3, 4, 5, 6, 7)));
+        assertThat(assignment.desired(), is(Set.of(3, 4, 7)));
+        assertThat(assignment.toBeAdded(), is(Set.of()));
+        assertThat(assignment.toBeRemoved(), is(Set.of(5, 6)));
+    }
+
+    @Test
     public void testDuplicateIds()  {
         InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> new NodeIdAssignor(
-                createPool("my-pool", 3, List.of(0, 1, 2)),
-                createPool("my-pool2", 3, List.of(2, 3, 4))
+                Reconciliation.DUMMY_RECONCILIATION, createPool("my-pool", 3, null, List.of(0, 1, 2)),
+                createPool("my-pool2", 3, null, List.of(2, 3, 4))
         ));
 
         assertThat(ex.getMessage(), is("Found duplicate node ID 2 in node pool my-pool2"));
+    }
+
+    @Test
+    public void testFindingIdsInGaps() {
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 2))), is(1));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 2, 3, 4, 5))), is(1));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 1, 3, 4, 5))), is(2));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 1, 2, 4, 5))), is(3));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 1, 2, 3, 5))), is(4));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 3, 4, 5))), is(1));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 4, 5))), is(1));
+        assertThat(NodeIdAssignor.findNextUnusedIdFromGap(new TreeSet<>(Set.of(0, 5))), is(1));
     }
 
     //////////////////////////////////////////////////
     // Utility methods
     //////////////////////////////////////////////////
 
-    private static KafkaNodePool createPool(String name, int replicas) {
+    private static KafkaNodePool createPool(String name, int replicas, Map<String, String> annotations) {
         return new KafkaNodePoolBuilder()
                 .withNewMetadata()
                     .withName(name)
+                    .withAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(replicas)
@@ -239,16 +458,17 @@ public class NodeIdAssignorTest {
                 .build();
     }
 
-    private static KafkaNodePool createPool(String name, int replicas, List<Integer> assignedIds) {
+    private static KafkaNodePool createPool(String name, int replicas, Map<String, String> annotations, List<Integer> assignedIds) {
         return new KafkaNodePoolBuilder()
                 .withNewMetadata()
                     .withName(name)
+                    .withAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(replicas)
                 .endSpec()
                 .withNewStatus()
-                .withNodeIds(assignedIds)
+                    .withNodeIds(assignedIds)
                 .endStatus()
                 .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRangeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/NodeIdRangeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.nodepools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NodeIdRangeTest {
+    private static final Set<String> VALID_RANGES = Set.of(
+            "[5]",
+            "[5-10]",
+            "[ 5 ]",
+            "[ 5 - 10    ]",
+            "[0, 1, 2]",
+            "[0,1,2]",
+            "[5,7-9]",
+            "[5 , 7-9, 13]",
+            "[1874-1919]",
+            "[0-999, 10000-10999, 20000-20999]"
+    );
+
+    private static final Set<String> INVALID_RANGES = Set.of(
+            "[]",
+            "[-5]",
+            "[-5-10]",
+            "[5-]",
+            "[5,]",
+            "[-10]",
+            " 5 - 10 ]",
+            "[0, 1, 2",
+            "[0,,2]",
+            "[0, a, 2]",
+            "[5,7---9]",
+            "foo, bar",
+            "[foo-bar]"
+    );
+
+    @Test
+    public void testRangeValidation()  {
+        VALID_RANGES.forEach(range -> {
+            assertThat(NodeIdRange.isValidNodeIdRange(range), is(true));
+        });
+
+        INVALID_RANGES.forEach(range -> {
+            assertThat(NodeIdRange.isValidNodeIdRange(range), is(false));
+        });
+    }
+
+    @Test
+    public void testParseRange()  {
+        VALID_RANGES.forEach(range -> {
+            assertThat(NodeIdRange.parseRanges(range), is(notNullValue()));
+        });
+    }
+
+    @Test
+    public void testNodeIdRangeConstructor()   {
+        assertDoesNotThrow(() -> new NodeIdRange.IdRange("1"));
+        assertDoesNotThrow(() -> new NodeIdRange.IdRange("5-10"));
+        assertDoesNotThrow(() -> new NodeIdRange.IdRange("10-5"));
+        assertDoesNotThrow(() -> new NodeIdRange.IdRange("10 - 5"));
+
+        NodeIdRange.InvalidNodeIdRangeException ex = assertThrows(NodeIdRange.InvalidNodeIdRangeException.class,
+                () -> new NodeIdRange.IdRange(""));
+        assertThat(ex.getMessage(), is("Invalid Node ID range (does not match a single node ID or node ID range): "));
+
+        ex = assertThrows(NodeIdRange.InvalidNodeIdRangeException.class,
+                () -> new NodeIdRange.IdRange("999999999999999999999999999999999"));
+        assertThat(ex.getMessage(), is("Invalid Node ID (not an integer): 999999999999999999999999999999999"));
+
+        ex = assertThrows(NodeIdRange.InvalidNodeIdRangeException.class,
+                () -> new NodeIdRange.IdRange("0-999999999999999999999999999999999"));
+        assertThat(ex.getMessage(), is("Invalid Node ID (not an integer): 0-999999999999999999999999999999999"));
+    }
+
+    @Test
+    public void testNextNodeId()    {
+        nodeIdRangeTester("", "");
+        nodeIdRangeTester("   ", "");
+        nodeIdRangeTester("[]", "");
+        nodeIdRangeTester("[  ]", "");
+        nodeIdRangeTester(" [ ] ", "");
+        nodeIdRangeTester("[ 1 ]", "1;");
+        nodeIdRangeTester("[ 1, 2, 3 ]", "1;2;3;");
+        nodeIdRangeTester("[ 1, 3, 2 ]", "1;3;2;");
+        nodeIdRangeTester("[ 1-3 ]", "1;2;3;");
+        nodeIdRangeTester("[ 1-3, 10 - 12 ]", "1;2;3;10;11;12;");
+        nodeIdRangeTester("[ 1-3, 6, 7, 8, 10 - 12 ]", "1;2;3;6;7;8;10;11;12;");
+        nodeIdRangeTester("[ 1-1 ]", "1;");
+        nodeIdRangeTester("[ 3-1 ]", "3;2;1;");
+        nodeIdRangeTester("[ 1-3, 12 - 10 ]", "1;2;3;12;11;10;");
+    }
+
+    private void nodeIdRangeTester(String rangeAnnotation, String expectedOrder)  {
+        NodeIdRange range = new NodeIdRange(rangeAnnotation);
+        StringBuilder actualOrder = new StringBuilder();
+
+        Integer nextId;
+        while ((nextId = range.getNextNodeId()) != null)  {
+            actualOrder.append(nextId).append(";");
+        }
+
+        assertThat(actualOrder.toString(), is(expectedOrder));
+    }
+
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -146,6 +146,16 @@ public class Annotations {
     public static final String ANNO_STRIMZI_IO_DELETE_CLAIM = STRIMZI_DOMAIN + "delete-claim";
 
     /**
+     * Annotation for configuring the ranges of node IDs which should be used for given node pool
+     */
+    public static final String ANNO_STRIMZI_IO_NEXT_NODE_IDS = STRIMZI_DOMAIN + "next-node-ids";
+
+    /**
+     * Annotation for configuring the ranges of node IDs which should be used for given node pool
+     */
+    public static final String ANNO_STRIMZI_IO_REMOVE_NODE_IDS = STRIMZI_DOMAIN + "remove-node-ids";
+
+    /**
      * Annotation for tracking Deployment revisions
      */
     public static final String ANNO_DEP_KUBE_IO_REVISION = "deployment.kubernetes.io/revision";


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for advanced management of the node IDs of brokers belonging to different Kafka Node Pools.

It introduces two annotations:
* `strimzi.io/next-node-ids`
* `strimzi.io/remove-node-ids`

These annotations (when set) are used to determine the next node ID (broker ID) when a node is being added or removed from the KafkaNodePool. They have a format like this: `[0, 1, 2, 10-20, 30]`. It allows to specify either individual node IDs (e.g. `5`) or ID ranges (e.g. `1000-1999`). When scaling up, the operator will go through the node IDs from the `strimzi.io/next-node-ids` annotation and pick the first available from it and use it for a new broker. During a scale-up, it will go through the IDs from the `strimzi.io/remove-node-ids` annotation and remove the broker(s) with the first used node ID.

When all IDs from the `strimzi.io/next-node-ids` annotation are already used or when no IDs from the `strimzi.io/remove-node-ids` annotation are used, the operator will follow its usual algorithm and remove the highest available node ID when scaling down or the lowest available when scaling up.

The annotations are used only during scaling events. In order to give users some _early feedback_ in case they misformatted the annotation, they will be also validated in every reconciliation and a warning will be thrown in case the format is wrong. This should help to detect it early and fix it. If it is not fixed when some scaling happens, the operator will ignore them and proceed with the scale-up / scale-down.

When the annotations are not set, the operator will pick up the lowest available node ID starting from 0 for scale-up or the highest used node ID for scale-down.

Users are in general expected to use this feature in two ways:
1) Give each node pool a range of IDs. E.g. 0-999 for `pool-a` and 1000-1999 for `pool-b` and use IDs from these ranges for the brokers.
2) Use these annotations to scale down / scale up with a particular node ID. E.g. use annotation `strimzi.io/remove-node-ids: [ 2 ]` to remove the second broker from an existing cluster.

Documentation will be updated in a separate PR.

This should resolve #8590.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging