### PR TITLE
[ST] Modify RecoveryIsolatedST tests to check cluster stability

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryIsolatedST.java
@@ -206,7 +206,7 @@ class RecoveryIsolatedST extends AbstractST {
         KafkaUtils.waitForKafkaReady(clusterOperator.getDeploymentNamespace(), sharedClusterName);
     }
 
-    void verifyStabilityBySendingAndReceivingMessages(ExtensionContext extensionContext, TestStorage testStorage) {
+    private void verifyStabilityBySendingAndReceivingMessages(ExtensionContext extensionContext, TestStorage testStorage) {
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withTopicName(testStorage.getTopicName())
             .withMessageCount(testStorage.getMessageCount())


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is refactoring and modifying RecoveryIsolatedST class  - deleting many unnecessary tests and adding a final check for some tests to verify cluster stability after the service has successfully recovered.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

