### PR TITLE
Log Cluster and User Operator configuration as multiline log message

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperatorConfig.java
@@ -388,7 +388,7 @@ public class ClusterOperatorConfig {
 
     static ConfigParameterParser<FeatureGates> parseFeatureGates() {
         return FeatureGates::new;
-    };
+    }
 
     static ConfigParameterParser<ImagePullPolicy> parseImagePullPolicy() {
         return imagePullPolicyEnvVar -> {
@@ -423,7 +423,7 @@ public class ClusterOperatorConfig {
         KafkaVersion.Lookup versions;
 
         /**
-         * Cosntructor
+         * Constructor
          *
          * @param config Existing ClusterOperatorConfig object
          * @param lookup Configured version
@@ -437,7 +437,7 @@ public class ClusterOperatorConfig {
          * Adds/updates the configuration parameter to the existing ClusterOperatorConfig object
          *
          * @param key     Configuration name
-         * @param value   Configuartion value
+         * @param value   Configuration value
          * @return ClusterOperatorConfigBuilder object
          */
         public ClusterOperatorConfigBuilder with(String key, String value) {
@@ -506,7 +506,7 @@ public class ClusterOperatorConfig {
     }
 
     /**
-     * @return  Supported Kafka versions and informations about them
+     * @return  Supported Kafka versions and information about them
      */
     public KafkaVersion.Lookup versions() {
         return versions;
@@ -609,27 +609,27 @@ public class ClusterOperatorConfig {
 
     @Override
     public String toString() {
-        return "ClusterOperatorConfig(" +
-                "namespaces=" + getNamespaces() +
-                ",reconciliationIntervalMs=" + getReconciliationIntervalMs() +
-                ",operationTimeoutMs=" + getOperationTimeoutMs() +
-                ",connectBuildTimeoutMs=" + getConnectBuildTimeoutMs() +
-                ",createClusterRoles=" + isCreateClusterRoles() +
-                ",networkPolicyGeneration=" + isNetworkPolicyGeneration() +
-                ",versions=" + versions() +
-                ",imagePullPolicy=" + getImagePullPolicy() +
-                ",imagePullSecrets=" + getImagePullSecrets() +
-                ",operatorNamespace=" + getOperatorNamespace() +
-                ",operatorNamespaceLabels=" + getOperatorNamespaceLabels() +
-                ",customResourceSelector=" + getCustomResourceSelector() +
-                ",featureGates=" + featureGates() +
-                ",zkAdminSessionTimeoutMs=" + getZkAdminSessionTimeoutMs() +
-                ",dnsCacheTtlSec=" + getDnsCacheTtlSec() +
-                ",podSetReconciliationOnly=" + isPodSetReconciliationOnly() +
-                ",podSetControllerWorkQueueSize=" + getPodSetControllerWorkQueueSize() +
-                ",operatorName=" + getOperatorName() +
-                ",podSecurityProviderClass=" + getPodSecurityProviderClass() +
-                ",leaderElectionConfig=" + getLeaderElectionConfig() +
-                ")";
+        return "ClusterOperatorConfig{" +
+                "\n\tnamespaces='" + getNamespaces() + '\'' +
+                "\n\treconciliationIntervalMs=" + getReconciliationIntervalMs() +
+                "\n\toperationTimeoutMs=" + getOperationTimeoutMs() +
+                "\n\tconnectBuildTimeoutMs=" + getConnectBuildTimeoutMs() +
+                "\n\tcreateClusterRoles=" + isCreateClusterRoles() +
+                "\n\tnetworkPolicyGeneration=" + isNetworkPolicyGeneration() +
+                "\n\tversions='" + versions() + '\'' +
+                "\n\timagePullPolicy='" + getImagePullPolicy() + '\'' +
+                "\n\timagePullSecrets='" + getImagePullSecrets() + '\'' +
+                "\n\toperatorNamespace='" + getOperatorNamespace() + '\'' +
+                "\n\toperatorNamespaceLabels='" + getOperatorNamespaceLabels() + '\'' +
+                "\n\tcustomResourceSelector='" + getCustomResourceSelector() + '\'' +
+                "\n\tfeatureGates='" + featureGates() + '\'' +
+                "\n\tzkAdminSessionTimeoutMs=" + getZkAdminSessionTimeoutMs() +
+                "\n\tdnsCacheTtlSec=" + getDnsCacheTtlSec() +
+                "\n\tpodSetReconciliationOnly=" + isPodSetReconciliationOnly() +
+                "\n\tpodSetControllerWorkQueueSize=" + getPodSetControllerWorkQueueSize() +
+                "\n\toperatorName='" + getOperatorName() + '\'' +
+                "\n\tpodSecurityProviderClass='" + getPodSecurityProviderClass() + '\'' +
+                "\n\tleaderElectionConfig='" + getLeaderElectionConfig() + '\'' +
+                "}";
     }
 }

--- a/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/UserOperatorConfig.java
@@ -370,30 +370,30 @@ public class UserOperatorConfig {
     @Override
     public String toString() {
         return "UserOperatorBuilderConfig{" +
-                "namespace='" + getNamespace() + '\'' +
-                ", reconciliationIntervalMs=" + getReconciliationIntervalMs() +
-                ", kafkaBootstrapServers='" + getKafkaBootstrapServers() + '\'' +
-                ", labels=" + getLabels() +
-                ", caCertSecretName='" + getCaCertSecretName() + '\'' +
-                ", caKeySecretName='" + getCaKeySecretName() + '\'' +
-                ", clusterCaCertSecretName='" + getClusterCaCertSecretName() + '\'' +
-                ", euoKeySecretName='" + getEuoKeySecretName() + '\'' +
-                ", caNamespace='" + getCaNamespaceOrNamespace() + '\'' +
-                ", secretPrefix='" + getSecretPrefix() + '\'' +
-                ", clientsCaValidityDays=" + getClientsCaValidityDays() +
-                ", clientsCaRenewalDays=" + getClientsCaRenewalDays() +
-                ", aclsAdminApiSupported=" + isAclsAdminApiSupported() +
-                ", scramPasswordLength=" + getScramPasswordLength() +
-                ", maintenanceWindows=" + getMaintenanceWindows() +
-                ", kafkaAdminClientConfiguration=" + getKafkaAdminClientConfiguration() +
-                ", operationTimeoutMs=" + getOperationTimeoutMs() +
-                ", workQueueSize=" + getWorkQueueSize() +
-                ", controllerThreadPoolSize=" + getControllerThreadPoolSize() +
-                ", cacheRefresh=" + getCacheRefresh() +
-                ", batchQueueSize=" + getBatchQueueSize() +
-                ", batchMaxBlockSize=" + getBatchMaxBlockSize() +
-                ", batchMaxBlockTime=" + getBatchMaxBlockTime() +
-                ", userOperationsThreadPoolSize=" + getUserOperationsThreadPoolSize() +
+                "\n\tnamespace='" + getNamespace() + '\'' +
+                "\n\treconciliationIntervalMs=" + getReconciliationIntervalMs() +
+                "\n\tkafkaBootstrapServers='" + getKafkaBootstrapServers() + '\'' +
+                "\n\tlabels=`" + getLabels() + '\'' +
+                "\n\tcaCertSecretName='" + getCaCertSecretName() + '\'' +
+                "\n\tcaKeySecretName='" + getCaKeySecretName() + '\'' +
+                "\n\tclusterCaCertSecretName='" + getClusterCaCertSecretName() + '\'' +
+                "\n\teuoKeySecretName='" + getEuoKeySecretName() + '\'' +
+                "\n\tcaNamespace='" + getCaNamespaceOrNamespace() + '\'' +
+                "\n\tsecretPrefix='" + getSecretPrefix() + '\'' +
+                "\n\tclientsCaValidityDays=" + getClientsCaValidityDays() +
+                "\n\tclientsCaRenewalDays=" + getClientsCaRenewalDays() +
+                "\n\taclsAdminApiSupported=" + isAclsAdminApiSupported() +
+                "\n\tscramPasswordLength=" + getScramPasswordLength() +
+                "\n\tmaintenanceWindows=`" + getMaintenanceWindows() + '\'' +
+                "\n\tkafkaAdminClientConfiguration=`" + getKafkaAdminClientConfiguration() + '\'' +
+                "\n\toperationTimeoutMs=" + getOperationTimeoutMs() +
+                "\n\tworkQueueSize=" + getWorkQueueSize() +
+                "\n\tcontrollerThreadPoolSize=" + getControllerThreadPoolSize() +
+                "\n\tcacheRefresh=" + getCacheRefresh() +
+                "\n\tbatchQueueSize=" + getBatchQueueSize() +
+                "\n\tbatchMaxBlockSize=" + getBatchMaxBlockSize() +
+                "\n\tbatchMaxBlockTime=" + getBatchMaxBlockTime() +
+                "\n\tuserOperationsThreadPoolSize=" + getUserOperationsThreadPoolSize() +
                 '}';
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, the Cluster and User Operator configurations are printed at startup as a single long message which is very hard to read. This PR splits it across multiple lines with tabs at the beginning to make it more readable. It also updates the format of the Cluster Operator configuration output to bring it in sync with the User and Topic Operators.

It also fixes some typos in the `ClusterOperatorConfig` class.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally