### PR TITLE
Fix some JavaDoc errors in `operator-common` and `user-operator`

### DIFF
--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.util.Random;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -58,7 +56,6 @@ public abstract class AbstractCustomResourceOperatorIT<
             .withStatus("True")
             .build();
 
-    protected static Executor asyncExecutor = ForkJoinPool.commonPool();
     protected static KubernetesClient client;
 
     protected abstract CrdOperator<C, T, L> operator();
@@ -130,8 +127,6 @@ public abstract class AbstractCustomResourceOperatorIT<
 
     /**
      * Tests what happens when the resource is deleted while updating the status
-     *
-     * @param context   Test context
      */
     @Test
     public void testUpdateStatusAfterResourceDeletedThrowsKubernetesClientException() {
@@ -165,8 +160,6 @@ public abstract class AbstractCustomResourceOperatorIT<
 
     /**
      * Tests what happens when the resource is modified while updating the status
-     *
-     * @param context   Test context
      */
     @Test
     public void testUpdateStatusAfterResourceUpdated() {

--- a/user-operator/src/main/java/io/strimzi/operator/user/Main.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/Main.java
@@ -136,7 +136,7 @@ public class Main {
      * Creates the Kafka Admin API client
      *
      * @param config                User Operator configuration
-     * @param client                Kubernetes client
+     * @param secretOperator        Secret operator for managing secrets
      * @param adminClientProvider   Admin client provider
      *
      * @return  An instance of the Admin API client


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes some minor issues in `operator-common` and `user-operator`:
* Removes one unused variable
* Fixes some JavaDoc errors on private and test methods
