### PR TITLE
[system test] - fix removal of namespace after test run

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -397,7 +397,7 @@ public class SetupClusterOperator {
     }
 
     private void deleteClusterOperatorNamespace() {
-        LOGGER.info("Deleting of Namespace " + this.namespaceInstallTo);
+        LOGGER.info("Deleting Namespace {}", this.namespaceInstallTo);
         cluster.deleteNamespace(CollectorElement.createCollectorElement(testClassName, testMethodName),
                 this.namespaceInstallTo);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -387,12 +387,12 @@ public class SetupClusterOperator {
                 ResourceManager.STORED_RESOURCES.computeIfAbsent(this.extensionContext.getDisplayName(), k -> new Stack<>());
                 ResourceManager.STORED_RESOURCES.get(this.extensionContext.getDisplayName()).push(
                     new ResourceItem<>(this::deleteClusterOperatorNamespace));
+
+                cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
+                StUtils.copyImagePullSecrets(namespaceInstallTo);
+
+                this.extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, true);
             }
-
-            cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
-            StUtils.copyImagePullSecrets(namespaceInstallTo);
-
-            extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, true);
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds a check for removing the cluster operator namespace at the end of the test execution.

### Checklist

- [x] Make sure all tests pass

