### PR TITLE
Fix possible places where reconciliations might get stuck

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -77,8 +77,9 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      */
     public Future<ReconcileResult<T>> createOrUpdate(Reconciliation reconciliation, T resource) {
         if (resource == null) {
-            throw new NullPointerException();
+            return Future.failedFuture(new IllegalArgumentException("The " + resourceKind + " resource should not be null."));
         }
+
         return reconcile(reconciliation, resource.getMetadata().getNamespace(), resource.getMetadata().getName(), resource);
     }
 
@@ -306,8 +307,9 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      */
     public Future<T> getAsync(String namespace, String name) {
         if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name.");
+            return Future.failedFuture(new IllegalArgumentException(namespace + "/" + resourceKind + " with an empty name cannot be configured. Please provide a name."));
         }
+
         return resourceSupport.getAsync(operation().inNamespace(namespace).withName(name));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -59,8 +59,9 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      */
     public Future<ReconcileResult<T>> createOrUpdate(Reconciliation reconciliation, T resource) {
         if (resource == null) {
-            throw new NullPointerException();
+            return Future.failedFuture(new IllegalArgumentException("The " + resourceKind + " resource should not be null."));
         }
+
         return reconcile(reconciliation, resource.getMetadata().getName(), resource);
     }
 
@@ -218,8 +219,9 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      */
     public Future<T> getAsync(String name) {
         if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name.");
+            return Future.failedFuture(new IllegalArgumentException(resourceKind + " with an empty name cannot be configured. Please provide a name."));
         }
+
         return resourceSupport.getAsync(operation().withName(name));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -100,7 +100,7 @@ public class CrdOperator<C extends KubernetesClient,
                 T result = operation().inNamespace(namespace).withName(name).patch(PatchContext.of(PatchType.JSON), resource);
                 LOGGER.debugCr(reconciliation, "{} {} in namespace {} has been patched", resourceKind, name, namespace);
                 future.complete(result);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOGGER.debugCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
                 future.fail(e);
             }
@@ -113,7 +113,7 @@ public class CrdOperator<C extends KubernetesClient,
      * Updates custom resource status asynchronously
      *
      * @param reconciliation    Reconciliation marker
-     * @param resource          Desired resource with the updated statis
+     * @param resource          Desired resource with the updated status
      *
      * @return  Future which completes when the status is patched
      */
@@ -128,7 +128,7 @@ public class CrdOperator<C extends KubernetesClient,
                 T result = operation().inNamespace(namespace).resource(resource).updateStatus();
                 LOGGER.infoCr(reconciliation, "Status of {} {} in namespace {} has been updated", resourceKind, name, namespace);
                 future.complete(result);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOGGER.debugCr(reconciliation, "Caught exception while updating status of {} {} in namespace {}", resourceKind, name, namespace, e);
                 future.fail(e);
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR tries to fix several places where reconciliations might get stuck which I found while investigating #8166. 4 of them are places where we throw an exception instead of returning failed futures. In these places, I also fixed the original empty `NullPointerException` which seemed a bit raw to return to the user with an `IllegalArgumentException` with an appropriate error message.

Another thing I changes was `executeBlocking` blocks which had try-catch only for `Exception` and not for `Throwable` which can in theory mean that some errors or throwables might be missed. This change follows other plces where we use `executeBlocking` in combination with catching all throwables.

As explained on the issue. The logs in the issue provide only limited information about what exactly got stuck. So these fixes are based on code walkthrough - we cannot be really 100% sure that they fix exactly what happened there.

This should close #8166.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging