### PR TITLE
Fix Cruise Control check for a number of nodes to calculate with NodePools

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -451,10 +451,11 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             addAll(metricReporterList, configuration.getConfigOption(KAFKA_METRIC_REPORTERS_CONFIG_FIELD).split(","));
         }
 
-        if (kafkaAssembly.getSpec().getCruiseControl() != null && kafkaAssembly.getSpec().getKafka().getReplicas() < 2) {
+        if (kafkaAssembly.getSpec().getCruiseControl() != null
+                && kafkaCluster.nodes().stream().filter(n -> n.broker()).count() < 2) {
             throw new InvalidResourceException("Kafka " +
                     kafkaAssembly.getMetadata().getNamespace() + "/" + kafkaAssembly.getMetadata().getName() +
-                    " has invalid configuration. Cruise Control cannot be deployed with a single-node Kafka cluster. It requires at least two Kafka nodes.");
+                    " has invalid configuration. Cruise Control cannot be deployed with a Kafka cluster which has only one broker. It requires at least two Kafka brokers.");
         }
         kafkaCluster.cruiseControlSpec = kafkaAssembly.getSpec().getCruiseControl();
         if (kafkaCluster.cruiseControlSpec != null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3706,11 +3706,12 @@ public class KafkaClusterTest {
 
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(ex.getMessage(), is("Kafka " + NAMESPACE + "/" + CLUSTER + " has invalid configuration. " +
-                "Cruise Control cannot be deployed with a single-node Kafka cluster. It requires at least two Kafka nodes."));
+                "Cruise Control cannot be deployed with a Kafka cluster which has only one broker. " +
+                "It requires at least two Kafka brokers."));
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -203,9 +203,9 @@ public class CruiseControlST extends AbstractST {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
-        final String errMessage =  "Kafka " + namespaceName + "/" + clusterName + " has invalid configuration." +
-            " Cruise Control cannot be deployed with a single-node Kafka cluster. It requires " +
-            "at least two Kafka nodes.";
+        final String errMessage =  "Kafka " + namespaceName + "/" + clusterName + " has invalid configuration. " +
+            "Cruise Control cannot be deployed with a Kafka cluster which has only one broker. " +
+                "It requires at least two Kafka brokers.";
 
         LOGGER.info("Deploying single node Kafka with CruiseControl");
         resourceManager.createResource(extensionContext, false, KafkaTemplates.kafkaWithCruiseControl(clusterName, 1, 1).build());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, we do not support Cruise Control being used with a Kafka cluster having a single Kafka broker. But the validation logic did not take KafkaNodePools into account. This PR updates it to use the KafkaNodePools to execute this check. It also updates the error message to make it more clear it is the broker nodes which matter here. And it adds additional tests with NodePools.

This should resolve #8770 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging