### PR TITLE
Remove reliance on TestcontainersKafkaCluster in topic operator tests.

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
-import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
@@ -200,7 +199,7 @@ class BatchingTopicControllerTest {
     @Test
     public void shouldHandleInterruptedExceptionFromListReassignments(
             @BrokerCluster(numBrokers = 2)
-            TestcontainersKafkaCluster cluster) throws ExecutionException, InterruptedException {
+            KafkaCluster cluster) throws ExecutionException, InterruptedException {
         admin[0] = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers()));
         admin[0].createTopics(List.of(new NewTopic(NAME, 2, (short) 2))).all().get();
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -11,7 +11,6 @@ import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
-import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
@@ -1451,7 +1450,7 @@ class TopicControllerIT {
     public void shouldAccountForReassigningPartitionsNoRfChange(
             @BrokerCluster(numBrokers = 3)
             @BrokerConfig(name = "auto.create.topics.enable", value = "false")
-            TestcontainersKafkaCluster kafkaCluster,
+            KafkaCluster kafkaCluster,
             Producer<String, String> producer)
             throws ExecutionException, InterruptedException, TimeoutException {
         var kt = kafkaTopic("ns", "foo", true, "foo", 1, 1);
@@ -1469,7 +1468,7 @@ class TopicControllerIT {
     public void shouldAccountForReassigningPartitionsIncreasingRf(
             @BrokerCluster(numBrokers = 3)
             @BrokerConfig(name = "auto.create.topics.enable", value = "false")
-            TestcontainersKafkaCluster kafkaCluster,
+            KafkaCluster kafkaCluster,
             Producer<String, String> producer)
             throws ExecutionException, InterruptedException, TimeoutException {
         var kt = kafkaTopic("ns", "foo", true, "foo", 1, 1);
@@ -1489,7 +1488,7 @@ class TopicControllerIT {
     public void shouldAccountForReassigningPartitionsDecreasingRf(
             @BrokerCluster(numBrokers = 3)
             @BrokerConfig(name = "auto.create.topics.enable", value = "false")
-            TestcontainersKafkaCluster kafkaCluster,
+            KafkaCluster kafkaCluster,
             Producer<String, String> producer)
             throws ExecutionException, InterruptedException, TimeoutException {
         var kt = kafkaTopic("ns", "foo", true, "foo", 1, 2);
@@ -1505,7 +1504,7 @@ class TopicControllerIT {
     private void accountForReassigningPartitions(
             @BrokerCluster(numBrokers = 3)
             @BrokerConfig(name = "auto.create.topics.enable", value = "false")
-            TestcontainersKafkaCluster kafkaCluster,
+            KafkaCluster kafkaCluster,
             Producer<String, String> producer,
             KafkaTopic kt,
             Function<List<Integer>, List<Integer>> newReplicasFn,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Change the Topic Operator tests that use `TestcontainersKafkaCluster` explicitly to use a default `KafkaCluster` instead.  This will mean, by default, they use in-VM kafka(s) rather than use the containerized native binaries.

Why: we don't have multi-arch container image available for the kafka native and zookeeper native image, so this is causing a problem with Strimzi's release pipeline. This change avoids the dependency.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

