### PR TITLE
Added pod name in the certificate SANs list

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -162,6 +162,7 @@ public class ClusterCa extends Ca {
             subject.addDnsName(ccDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(ccDnsGenerator.serviceDnsName());
             subject.addDnsName(CruiseControlResources.serviceName(kafkaName));
+            subject.addDnsName(node.podName());
             subject.addDnsName("localhost");
             return subject.build();
         };
@@ -198,6 +199,7 @@ public class ClusterCa extends Ca {
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsName());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsName());
+            subject.addDnsName(node.podName());
             return subject.build();
         };
 
@@ -228,6 +230,7 @@ public class ClusterCa extends Ca {
 
             subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
             subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
+            subject.addDnsName(node.podName());
 
             if (externalBootstrapAddresses != null)   {
                 for (String dnsName : externalBootstrapAddresses) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -162,7 +162,6 @@ public class ClusterCa extends Ca {
             subject.addDnsName(ccDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(ccDnsGenerator.serviceDnsName());
             subject.addDnsName(CruiseControlResources.serviceName(kafkaName));
-            subject.addDnsName(node.podName());
             subject.addDnsName("localhost");
             return subject.build();
         };
@@ -193,13 +192,13 @@ public class ClusterCa extends Ca {
             subject.addDnsName(String.format("%s.%s", KafkaResources.zookeeperServiceName(crName), namespace));
             subject.addDnsName(zkDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.serviceDnsName());
+            subject.addDnsName(node.podName());
             subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.zookeeperHeadlessServiceName(crName), node.podName()));
             subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.zookeeperHeadlessServiceName(crName), node.podName()));
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsName());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsName());
-            subject.addDnsName(node.podName());
             return subject.build();
         };
 
@@ -230,7 +229,6 @@ public class ClusterCa extends Ca {
 
             subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
             subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
-            subject.addDnsName(node.podName());
 
             if (externalBootstrapAddresses != null)   {
                 for (String dnsName : externalBootstrapAddresses) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2359,9 +2359,7 @@ public class KafkaClusterTest {
                 asList(2, "foo-kafka-brokers"),
                 asList(2, "foo-kafka-brokers.test"),
                 asList(2, "foo-kafka-brokers.test.svc"),
-                asList(2, "foo-kafka-brokers.test.svc.cluster.local"),
-                asList(2, "foo-kafka-0"))));
-
+                asList(2, "foo-kafka-brokers.test.svc.cluster.local"))));
     }
 
     @ParallelTest
@@ -2381,7 +2379,6 @@ public class KafkaClusterTest {
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
-                asList(2, "foo-kafka-0"),
                 asList(2, "foo-kafka-bootstrap"),
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),
@@ -2411,7 +2408,6 @@ public class KafkaClusterTest {
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
-                asList(2, "foo-kafka-0"),
                 asList(2, "foo-kafka-bootstrap"),
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2359,7 +2359,8 @@ public class KafkaClusterTest {
                 asList(2, "foo-kafka-brokers"),
                 asList(2, "foo-kafka-brokers.test"),
                 asList(2, "foo-kafka-brokers.test.svc"),
-                asList(2, "foo-kafka-brokers.test.svc.cluster.local"))));
+                asList(2, "foo-kafka-brokers.test.svc.cluster.local"),
+                asList(2, "foo-kafka-0"))));
 
     }
 
@@ -2380,6 +2381,7 @@ public class KafkaClusterTest {
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
+                asList(2, "foo-kafka-0"),
                 asList(2, "foo-kafka-bootstrap"),
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),
@@ -2409,6 +2411,7 @@ public class KafkaClusterTest {
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
+                asList(2, "foo-kafka-0"),
                 asList(2, "foo-kafka-bootstrap"),
                 asList(2, "foo-kafka-bootstrap.test"),
                 asList(2, "foo-kafka-bootstrap.test.svc"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -420,6 +420,7 @@ public class ZookeeperClusterTest {
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
         assertThat(cert.getSubjectDN().getName(), is("CN=foo-zookeeper, O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+                asList(2, "foo-zookeeper-0"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc.cluster.local"),
                 asList(2, "foo-zookeeper-client"),
@@ -429,8 +430,7 @@ public class ZookeeperClusterTest {
                 asList(2, "*.foo-zookeeper-client.test.svc"),
                 asList(2, "*.foo-zookeeper-client.test.svc.cluster.local"),
                 asList(2, "*.foo-zookeeper-nodes.test.svc"),
-                asList(2, "*.foo-zookeeper-nodes.test.svc.cluster.local"),
-                asList(2, "foo-zookeeper-0"))));
+                asList(2, "*.foo-zookeeper-nodes.test.svc.cluster.local"))));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -429,7 +429,8 @@ public class ZookeeperClusterTest {
                 asList(2, "*.foo-zookeeper-client.test.svc"),
                 asList(2, "*.foo-zookeeper-client.test.svc.cluster.local"),
                 asList(2, "*.foo-zookeeper-nodes.test.svc"),
-                asList(2, "*.foo-zookeeper-nodes.test.svc.cluster.local"))));
+                asList(2, "*.foo-zookeeper-nodes.test.svc.cluster.local"),
+                asList(2, "foo-zookeeper-0"))));
     }
 
     @ParallelTest


### PR DESCRIPTION
While investigating why the `DynamicConfSharedST` is failing on PR #8752 , it turned out that ZooKeeper is resolving to just the pod name what doing the DNS reverse lookup for hostname verification.
This PR adds the podname to the SANs list as well.