### PR TITLE
Allow using Unidirectional Topic Operator in KRaft mode

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -21,13 +21,14 @@ public class KRaftUtils {
      * unsupported features and if they are used, throws an InvalidResourceException exception.
      *
      * @param kafkaSpec   The .spec section of the Kafka CR which should be checked
+     * @param utoEnabled  Flag indicating whether Unidirectional Topic Operator is enabled or not
      */
-    public static void validateKafkaCrForKRaft(KafkaSpec kafkaSpec)   {
+    public static void validateKafkaCrForKRaft(KafkaSpec kafkaSpec, boolean utoEnabled)   {
         Set<String> errors = new HashSet<>(0);
 
         if (kafkaSpec != null)  {
             validateKafkaSpec(errors, kafkaSpec.getKafka());
-            validateEntityOperatorSpec(errors, kafkaSpec.getEntityOperator());
+            validateEntityOperatorSpec(errors, kafkaSpec.getEntityOperator(), utoEnabled);
         } else {
             errors.add("The .spec section of the Kafka custom resource is missing");
         }
@@ -42,10 +43,11 @@ public class KRaftUtils {
      *
      * @param errors            Set with detected errors to which any new errors should be added
      * @param entityOperator    The Entity Operator spec which should be checked
+     * @param utoEnabled        Flag indicating whether Unidirectional Topic Operator is enabled or not
      */
-    /* test */ static void validateEntityOperatorSpec(Set<String> errors, EntityOperatorSpec entityOperator) {
-        if (entityOperator != null && entityOperator.getTopicOperator() != null) {
-            errors.add("Topic Operator is currently not supported when the UseKRaft feature gate is enabled");
+    /* test */ static void validateEntityOperatorSpec(Set<String> errors, EntityOperatorSpec entityOperator, boolean utoEnabled) {
+        if (entityOperator != null && entityOperator.getTopicOperator() != null && !utoEnabled) {
+            errors.add("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -166,7 +166,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         // Validates features which are currently not supported in KRaft mode
         if (featureGates.useKRaftEnabled()) {
             try {
-                KRaftUtils.validateKafkaCrForKRaft(reconcileState.kafkaAssembly.getSpec());
+                KRaftUtils.validateKafkaCrForKRaft(reconcileState.kafkaAssembly.getSpec(), featureGates.unidirectionalTopicOperatorEnabled());
             } catch (InvalidResourceException e)    {
                 return Future.failedFuture(e);
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -47,7 +47,7 @@ public class KRaftUtilsTest {
                 .endKafka()
                 .build();
 
-        assertDoesNotThrow(() -> KRaftUtils.validateKafkaCrForKRaft(spec));
+        assertDoesNotThrow(() -> KRaftUtils.validateKafkaCrForKRaft(spec, false));
     }
 
     @ParallelTest
@@ -71,7 +71,7 @@ public class KRaftUtilsTest {
                 .endKafka()
                 .build();
 
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateKafkaCrForKRaft(spec));
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateKafkaCrForKRaft(spec, false));
 
         assertThat(ex.getMessage(), is("Kafka configuration is not valid: [Using more than one disk in a JBOD storage is currently not supported when the UseKRaft feature gate is enabled]"));
     }
@@ -79,7 +79,7 @@ public class KRaftUtilsTest {
     @ParallelTest
     public void testNoEntityOperator() {
         Set<String> errors = new HashSet<>(0);
-        KRaftUtils.validateEntityOperatorSpec(errors, null);
+        KRaftUtils.validateEntityOperatorSpec(errors, null, false);
 
         assertThat(errors, is(Collections.emptySet()));
     }
@@ -92,7 +92,7 @@ public class KRaftUtilsTest {
                 .endUserOperator()
                 .build();
 
-        KRaftUtils.validateEntityOperatorSpec(errors, eo);
+        KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
         assertThat(errors, is(Collections.emptySet()));
     }
 
@@ -106,9 +106,24 @@ public class KRaftUtilsTest {
                 .endTopicOperator()
                 .build();
 
-        KRaftUtils.validateEntityOperatorSpec(errors, eo);
+        KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
 
-        assertThat(errors, is(Set.of("Topic Operator is currently not supported when the UseKRaft feature gate is enabled")));
+        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.")));
+    }
+
+    @ParallelTest
+    public void testEnabledUnidirectionalTopicOperator() {
+        Set<String> errors = new HashSet<>(0);
+        EntityOperatorSpec eo = new EntityOperatorSpecBuilder()
+                .withNewUserOperator()
+                .endUserOperator()
+                .withNewTopicOperator()
+                .endTopicOperator()
+                .build();
+
+        KRaftUtils.validateEntityOperatorSpec(errors, eo, true);
+
+        assertThat(errors.size(), is(0));
     }
 
     @ParallelTest
@@ -119,9 +134,9 @@ public class KRaftUtilsTest {
                 .endTopicOperator()
                 .build();
 
-        KRaftUtils.validateEntityOperatorSpec(errors, eo);
+        KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
 
-        assertThat(errors, is(Set.of("Topic Operator is currently not supported when the UseKRaft feature gate is enabled")));
+        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.")));
     }
 
     @ParallelTest

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -77,8 +77,9 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 * Controller-only nodes cannot undergo rolling updates or be updated individually.
 * Upgrades and downgrades of Apache Kafka versions or the Strimzi operator are not supported.
   Users might need to delete the cluster, upgrade the operator and deploy a new Kafka cluster.
-* The Topic Operator is not supported.
-  The `spec.entityOperator.topicOperator` property *must be removed* from the `Kafka` custom resource.
+* Only the _Unidirectional_ Topic Operator is supported in KRaft mode.
+  You can enable it using the `UnidirectionalTopicOperator` feature gate.
+  The _Bidirectional_ Topic Operator is not supported and when the `UnidirectionalTopicOperator` feature gate is not enabled, the `spec.entityOperator.topicOperator` property *must be removed* from the `Kafka` custom resource.
 * JBOD storage is not supported. 
   The `type: jbod` storage can be used, but the JBOD array can contain only one disk.
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The new Unidirectional Topic Operator (UTO) does not need a ZooKeeper anymore and can therefore work even in KRaft mode. This PR updates the existing KRaft validation to check whether UTO is enabled and allows the use of the Topic Operator in such a case.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally