### PR TITLE
[systemtest] Add `CRUISE_CONTROL` tag to tests that use CC

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -76,6 +76,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
+@Tag(CRUISE_CONTROL)
 @TestMethodOrder(OrderAnnotation.class)
 class LogSettingST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(LogSettingST.class);
@@ -414,7 +415,6 @@ class LogSettingST extends AbstractST {
     }
 
     @IsolatedTest("Updating shared Kafka")
-    @Tag(CRUISE_CONTROL)
     // This test might be flaky, as it gets real logs from CruiseControl pod
     void testCruiseControlLogChange(ExtensionContext extensionContext) {
         final String debugText = " DEBUG ";

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAllNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAllNamespaceIsolatedST.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
@@ -73,6 +74,7 @@ public class OlmAllNamespaceIsolatedST extends OlmAbstractST {
 
     @Test
     @Order(8)
+    @Tag(CRUISE_CONTROL)
     void testDeployExampleKafkaRebalance(ExtensionContext extensionContext) {
         doTestDeployExampleKafkaRebalance(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmSingleNamespaceIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmSingleNamespaceIsolatedST.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.CONNECT;
+import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER2;
 import static io.strimzi.systemtest.Constants.OLM;
@@ -74,6 +75,7 @@ public class OlmSingleNamespaceIsolatedST extends OlmAbstractST {
 
     @Test
     @Order(8)
+    @Tag(CRUISE_CONTROL)
     void testDeployExampleKafkaRebalance(ExtensionContext extensionContext) {
         doTestDeployExampleKafkaRebalance(extensionContext);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesIsolatedST.java
@@ -46,9 +46,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.strimzi.systemtest.Constants.REGRESSION;
-import static io.strimzi.systemtest.Constants.NETWORKPOLICIES_SUPPORTED;
+import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.NETWORKPOLICIES_SUPPORTED;
+import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -295,6 +296,7 @@ public class NetworkPoliciesIsolatedST extends AbstractST {
     }
 
     @IsolatedTest("Specific Cluster Operator for test case")
+    @Tag(CRUISE_CONTROL)
     void testNPGenerationEnvironmentVariable(ExtensionContext extensionContext) {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -81,6 +81,7 @@ import static io.strimzi.api.kafka.model.KafkaResources.clusterCaKeySecretName;
 import static io.strimzi.systemtest.Constants.ACCEPTANCE;
 import static io.strimzi.systemtest.Constants.CONNECT;
 import static io.strimzi.systemtest.Constants.CONNECT_COMPONENTS;
+import static io.strimzi.systemtest.Constants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.Constants.EXTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.MIRROR_MAKER;
@@ -165,6 +166,7 @@ class SecurityST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("ClusterCaCerts")
     void testAutoRenewClusterCaCertsTriggeredByAnno(ExtensionContext extensionContext) {
         autoRenewSomeCaCertsTriggeredByAnno(
@@ -181,6 +183,7 @@ class SecurityST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("ClientsCaCerts")
     void testAutoRenewClientsCaCertsTriggeredByAnno(ExtensionContext extensionContext) {
         autoRenewSomeCaCertsTriggeredByAnno(
@@ -199,6 +202,7 @@ class SecurityST extends AbstractST {
     @Tag(ACCEPTANCE)
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("AllCaCerts")
     void testAutoRenewAllCaCertsTriggeredByAnno(ExtensionContext extensionContext) {
         autoRenewSomeCaCertsTriggeredByAnno(
@@ -345,6 +349,7 @@ class SecurityST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("ClusterCaKeys")
     void testAutoReplaceClusterCaKeysTriggeredByAnno(ExtensionContext extensionContext) {
         autoReplaceSomeKeysTriggeredByAnno(
@@ -359,6 +364,7 @@ class SecurityST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("ClientsCaKeys")
     void testAutoReplaceClientsCaKeysTriggeredByAnno(ExtensionContext extensionContext) {
         autoReplaceSomeKeysTriggeredByAnno(
@@ -373,6 +379,7 @@ class SecurityST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
+    @Tag(CRUISE_CONTROL)
     @Tag("AllCaKeys")
     void testAutoReplaceAllCaKeysTriggeredByAnno(ExtensionContext extensionContext) {
         autoReplaceSomeKeysTriggeredByAnno(
@@ -586,6 +593,7 @@ class SecurityST extends AbstractST {
 
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
+    @Tag(CRUISE_CONTROL)
     void testAutoRenewCaCertsTriggerByExpiredCertificate(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds tag `CRUISE_CONTROL` to tests that use CC, but miss it somehow.

Fixes #8618 

### Checklist

- [x] Make sure all tests pass

