### PR TITLE
Integrate OAuth 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Update OpenTelemetry 1.19.0
 * Fixed ordering of JVM performance options [#8579](https://github.com/strimzi/strimzi-kafka-operator/issues/8579)
 * Log a warning when a KafkaTopic has no spec [#8465](https://github.com/strimzi/strimzi-kafka-operator/issues/8465)
-* Update Strimzi OAuth library to 0.13.0
+* Updated Strimzi OAuth library to 0.13.0 with better support for KRaft
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update OpenTelemetry 1.19.0
 * Fixed ordering of JVM performance options [#8579](https://github.com/strimzi/strimzi-kafka-operator/issues/8579)
 * Log a warning when a KafkaTopic has no spec [#8465](https://github.com/strimzi/strimzi-kafka-operator/issues/8465)
+* Update Strimzi OAuth library to 0.13.0
 
 ### Changes, deprecations and removals
 
@@ -20,6 +21,7 @@
   Kubernetes 1.19 and 1.20 are not supported anymore.
 * The Helm Chart repository at `https://strimzi.io/charts/` is now deprecated.
   Please use the Helm Chart OCI artifacts from our [Helm Chart OCI repository instead](https://quay.io/organization/strimzi-helm).
+* Option `customClaimCheck` of 'oauth' authentication which relies on JsonPath changed the handling of equal comparison against `null` as the behaviour was buggy and is now fixed in the updated version of JsonPath library [OAuth #196](https://github.com/strimzi/strimzi-kafka-oauth/pull/196)
 
 ## 0.35.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -164,7 +164,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.grantsGcPeriodSeconds = grantsGcPeriodSeconds;
     }
 
-    @Description("Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.")
+    @Description("Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isGrantsAlwaysLatest() {
         return grantsAlwaysLatest;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -25,9 +25,10 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "clientId", "tokenEndpointUri",
     "tlsTrustedCertificates", "disableTlsHostnameVerification",
-    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize", "superUsers",
+    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize",
+    "grantsMaxIdleSeconds", "grantsGcPeriodSeconds", "grantsAlwaysLatest", "superUsers",
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "enableMetrics"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 
@@ -42,6 +43,9 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     private boolean delegateToKafkaAcls = false;
     private Integer grantsRefreshPeriodSeconds;
     private Integer grantsRefreshPoolSize;
+    private Integer grantsMaxIdleTimeSeconds;
+    private Integer grantsGcPeriodSeconds;
+    private boolean grantsAlwaysLatest = false;
     private Integer connectTimeoutSeconds;
     private Integer readTimeoutSeconds;
     private Integer httpRetries;
@@ -138,6 +142,38 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.grantsRefreshPoolSize = grantsRefreshPoolSize;
     }
 
+    @Description("The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.")
+    @Minimum(1)
+    @JsonProperty(defaultValue = "300")
+    public Integer getGrantsMaxIdleTimeSeconds() {
+        return grantsMaxIdleTimeSeconds;
+    }
+
+    public void setGrantsMaxIdleTimeSeconds(Integer grantsMaxIdleTimeSeconds) {
+        this.grantsMaxIdleTimeSeconds = grantsMaxIdleTimeSeconds;
+    }
+
+    @Description("A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.")
+    @Minimum(1)
+    @JsonProperty(defaultValue = "300")
+    public Integer getGrantsGcPeriodSeconds() {
+        return grantsGcPeriodSeconds;
+    }
+
+    public void setGrantsGcPeriodSeconds(Integer grantsGcPeriodSeconds) {
+        this.grantsGcPeriodSeconds = grantsGcPeriodSeconds;
+    }
+
+    @Description("Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean isGrantsAlwaysLatest() {
+        return grantsAlwaysLatest;
+    }
+
+    public void setGrantsAlwaysLatest(boolean grantsAlwaysLatest) {
+        this.grantsAlwaysLatest = grantsAlwaysLatest;
+    }
+
     @Description("List of super users. Should contain list of user principals which should get unlimited access rights.")
     @Example("- CN=my-user\n" +
             "- CN=my-other-user")
@@ -183,7 +219,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.httpRetries = httpRetries;
     }
 
-    @Description("Enable or disable OAuth metrics. Default value is `false`.")
+    @Description("Enable or disable OAuth metrics. The default value is `false`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean isEnableMetrics() {
         return enableMetrics;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -142,7 +142,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.grantsRefreshPoolSize = grantsRefreshPoolSize;
     }
 
-    @Description("The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.")
+    @Description("The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300.")
     @Minimum(1)
     @JsonProperty(defaultValue = "300")
     public Integer getGrantsMaxIdleTimeSeconds() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -34,7 +34,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
 
     public static final String TYPE_KEYCLOAK = "keycloak";
 
-    public static final String AUTHORIZER_CLASS_NAME = "io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer";
+    public static final String AUTHORIZER_CLASS_NAME = "io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer";
 
     private String clientId;
     private String tokenEndpointUri;
@@ -142,7 +142,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.grantsRefreshPoolSize = grantsRefreshPoolSize;
     }
 
-    @Description("The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.")
+    @Description("The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.")
     @Minimum(1)
     @JsonProperty(defaultValue = "300")
     public Integer getGrantsMaxIdleTimeSeconds() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorizationKeycloak.java
@@ -153,7 +153,7 @@ public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
         this.grantsMaxIdleTimeSeconds = grantsMaxIdleTimeSeconds;
     }
 
-    @Description("A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.")
+    @Description("The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300.")
     @Minimum(1)
     @JsonProperty(defaultValue = "300")
     public Integer getGrantsGcPeriodSeconds() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -695,10 +695,14 @@ public class KafkaBrokerConfigurationBuilder {
         writer.println("strimzi.authorization.delegate.to.kafka.acl=" + authorization.isDelegateToKafkaAcls());
         addOption(writer, "strimzi.authorization.grants.refresh.period.seconds", authorization.getGrantsRefreshPeriodSeconds());
         addOption(writer, "strimzi.authorization.grants.refresh.pool.size", authorization.getGrantsRefreshPoolSize());
+        addOption(writer, "strimzi.authorization.grants.max.idle.time.seconds", authorization.getGrantsMaxIdleTimeSeconds());
+        addOption(writer, "strimzi.authorization.grants.gc.period.seconds", authorization.getGrantsGcPeriodSeconds());
         addOption(writer, "strimzi.authorization.connect.timeout.seconds", authorization.getConnectTimeoutSeconds());
         addOption(writer, "strimzi.authorization.read.timeout.seconds", authorization.getReadTimeoutSeconds());
         addOption(writer, "strimzi.authorization.http.retries", authorization.getHttpRetries());
-
+        if (authorization.isGrantsAlwaysLatest()) {
+            writer.println("strimzi.authorization.reuse.grants=false");
+        }
         if (authorization.isEnableMetrics()) {
             writer.println("strimzi.authorization.enable.metrics=true");
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -307,6 +307,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withDelegateToKafkaAcls(false)
                 .withGrantsRefreshPeriodSeconds(120)
                 .withGrantsRefreshPoolSize(10)
+                .withGrantsMaxIdleTimeSeconds(600)
+                .withGrantsGcPeriodSeconds(120)
+                .withGrantsAlwaysLatest(true)
                 .withTlsTrustedCertificates(cert)
                 .withDisableTlsHostnameVerification(true)
                 .addToSuperUsers("giada", "CN=paccu")
@@ -333,6 +336,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "strimzi.authorization.ssl.endpoint.identification.algorithm=",
                 "strimzi.authorization.grants.refresh.period.seconds=120",
                 "strimzi.authorization.grants.refresh.pool.size=10",
+                "strimzi.authorization.grants.max.idle.time.seconds=600",
+                "strimzi.authorization.grants.gc.period.seconds=120",
+                "strimzi.authorization.reuse.grants=false",
                 "strimzi.authorization.connect.timeout.seconds=30",
                 "strimzi.authorization.read.timeout.seconds=10",
                 "strimzi.authorization.http.retries=2",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -325,7 +325,7 @@ public class KafkaBrokerConfigurationBuilderTest {
 
         assertThat(configuration, isEquivalent("broker.id=2",
                 "node.id=2",
-                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer",
+                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer",
                 "strimzi.authorization.token.endpoint.uri=http://token-endpoint-uri",
                 "strimzi.authorization.client.id=my-client-id",
                 "strimzi.authorization.delegate.to.kafka.acl=false",
@@ -366,7 +366,7 @@ public class KafkaBrokerConfigurationBuilderTest {
 
         assertThat(configuration, isEquivalent("broker.id=2",
                 "node.id=2",
-                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer",
+                "authorizer.class.name=io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer",
                 "strimzi.authorization.token.endpoint.uri=http://token-endpoint-uri",
                 "strimzi.authorization.client.id=my-client-id",
                 "strimzi.authorization.delegate.to.kafka.acl=false",

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -38,6 +38,10 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -38,10 +38,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.13.0</strimzi-oauth.version>
         <cruise-control.version>2.5.123</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -38,6 +38,10 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -38,10 +38,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.13.0</strimzi-oauth.version>
         <cruise-control.version>2.5.123</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>

--- a/documentation/assemblies/metrics/assembly-metrics.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics.adoc
@@ -10,7 +10,7 @@ Collecting metrics is critical for understanding the health and performance of y
 By monitoring metrics, you can actively identify issues before they become critical and make informed decisions about resource allocation and capacity planning. Without metrics, you may be left with limited visibility into the behavior of your Kafka deployment, which can make troubleshooting more difficult and time-consuming. Setting up metrics can save you time and resources in the long run, and help ensure the reliability of your Kafka deployment.
 
 Metrics are available for each Strimzi component, allowing you to gain insights into their individual performance. 
-Additionally, you can collect metrics specific to `oauth` authentication and `opa` or `keycloak` authorization by enabling the `enableMetrics` property in the listener configuration of the `Kafka` resource. 
+Additionally, you can collect metrics specific to `oauth` authentication and `opa` or `keycloak` authorization by enabling the `enableMetrics` property in the listener or authorization configuration of the `Kafka` resource.
 Similarly, you can enable metrics for `oauth` authentication in custom resources such as `KafkaBridge`, `KafkaConnect`, `KafkaMirrorMaker`, and `KafkaMirrorMaker2`.
 
 You can use Prometheus and Grafana to monitor Strimzi.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -630,7 +630,7 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |enableMetrics                   1.2+<.<a|Enable or disable OAuth metrics. The default value is `false`.
 |boolean
-|grantsMaxIdleTimeSeconds        1.2+<.<a|The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
+|grantsMaxIdleTimeSeconds        1.2+<.<a|The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -616,6 +616,10 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |grantsRefreshPoolSize           1.2+<.<a|The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.
 |integer
+|grantsGcPeriodSeconds           1.2+<.<a|A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+|integer
+|grantsAlwaysLatest              1.2+<.<a|Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.
+|boolean
 |superUsers                      1.2+<.<a|List of super users. Should contain list of user principals which should get unlimited access rights.
 |string array
 |connectTimeoutSeconds           1.2+<.<a|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
@@ -624,8 +628,10 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |httpRetries                     1.2+<.<a|The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.
 |integer
-|enableMetrics                   1.2+<.<a|Enable or disable OAuth metrics. Default value is `false`.
+|enableMetrics                   1.2+<.<a|Enable or disable OAuth metrics. The default value is `false`.
 |boolean
+|grantsMaxIdleTimeSeconds        1.2+<.<a|The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
+|integer
 |====
 
 [id='type-KafkaAuthorizationCustom-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -616,9 +616,9 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |grantsRefreshPoolSize           1.2+<.<a|The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.
 |integer
-|grantsGcPeriodSeconds           1.2+<.<a|A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+|grantsGcPeriodSeconds           1.2+<.<a|The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300.
 |integer
-|grantsAlwaysLatest              1.2+<.<a|Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.
+|grantsAlwaysLatest              1.2+<.<a|Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`.
 |boolean
 |superUsers                      1.2+<.<a|List of super users. Should contain list of user principals which should get unlimited access rights.
 |string array
@@ -630,7 +630,7 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |integer
 |enableMetrics                   1.2+<.<a|Enable or disable OAuth metrics. The default value is `false`.
 |boolean
-|grantsMaxIdleTimeSeconds        1.2+<.<a|The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
+|grantsMaxIdleTimeSeconds        1.2+<.<a|The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
 |integer
 |====
 

--- a/documentation/modules/oauth/con-kafka-keycloak-authz-models.adoc
+++ b/documentation/modules/oauth/con-kafka-keycloak-authz-models.adoc
@@ -9,7 +9,7 @@ Kafka and Keycloak Authorization Services use different authorization models.
 == Kafka authorization model
 
 Kafka's authorization model uses _resource types_. 
-When a Kafka client performs an action on a broker, the broker uses the configured `KeycloakRBACAuthorizer` to check the client's permissions, based on the action and resource type.
+When a Kafka client performs an action on a broker, the broker uses the configured `KeycloakAuthorizer` to check the client's permissions, based on the action and resource type.
 
 Kafka uses five resource types to control access: `Topic`, `Group`, `Cluster`, `TransactionalId`, and `DelegationToken`.
 Each resource type has a set of available permissions.

--- a/documentation/modules/oauth/con-mapping-keycloak-authz-services-to-kafka-model.adoc
+++ b/documentation/modules/oauth/con-mapping-keycloak-authz-services-to-kafka-model.adoc
@@ -21,7 +21,7 @@ The `kafka` client definition must have the *Authorization Enabled* option enabl
 
 All permissions exist within the scope of the `kafka` client. If you have different Kafka clusters configured with different OAuth client IDs, they each need a separate set of permissions even though they're part of the same Keycloak realm.
 
-When the Kafka client uses OAUTHBEARER authentication, the Keycloak authorizer (`KeycloakRBACAuthorizer`) uses the access token of the current session to retrieve a list of grants from the Keycloak server.
+When the Kafka client uses OAUTHBEARER authentication, the Keycloak authorizer (`KeycloakAuthorizer`) uses the access token of the current session to retrieve a list of grants from the Keycloak server.
 To retrieve the grants, the authorizer evaluates the Keycloak Authorization Services policies and permissions.
 
 .Authorization scopes for Kafka permissions

--- a/documentation/modules/oauth/con-oauth-authorization-keycloak-authorization-services.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-keycloak-authorization-services.adoc
@@ -77,7 +77,7 @@ The OAuth 2.0 client definition must have the _Authorization Enabled_ option act
 
 All permissions exist within the scope of this OAuth 2.0 client, which means that if you have different Kafka clusters configured with different OAuth 2.0 client IDs they would each have a separate set of permissions even though they are part of the same realm.
 
-When the Kafka client use the _SASL OAUTHBEARER_ mechanism, the Keycloak authorizer (`KeycloakRBACAuthorizer`) retrieves the list of grants for the current session from the Keycloak server using the access token of the current session.
+When the Kafka client use the _SASL OAUTHBEARER_ mechanism, the Keycloak authorizer (`KeycloakAuthorizer`) retrieves the list of grants for the current session from the Keycloak server using the access token of the current session.
 This list of grants is the result of evaluating the Keycloak Authorization Services policies and permissions.
 
 .Introducing authorization scopes

--- a/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-mechanism.adoc
@@ -12,7 +12,7 @@ OAuth 2.0 authorization enforces permissions locally based on the received list 
 
 == Kafka broker custom authorizer
 
-A Keycloak _authorizer_ (`KeycloakRBACAuthorizer`) is provided with Strimzi.
+A Keycloak _authorizer_ (`KeycloakAuthorizer`) is provided with Strimzi.
 To be able to use the Keycloak REST endpoints for Authorization Services provided by Keycloak,
 you configure a custom authorizer on the Kafka broker.
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -88,7 +88,7 @@ Default is `false`.
 <9> (Optional) The number of threads to use to refresh (in parallel) the grants for the active sessions. The default value is 5.
 <10> (Optional) The time in seconds after which an idle grant in the cache can be evicted. The default value is 300.
 <11> (Optional) A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
-<12> (Optional) Whether latest grants should be fetched for a new session. Grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.
+<12> (Optional) Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`.
 <13> (Optional) The connect timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
 <14> (Optional) The read timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
 <15> (Optional) The maximum number of times to retry (without pausing) a failed HTTP request to the authorization server. The default value is `0`, meaning that no retries are performed. To use this option effectively, consider reducing the timeout times for the `connectTimeoutSeconds` and `readTimeoutSeconds` options. However, note that retries may prevent the current worker thread from being available to other requests, and if too many requests stall, it could make the Kafka broker unresponsive.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -65,9 +65,13 @@ spec:
         certificate: ca.crt
       grantsRefreshPeriodSeconds: 60 <8>
       grantsRefreshPoolSize: 5 <9>
-      connectTimeoutSeconds: 60 <10>
-      readTimeoutSeconds: 60 <11>
-      httpRetries: 2 <12>
+      grantsMaxIdleSeconds: 300 <10>
+      grantsGcPeriodSeconds: 300 <11>
+      grantsAlwaysLatest: false <12>
+      connectTimeoutSeconds: 60 <13>
+      readTimeoutSeconds: 60 <14>
+      httpRetries: 2 <15>
+      enableMetrics: false <16>
     #...
 ----
 <1> Type `keycloak` enables Keycloak authorization.
@@ -82,9 +86,13 @@ Default is `false`.
 <7> (Optional) Trusted certificates for TLS connection to the authorization server.
 <8> (Optional) The time between two consecutive grants refresh runs. That is the maximum time for active sessions to detect any permissions changes for the user on Keycloak. The default value is 60.
 <9> (Optional) The number of threads to use to refresh (in parallel) the grants for the active sessions. The default value is 5.
-<10> (Optional) The connect timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
-<11> (Optional) The read timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
-<12> (Optional) The maximum number of times to retry (without pausing) a failed HTTP request to the authorization server. The default value is `0`, meaning that no retries are performed. To use this option effectively, consider reducing the timeout times for the `connectTimeoutSeconds` and `readTimeoutSeconds` options. However, note that retries may prevent the current worker thread from being available to other requests, and if too many requests stall, it could make the Kafka broker unresponsive.
+<10> (Optional) The time in seconds after which an idle grant in the cache can be evicted. The default value is 300.
+<11> (Optional) A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+<12> (Optional) Whether latest grants should be fetched for a new session. Grants will be fetched anew from Keycloak and cached for the user. The default value is `false`.
+<13> (Optional) The connect timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
+<14> (Optional) The read timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
+<15> (Optional) The maximum number of times to retry (without pausing) a failed HTTP request to the authorization server. The default value is `0`, meaning that no retries are performed. To use this option effectively, consider reducing the timeout times for the `connectTimeoutSeconds` and `readTimeoutSeconds` options. However, note that retries may prevent the current worker thread from being available to other requests, and if too many requests stall, it could make the Kafka broker unresponsive.
+<16> (Optional) Enable or disable OAuth metrics. The default value is `false`.
 . Save and exit the editor, then wait for rolling updates to complete.
 
 . Check the update in the logs or by watching the pod state transitions:

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -86,8 +86,8 @@ Default is `false`.
 <7> (Optional) Trusted certificates for TLS connection to the authorization server.
 <8> (Optional) The time between two consecutive grants refresh runs. That is the maximum time for active sessions to detect any permissions changes for the user on Keycloak. The default value is 60.
 <9> (Optional) The number of threads to use to refresh (in parallel) the grants for the active sessions. The default value is 5.
-<10> (Optional) The time in seconds after which an idle grant in the cache can be evicted. The default value is 300.
-<11> (Optional) A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+<10> (Optional) The time, in seconds, after which an idle grant in the cache can be evicted. The default value is 300.
+<11> (Optional) The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300.
 <12> (Optional) Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`.
 <13> (Optional) The connect timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.
 <14> (Optional) The read timeout in seconds when connecting to the Keycloak token endpoint. The default value is 60.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -49,7 +49,7 @@
 :keycloak-server-install-doc: link:https://www.keycloak.org/operator/installation[Installing the Keycloak Operator^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]
-:OAuthVersion: 0.12.0
+:OAuthVersion: 0.13.0
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples/docker#running-with-hydra-using-ssl-and-opaque-tokens[Using Hydra as the OAuth 2.0 authorization server^]
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -584,10 +584,21 @@ spec:
                           description: Enable or disable TLS hostname verification. Default value is `false`.
                         enableMetrics:
                           type: boolean
-                          description: Enable or disable OAuth metrics. Default value is `false`.
+                          description: Enable or disable OAuth metrics. The default value is `false`.
                         expireAfterMs:
                           type: integer
                           description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+                        grantsAlwaysLatest:
+                          type: boolean
+                          description: "Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`."
+                        grantsGcPeriodSeconds:
+                          type: integer
+                          minimum: 1
+                          description: A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+                        grantsMaxIdleTimeSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
                         grantsRefreshPeriodSeconds:
                           type: integer
                           minimum: 0

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -598,7 +598,7 @@ spec:
                         grantsMaxIdleTimeSeconds:
                           type: integer
                           minimum: 1
-                          description: The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
+                          description: "The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300."
                         grantsRefreshPeriodSeconds:
                           type: integer
                           minimum: 0

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -590,15 +590,15 @@ spec:
                           description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
                         grantsAlwaysLatest:
                           type: boolean
-                          description: "Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`."
+                          description: "Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`."
                         grantsGcPeriodSeconds:
                           type: integer
                           minimum: 1
-                          description: A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+                          description: "The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300."
                         grantsMaxIdleTimeSeconds:
                           type: integer
                           minimum: 1
-                          description: The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
+                          description: The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
                         grantsRefreshPeriodSeconds:
                           type: integer
                           minimum: 0

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -583,10 +583,21 @@ spec:
                         description: Enable or disable TLS hostname verification. Default value is `false`.
                       enableMetrics:
                         type: boolean
-                        description: Enable or disable OAuth metrics. Default value is `false`.
+                        description: Enable or disable OAuth metrics. The default value is `false`.
                       expireAfterMs:
                         type: integer
                         description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
+                      grantsAlwaysLatest:
+                        type: boolean
+                        description: "Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`."
+                      grantsGcPeriodSeconds:
+                        type: integer
+                        minimum: 1
+                        description: A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+                      grantsMaxIdleTimeSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
                       grantsRefreshPeriodSeconds:
                         type: integer
                         minimum: 0

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -589,15 +589,15 @@ spec:
                         description: The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.
                       grantsAlwaysLatest:
                         type: boolean
-                        description: "Enable or disable fetching the latest grants for a new session. When enabled, grants will be fetched anew from Keycloak and cached for the user. The default value is `false`."
+                        description: "Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`."
                       grantsGcPeriodSeconds:
                         type: integer
                         minimum: 1
-                        description: A period in seconds in which cleaning of stale grants from cache is performed. The default value is 300.
+                        description: "The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300."
                       grantsMaxIdleTimeSeconds:
                         type: integer
                         minimum: 1
-                        description: The time in seconds after which an idle grant in the cache can be evicted. The fefault value is 300.
+                        description: The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
                       grantsRefreshPeriodSeconds:
                         type: integer
                         minimum: 0

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -597,7 +597,7 @@ spec:
                       grantsMaxIdleTimeSeconds:
                         type: integer
                         minimum: 1
-                        description: The time in seconds after which an idle grant can be evicted from the cache. The default value is 300.
+                        description: "The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300."
                       grantsRefreshPeriodSeconds:
                         type: integer
                         minimum: 0

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
+        </repository>
+    </repositories>
+
     <modules>
         <module>kafka-agent</module>
         <module>mirror-maker-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -191,13 +191,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1186/</url>
-        </repository>
-    </repositories>
-
     <modules>
         <module>kafka-agent</module>
         <module>mirror-maker-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
-        <strimzi-oauth.version>0.12.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.13.0</strimzi-oauth.version>
         <netty.version>4.1.94.Final</netty.version>
         <micrometer.version>1.9.5</micrometer.version>
         <jayway-jsonpath.version>2.8.0</jayway-jsonpath.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

Integrate new features / config options from OAuth 0.13.0

- Keycloak authorization now uses a new `Authorizer` class that supports KRaft mode as well as Zookeeper mode.
- New config options were introduced to `keycloak` authorization:
  - `grantsMaxIdleSeconds` to control the removal of idle grants from the cache
  - `grantsGcPeriodSeconds` to control the periodicity of the background job that removes idle grant from the cache
  - `grantsAlwaysLatest` to control if latest grants should always be fetched from Keycloak at the start of a new session
- Environment variable `STRIMZI_OAUTH_METRIC_REPORTERS` can now be used similarly to `metric.reporters` to list the reporters to be instantiated and integrated with OAuth metrics. By default `JmxReporter` is automatically used. If `STRIMZI_OAUTH_METRIC_REPORTERS` is set, only the listed reporter classes will be used.
- An issue with processing JsonPath filter queries used in `oauth` authentication `customClaimCheck` configuration was fixed by updating the dependency library. Comparing nonexistent attribute against `null` using equals now evaluates differently. Check your configuration. Avoid using `null` in queries.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

