### PR TITLE
Update various validations to work with Kafka Node Pools

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -24,14 +24,18 @@ import io.strimzi.test.annotations.ParallelTest;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ParallelSuite
 public class KafkaClusterOAuthValidationTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
+    private final static Set<NodeRef> THREE_NODES = Set.of(
+            new NodeRef("name-kafka-0", 0, "kafka", false, true),
+            new NodeRef("name-kafka-1", 1, "kafka", false, true),
+            new NodeRef("name-kafka-2", 2, "kafka", false, true));
 
     private List<GenericKafkaListener> getListeners(KafkaListenerAuthenticationOAuth auth)   {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
@@ -41,7 +45,7 @@ public class KafkaClusterOAuthValidationTest {
                 .withAuth(auth)
                 .build();
 
-        return asList(listener1);
+        return List.of(listener1);
     }
 
     @ParallelTest
@@ -56,12 +60,12 @@ public class KafkaClusterOAuthValidationTest {
                 .endClientSecret()
                 .build();
 
-        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
     }
 
     @ParallelTest
     public void testOAuthAuthnAuthz() {
-        List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
+        List<GenericKafkaListener> listeners = List.of(new GenericKafkaListenerBuilder()
                 .withName("listener1")
                 .withPort(9900)
                 .withType(KafkaListenerType.INTERNAL)
@@ -111,13 +115,13 @@ public class KafkaClusterOAuthValidationTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
     }
 
     @ParallelTest
     public void testOAuthAuthzWithoutAuthn() {
         assertThrows(InvalidResourceException.class, () -> {
-            List<GenericKafkaListener> listeners = asList(new GenericKafkaListenerBuilder()
+            List<GenericKafkaListener> listeners = List.of(new GenericKafkaListenerBuilder()
                     .withName("listener1")
                     .withPort(9900)
                     .withType(KafkaListenerType.INTERNAL)
@@ -153,7 +157,7 @@ public class KafkaClusterOAuthValidationTest {
                     .build();
 
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -171,7 +175,7 @@ public class KafkaClusterOAuthValidationTest {
                     .endClientSecret()
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -189,7 +193,7 @@ public class KafkaClusterOAuthValidationTest {
                     .endClientSecret()
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -207,7 +211,7 @@ public class KafkaClusterOAuthValidationTest {
                     .endClientSecret()
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -224,7 +228,7 @@ public class KafkaClusterOAuthValidationTest {
                 .endClientSecret()
                 .build();
 
-        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
     }
 
     @ParallelTest
@@ -239,7 +243,7 @@ public class KafkaClusterOAuthValidationTest {
                     .endClientSecret()
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -253,7 +257,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withJwksExpirySeconds(89)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -266,7 +270,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withJwksRefreshSeconds(333)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -279,7 +283,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withJwksExpirySeconds(150)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -288,7 +292,7 @@ public class KafkaClusterOAuthValidationTest {
         assertThrows(InvalidResourceException.class, () -> {
             KafkaListenerAuthenticationOAuth auth = new KafkaListenerAuthenticationOAuthBuilder().build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -299,7 +303,7 @@ public class KafkaClusterOAuthValidationTest {
                 .withJwksEndpointUri("http://jwks-endpoint")
                 .build();
 
-        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
     }
 
     @ParallelTest
@@ -311,7 +315,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withConnectTimeoutSeconds(0)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -324,7 +328,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withReadTimeoutSeconds(0)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -337,7 +341,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withGroupsClaim("['bad'.'query']")
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -352,7 +356,7 @@ public class KafkaClusterOAuthValidationTest {
                     .endClientSecret()
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -364,7 +368,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withIntrospectionEndpointUri("http://introspection")
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -377,7 +381,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withJwksExpirySeconds(100)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -390,7 +394,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withJwksRefreshSeconds(40)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -408,7 +412,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withCheckAccessTokenType(false)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 
@@ -424,7 +428,7 @@ public class KafkaClusterOAuthValidationTest {
                     .withAccessTokenIsJwt(false)
                     .build();
 
-            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, getListeners(auth));
+            ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, getListeners(auth));
         });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3566,8 +3566,8 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.validateIntConfigProperty(propertyName, kafkaAssembly.getSpec().getKafka()));
-        assertThat(ex.getMessage().equals("Kafka configuration option '" + propertyName + "' should be set to " + REPLICAS + " or less because 'spec.kafka.replicas' is " + REPLICAS), is(true));
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.validateIntConfigProperty(propertyName, kafkaAssembly.getSpec().getKafka(), REPLICAS));
+        assertThat(ex.getMessage(), is("Kafka configuration option '" + propertyName + "' should be set to " + REPLICAS + " or less because this cluster has only " + REPLICAS + " Kafka broker(s)."));
     }
 
     @ParallelTest
@@ -3580,7 +3580,7 @@ public class KafkaClusterTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka());
+        KafkaCluster.validateIntConfigProperty("offsets.topic.replication.factor", kafkaAssembly.getSpec().getKafka(), REPLICAS);
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -20,11 +20,10 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -37,6 +36,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ParallelSuite
 public class ListenersValidatorTest {
+    private final static Set<NodeRef> THREE_NODES = Set.of(
+            new NodeRef("name-kafka-0", 0, "kafka", false, true),
+            new NodeRef("name-kafka-1", 1, "kafka", false, true),
+            new NodeRef("name-kafka-2", 2, "kafka", false, true));
+    private final static Set<NodeRef> TWO_NODES = Set.of(
+            new NodeRef("name-kafka-0", 0, "kafka", false, true),
+            new NodeRef("name-kafka-1", 1, "kafka", false, true));
+    private final static Set<NodeRef> NODE_POOL_NODES = Set.of(
+            new NodeRef("foo-kafka-1000", 1000, "kafka", false, true),
+            new NodeRef("bar-kafka-2000", 2000, "kafka", false, true),
+            new NodeRef("bar-kafka-2001", 2001, "kafka", false, true));
+
     @ParallelTest
     public void testValidateListeners() {
         GenericKafkaListener listener1 = new GenericKafkaListenerBuilder()
@@ -51,8 +62,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1, listener2);
-        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners);
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2);
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners);
     }
 
     @ParallelTest
@@ -69,9 +80,9 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1, listener2);
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), containsString("every listener needs to have a unique port number"));
     }
 
@@ -95,8 +106,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("every listener needs to have a unique port number"));
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique port number"));
     }
 
     @ParallelTest
@@ -107,8 +118,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
+        List<GenericKafkaListener> listeners = List.of(listener1);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
     }
 
     @ParallelTest
@@ -119,8 +130,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
+        List<GenericKafkaListener> listeners = List.of(listener1);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
     }
 
     @ParallelTest
@@ -143,8 +154,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("every listener needs to have a unique name"));
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique name"));
     }
 
     @ParallelTest
@@ -167,8 +178,8 @@ public class ListenersValidatorTest {
                 .withType(KafkaListenerType.INTERNAL)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
     }
 
     @ParallelTest
@@ -182,8 +193,8 @@ public class ListenersValidatorTest {
                 .endKafkaListenerAuthenticationTlsAuth()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener plain cannot use tls type authentication with disabled TLS encryption"));
+        List<GenericKafkaListener> listeners = List.of(listener1);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener plain cannot use tls type authentication with disabled TLS encryption"));
     }
 
     @ParallelTest
@@ -202,8 +213,8 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder("listener plain cannot configure custom TLS certificate with disabled TLS encryption"));
+        List<GenericKafkaListener> listeners = List.of(listener1);
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener plain cannot configure custom TLS certificate with disabled TLS encryption"));
     }
 
     @ParallelTest
@@ -221,10 +232,10 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                    .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
-                        .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
                         .withNodePort(32189)
                         .withHost("my-host")
@@ -254,9 +265,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
@@ -276,7 +287,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure ipFamilies because it is internal listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -294,10 +305,10 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                    .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
-                        .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
                         .withNodePort(32189)
                         .withHost("my-host")
@@ -324,16 +335,16 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure preferredAddressType because it is not NodePort based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -351,9 +362,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners);
+        ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners);
     }
 
     @ParallelTest
@@ -371,10 +382,10 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                    .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
-                        .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
                         .withNodePort(32189)
                         .withHost("my-host")
@@ -401,9 +412,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
@@ -414,7 +425,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -428,13 +439,13 @@ public class ListenersValidatorTest {
                 .withTls(false)
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " is Route or Ingress type listener and requires enabled TLS encryption"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -453,10 +464,10 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                    .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
-                        .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
                         .withNodePort(32189)
                         .withHost("my-host")
@@ -486,9 +497,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
@@ -501,7 +512,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -528,13 +539,13 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " is Route or Ingress type listener and requires enabled TLS encryption"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -553,10 +564,10 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                    .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                    .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                    .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withNewBootstrap()
-                        .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                        .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
                         .withNodePort(32189)
                         .withHost("my-host")
@@ -583,9 +594,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure useServiceDnsDomain because it is not internal or cluster-ip listener",
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
@@ -597,7 +608,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -609,13 +620,13 @@ public class ListenersValidatorTest {
                 .withTls(true)
                 .build();
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
@@ -629,7 +640,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 1 which is required for Ingress based listeners"));
 
@@ -643,7 +654,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -659,7 +670,81 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, asList(listener)), hasSize(0));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), hasSize(0));
+    }
+
+    @ParallelTest
+    public void testIngressListenerHostNamesInNodePools() {
+        GenericKafkaListener listener = new GenericKafkaListenerBuilder()
+                .withName("ingress")
+                .withPort(9092)
+                .withType(KafkaListenerType.INGRESS)
+                .withTls(true)
+                .build();
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+                "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                                .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2000)
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+                "listener ingress is missing a broker host name for broker with ID 1000 which is required for Ingress based listeners",
+                "listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners",
+                "listener ingress is missing a broker host name for broker with ID 2001 which is required for Ingress based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                        .withHost("bootstrap-host")
+                        .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .withHost("host-1000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .withHost("host-2001")
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners"));
+
+        listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
+                .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
+                        .withHost("bootstrap-host")
+                        .build())
+                .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(1000)
+                                .withHost("host-1000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2000)
+                                .withHost("host-2000")
+                                .build(),
+                        new GenericKafkaListenerConfigurationBrokerBuilder()
+                                .withBroker(2001)
+                                .withHost("host-2001")
+                                .build())
+                .build());
+
+        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), hasSize(0));
     }
 
     @ParallelTest
@@ -685,9 +770,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), hasSize(0));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), hasSize(0));
     }
 
     @ParallelTest
@@ -706,10 +791,10 @@ public class ListenersValidatorTest {
                 .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                 .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                 .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
-                .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
-                .withFinalizers(asList("service.kubernetes.io/load-balancer-cleanup"))
+                .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                 .withNewBootstrap()
-                .withAlternativeNames(asList("my-name-1", "my-name-2"))
+                .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                 .withLoadBalancerIP("130.211.204.1")
                 .withNodePort(32189)
                 .withHost("my-host")
@@ -736,9 +821,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        List<String> expectedErrors = asList(
+        List<String> expectedErrors = List.of(
                 "listener " + name + " cannot configure externalTrafficPolicy because it is not LoadBalancer or NodePort based listener",
                 "listener " + name + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure finalizers because it is not LoadBalancer based listener",
@@ -752,7 +837,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(2, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -764,9 +849,9 @@ public class ListenersValidatorTest {
                 .withAuth(new KafkaListenerAuthenticationOAuthBuilder().build())
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: Introspection endpoint URI or JWKS endpoint URI has to be specified"),
                 containsString("listener listener1: Valid Issuer URI has to be specified or 'checkIssuer' set to 'false'")));
@@ -786,9 +871,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener1);
+        List<GenericKafkaListener> listeners = List.of(listener1);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener 'listener1' cannot have an empty secret name in the brokerCertChainAndKey"),
                 containsString("listener 'listener1' cannot have an empty key in the brokerCertChainAndKey"),
@@ -846,9 +931,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(internal, route, lb, np, inq);
+        List<GenericKafkaListener> listeners = List.of(internal, route, lb, np, inq);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), empty());
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), empty());
     }
 
     @ParallelTest
@@ -865,9 +950,9 @@ public class ListenersValidatorTest {
         GenericKafkaListener listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener);
+        List<GenericKafkaListener> listeners = List.of(listener);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: At least one of 'enablePlain', 'enableOauthBearer' has to be set to 'true'")));
 
@@ -875,9 +960,9 @@ public class ListenersValidatorTest {
         authBuilder.withEnablePlain(true);
         listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
-        List<GenericKafkaListener> listeners2 = asList(listener);
+        List<GenericKafkaListener> listeners2 = List.of(listener);
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners2));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners2));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: Introspection endpoint URI or JWKS endpoint URI has to be specified")));
 
@@ -885,9 +970,9 @@ public class ListenersValidatorTest {
         authBuilder.withJwksEndpointUri("http://localhost:8080/jwks").withCheckIssuer(false);
         listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
-        List<GenericKafkaListener> listeners3 = asList(listener);
+        List<GenericKafkaListener> listeners3 = List.of(listener);
 
-        assertDoesNotThrow(() -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners3));
+        assertDoesNotThrow(() -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners3));
     }
 
     @ParallelTest
@@ -904,9 +989,9 @@ public class ListenersValidatorTest {
         GenericKafkaListener listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener);
+        List<GenericKafkaListener> listeners = List.of(listener);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: 'clientId' has to be configured when 'checkAudience' is 'true'")));
 
@@ -915,9 +1000,9 @@ public class ListenersValidatorTest {
 
         listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
-        List<GenericKafkaListener> listeners2 = asList(listener);
+        List<GenericKafkaListener> listeners2 = List.of(listener);
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners2));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners2));
         assertThat(exception.getMessage(), allOf(
                 not(containsString("listener listener1: 'clientId' has to be configured when 'checkAudience' is 'true'"))));
     }
@@ -936,9 +1021,9 @@ public class ListenersValidatorTest {
         GenericKafkaListener listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
 
-        List<GenericKafkaListener> listeners = asList(listener);
+        List<GenericKafkaListener> listeners = List.of(listener);
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: 'customClaimCheck' value not a valid JsonPath filter query - Failed to parse filter query: \"invalid\"")));
 
@@ -947,9 +1032,9 @@ public class ListenersValidatorTest {
 
         listener = listenerBuilder.withAuth(authBuilder.build())
                 .build();
-        List<GenericKafkaListener> listeners2 = asList(listener);
+        List<GenericKafkaListener> listeners2 = List.of(listener);
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners2));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners2));
         assertThat(exception.getMessage(), allOf(
                 not(containsString("listener listener1: 'customClaimCheck' value not a valid JsonPath filter query - Failed to parse query: \"invalid\" at position: 0"))));
     }
@@ -966,18 +1051,18 @@ public class ListenersValidatorTest {
                 .withAuth(authBuilder.build());
 
 
-        List<GenericKafkaListener> listeners = asList(listenerBuilder.withAuth(authBuilder.build()).build());
+        List<GenericKafkaListener> listeners = List.of(listenerBuilder.withAuth(authBuilder.build()).build());
 
-        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners));
+        Exception exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: 'connectTimeoutSeconds' needs to be a positive integer (set to: 0)")));
 
         // set valid connectTimeoutSeconds
         authBuilder.withConnectTimeoutSeconds(1);
 
-        List<GenericKafkaListener> listeners2 = asList(listenerBuilder.withAuth(authBuilder.build()).build());
+        List<GenericKafkaListener> listeners2 = List.of(listenerBuilder.withAuth(authBuilder.build()).build());
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners2));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners2));
         assertThat(exception.getMessage(), allOf(
                 not(containsString("listener listener1: 'connectTimeoutSeconds' needs to be a positive integer"))));
 
@@ -987,18 +1072,18 @@ public class ListenersValidatorTest {
         authBuilder.withConnectTimeoutSeconds(null)
                 .withReadTimeoutSeconds(0);
 
-        List<GenericKafkaListener> listeners3 = asList(listenerBuilder.withAuth(authBuilder.build()).build());
+        List<GenericKafkaListener> listeners3 = List.of(listenerBuilder.withAuth(authBuilder.build()).build());
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners3));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners3));
         assertThat(exception.getMessage(), allOf(
                 containsString("listener listener1: 'readTimeoutSeconds' needs to be a positive integer (set to: 0)")));
 
         // set valid readTimeoutSeconds
         authBuilder.withReadTimeoutSeconds(1);
 
-        List<GenericKafkaListener> listeners4 = asList(listenerBuilder.withAuth(authBuilder.build()).build());
+        List<GenericKafkaListener> listeners4 = List.of(listenerBuilder.withAuth(authBuilder.build()).build());
 
-        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, 3, listeners4));
+        exception = assertThrows(InvalidResourceException.class, () -> ListenersValidator.validate(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners4));
         assertThat(exception.getMessage(), allOf(
                 not(containsString("listener listener1: 'readTimeoutSeconds' needs to be a positive integer"))));
 
@@ -1033,9 +1118,9 @@ public class ListenersValidatorTest {
                 .endConfiguration()
                 .build();
 
-        List<GenericKafkaListener> listeners = Arrays.asList(listener1, listener2, listener3);
+        List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(3, listeners), containsInAnyOrder(
+        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(
                 "listener listener1 cannot configure createBootstrapService because it is not load balancer listener",
                 "listener listener2 cannot configure createBootstrapService because it is not load balancer listener",
                 "listener listener3 cannot configure createBootstrapService because it is not load balancer listener"));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR updates various validations of the Kafka cluster which are based on the number of nodes and used the number of replicas from the `Kafka` CR instead of the number of replicas based on the Node Pools. This includes for example:
* Validation of various replication factors in the Kafka configuration
* Validation of the host configurations for Ingress listeners

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally