### PR TITLE
[ST] Add update method for all resources and fix UserScalabilityIsolatedST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -157,7 +157,7 @@ public class ResourceManager {
     }
 
     @SafeVarargs
-        public final <T extends HasMetadata> void createResource(ExtensionContext testContext, boolean waitReady, T... resources) {
+    public final <T extends HasMetadata> void createResource(ExtensionContext testContext, boolean waitReady, T... resources) {
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
             if (resource.getMetadata().getNamespace() == null) {
@@ -331,6 +331,14 @@ public class ResourceManager {
                 }
             }
 
+        }
+    }
+
+    @SafeVarargs
+    public final <T extends HasMetadata> void updateResource(ExtensionContext testContext, T... resources) {
+        for (T resource : resources) {
+            ResourceType<T> type = findResourceType(resource);
+            type.update(resource);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceType.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceType.java
@@ -30,6 +30,11 @@ public interface ResourceType<T extends HasMetadata> {
     void delete(T resource);
 
     /**
+     * Update specific resource based on T type using Kubernetes API
+     */
+    void update(T resource);
+
+    /**
      * Check if this resource is marked as ready or not with wait.
      *
      * @return true if ready.

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaBridgeResource.java
@@ -42,6 +42,12 @@ public class KafkaBridgeResource implements ResourceType<KafkaBridge> {
         kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaBridge resource) {
+        kafkaBridgeClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaBridge resource) {
         return ResourceManager.waitForResourceStatus(kafkaBridgeClient(), resource, CustomResourceStatus.Ready);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaClientsResource.java
@@ -34,6 +34,11 @@ public class KafkaClientsResource implements ResourceType<Deployment> {
     }
 
     @Override
+    public void update(Deployment resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).updateDeployment(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(Deployment resource) {
         return DeploymentUtils.waitForDeploymentReady(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectResource.java
@@ -42,6 +42,12 @@ public class KafkaConnectResource implements ResourceType<KafkaConnect> {
         kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaConnect resource) {
+        kafkaConnectClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaConnect resource) {
         return KafkaConnectUtils.waitForConnectReady(resource.getMetadata().getNamespace(), resource.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaConnectorResource.java
@@ -38,6 +38,12 @@ public class KafkaConnectorResource implements ResourceType<KafkaConnector> {
         kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaConnector resource) {
+        kafkaConnectorClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaConnector resource) {
         return KafkaConnectorUtils.waitForConnectorReady(resource.getMetadata().getNamespace(), resource.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMaker2Resource.java
@@ -40,6 +40,12 @@ public class KafkaMirrorMaker2Resource implements ResourceType<KafkaMirrorMaker2
         kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaMirrorMaker2 resource) {
+        kafkaMirrorMaker2Client().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaMirrorMaker2 resource) {
         return KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(resource.getMetadata().getNamespace(), resource.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaMirrorMakerResource.java
@@ -37,6 +37,12 @@ public class KafkaMirrorMakerResource implements ResourceType<KafkaMirrorMaker> 
         kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaMirrorMaker resource) {
+        kafkaMirrorMakerClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaMirrorMaker resource) {
         return ResourceManager.waitForResourceStatus(kafkaMirrorMakerClient(), resource, CustomResourceStatus.Ready);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -47,6 +47,11 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
     }
 
     @Override
+    public void update(KafkaNodePool resource) {
+        kafkaNodePoolClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(KafkaNodePool resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaRebalanceResource.java
@@ -39,6 +39,12 @@ public class KafkaRebalanceResource implements ResourceType<KafkaRebalance> {
         kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaRebalance resource) {
+        kafkaRebalanceClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaRebalance resource) {
         return KafkaRebalanceUtils.waitForKafkaRebalanceCustomResourceState(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), KafkaRebalanceState.PendingProposal);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaResource.java
@@ -94,6 +94,11 @@ public class KafkaResource implements ResourceType<Kafka> {
     }
 
     @Override
+    public void update(Kafka resource) {
+        kafkaClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(Kafka resource) {
         long timeout = ResourceOperation.getTimeoutForResourceReadiness(resource.getKind());
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaTopicResource.java
@@ -38,6 +38,12 @@ public class KafkaTopicResource implements ResourceType<KafkaTopic> {
         kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).withName(
             resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
     }
+
+    @Override
+    public void update(KafkaTopic resource) {
+        kafkaTopicClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
     @Override
     public boolean waitForReadiness(KafkaTopic resource) {
         return ResourceManager.waitForResourceStatus(kafkaTopicClient(), resource.getKind(), resource.getMetadata().getNamespace(),

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -47,6 +47,9 @@ public class KafkaUserResource implements ResourceType<KafkaUser> {
     public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserClient() {
         return Crds.kafkaUserOperation(ResourceManager.kubeClient().getClient());
     }
+    public void update(KafkaUser kafkaUser) {
+        kafkaUserClient().inNamespace(kafkaUser.getMetadata().getNamespace()).resource(kafkaUser).update();
+    }
 
     public static void replaceUserResourceInSpecificNamespace(String resourceName, Consumer<KafkaUser> editor, String namespaceName) {
         ResourceManager.replaceCrdResource(KafkaUser.class, KafkaUserList.class, resourceName, editor, namespaceName);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaUserResource.java
@@ -47,6 +47,8 @@ public class KafkaUserResource implements ResourceType<KafkaUser> {
     public static MixedOperation<KafkaUser, KafkaUserList, Resource<KafkaUser>> kafkaUserClient() {
         return Crds.kafkaUserOperation(ResourceManager.kubeClient().getClient());
     }
+
+    @Override
     public void update(KafkaUser kafkaUser) {
         kafkaUserClient().inNamespace(kafkaUser.getMetadata().getNamespace()).resource(kafkaUser).update();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
@@ -38,6 +38,11 @@ public class StrimziPodSetResource implements ResourceType<StrimziPodSet> {
     }
 
     @Override
+    public void update(StrimziPodSet resource) {
+        strimziPodSetClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(StrimziPodSet resource) {
         return ResourceManager.waitForResourceStatus(strimziPodSetClient(), resource, Ready);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/DrainCleanerResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/DrainCleanerResource.java
@@ -39,6 +39,11 @@ public class DrainCleanerResource implements ResourceType<Deployment> {
     }
 
     @Override
+    public void update(Deployment resource) {
+        ResourceManager.kubeClient().updateDeployment(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(Deployment resource) {
         return resource != null
             && resource.getMetadata() != null

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterOperatorCustomResourceDefinition.java
@@ -28,6 +28,12 @@ public class ClusterOperatorCustomResourceDefinition implements ResourceType<Cus
     public void delete(CustomResourceDefinition resource) {
         kubeClient().deleteCustomResourceDefinition(resource);
     }
+
+    @Override
+    public void update(CustomResourceDefinition resource) {
+        kubeClient().createOrUpdateCustomResourceDefinition(resource);
+    }
+
     @Override
     public boolean waitForReadiness(CustomResourceDefinition resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -39,6 +39,12 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
         // ClusterRoleBinding his operation namespace is only 'default'
         kubeClient(KubeClusterResource.getInstance().defaultNamespace()).deleteClusterRoleBinding(resource);
     }
+
+    @Override
+    public void update(ClusterRoleBinding resource) {
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrUpdateClusterRoleBinding(resource);
+    }
+
     @Override
     public boolean waitForReadiness(ClusterRoleBinding resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleResource.java
@@ -31,6 +31,12 @@ public class ClusterRoleResource implements ResourceType<ClusterRole> {
         // ClusterRole his operation namespace is only 'default'
         kubeClient(KubeClusterResource.getInstance().defaultNamespace()).deleteClusterRole(resource);
     }
+
+    @Override
+    public void update(ClusterRole resource) {
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createOrUpdateClusterRoles(resource);
+    }
+
     @Override
     public boolean waitForReadiness(ClusterRole resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ConfigMapResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ConfigMapResource.java
@@ -28,6 +28,12 @@ public class ConfigMapResource implements ResourceType<ConfigMap> {
     public void delete(ConfigMap resource) {
         kubeClient().deleteConfigMap(resource);
     }
+
+    @Override
+    public void update(ConfigMap resource) {
+        kubeClient().updateConfigMapInNamespace(resource.getMetadata().getNamespace(), resource);
+    }
+
     @Override
     public boolean waitForReadiness(ConfigMap resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -35,6 +35,11 @@ public class DeploymentResource implements ResourceType<Deployment> {
     }
 
     @Override
+    public void update(Deployment resource) {
+        ResourceManager.kubeClient().updateDeployment(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(Deployment resource) {
         return DeploymentUtils.waitForDeploymentAndPodsReady(resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource.getSpec().getReplicas());
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
@@ -28,6 +28,14 @@ public class JobResource implements ResourceType<Job> {
     public void delete(Job resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteJob(resource.getMetadata().getName());
     }
+
+    @Override
+    @Deprecated
+    public void update(Job resource) {
+        // Job cannot be updated, only created
+        ResourceManager.kubeClient().createJob(resource);
+    }
+
     @Override
     public boolean waitForReadiness(Job resource) {
         return JobUtils.waitForJobRunning(resource.getMetadata().getName(), resource.getMetadata().getNamespace());

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/JobResource.java
@@ -30,10 +30,8 @@ public class JobResource implements ResourceType<Job> {
     }
 
     @Override
-    @Deprecated
     public void update(Job resource) {
-        // Job cannot be updated, only created
-        ResourceManager.kubeClient().createJob(resource);
+        ResourceManager.kubeClient().updateJob(resource);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/LeaseResource.java
@@ -32,6 +32,11 @@ public class LeaseResource implements ResourceType<Lease> {
     }
 
     @Override
+    public void update(Lease resource) {
+        kubeClient().getClient().leases().resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(Lease resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -51,6 +51,14 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
     public void delete(NetworkPolicy resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteNetworkPolicy(resource.getMetadata().getName());
     }
+
+    @Override
+    @Deprecated
+    public void update(NetworkPolicy resource) {
+        // Network policy cannot be updated, only deleted and created
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createNetworkPolicy(resource);
+    }
+
     @Override
     public boolean waitForReadiness(NetworkPolicy resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -53,10 +53,8 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
     }
 
     @Override
-    @Deprecated
     public void update(NetworkPolicy resource) {
-        // Network policy cannot be updated, only deleted and created
-        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createNetworkPolicy(resource);
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).updateNetworkPolicy(resource);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -34,6 +34,12 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
     public void delete(RoleBinding resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRoleBinding(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
+
+    @Override
+    public void update(RoleBinding resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrUpdateRoleBinding(resource);
+    }
+
     @Override
     public boolean waitForReadiness(RoleBinding resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -34,6 +34,12 @@ public class RoleResource implements ResourceType<Role> {
     public void delete(Role resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteRole(resource.getMetadata().getNamespace(), resource.getMetadata().getName());
     }
+
+    @Override
+    public void update(Role resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createOrUpdateRole(resource);
+    }
+
     @Override
     public boolean waitForReadiness(Role resource) {
         return resource != null && get(resource.getMetadata().getNamespace(), resource.getMetadata().getName()) != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/SecretResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/SecretResource.java
@@ -32,6 +32,11 @@ public class SecretResource implements ResourceType<Secret> {
     }
 
     @Override
+    public void update(Secret resource) {
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).updateSecret(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(Secret resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceAccountResource.java
@@ -30,6 +30,11 @@ public class ServiceAccountResource implements ResourceType<ServiceAccount> {
     }
 
     @Override
+    public void update(ServiceAccount resource) {
+        kubeClient().createOrUpdateServiceAccount(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(ServiceAccount resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
@@ -32,6 +32,14 @@ public class ServiceResource implements ResourceType<Service> {
     public void delete(Service resource) {
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).deleteService(resource);
     }
+
+    @Override
+    @Deprecated
+    public void update(Service resource) {
+        // Service cannot be updated, only created or deleted
+        ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createService(resource);
+    }
+
     @Override
     public boolean waitForReadiness(Service resource) {
         return resource != null;

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ServiceResource.java
@@ -36,7 +36,6 @@ public class ServiceResource implements ResourceType<Service> {
     @Override
     @Deprecated
     public void update(Service resource) {
-        // Service cannot be updated, only created or deleted
         ResourceManager.kubeClient().namespace(resource.getMetadata().getNamespace()).createService(resource);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ValidatingWebhookConfigurationResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ValidatingWebhookConfigurationResource.java
@@ -34,6 +34,13 @@ public class ValidatingWebhookConfigurationResource implements ResourceType<Vali
     }
 
     @Override
+    @Deprecated
+    public void update(ValidatingWebhookConfiguration resource) {
+        // ValidatingWebhookConfiguration cannot be updated, only deleted and created
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createValidatingWebhookConfiguration(resource);
+    }
+
+    @Override
     public boolean waitForReadiness(ValidatingWebhookConfiguration resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ValidatingWebhookConfigurationResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ValidatingWebhookConfigurationResource.java
@@ -34,10 +34,8 @@ public class ValidatingWebhookConfigurationResource implements ResourceType<Vali
     }
 
     @Override
-    @Deprecated
     public void update(ValidatingWebhookConfiguration resource) {
-        // ValidatingWebhookConfiguration cannot be updated, only deleted and created
-        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).createValidatingWebhookConfiguration(resource);
+        kubeClient(KubeClusterResource.getInstance().defaultNamespace()).updateValidatingWebhookConfiguration(resource);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/OperatorGroupResource.java
@@ -36,6 +36,11 @@ public class OperatorGroupResource implements ResourceType<OperatorGroup> {
     }
 
     @Override
+    public void update(OperatorGroup resource) {
+        operatorGroupClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(OperatorGroup resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/SubscriptionResource.java
@@ -39,6 +39,11 @@ public class SubscriptionResource implements ResourceType<Subscription> {
     }
 
     @Override
+    public void update(Subscription resource) {
+        subscriptionClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
     public boolean waitForReadiness(Subscription resource) {
         return resource != null;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/BundleResource.java
@@ -61,6 +61,11 @@ public class BundleResource implements ResourceType<Deployment> {
     }
 
     @Override
+    public void update(Deployment resource) {
+        ResourceManager.kubeClient().updateDeployment(resource);
+    }
+
+    @Override
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public boolean waitForReadiness(Deployment resource) {
         return resource != null

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaUserSpec;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.enums.UserAuthType;
+import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
@@ -117,7 +118,8 @@ public class UserScalabilityIsolatedST extends AbstractST {
         // get one user spec as the template for wait
         KafkaUserSpec kafkaUserSpec = listOfUsers.stream().findFirst().get().getSpec();
 
-        resourceManager.createResource(extensionContext, false, listOfUsers.toArray(new KafkaUser[listOfUsers.size()]));
+        listOfUsers.forEach(user -> KafkaUserResource.kafkaUserClient().inNamespace(clusterOperator.getDeploymentNamespace()).resource(user).update());
+
         KafkaUserUtils.waitForConfigToBeChangedInAllUsersWithPrefix(clusterOperator.getDeploymentNamespace(), usersPrefix, kafkaUserSpec);
         KafkaUserUtils.waitForAllUsersWithPrefixReady(clusterOperator.getDeploymentNamespace(), usersPrefix);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
@@ -113,10 +113,10 @@ public class UserScalabilityIsolatedST extends AbstractST {
             .build();
 
         listOfUsers.replaceAll(kafkaUser -> new KafkaUserBuilder(kafkaUser)
-                .editSpec()
-                    .withKafkaUserAuthorizationSimple(updatedAcl)
-                .endSpec()
-                .build());
+            .editSpec()
+                .withKafkaUserAuthorizationSimple(updatedAcl)
+            .endSpec()
+            .build());
 
         // get one user spec as the template for wait
         KafkaUserSpec kafkaUserSpec = listOfUsers.stream().findFirst().get().getSpec();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.KafkaUserSpec;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.enums.UserAuthType;
-import io.strimzi.systemtest.resources.crd.KafkaUserResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
@@ -51,7 +50,7 @@ public class UserScalabilityIsolatedST extends AbstractST {
     }
 
     void testCreateAndAlterBigAmountOfUsers(ExtensionContext extensionContext, final TestStorage testStorage, final UserAuthType authType) {
-        int numberOfUsers = 1000;
+        int numberOfUsers = 10;
 
         List<KafkaUser> usersList = getListOfKafkaUsers(testStorage.getUsername(), numberOfUsers, authType);
 
@@ -118,8 +117,7 @@ public class UserScalabilityIsolatedST extends AbstractST {
         // get one user spec as the template for wait
         KafkaUserSpec kafkaUserSpec = listOfUsers.stream().findFirst().get().getSpec();
 
-        listOfUsers.forEach(user -> KafkaUserResource.kafkaUserClient().inNamespace(clusterOperator.getDeploymentNamespace()).resource(user).update());
-
+        resourceManager.updateResource(extensionContext, listOfUsers.toArray(new KafkaUser[listOfUsers.size()]));
         KafkaUserUtils.waitForConfigToBeChangedInAllUsersWithPrefix(clusterOperator.getDeploymentNamespace(), usersPrefix, kafkaUserSpec);
         KafkaUserUtils.waitForAllUsersWithPrefixReady(clusterOperator.getDeploymentNamespace(), usersPrefix);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserScalabilityIsolatedST.java
@@ -50,7 +50,7 @@ public class UserScalabilityIsolatedST extends AbstractST {
     }
 
     void testCreateAndAlterBigAmountOfUsers(ExtensionContext extensionContext, final TestStorage testStorage, final UserAuthType authType) {
-        int numberOfUsers = 10;
+        int numberOfUsers = 1000;
 
         List<KafkaUser> usersList = getListOfKafkaUsers(testStorage.getUsername(), numberOfUsers, authType);
 
@@ -112,7 +112,11 @@ public class UserScalabilityIsolatedST extends AbstractST {
             .endAcl()
             .build();
 
-        listOfUsers.forEach(kafkaUser -> new KafkaUserBuilder(kafkaUser).editOrNewSpec().withKafkaUserAuthorizationSimple(updatedAcl).endSpec().build());
+        listOfUsers.replaceAll(kafkaUser -> new KafkaUserBuilder(kafkaUser)
+                .editSpec()
+                    .withKafkaUserAuthorizationSimple(updatedAcl)
+                .endSpec()
+                .build());
 
         // get one user spec as the template for wait
         KafkaUserSpec kafkaUserSpec = listOfUsers.stream().findFirst().get().getSpec();

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -481,6 +481,10 @@ public class KubeClient {
         client.batch().v1().jobs().inNamespace(getNamespace()).withName(jobName).delete();
     }
 
+    public void updateJob(Job job) {
+        client.batch().v1().jobs().inNamespace(job.getMetadata().getNamespace()).resource(job).update();
+    }
+
     public void deleteJob(final String namespaceName, String jobName) {
         client.batch().v1().jobs().inNamespace(namespaceName).withName(jobName).delete();
     }
@@ -864,6 +868,10 @@ public class KubeClient {
         client.network().networkPolicies().inNamespace(getNamespace()).withName(name).delete();
     }
 
+    public void updateNetworkPolicy(NetworkPolicy networkPolicy) {
+        client.network().networkPolicies().inNamespace(getNamespace()).resource(networkPolicy).update();
+    }
+
     // =====================================
     // ---> CUSTOM RESOURCE DEFINITIONS <---
     // =====================================
@@ -949,6 +957,10 @@ public class KubeClient {
 
     public void deleteValidatingWebhookConfiguration(ValidatingWebhookConfiguration validatingWebhookConfiguration) {
         client.admissionRegistration().v1().validatingWebhookConfigurations().resource(validatingWebhookConfiguration).delete();
+    }
+
+    public void updateValidatingWebhookConfiguration(ValidatingWebhookConfiguration validatingWebhookConfiguration) {
+        client.admissionRegistration().v1().validatingWebhookConfigurations().resource(validatingWebhookConfiguration).update();
     }
 
     // =====================================================


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR introduces UPDATE method for all resources implementing ResourceType. It adds the ability to use update for resources which did not have this opportunity and used replace methods within their respective utils class. This is taken advantage of and respectively fixes UserScalabilityIsolatedST where a large amount of kafka users were created and then altered. This alteration caused issues as users were already created and method in resourceManager provided only creation and not replacement / update, so this was fixed with simple use of update method for the kafka user spec in the ST.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

