### PR TITLE
Use Cruise control only on Kafka broker nodes when running in KRaft mode

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -25,6 +25,16 @@ public abstract class AbstractConfiguration {
     private final OrderedProperties options = new OrderedProperties();
 
     /**
+     * Copy constructor which creates new instance of the Abstract Configuration from existing configuration. It is
+     * useful when you need to modify an instance of the configuration without permanently changing the original.
+     *
+     * @param configuration     Existing configuration
+     */
+    public AbstractConfiguration(AbstractConfiguration configuration)   {
+        options.addMapPairs(configuration.asOrderedProperties().asMap());
+    }
+
+    /**
      * Constructor used to instantiate this class from String configuration. Should be used to create configuration
      * from the Assembly.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -70,7 +70,6 @@ import static io.strimzi.operator.cluster.model.VolumeUtils.createVolumeMount;
  */
 public class CruiseControl extends AbstractModel implements SupportsMetrics, SupportsLogging {
     protected static final String COMPONENT_TYPE = "cruise-control";
-    protected static final String CRUISE_CONTROL_METRIC_REPORTER = "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter";
     protected static final String CRUISE_CONTROL_CONTAINER_NAME = "cruise-control";
 
     // Fields used for Cruise Control API authentication

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -168,24 +168,24 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
      * Creates an instance of the Cruise Control model from the custom resource. When Cruise Control is not enabled,
      * this will return null.
      *
-     * @param reconciliation    Reconciliation marker used for logging
-     * @param kafkaCr           The Kafka custom resource
-     * @param versions          Supported Kafka versions
-     * @param kafkaNodes                List of the nodes which are part of the Kafka cluster
-     * @param kafkaStorage              A map with storage configuration used by the Kafka cluster and its node pools
-     * @param kafkaResources            A map with resource configuration used by the Kafka cluster and its node pools
-     * @param sharedEnvironmentProvider Shared environment provider
+     * @param reconciliation                Reconciliation marker used for logging
+     * @param kafkaCr                       The Kafka custom resource
+     * @param versions                      Supported Kafka versions
+     * @param kafkaBrokerNodes              List of the broker nodes which are part of the Kafka cluster
+     * @param kafkaStorage                  A map with storage configuration used by the Kafka cluster and its node pools
+     * @param kafkaBrokerResources          A map with resource configuration used by the Kafka cluster and its broker pools
+     * @param sharedEnvironmentProvider     Shared environment provider
      *
-     * @return                  Instance of the Cruise Control model
+     * @return  Instance of the Cruise Control model
      */
     @SuppressWarnings({"checkstyle:NPathComplexity", "checkstyle:CyclomaticComplexity"})
     public static CruiseControl fromCrd(
             Reconciliation reconciliation,
             Kafka kafkaCr,
             KafkaVersion.Lookup versions,
-            Set<NodeRef> kafkaNodes,
+            Set<NodeRef> kafkaBrokerNodes,
             Map<String, Storage> kafkaStorage,
-            Map<String, ResourceRequirements> kafkaResources,
+            Map<String, ResourceRequirements> kafkaBrokerResources,
             SharedEnvironmentProvider sharedEnvironmentProvider
     ) {
         CruiseControlSpec ccSpec = kafkaCr.getSpec().getCruiseControl();
@@ -212,7 +212,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
 
             // To avoid illegal storage configurations provided by the user,
             // we rely on the storage configuration provided by the KafkaAssemblyOperator
-            result.capacity = new Capacity(reconciliation, kafkaCr.getSpec(), kafkaNodes, kafkaStorage, kafkaResources);
+            result.capacity = new Capacity(reconciliation, kafkaCr.getSpec(), kafkaBrokerNodes, kafkaStorage, kafkaBrokerResources);
             result.readinessProbeOptions = ProbeUtils.extractReadinessProbeOptionsOrDefault(ccSpec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
             result.livenessProbeOptions = ProbeUtils.extractLivenessProbeOptionsOrDefault(ccSpec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
             result.gcLoggingEnabled = ccSpec.getJvmOptions() == null ? JvmOptions.DEFAULT_GC_LOGGING_ENABLED : ccSpec.getJvmOptions().isGcLoggingEnabled();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1800,8 +1800,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * @return A Map with the storage configuration used by the different node pool. the key in the map is the name of
-     *         the node pool and the value is the storage configuration from the custom resource.
+     * @return A Map with the storage configuration used by the different node pools. The key in the map is the name of
+     *         the node pool and the value is the storage configuration from the custom resource. The map includes the
+     *         storage for both broker and controller pools as it is used also for Storage validation.
      */
     public Map<String, Storage> getStorageByPoolName() {
         Map<String, Storage> storage = new HashMap<>();
@@ -1814,17 +1815,20 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * @return A Map with the resources configuration used by the different node pool. the key in the map is the name of
-     *         the node pool and the value is the ResourceRequirements configuration from the custom resource.
+     * @return A Map with the resources configuration used by the different node pool with brokers. the key in the map
+     *         is the name of the node pool and the value is the ResourceRequirements configuration from the custom
+     *         resource. The map includes only pools with broker role. Controller-only node pools are not included.
      */
-    public Map<String, ResourceRequirements> getResourceRequirementsByPoolName() {
-        Map<String, ResourceRequirements> storage = new HashMap<>();
+    public Map<String, ResourceRequirements> getBrokerResourceRequirementsByPoolName() {
+        Map<String, ResourceRequirements> resources = new HashMap<>();
 
         for (KafkaPool pool : nodePools)    {
-            storage.put(pool.poolName, pool.resources);
+            if (pool.isBroker()) {
+                resources.put(pool.poolName, pool.resources);
+            }
         }
 
-        return storage;
+        return resources;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -40,7 +40,6 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.strimzi.api.kafka.model.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.CruiseControlResources;
-import io.strimzi.api.kafka.model.CruiseControlSpec;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaAuthorization;
 import io.strimzi.api.kafka.model.KafkaAuthorizationKeycloak;
@@ -66,6 +65,7 @@ import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.ResourceTemplate;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
@@ -75,11 +75,10 @@ import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
 import io.strimzi.operator.cluster.model.securityprofiles.ContainerSecurityProviderContextImpl;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderContextImpl;
 import io.strimzi.operator.cluster.operator.resource.KafkaSpecChecker;
-import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
+import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.MetricsAndLogging;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.json.JsonArray;
@@ -89,7 +88,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -97,10 +95,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.cluster.model.CruiseControl.CRUISE_CONTROL_METRIC_REPORTER;
 import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithCustomAuth;
 import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithOAuth;
-import static java.util.Collections.addAll;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 
@@ -153,10 +149,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "kafka-metrics-and-logging";
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/kafka/custom-config/";
 
-    private static final String KAFKA_METRIC_REPORTERS_CONFIG_FIELD = "metric.reporters";
-    private static final String KAFKA_NUM_PARTITIONS_CONFIG_FIELD = "num.partitions";
-    private static final String KAFKA_REPLICATION_FACTOR_CONFIG_FIELD = "default.replication.factor";
-
     protected static final String CO_ENV_VAR_CUSTOM_KAFKA_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_LABELS";
 
     /**
@@ -204,23 +196,16 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     public static final String BROKER_LISTENERS_FILENAME = "listeners.config";
 
-    // Cruise Control defaults
-    private static final String CRUISE_CONTROL_DEFAULT_NUM_PARTITIONS = "1";
-    private static final String CRUISE_CONTROL_DEFAULT_REPLICATION_FACTOR = "1";
-
     // Kafka configuration
     private Rack rack;
     private String initImage;
     private List<GenericKafkaListener> listeners;
     private KafkaAuthorization authorization;
     private KafkaVersion kafkaVersion;
-    private CruiseControlSpec cruiseControlSpec;
-    private String ccNumPartitions = null;
-    private String ccReplicationFactor = null;
-    private String ccMinInSyncReplicas = null;
     private boolean useKRaft = false;
     private String clusterId;
     private JmxModel jmx;
+    private CruiseControlMetricsReporter ccMetricsReporter;
     private MetricsModel metrics;
     private LoggingModel logging;
     /* test */ KafkaConfiguration configuration;
@@ -323,9 +308,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
         // Handle Kafka broker configuration
         KafkaConfiguration configuration = new KafkaConfiguration(reconciliation, kafkaClusterSpec.getConfig().entrySet());
-        configureCruiseControlMetrics(kafka, result, numberOfBrokers, configuration);
         validateConfiguration(reconciliation, kafka, result.kafkaVersion, configuration);
         result.configuration = configuration;
+
+        result.ccMetricsReporter = CruiseControlMetricsReporter.fromCrd(kafka, configuration, numberOfBrokers);
 
         // Configure listeners
         if (kafkaClusterSpec.getListeners() == null || kafkaClusterSpec.getListeners().isEmpty()) {
@@ -451,63 +437,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
 
         throw new RuntimeException("Node ID " + nodeId + " does not belong to any known node pool!");
-    }
-
-    /**
-     * Depending on the Cruise Control configuration, it enhances the Kafka configuration to enable the Cruise Control
-     * metric reporter and the configuration of its topics.
-     *
-     * @param kafkaAssembly     Kafka custom resource
-     * @param kafkaCluster      KafkaCluster instance
-     * @param numberOfBrokers   Number of broker nodes in the Kafka cluster
-     * @param configuration     Kafka broker configuration
-     */
-    private static void configureCruiseControlMetrics(Kafka kafkaAssembly, KafkaCluster kafkaCluster, long numberOfBrokers, KafkaConfiguration configuration) {
-        // If required Cruise Control metric reporter configurations are missing set them using Kafka defaults
-        if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()) == null) {
-            kafkaCluster.ccNumPartitions = configuration.getConfigOption(KAFKA_NUM_PARTITIONS_CONFIG_FIELD, CRUISE_CONTROL_DEFAULT_NUM_PARTITIONS);
-        }
-        if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) == null) {
-            kafkaCluster.ccReplicationFactor = configuration.getConfigOption(KAFKA_REPLICATION_FACTOR_CONFIG_FIELD, CRUISE_CONTROL_DEFAULT_REPLICATION_FACTOR);
-        }
-        if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()) == null) {
-            kafkaCluster.ccMinInSyncReplicas = "1";
-        } else {
-            // If the user has set the CC minISR, but it is higher than the set number of replicas for the metrics topics then we need to abort and make
-            // sure that the user sets minISR <= replicationFactor
-            int userConfiguredMinInsync = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()));
-            int configuredCcReplicationFactor = Integer.parseInt(kafkaCluster.ccReplicationFactor != null ? kafkaCluster.ccReplicationFactor : configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()));
-            if (userConfiguredMinInsync > configuredCcReplicationFactor) {
-                throw new IllegalArgumentException(
-                        "The Cruise Control metric topic minISR was set to a value (" + userConfiguredMinInsync + ") " +
-                                "which is higher than the number of replicas for that topic (" + configuredCcReplicationFactor + "). " +
-                                "Please ensure that the CC metrics topic minISR is <= to the topic's replication factor."
-                );
-            }
-        }
-        String metricReporters = configuration.getConfigOption(KAFKA_METRIC_REPORTERS_CONFIG_FIELD);
-        Set<String> metricReporterList = new HashSet<>();
-        if (metricReporters != null) {
-            addAll(metricReporterList, configuration.getConfigOption(KAFKA_METRIC_REPORTERS_CONFIG_FIELD).split(","));
-        }
-
-        if (kafkaAssembly.getSpec().getCruiseControl() != null
-                && numberOfBrokers < 2) {
-            throw new InvalidResourceException("Kafka " +
-                    kafkaAssembly.getMetadata().getNamespace() + "/" + kafkaAssembly.getMetadata().getName() +
-                    " has invalid configuration. Cruise Control cannot be deployed with a Kafka cluster which has only one broker. It requires at least two Kafka brokers.");
-        }
-        kafkaCluster.cruiseControlSpec = kafkaAssembly.getSpec().getCruiseControl();
-        if (kafkaCluster.cruiseControlSpec != null) {
-            metricReporterList.add(CRUISE_CONTROL_METRIC_REPORTER);
-        } else {
-            metricReporterList.remove(CRUISE_CONTROL_METRIC_REPORTER);
-        }
-        if (!metricReporterList.isEmpty()) {
-            configuration.setConfigOption(KAFKA_METRIC_REPORTERS_CONFIG_FIELD, String.join(",", metricReporterList));
-        } else {
-            configuration.removeConfigOption(KAFKA_METRIC_REPORTERS_CONFIG_FIELD);
-        }
     }
 
     /**
@@ -1680,8 +1609,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                             listenerId -> advertisedPorts.get(node.nodeId()).get(listenerId),
                             true)
                     .withAuthorization(cluster, authorization, true)
-                    .withCruiseControl(cluster, cruiseControlSpec, ccNumPartitions, ccReplicationFactor, ccMinInSyncReplicas)
-                    .withUserConfiguration(configuration)
+                    .withCruiseControl(cluster, ccMetricsReporter, node.broker())
+                    .withUserConfiguration(configuration, node.broker() && ccMetricsReporter != null)
                     .build().trim();
         } else {
             return new KafkaBrokerConfigurationBuilder(reconciliation, String.valueOf(node.nodeId()))
@@ -1696,8 +1625,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                             listenerId -> advertisedPorts.get(node.nodeId()).get(listenerId),
                             false)
                     .withAuthorization(cluster, authorization, false)
-                    .withCruiseControl(cluster, cruiseControlSpec, ccNumPartitions, ccReplicationFactor, ccMinInSyncReplicas)
-                    .withUserConfiguration(configuration)
+                    .withCruiseControl(cluster, ccMetricsReporter, node.broker())
+                    .withUserConfiguration(configuration, node.broker() && ccMetricsReporter != null)
                     .build().trim();
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -54,6 +54,16 @@ public class KafkaConfiguration extends AbstractConfiguration {
     }
 
     /**
+     * Copy constructor which creates new instance of the Kafka Configuration from existing configuration. It is
+     * useful when you need to modify an instance of the configuration without permanently changing the original.
+     *
+     * @param configuration     Existing configuration
+     */
+    public KafkaConfiguration(KafkaConfiguration configuration)   {
+        super(configuration);
+    }
+
+    /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
      * ConfigMap / CRD.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -185,23 +185,23 @@ public class Capacity {
     /**
      * Constructor
      *
-     * @param reconciliation    Reconciliation marker
-     * @param spec              Spec of the Kafka custom resource
-     * @param kafkaNodes                List of the nodes which are part of the Kafka cluster
-     * @param kafkaStorage              A map with storage configuration used by the Kafka cluster and its node pools
-     * @param kafkaResources            A map with resource configuration used by the Kafka cluster and its node pools
+     * @param reconciliation        Reconciliation marker
+     * @param spec                  Spec of the Kafka custom resource
+     * @param kafkaBrokerNodes      List of the broker nodes which are part of the Kafka cluster
+     * @param kafkaStorage          A map with storage configuration used by the Kafka cluster and its node pools
+     * @param kafkaBrokerResources  A map with resource configuration used by the Kafka cluster and its broker pools
      */
     public Capacity(
             Reconciliation reconciliation,
             KafkaSpec spec,
-            Set<NodeRef> kafkaNodes,
+            Set<NodeRef> kafkaBrokerNodes,
             Map<String, Storage> kafkaStorage,
-            Map<String, ResourceRequirements> kafkaResources
+            Map<String, ResourceRequirements> kafkaBrokerResources
     ) {
         this.reconciliation = reconciliation;
         this.capacityEntries = new TreeMap<>();
 
-        processCapacityEntries(spec.getCruiseControl(), kafkaNodes, kafkaStorage, kafkaResources);
+        processCapacityEntries(spec.getCruiseControl(), kafkaBrokerNodes, kafkaStorage, kafkaBrokerResources);
     }
 
     private static Integer getResourceRequirement(ResourceRequirements resources, ResourceRequirementType requirementType) {
@@ -341,16 +341,16 @@ public class Capacity {
         return String.valueOf(StorageUtils.convertTo(size, "Ki"));
     }
 
-    private void processCapacityEntries(CruiseControlSpec spec, Set<NodeRef> kafkaNodes, Map<String, Storage> kafkaStorage, Map<String, ResourceRequirements> kafkaResources) {
+    private void processCapacityEntries(CruiseControlSpec spec, Set<NodeRef> kafkaBrokerNodes, Map<String, Storage> kafkaStorage, Map<String, ResourceRequirements> kafkaBrokerResources) {
         io.strimzi.api.kafka.model.balancing.BrokerCapacity brokerCapacity = spec.getBrokerCapacity();
 
         String inboundNetwork = processInboundNetwork(brokerCapacity, null);
         String outboundNetwork = processOutboundNetwork(brokerCapacity, null);
 
         // We create a capacity for each broker node
-        for (NodeRef node : kafkaNodes)   {
+        for (NodeRef node : kafkaBrokerNodes)   {
             DiskCapacity disk = processDisk(kafkaStorage.get(node.poolName()), node.nodeId());
-            CpuCapacity cpu = processCpu(brokerCapacity, null, getCpuBasedOnRequirements(kafkaResources.get(node.poolName())));
+            CpuCapacity cpu = processCpu(brokerCapacity, null, getCpuBasedOnRequirements(kafkaBrokerResources.get(node.poolName())));
 
             BrokerCapacity broker = new BrokerCapacity(node.nodeId(), cpu, disk, inboundNetwork, outboundNetwork);
             capacityEntries.put(node.nodeId(), broker);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
@@ -16,7 +16,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
  * @param topicName             Name of the Metrics Reporter topic
  * @param numPartitions         Number of partitions of the Metrics Reporter topic
  * @param replicationFactor     Replication factor of the Metrics Reporter topic
- * @param minInSyncReplicas     Minimal number of in sync replicas in the of the metrics reporter topic
+ * @param minInSyncReplicas     Minimal number of in sync replicas of the metrics reporter topic
  */
 public record CruiseControlMetricsReporter(String topicName, Integer numPartitions, Integer replicationFactor, Integer minInSyncReplicas) {
     // Configuration field names
@@ -101,7 +101,7 @@ public record CruiseControlMetricsReporter(String topicName, Integer numPartitio
                 throw new IllegalArgumentException(
                         "The Cruise Control metric topic minISR was set to a value (" + userConfiguredMinInSync + ") " +
                                 "which is higher than the number of replicas for that topic (" + configuredCcReplicationFactor + "). " +
-                                "Please ensure that the CC metrics topic minISR is <= to the topic's replication factor."
+                                "Please ensure that the Cruise Control metrics topic minISR is <= to the topic's replication factor."
                 );
             }
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.KafkaConfiguration;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
+
+
+/**
+ * Represents a model for the Cruise Control Metrics Reporter
+ *
+ * @param topicName             Name of the Metrics Reporter topic
+ * @param numPartitions         Number of partitions of the Metrics Reporter topic
+ * @param replicationFactor     Replication factor of the Metrics Reporter topic
+ * @param minInSyncReplicas     Minimal number of in sync replicas in the of the metrics reporter topic
+ */
+public record CruiseControlMetricsReporter(String topicName, Integer numPartitions, Integer replicationFactor, Integer minInSyncReplicas) {
+    // Configuration field names
+    private static final String KAFKA_NUM_PARTITIONS_CONFIG_FIELD = "num.partitions";
+    private static final String KAFKA_REPLICATION_FACTOR_CONFIG_FIELD = "default.replication.factor";
+
+    /**
+     * Kafka configuration option for configuring metrics reporters
+     */
+    public static final String KAFKA_METRIC_REPORTERS_CONFIG_FIELD = "metric.reporters";
+    /**
+     * Class of the Cruise Control Metrics reporter
+     */
+    public static final String CRUISE_CONTROL_METRIC_REPORTER = "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter";
+
+    /**
+     * Creates an CruiseControlMetricsReporter instance based on the Kafka custom resource, its configuration and number of brokers
+     *
+     * @param kafka             The Kafka custom resource
+     * @param configuration     The user-provider configuration of the Kafka cluster
+     * @param numberOfBrokers   Number of broker nodes in the Kafka cluster
+     *
+     * @return  Instance of CruiseControlMetricsReporter or null if Cruise Control is not enabled
+     */
+    public static CruiseControlMetricsReporter fromCrd(Kafka kafka, KafkaConfiguration configuration, long numberOfBrokers)  {
+        if (kafka.getSpec().getCruiseControl() != null) {
+            String topicName = CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME;
+            if (kafka.getSpec().getCruiseControl().getConfig() != null
+                    && kafka.getSpec().getCruiseControl().getConfig().get(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue()) != null)  {
+                topicName = kafka.getSpec().getCruiseControl().getConfig().get(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue()).toString();
+            }
+
+            Integer numPartitions = null;
+            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()) == null) {
+                numPartitions = Integer.parseInt(configuration.getConfigOption(KAFKA_NUM_PARTITIONS_CONFIG_FIELD, "1"));
+            }
+
+            Integer replicationFactor = null;
+            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) == null) {
+                replicationFactor = Integer.parseInt(configuration.getConfigOption(KAFKA_REPLICATION_FACTOR_CONFIG_FIELD, "1"));
+            }
+
+            Integer minInSyncReplicas = null;
+            if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()) == null) {
+                minInSyncReplicas = 1;
+            }
+
+            validateCruiseControl(kafka, configuration, numberOfBrokers, replicationFactor, minInSyncReplicas);
+
+            return new CruiseControlMetricsReporter(topicName, numPartitions, replicationFactor, minInSyncReplicas);
+        } else {
+            // Cruise Control is not enabled
+            return null;
+        }
+    }
+
+    /**
+     * Validates the different values of the Cruise Control configuration such as number of replicas for the Metrics Reporter topic etc.
+     *
+     * @param kafka                 The Kafka custom resource
+     * @param configuration         The user-provider configuration of the Kafka cluster
+     * @param numberOfBrokers       Number of broker nodes in the Kafka cluster
+     * @param replicationFactor     The replication factor of the Metrics Reporter topic
+     * @param minInSyncReplicas     The minimal number of in-sync replicas of the Metrics Reporter topic
+     */
+    private static void validateCruiseControl(Kafka kafka, KafkaConfiguration configuration, long numberOfBrokers, Integer replicationFactor, Integer minInSyncReplicas)  {
+        if (numberOfBrokers < 2) {
+            throw new InvalidResourceException("Kafka " + kafka.getMetadata().getNamespace() + "/" + kafka.getMetadata().getName() +
+                    " has invalid configuration. Cruise Control cannot be deployed with a Kafka cluster which has only one broker. It requires at least two Kafka brokers.");
+        }
+
+        if (replicationFactor == null // When it is null, we validate the value from the user configuration. If it is not null, it is either 1 or it was already validated in the KafkaCluster class
+                && Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue())) > numberOfBrokers) {
+            throw new InvalidResourceException("Kafka " + kafka.getMetadata().getNamespace() + "/" + kafka.getMetadata().getName() +
+                    " has invalid configuration. Cruise Control metrics reporter replication factor (" + configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) + ") cannot be higher than number of brokers (" + numberOfBrokers + ").");
+        }
+
+        if (minInSyncReplicas == null) { // When it is null, we validate the value from the user configuration
+            int userConfiguredMinInSync = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()));
+            int configuredCcReplicationFactor = replicationFactor != null ? replicationFactor : Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()));
+            if (userConfiguredMinInSync > configuredCcReplicationFactor) {
+                throw new IllegalArgumentException(
+                        "The Cruise Control metric topic minISR was set to a value (" + userConfiguredMinInSync + ") " +
+                                "which is higher than the number of replicas for that topic (" + configuredCcReplicationFactor + "). " +
+                                "Please ensure that the CC metrics topic minISR is <= to the topic's replication factor."
+                );
+            }
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -74,9 +74,9 @@ public class CruiseControlReconciler {
      * @param supplier                  Supplier with Kubernetes Resource Operators
      * @param kafkaAssembly             The Kafka custom resource
      * @param versions                  The supported Kafka versions
-     * @param kafkaNodes                List of the nodes which are part of the Kafka cluster
-     * @param kafkaStorage              A map with storage configuration used by the Kafka cluster and its node pools
-     * @param kafkaResources            A map with resource configuration used by the Kafka cluster and its node pools
+     * @param kafkaBrokerNodes          List of the broker nodes which are part of the Kafka cluster
+     * @param kafkaBrokerStorage        A map with storage configuration used by the Kafka cluster and its broker pools
+     * @param kafkaBrokerResources      A map with resource configuration used by the Kafka cluster and its broker pools
      * @param clusterCa                 The Cluster CA instance
      */
     @SuppressWarnings({"checkstyle:ParameterNumber"})
@@ -86,13 +86,13 @@ public class CruiseControlReconciler {
             ResourceOperatorSupplier supplier,
             Kafka kafkaAssembly,
             KafkaVersion.Lookup versions,
-            Set<NodeRef> kafkaNodes,
-            Map<String, Storage> kafkaStorage,
-            Map<String, ResourceRequirements> kafkaResources,
+            Set<NodeRef> kafkaBrokerNodes,
+            Map<String, Storage> kafkaBrokerStorage,
+            Map<String, ResourceRequirements> kafkaBrokerResources,
             ClusterCa clusterCa
     ) {
         this.reconciliation = reconciliation;
-        this.cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions, kafkaNodes, kafkaStorage, kafkaResources, supplier.sharedEnvironmentProvider);
+        this.cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions, kafkaBrokerNodes, kafkaBrokerStorage, kafkaBrokerResources, supplier.sharedEnvironmentProvider);
         this.clusterCa = clusterCa;
         this.maintenanceWindows = kafkaAssembly.getSpec().getMaintenanceTimeWindows();
         this.operationTimeoutMs = config.getOperationTimeoutMs();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -211,9 +211,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         /* test */ ClientsCa clientsCa;
 
         // Needed by Cruise control to configure the cluster, its nodes and their storage and resource configuration
-        private Set<NodeRef> kafkaNodes;
-        private Map<String, Storage> kafkaStorage;
-        private Map<String, ResourceRequirements> kafkaResources;
+        private Set<NodeRef> kafkaBrokerNodes;
+        private Map<String, Storage> kafkaBrokerStorage;
+        private Map<String, ResourceRequirements> kafkaBrokerResources;
 
         /* test */ KafkaStatus kafkaStatus = new KafkaStatus();
 
@@ -570,9 +570,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         KafkaReconciler reconciler = kafkaReconciler(nodePools, oldStorage, currentPods);
 
                         // We store this for use with Cruise Control later
-                        kafkaNodes = reconciler.kafkaNodes();
-                        kafkaStorage = reconciler.kafkaStorage();
-                        kafkaResources = reconciler.kafkaResourceRequirements();
+                        kafkaBrokerNodes = reconciler.kafkaBrokerNodes();
+                        kafkaBrokerStorage = reconciler.kafkaStorage();
+                        kafkaBrokerResources = reconciler.kafkaBrokerResourceRequirements();
 
                         return Future.succeededFuture(reconciler);
                     });
@@ -657,9 +657,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     supplier,
                     kafkaAssembly,
                     versions,
-                    kafkaNodes,
-                    kafkaStorage,
-                    kafkaResources,
+                    kafkaBrokerNodes,
+                    kafkaBrokerStorage,
+                    kafkaBrokerResources,
                     clusterCa
             );
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1047,7 +1047,7 @@ public class KafkaReconciler {
     }
 
     /**
-     * This is used to get the Storage configuration used by the Kafka brokers. The storage configuration is needed by
+     * This is used to get the Storage configuration used by the Kafka nodes. The storage configuration is needed by
      * Cruise Control. But collecting it directly in Cruise Control from the custom resources would be complicated as
      * it would need to figure out the node pools and the node IDs belonging to them. In addition, the storage
      * configuration might change (in case of un-allowed changes), but due to the possibility of illegal storage changes
@@ -1062,21 +1062,23 @@ public class KafkaReconciler {
     /**
      * This is used to get the resource configuration used by the Kafka brokers. The resource configuration is needed by
      * Cruise Control. But collecting it directly in Cruise Control from the custom resources would be complicated as
-     * it would need to figure out the node pools and the node IDs belonging to them.
+     * it would need to figure out the node pools and the node IDs belonging to them. This includes only the broker
+     * nodes. Controller nodes are not included in this map.
      *
      * @return  Map with the pool names as the keys and resource requirements for given pools as the values
      */
-    public Map<String, ResourceRequirements> kafkaResourceRequirements()   {
-        return kafka.getResourceRequirementsByPoolName();
+    public Map<String, ResourceRequirements> kafkaBrokerResourceRequirements()   {
+        return kafka.getBrokerResourceRequirementsByPoolName();
     }
 
     /**
-     * This returns the list of Kafka nodes which will be later used for Cruise Control configuration so that Cruise
-     * Control does not need to collect it itself from the different custom resources.
+     * This returns the list of Kafka brokers which will be later used for Cruise Control configuration so that Cruise
+     * Control does not need to collect it itself from the different custom resources. This includes only the broker
+     * nodes. Controller nodes are not included in this set.
      *
      * @return  Set with node references for the Kafka nodes
      */
-    public Set<NodeRef> kafkaNodes()   {
-        return kafka.nodes();
+    public Set<NodeRef> kafkaBrokerNodes()   {
+        return kafka.brokerNodes();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -367,9 +367,8 @@ public class KafkaClusterWithKRaftTest {
         assertThat(storage.get("controllers"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
         assertThat(storage.get("brokers"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
 
-        Map<String, ResourceRequirements> resources = kc.getResourceRequirementsByPoolName();
-        assertThat(resources.size(), is(2));
-        assertThat(resources.get("controllers").getRequests(), is(Map.of("cpu", new Quantity("4"), "memory", new Quantity("16Gi"))));
+        Map<String, ResourceRequirements> resources = kc.getBrokerResourceRequirementsByPoolName();
+        assertThat(resources.size(), is(1));
         assertThat(resources.get("brokers").getRequests(), is(Map.of("cpu", new Quantity("4"), "memory", new Quantity("16Gi"))));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
@@ -406,7 +406,7 @@ public class KafkaClusterWithPoolsTest {
         assertThat(storage.get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
         assertThat(storage.get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
 
-        Map<String, ResourceRequirements> resources = kc.getResourceRequirementsByPoolName();
+        Map<String, ResourceRequirements> resources = kc.getBrokerResourceRequirementsByPoolName();
         assertThat(resources.size(), is(2));
         assertThat(resources.get("pool-a").getRequests(), is(Map.of("cpu", new Quantity("4"), "memory", new Quantity("16Gi"))));
         assertThat(resources.get("pool-b").getRequests(), is(Map.of("cpu", new Quantity("6"), "memory", new Quantity("20Gi"))));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
@@ -134,6 +134,6 @@ public class CruiseControlMetricsReporterTest {
 
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 3));
 
-        assertThat(e.getMessage(), is("The Cruise Control metric topic minISR was set to a value (4) which is higher than the number of replicas for that topic (3). Please ensure that the CC metrics topic minISR is <= to the topic's replication factor."));
+        assertThat(e.getMessage(), is("The Cruise Control metric topic minISR was set to a value (4) which is higher than the number of replicas for that topic (3). Please ensure that the Cruise Control metrics topic minISR is <= to the topic's replication factor."));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.KafkaConfiguration;
+import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlConfigurationParameters;
+import io.strimzi.operator.common.Reconciliation;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CruiseControlMetricsReporterTest {
+    private final static String NAME = "my-cluster";
+    private final static String NAMESPACE = "my-namespace";
+
+    private final static Kafka KAFKA = new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(NAME)
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .endKafka()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+    @Test
+    public void testDisabledCruiseControl() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        assertThat(CruiseControlMetricsReporter.fromCrd(kafka, null, 3), is(nullValue()));
+    }
+
+    @Test
+    public void testEnabledCruiseControlWithDefaults() {
+        CruiseControlMetricsReporter ccmr = CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of()), 3);
+
+        assertThat(ccmr, is(notNullValue()));
+        assertThat(ccmr.numPartitions(), is(1));
+        assertThat(ccmr.replicationFactor(), is(1));
+        assertThat(ccmr.minInSyncReplicas(), is(1));
+        assertThat(ccmr.topicName(), is(CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME));
+    }
+
+    @Test
+    public void testEnabledCruiseControlWithSettingsFromKafka() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("default.replication.factor", 3);
+        userConfiguration.put("min.insync.replicas", 2);
+        userConfiguration.put("num.partitions", 20);
+
+        CruiseControlMetricsReporter ccmr = CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 3);
+
+        assertThat(ccmr, is(notNullValue()));
+        assertThat(ccmr.numPartitions(), is(20));
+        assertThat(ccmr.replicationFactor(), is(3));
+        assertThat(ccmr.minInSyncReplicas(), is(1)); // This does not inherit the Kafka value
+        assertThat(ccmr.topicName(), is(CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME));
+    }
+
+    @Test
+    public void testEnabledCruiseControlWithSettingsFromCC() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .withNewSpec()
+                    .withNewCruiseControl()
+                        .withConfig(Map.of("metric.reporter.topic", "my-custom-topic"))
+                    .endCruiseControl()
+                .endSpec()
+                .build();
+
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("cruise.control.metrics.topic.num.partitions", 50);
+        userConfiguration.put("cruise.control.metrics.topic.replication.factor", 5);
+        userConfiguration.put("cruise.control.metrics.topic.min.insync.replicas", 4);
+        userConfiguration.put("default.replication.factor", 3);
+        userConfiguration.put("min.insync.replicas", 2);
+        userConfiguration.put("num.partitions", 20);
+
+        CruiseControlMetricsReporter ccmr = CruiseControlMetricsReporter.fromCrd(kafka, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 5);
+
+        assertThat(ccmr, is(notNullValue()));
+        assertThat(ccmr.numPartitions(), is(nullValue()));
+        assertThat(ccmr.replicationFactor(), is(nullValue()));
+        assertThat(ccmr.minInSyncReplicas(), is(nullValue())); // This does not inherit the Kafka value
+        assertThat(ccmr.topicName(), is("my-custom-topic"));
+    }
+
+    @Test
+    public void testValidationWithOneBroker() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("default.replication.factor", 3);
+        userConfiguration.put("min.insync.replicas", 2);
+        userConfiguration.put("num.partitions", 20);
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 1));
+
+        assertThat(e.getMessage(), is("Kafka my-namespace/my-cluster has invalid configuration. Cruise Control cannot be deployed with a Kafka cluster which has only one broker. It requires at least two Kafka brokers."));
+    }
+
+    @Test
+    public void testValidationWithReplicasMoreThanBrokers() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("cruise.control.metrics.topic.replication.factor", 5);
+        userConfiguration.put("cruise.control.metrics.topic.min.insync.replicas", 4);
+
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 2));
+
+        assertThat(e.getMessage(), is("Kafka my-namespace/my-cluster has invalid configuration. Cruise Control metrics reporter replication factor (5) cannot be higher than number of brokers (2)."));
+    }
+
+    @Test
+    public void testValidationWithReplicasMoreThanMinIsr() {
+        Map<String, Object> userConfiguration = new HashMap<>();
+        userConfiguration.put("cruise.control.metrics.topic.replication.factor", 3);
+        userConfiguration.put("cruise.control.metrics.topic.min.insync.replicas", 4);
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> CruiseControlMetricsReporter.fromCrd(KAFKA, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 3));
+
+        assertThat(e.getMessage(), is("The Cruise Control metric topic minISR was set to a value (4) which is higher than the number of replicas for that topic (3). Please ensure that the CC metrics topic minISR is <= to the topic's replication factor."));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -362,16 +362,16 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
-                    assertThat(kr.kafkaNodes().size(), is(5));
-                    assertThat(kr.kafkaNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
+                    assertThat(kr.kafkaBrokerNodes().size(), is(5));
+                    assertThat(kr.kafkaBrokerNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
 
                     assertThat(kr.kafkaStorage().size(), is(2));
                     assertThat(kr.kafkaStorage().get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
 
-                    assertThat(kr.kafkaResourceRequirements().size(), is(2));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().size(), is(2));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
 
                     async.flag();
                 })));
@@ -778,16 +778,16 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
-                    assertThat(kr.kafkaNodes().size(), is(5));
-                    assertThat(kr.kafkaNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
+                    assertThat(kr.kafkaBrokerNodes().size(), is(5));
+                    assertThat(kr.kafkaBrokerNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
 
                     assertThat(kr.kafkaStorage().size(), is(2));
                     assertThat(kr.kafkaStorage().get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
 
-                    assertThat(kr.kafkaResourceRequirements().size(), is(2));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().size(), is(2));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
 
                     async.flag();
                 })));
@@ -954,16 +954,16 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
-                    assertThat(kr.kafkaNodes().size(), is(5));
-                    assertThat(kr.kafkaNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
+                    assertThat(kr.kafkaBrokerNodes().size(), is(5));
+                    assertThat(kr.kafkaBrokerNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
 
                     assertThat(kr.kafkaStorage().size(), is(2));
                     assertThat(kr.kafkaStorage().get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
 
-                    assertThat(kr.kafkaResourceRequirements().size(), is(2));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().size(), is(2));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
 
                     async.flag();
                 })));
@@ -1119,18 +1119,18 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b", "pool-c")));
 
                     // Assert the info passed over for Cruise Control
-                    assertThat(kr.kafkaNodes().size(), is(7));
-                    assertThat(kr.kafkaNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4", "my-cluster-pool-c-5", "my-cluster-pool-c-6")));
+                    assertThat(kr.kafkaBrokerNodes().size(), is(7));
+                    assertThat(kr.kafkaBrokerNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4", "my-cluster-pool-c-5", "my-cluster-pool-c-6")));
 
                     assertThat(kr.kafkaStorage().size(), is(3));
                     assertThat(kr.kafkaStorage().get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-c"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("300Gi").build()).build()));
 
-                    assertThat(kr.kafkaResourceRequirements().size(), is(3));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-c"), is(nullValue()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().size(), is(3));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-c"), is(nullValue()));
 
                     async.flag();
                 })));
@@ -1291,16 +1291,16 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
-                    assertThat(kr.kafkaNodes().size(), is(5));
-                    assertThat(kr.kafkaNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
+                    assertThat(kr.kafkaBrokerNodes().size(), is(5));
+                    assertThat(kr.kafkaBrokerNodes().stream().map(NodeRef::podName).toList(), is(List.of("my-cluster-pool-a-0", "my-cluster-pool-a-1", "my-cluster-pool-a-2", "my-cluster-pool-b-3", "my-cluster-pool-b-4")));
 
                     assertThat(kr.kafkaStorage().size(), is(2));
                     assertThat(kr.kafkaStorage().get("pool-a"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build()).build()));
                     assertThat(kr.kafkaStorage().get("pool-b"), is(new JbodStorageBuilder().withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("200Gi").build()).build()));
 
-                    assertThat(kr.kafkaResourceRequirements().size(), is(2));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
-                    assertThat(kr.kafkaResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().size(), is(2));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-a"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("4"))).build()));
+                    assertThat(kr.kafkaBrokerResourceRequirements().get("pool-b"), is(new ResourceRequirementsBuilder().withRequests(Map.of("cpu", new Quantity("6"))).build()));
 
                     async.flag();
                 })));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When running in KRaft mode, we currently configure all nodes in Cruise Control capacity configuration even through the controller-only nodes do not really host any regular topics and don't have anything to rebalance. This PR updates the way we configure the Cruise Control capacity to include only the Kafka nodes with the broker-role. It does so by passing only the broker node information to Cruise Control where possible (since nobody else uses it and it does not need the controller info, so we safe some memory).

It also configures the Cruise Control metric reporters only on the broker nodes to not have them started / running on the cntroller-only nodes.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally