### PR TITLE
docs(listeners): updates property descriptions for generic listener schema configuration

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
@@ -56,7 +56,7 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
         this.broker = broker;
     }
 
-    @Description("The host name which will be used in the brokers' `advertised.brokers`")
+    @Description("The host name used in the brokers' `advertised.listeners`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String getAdvertisedHost() {
         return advertisedHost;
@@ -66,7 +66,7 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
         this.advertisedHost = advertisedHost;
     }
 
-    @Description("The port number which will be used in the brokers' `advertised.brokers`")
+    @Description("The port number used in the brokers' `advertised.listeners`.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Integer getAdvertisedPort() {
         return advertisedPort;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -433,9 +433,9 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |Property               |Description
 |broker          1.2+<.<a|ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.
 |integer
-|advertisedHost  1.2+<.<a|The host name which will be used in the brokers' `advertised.brokers`.
+|advertisedHost  1.2+<.<a|The host name used in the brokers' `advertised.listeners`.
 |string
-|advertisedPort  1.2+<.<a|The port number which will be used in the brokers' `advertised.brokers`.
+|advertisedPort  1.2+<.<a|The port number used in the brokers' `advertised.listeners`.
 |integer
 |host            1.2+<.<a|The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
 |string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -326,10 +326,10 @@ spec:
                                       description: ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.
                                     advertisedHost:
                                       type: string
-                                      description: The host name which will be used in the brokers' `advertised.brokers`.
+                                      description: The host name used in the brokers' `advertised.listeners`.
                                     advertisedPort:
                                       type: integer
-                                      description: The port number which will be used in the brokers' `advertised.brokers`.
+                                      description: The port number used in the brokers' `advertised.listeners`.
                                     host:
                                       type: string
                                       description: The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -325,10 +325,10 @@ spec:
                                     description: ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.
                                   advertisedHost:
                                     type: string
-                                    description: The host name which will be used in the brokers' `advertised.brokers`.
+                                    description: The host name used in the brokers' `advertised.listeners`.
                                   advertisedPort:
                                     type: integer
-                                    description: The port number which will be used in the brokers' `advertised.brokers`.
+                                    description: The port number used in the brokers' `advertised.listeners`.
                                   host:
                                     type: string
                                     description: The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.


### PR DESCRIPTION
**Documentation**

Fixes descriptions for `GenericKafkaListenerConfigurationBroker` schema properties `advertisedHost` and `advertisedPort`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

