### PR TITLE
Create listener-related resources only for broker nodes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -36,11 +36,11 @@ public class ListenersValidator {
      * Validated the listener configuration. If the configuration is not valid, InvalidResourceException will be thrown.
      *
      * @param reconciliation    The reconciliation
-     * @param nodes             Nodes which are part of this Kafka cluster
+     * @param brokerNodes       Broker nodes which are part of this Kafka cluster
      * @param listeners         Listeners which should be validated
      */
-    public static void validate(Reconciliation reconciliation, Set<NodeRef> nodes, List<GenericKafkaListener> listeners) throws InvalidResourceException {
-        Set<String> errors = validateAndGetErrorMessages(nodes, listeners);
+    public static void validate(Reconciliation reconciliation, Set<NodeRef> brokerNodes, List<GenericKafkaListener> listeners) throws InvalidResourceException {
+        Set<String> errors = validateAndGetErrorMessages(brokerNodes, listeners);
 
         if (!errors.isEmpty())  {
             LOGGER.errorCr(reconciliation, "Listener configuration is not valid: {}", errors);
@@ -48,7 +48,7 @@ public class ListenersValidator {
         }
     }
 
-    /*test*/ static Set<String> validateAndGetErrorMessages(Set<NodeRef> nodes, List<GenericKafkaListener> listeners)    {
+    /*test*/ static Set<String> validateAndGetErrorMessages(Set<NodeRef> brokerNodes, List<GenericKafkaListener> listeners)    {
         Set<String> errors = new HashSet<>(0);
         List<Integer> ports = getPorts(listeners);
         List<String> names = getNames(listeners);
@@ -106,7 +106,7 @@ public class ListenersValidator {
             }
 
             if (KafkaListenerType.INGRESS.equals(listener.getType()))    {
-                validateIngress(errors, nodes, listener);
+                validateIngress(errors, brokerNodes, listener);
             }
         }
 
@@ -154,11 +154,11 @@ public class ListenersValidator {
     /**
      * Validates that Ingress type listener has the right host configurations
      *
-     * @param errors    List where any found errors will be added
-     * @param nodes     Nodes which are part of this Kafka cluster
-     * @param listener  Listener which needs to be validated
+     * @param errors        List where any found errors will be added
+     * @param brokerNodes   Broker nodes which are part of this Kafka cluster
+     * @param listener      Listener which needs to be validated
      */
-    private static void validateIngress(Set<String> errors, Set<NodeRef> nodes, GenericKafkaListener listener) {
+    private static void validateIngress(Set<String> errors, Set<NodeRef> brokerNodes, GenericKafkaListener listener) {
         if (listener.getConfiguration() != null)    {
             GenericKafkaListenerConfiguration conf = listener.getConfiguration();
 
@@ -168,7 +168,7 @@ public class ListenersValidator {
             }
 
             if (conf.getBrokers() != null) {
-                for (NodeRef node : nodes)  {
+                for (NodeRef node : brokerNodes)    {
                     GenericKafkaListenerConfigurationBroker broker = conf.getBrokers().stream().filter(b -> b.getBroker() == node.nodeId()).findFirst().orElse(null);
 
                     if (broker == null || broker.getHost() == null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -327,7 +327,7 @@ public class KafkaListenersReconciler {
             result.listenerStatuses.add(ls);
 
             // Set advertised hostnames and ports
-            for (NodeRef node : kafka.nodes()) {
+            for (NodeRef node : kafka.brokerNodes()) {
                 String brokerServiceName = ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener);
                 String brokerAddress = getInternalServiceHostname(reconciliation.namespace(), brokerServiceName, useServiceDnsDomain);
                 if (listener.isTls()) {
@@ -391,7 +391,7 @@ public class KafkaListenersReconciler {
             }).compose(res -> {
                 List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                for (NodeRef node : kafka.nodes()) {
+                for (NodeRef node : kafka.brokerNodes()) {
                     perPodFutures.add(
                             serviceOperator.hasIngressAddress(reconciliation, reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener), 1_000, operationTimeoutMs)
                     );
@@ -401,7 +401,7 @@ public class KafkaListenersReconciler {
             }).compose(res -> {
                 List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                for (NodeRef node : kafka.nodes()) {
+                for (NodeRef node : kafka.brokerNodes()) {
                     Future<Void> perBrokerFut = serviceOperator.getAsync(reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener))
                             .compose(svc -> {
                                 String brokerAddress;
@@ -485,7 +485,7 @@ public class KafkaListenersReconciler {
                     .compose(res -> {
                         List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             perPodFutures.add(
                                     serviceOperator.hasNodePort(reconciliation, reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener), 1_000, operationTimeoutMs)
                             );
@@ -496,7 +496,7 @@ public class KafkaListenersReconciler {
                     .compose(res -> {
                         List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             Future<Void> perBrokerFut = serviceOperator.getAsync(reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener))
                                     .compose(svc -> {
                                         Integer externalBrokerNodePort = svc.getSpec().getPorts().get(0).getNodePort();
@@ -576,7 +576,7 @@ public class KafkaListenersReconciler {
                     .compose(res -> {
                         List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             perPodFutures.add(
                                     routeOperator.hasAddress(reconciliation, reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener), 1_000, operationTimeoutMs)
                             );
@@ -587,7 +587,7 @@ public class KafkaListenersReconciler {
                     .compose(res -> {
                         List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             //final int finalBrokerId = brokerId;
                             Future<Void> perBrokerFut = routeOperator.getAsync(reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener))
                                     .compose(route -> {
@@ -658,7 +658,7 @@ public class KafkaListenersReconciler {
                         // Check if broker ingresses are ready
                         List<Future<Void>> perPodFutures = new ArrayList<>();
 
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             perPodFutures.add(
                                     ingressOperator.hasIngressAddress(reconciliation, reconciliation.namespace(), ListenersUtils.backwardsCompatiblePerBrokerServiceName(ReconcilerUtils.getControllerNameFromPodName(node.podName()), node.nodeId(), listener), 1_000, operationTimeoutMs)
                             );
@@ -667,7 +667,7 @@ public class KafkaListenersReconciler {
                         return Future.join(perPodFutures);
                     })
                     .compose(res -> {
-                        for (NodeRef node : kafka.nodes()) {
+                        for (NodeRef node : kafka.brokerNodes()) {
                             //final int finalBrokerId = brokerId;
                             String brokerAddress = listener.getConfiguration().getBrokers().stream()
                                     .filter(broker -> broker.getBroker() == node.nodeId())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaSpecChecker.java
@@ -84,14 +84,14 @@ public class KafkaSpecChecker {
         String defaultReplicationFactor = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR);
         String minInsyncReplicas = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.MIN_INSYNC_REPLICAS);
 
-        if (defaultReplicationFactor == null && kafkaCluster.nodes().stream().filter(NodeRef::broker).count() > 1)   {
+        if (defaultReplicationFactor == null && kafkaCluster.brokerNodes().size() > 1)   {
             warnings.add(StatusUtils.buildWarningCondition("KafkaDefaultReplicationFactor",
                     "default.replication.factor option is not configured. " +
                             "It defaults to 1 which does not guarantee reliability and availability. " +
                             "You should configure this option in .spec.kafka.config."));
         }
 
-        if (minInsyncReplicas == null && kafkaCluster.nodes().stream().filter(NodeRef::broker).count() > 1)   {
+        if (minInsyncReplicas == null && kafkaCluster.brokerNodes().size() > 1)   {
             warnings.add(StatusUtils.buildWarningCondition("KafkaMinInsyncReplicas",
                     "min.insync.replicas option is not configured. " +
                             "It defaults to 1 which does not guarantee reliability and availability. " +
@@ -149,8 +149,8 @@ public class KafkaSpecChecker {
      * @param warnings List to add a warning to, if appropriate.
      */
     private void checkKafkaBrokersStorage(List<Condition> warnings) {
-        if (kafkaCluster.nodes().stream().filter(NodeRef::broker).count() == 1
-                && StorageUtils.usesEphemeral(kafkaCluster.getStorageByPoolName().get(kafkaCluster.nodes().stream().filter(NodeRef::broker).toList().toArray(new NodeRef[]{})[0].poolName()))) {
+        if (kafkaCluster.brokerNodes().size() == 1
+                && StorageUtils.usesEphemeral(kafkaCluster.getStorageByPoolName().get(kafkaCluster.brokerNodes().toArray(new NodeRef[]{})[0].poolName()))) {
             warnings.add(StatusUtils.buildWarningCondition("KafkaStorage",
                     "A Kafka cluster with a single broker node and ephemeral storage will lose topic messages after any restart or rolling update."));
         }
@@ -164,8 +164,8 @@ public class KafkaSpecChecker {
      * @param warnings List to add a warning to, if appropriate.
      */
     private void checkKRaftControllerStorage(List<Condition> warnings) {
-        if (kafkaCluster.nodes().stream().filter(NodeRef::controller).count() == 1
-                && StorageUtils.usesEphemeral(kafkaCluster.getStorageByPoolName().get(kafkaCluster.nodes().stream().filter(NodeRef::controller).toList().toArray(new NodeRef[]{})[0].poolName()))) {
+        if (kafkaCluster.controllerNodes().size() == 1
+                && StorageUtils.usesEphemeral(kafkaCluster.getStorageByPoolName().get(kafkaCluster.controllerNodes().toArray(new NodeRef[]{})[0].poolName()))) {
             warnings.add(StatusUtils.buildWarningCondition("KafkaStorage",
                     "A Kafka cluster with a single controller node and ephemeral storage will lose data after any restart or rolling update."));
         }
@@ -177,7 +177,7 @@ public class KafkaSpecChecker {
      * @param warnings List to add a warning to, if appropriate.
      */
     private void checkKRaftControllerCount(List<Condition> warnings)    {
-        long controllerCount = kafkaCluster.nodes().stream().filter(NodeRef::controller).count();
+        long controllerCount = kafkaCluster.controllerNodes().size();
 
         if (controllerCount == 2) {
             warnings.add(StatusUtils.buildWarningCondition("KafkaKRaftControllerNodeCount",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -44,7 +44,7 @@ public class ListenersValidatorTest {
             new NodeRef("name-kafka-0", 0, "kafka", false, true),
             new NodeRef("name-kafka-1", 1, "kafka", false, true));
     private final static Set<NodeRef> NODE_POOL_NODES = Set.of(
-            new NodeRef("foo-kafka-1000", 1000, "kafka", false, true),
+            new NodeRef("foo-kafka-1000", 1000, "kafka", true, true),
             new NodeRef("bar-kafka-2000", 2000, "kafka", false, true),
             new NodeRef("bar-kafka-2001", 2001, "kafka", false, true));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
@@ -85,7 +85,7 @@ public class NodePoolUtilsTest {
 
         assertThat(pools.size(), is(1));
         assertThat(pools.get(0).poolName, is(VirtualNodePoolConverter.DEFAULT_NODE_POOL_NAME));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of(0, 1, 2)));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of()));
@@ -107,7 +107,7 @@ public class NodePoolUtilsTest {
 
         assertThat(pools.size(), is(1));
         assertThat(pools.get(0).poolName, is(VirtualNodePoolConverter.DEFAULT_NODE_POOL_NAME));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(0, 1, 2)));
@@ -128,7 +128,7 @@ public class NodePoolUtilsTest {
 
         assertThat(pools.size(), is(1));
         assertThat(pools.get(0).poolName, is(VirtualNodePoolConverter.DEFAULT_NODE_POOL_NAME));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of(2)));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(0, 1)));
@@ -166,7 +166,7 @@ public class NodePoolUtilsTest {
 
         assertThat(pools.size(), is(1));
         assertThat(pools.get(0).poolName, is(VirtualNodePoolConverter.DEFAULT_NODE_POOL_NAME));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of(0, 1, 2)));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of()));
@@ -180,14 +180,14 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of(0, 1, 2)));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.desired(), is(Set.of(0, 1, 2)));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(1).idAssignment.toBeAdded(), is(Set.of(3, 4)));
         assertThat(pools.get(1).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.current(), is(Set.of()));
@@ -220,7 +220,7 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(0, 1, 2)));
@@ -230,7 +230,7 @@ public class NodePoolUtilsTest {
         assertThat(((PersistentClaimStorage) storage.getVolumes().get(0)).getSize(), is("100Gi"));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(1).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.current(), is(Set.of(10, 11)));
@@ -265,14 +265,14 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of(2)));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(0, 1, 2)));
         assertThat(pools.get(0).idAssignment.desired(), is(Set.of(0, 1)));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(1).idAssignment.toBeAdded(), is(Set.of(3)));
         assertThat(pools.get(1).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.current(), is(Set.of(10, 11)));
@@ -312,14 +312,14 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of(12)));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(10, 11, 12)));
         assertThat(pools.get(0).idAssignment.desired(), is(Set.of(10, 11)));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(1).idAssignment.toBeAdded(), is(Set.of(22)));
         assertThat(pools.get(1).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.current(), is(Set.of(20, 21)));
@@ -345,10 +345,10 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)));
     }
 
     @Test
@@ -370,10 +370,10 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.CONTROLLER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.CONTROLLER)));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
     }
 
     @Test
@@ -402,7 +402,7 @@ public class NodePoolUtilsTest {
         assertThat(pools.size(), is(2));
 
         assertThat(pools.get(0).poolName, is("pool-a"));
-        assertThat(pools.get(0).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(0).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(0).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(0).idAssignment.current(), is(Set.of(0, 1, 2)));
@@ -412,7 +412,7 @@ public class NodePoolUtilsTest {
         assertThat(((PersistentClaimStorage) storage.getVolumes().get(0)).getSize(), is("100Gi"));
 
         assertThat(pools.get(1).poolName, is("pool-b"));
-        assertThat(pools.get(1).kraftRoles, is(Set.of(ProcessRoles.BROKER)));
+        assertThat(pools.get(1).processRoles, is(Set.of(ProcessRoles.BROKER)));
         assertThat(pools.get(1).idAssignment.toBeAdded(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.toBeRemoved(), is(Set.of()));
         assertThat(pools.get(1).idAssignment.current(), is(Set.of(10, 11)));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Right now, when running in KRaft mode, we create the listener-related resources (per-broker services, routes, and ingresses) for all Kafka nodes. This includes also controller-only nodes where the regular clients are not connecting. This PR updates the logic in `KafkaCluster` class to generate these resources only for nodes with the broker role (both broker-only as well as mixed). It also updates `KafkaListenerReconciler` to wait for the readiness of these resources only for broker nodes. Plus it also fixes the related listener validations.

As part of this change, I needed to do in many different places checks whether a node pool has broker or controller roles. And I also needed to filter the broker nodes from the list with all nodes. To avoid having this logic copied around in many different places, I created new methods in `KafkaCluster` and `KafkaPool` for these checks. I also renamed the field `kraftRoles` to `processRoles`. Originally, this field was used only in KRaft mode. But as we made it mandatory even with ZooKeeper in the Node Pool API, I think calling it `processRoles` fits better the purpose.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally