### PR TITLE
Recreate watcher when closed with an exception

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorWatcher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorWatcher.java
@@ -34,8 +34,8 @@ import static io.strimzi.operator.cluster.operator.assembly.AbstractConnectOpera
 import static io.strimzi.operator.common.AbstractOperator.LOCK_TIMEOUT_MS;
 
 /**
- * Watcher implementation for watching node pools and triggering Kafka reconciliations based on changes to node pool
- * configurations.
+ * Watcher implementation for watching Kafka connectors and triggering reconciliations based on changes to Kafka
+ * Connector configurations.
  */
 public class KafkaConnectorWatcher implements Watcher<KafkaConnector> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaNodePoolWatcher.class);
@@ -46,7 +46,7 @@ public class KafkaConnectorWatcher implements Watcher<KafkaConnector> {
     private final Labels selectorLabels;
 
     /**
-     * Constructs the KafkaNodePool watcher
+     * Constructs the KafkaConnector watcher
      *
      * @param namespace                 Namespace to watch (or asterisk for all namespaces)
      * @param selector                  The selector to check if the Kafka cluster is operated by this instance of the CLuster Operator
@@ -67,7 +67,7 @@ public class KafkaConnectorWatcher implements Watcher<KafkaConnector> {
      * Handles the event received from the watch
      *
      * @param action    Action describing the event
-     * @param kafkaConnector  KafkaConnectorPool resource to which the event happened
+     * @param kafkaConnector  KafkaConnector resource to which the event happened
      */
     public void eventReceived(Action action, KafkaConnector kafkaConnector) {
         String connectorName = kafkaConnector.getMetadata().getName();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorWatcher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorWatcher.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.strimzi.api.kafka.KafkaConnectList;
+import io.strimzi.api.kafka.model.KafkaConnect;
+import io.strimzi.api.kafka.model.KafkaConnectResources;
+import io.strimzi.api.kafka.model.KafkaConnectSpec;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.status.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.status.KafkaConnectorStatus;
+import io.strimzi.operator.cluster.model.InvalidResourceException;
+import io.strimzi.operator.cluster.model.StatusDiff;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.operator.common.operator.resource.StatusUtils;
+import io.vertx.core.Future;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator.isUseResources;
+import static io.strimzi.operator.common.AbstractOperator.LOCK_TIMEOUT_MS;
+
+/**
+ * Watcher implementation for watching node pools and triggering Kafka reconciliations based on changes to node pool
+ * configurations.
+ */
+public class KafkaConnectorWatcher implements Watcher<KafkaConnector> {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaNodePoolWatcher.class);
+
+    private final Optional<LabelSelector> selector;
+    private final AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, Resource<KafkaConnect>, KafkaConnectSpec, KafkaConnectStatus> connectOperator;
+    private final Consumer<WatcherException> onClose;
+    private final Labels selectorLabels;
+
+    /**
+     * Constructs the KafkaNodePool watcher
+     *
+     * @param namespace                 Namespace to watch (or asterisk for all namespaces)
+     * @param selector                  The selector to check if the Kafka cluster is operated by this instance of the CLuster Operator
+     * @param connectOperator           Kafka operator for managing the Kafka custom resources
+     * @param onClose                   On-close method which is called when the watch is closed
+     * @param selectorLabels            Selector labels for filtering the custom resources
+     */
+    public KafkaConnectorWatcher(String namespace, Optional<LabelSelector> selector,
+                                 AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, Resource<KafkaConnect>, KafkaConnectSpec, KafkaConnectStatus> connectOperator,
+                                 Consumer<WatcherException> onClose, Labels selectorLabels) {
+        this.selector = selector;
+        this.connectOperator = connectOperator;
+        this.onClose = onClose;
+        this.selectorLabels = selectorLabels;
+    }
+
+    /**
+     * Handles the event received from the watch
+     *
+     * @param action    Action describing the event
+     * @param kafkaConnector  KafkaConnectorPool resource to which the event happened
+     */
+    public void eventReceived(Action action, KafkaConnector kafkaConnector) {
+        String connectorName = kafkaConnector.getMetadata().getName();
+        String connectorNamespace = kafkaConnector.getMetadata().getNamespace();
+        String connectorKind = kafkaConnector.getKind();
+        String connectName = kafkaConnector.getMetadata().getLabels() == null ? null : kafkaConnector.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        String connectNamespace = connectorNamespace;
+
+        switch (action) {
+            case ADDED:
+            case DELETED:
+            case MODIFIED:
+                if (connectName != null) {
+                    // Check whether a KafkaConnect exists
+                    connectOperator.resourceOperator.getAsync(connectNamespace, connectName)
+                            .compose(connect -> {
+                                KafkaConnectApi apiClient = connectOperator.connectClientProvider.apply(connectOperator.vertx);
+                                if (connect == null) {
+                                    Reconciliation r = new Reconciliation("connector-watch", connectOperator.kind(),
+                                            kafkaConnector.getMetadata().getNamespace(), connectName);
+                                    updateStatus(r, connectOperator.noConnectCluster(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
+                                    LOGGER.infoCr(r, "{} {} in namespace {} was {}, but Connect cluster {} does not exist", connectorKind, connectorName, connectorNamespace, action, connectName);
+                                    return Future.succeededFuture();
+                                } else {
+                                    // grab the lock and call reconcileConnectors()
+                                    // (i.e. short circuit doing a whole KafkaConnect reconciliation).
+                                    Reconciliation reconciliation = new Reconciliation("connector-watch", connectOperator.kind(),
+                                            kafkaConnector.getMetadata().getNamespace(), connectName);
+
+                                    if (!Util.matchesSelector(selector, connect))   {
+                                        LOGGER.debugCr(reconciliation, "{} {} in namespace {} was {}, but Connect cluster {} does not match label selector {} and will be ignored", connectorKind, connectorName, connectorNamespace, action, connectName, selectorLabels);
+                                        return Future.succeededFuture();
+                                    } else if (connect.getSpec() != null && connect.getSpec().getReplicas() == 0)  {
+                                        LOGGER.infoCr(reconciliation, "{} {} in namespace {} was {}, but Connect cluster {} has 0 replicas", connectorKind, connectorName, connectorNamespace, action, connectName);
+                                        updateStatus(reconciliation, connectOperator.zeroReplicas(connectNamespace, connectName), kafkaConnector, connectOperator.connectorOperator);
+                                        return Future.succeededFuture();
+                                    } else {
+                                        LOGGER.infoCr(reconciliation, "{} {} in namespace {} was {}", connectorKind, connectorName, connectorNamespace, action);
+
+                                        return connectOperator.withLock(reconciliation, LOCK_TIMEOUT_MS,
+                                                () -> connectOperator.reconcileConnectorAndHandleResult(reconciliation,
+                                                        KafkaConnectResources.qualifiedServiceName(connectName, connectNamespace), apiClient,
+                                                        isUseResources(connect),
+                                                        kafkaConnector.getMetadata().getName(), action == Action.DELETED ? null : kafkaConnector)
+                                                        .compose(reconcileResult -> {
+                                                            LOGGER.infoCr(reconciliation, "reconciled");
+                                                            return Future.succeededFuture(reconcileResult);
+                                                        }));
+                                    }
+                                }
+                            });
+                } else {
+                    updateStatus(new Reconciliation("connector-watch", connectOperator.kind(),
+                                    kafkaConnector.getMetadata().getNamespace(), null),
+                            new InvalidResourceException("Resource lacks label '"
+                                    + Labels.STRIMZI_CLUSTER_LABEL
+                                    + "': No connect cluster in which to create this connector."),
+                            kafkaConnector, connectOperator.connectorOperator);
+                }
+
+                break;
+            case ERROR:
+                LOGGER.errorCr(new Reconciliation("connector-watch", connectorKind, connectName, connectorNamespace), "Failed {} {} in namespace {} ", connectorKind, connectorName, connectorNamespace);
+                break;
+            default:
+                LOGGER.errorCr(new Reconciliation("connector-watch", connectorKind, connectName, connectorNamespace), "Unknown action: {} {} in namespace {}", connectorKind, connectorName, connectorNamespace);
+        }
+    }
+
+    @Override
+    public void onClose(WatcherException e) {
+        onClose.accept(e);
+    }
+
+    /**
+     * Update the status of the Kafka Connector custom resource
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param error                 Throwable indicating if any errors occurred during the reconciliation
+     * @param kafkaConnector2       Latest version of the KafkaConnector resource where the status should be updated
+     * @param connectorOperations   The KafkaConnector operations for updating the status
+     */
+    public static void updateStatus(Reconciliation reconciliation, Throwable error, KafkaConnector kafkaConnector2, CrdOperator<?, KafkaConnector, ?> connectorOperations) {
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnector2, status, error);
+        StatusDiff diff = new StatusDiff(kafkaConnector2.getStatus(), status);
+        if (!diff.isEmpty()) {
+            KafkaConnector copy = new KafkaConnectorBuilder(kafkaConnector2).build();
+            copy.setStatus(status);
+            connectorOperations.updateStatusAsync(reconciliation, copy);
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -210,28 +210,6 @@ public class KafkaRebalanceAssemblyOperator
     }
 
     /**
-     * Recreates a Kubernetes watch
-     *
-     * @param namespace Namespace which should be watched
-     *
-     * @return  Consumer for a Watched exception
-     */
-    public Consumer<WatcherException> recreateWatch(String namespace) {
-        Consumer<WatcherException> kubernetesClientExceptionConsumer = new Consumer<WatcherException>() {
-            @Override
-            public void accept(WatcherException e) {
-                if (e != null) {
-                    LOGGER.errorOp("Watcher closed with exception in namespace {}", namespace, e);
-                    createWatch(namespace, this);
-                } else {
-                    LOGGER.infoOp("Watcher closed in namespace {}", namespace);
-                }
-            }
-        };
-        return kubernetesClientExceptionConsumer;
-    }
-
-    /**
      * Create a watch on {@code KafkaRebalance} in the given {@code watchNamespaceOrWildcard}.
      *
      * @param watchNamespaceOrWildcard The namespace to watch, or "*" to watch all namespaces.

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.StatusDetails;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
@@ -27,6 +28,7 @@ import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.ConnectorPluginBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.Status;
+import io.strimzi.operator.common.OperatorWatcher;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -118,6 +120,7 @@ public class ConnectorMockTest {
     @SuppressWarnings("unused")
     private KubernetesClient client;
     private MockKube2 mockKube;
+    public OperatorWatcher<io.fabric8.kubernetes.api.model.HasMetadata> connectWatcher;
     private Watch connectWatch;
     private Watch connectorWatch;
     private KafkaConnectApi api;
@@ -178,7 +181,7 @@ public class ConnectorMockTest {
             ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString(),
             ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString(),
             ClusterOperatorConfig.FULL_RECONCILIATION_INTERVAL_MS.key(), Long.toString(Long.MAX_VALUE)),
-                KafkaVersionTestUtils.getKafkaVersionLookup());
+            KafkaVersionTestUtils.getKafkaVersionLookup());
         kafkaConnectOperator = spy(new KafkaConnectAssemblyOperator(vertx,
             pfa,
             ros,
@@ -186,17 +189,56 @@ public class ConnectorMockTest {
             x -> api));
 
         Checkpoint async = testContext.checkpoint();
-        // Fail test if watcher closes for any reason
-        kafkaConnectOperator.createWatch(NAMESPACE, e -> testContext.failNow(e))
+
+        kafkaConnectOperator.createWatch(NAMESPACE, kafkaConnectOperator.recreateWatch(NAMESPACE))
             .onComplete(testContext.succeeding(i -> { }))
             .compose(watch -> {
                 connectWatch = watch;
-                return AbstractConnectOperator.createConnectorWatch(kafkaConnectOperator, NAMESPACE, null);
+                return kafkaConnectOperator.createConnectorWatch(NAMESPACE, kafkaConnectOperator.recreateWatch(NAMESPACE));
             }).compose(watch -> {
                 connectorWatch = watch;
                 //async.flag();
                 return Future.succeededFuture();
             }).onComplete(testContext.succeeding(v -> async.flag()));
+    }
+
+    @Test
+    public void testKafkaConnectWatchClosedWithException() throws WatcherException {
+        String connectName = "cluster";
+        String connectorName = "connector";
+        WatcherException e = new WatcherException("WatcherException");
+
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(connectName)
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                    .withReplicas(1)
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).resource(connect).create();
+
+        kafkaConnectOperator.getWatcher().onClose(e);
+        waitForConnectReady(connectName);
+
+        // Create KafkaConnector and wait till it's ready
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName(connectorName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                    .withTasksMax(1)
+                    .withClassName("Dummy")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
+
+        kafkaConnectOperator.getConnectorWatcher().onClose(e);
+        waitForConnectorReady(connectorName);
     }
 
     private void setupMockConnectAPI() {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
@@ -193,21 +192,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 .thenReturn(Future.succeededFuture(MockCruiseControl.CC_SECRET));
         when(mockSecretOps.getAsync(CLUSTER_NAMESPACE, CruiseControlResources.apiSecretName(CLUSTER_NAME)))
                 .thenReturn(Future.succeededFuture(MockCruiseControl.CC_API_SECRET));
-    }
-
-    /**
-     * Tests that KafkaRebalance watch is recreated after being closed with an exception.
-     */
-    @Test
-    public void testKafkaRebalanceWatchClosedWithException(VertxTestContext context) throws IOException, URISyntaxException {
-        KafkaRebalance kr = createKafkaRebalance(CLUSTER_NAMESPACE, CLUSTER_NAME, RESOURCE_NAME, EMPTY_KAFKA_REBALANCE_SPEC, false);
-        kcrao.createWatch(CLUSTER_NAMESPACE, kcrao.recreateWatch(CLUSTER_NAMESPACE));
-
-        // Test what happens when watcher is closed with an exception
-        WatcherException e = new WatcherException("WatcherException");
-        kcrao.getWatcher().onClose(e);
-
-        this.krNewToProposalReady(context, 0, CruiseControlEndpoints.REBALANCE, kr);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AbstractOperator.java
@@ -67,15 +67,24 @@ public abstract class AbstractOperator<
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(AbstractOperator.class);
 
     private static final long PROGRESS_WARNING = 60_000L;
-    protected static final int LOCK_TIMEOUT_MS = 10000;
+    /**
+     * Lock timeout
+     */
+    public static final int LOCK_TIMEOUT_MS = 10000;
 
     /**
      * Prefix used for metrics provided by Strimzi operators
      */
     public static final String METRICS_PREFIX = "strimzi.";
 
-    protected final Vertx vertx;
-    protected final O resourceOperator;
+    /**
+     * Vert.x instance
+     */
+    public final Vertx vertx;
+    /**
+     * Resource operator for given custom resource
+     */
+    public final O resourceOperator;
     private final String kind;
 
     private final Optional<LabelSelector> selector;
@@ -358,12 +367,14 @@ public abstract class AbstractOperator<
      * and call the given {@code callable} with the lock held.
      * Once the callable returns (or if it throws) release the lock and complete the returned Future.
      * If the lock cannot be acquired the given {@code callable} is not called and the returned Future is completed with {@link UnableToAcquireLockException}.
-     * @param reconciliation
-     * @param callable
-     * @param <T>
-     * @return
+     * @param reconciliation The reconciliation
+     * @param lockTimeoutMs The timeout for the lock
+     * @param callable The callable routine for processing the reconciliation
+     * @param <T> The custom resource type
+     *
+     * @return A Future that completes lock operation has completed.
      */
-    protected final <T> Future<T> withLock(Reconciliation reconciliation, long lockTimeoutMs, Callable<Future<T>> callable) {
+    public final <T> Future<T> withLock(Reconciliation reconciliation, long lockTimeoutMs, Callable<Future<T>> callable) {
         Promise<T> handler = Promise.promise();
         String namespace = reconciliation.namespace();
         String name = reconciliation.name();

--- a/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/OperatorWatcher.java
@@ -14,13 +14,20 @@ import java.util.function.Consumer;
  * The fabric8 Watcher used to trigger reconciliation of an {@link Operator}.
  * @param <T> The resource type
  */
-class OperatorWatcher<T extends HasMetadata> implements Watcher<T> {
+public class OperatorWatcher<T extends HasMetadata> implements Watcher<T> {
     private final String namespace;
     private final Consumer<WatcherException> onClose;
     private Operator operator;
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(OperatorWatcher.class);
 
-    OperatorWatcher(Operator operator, String namespace, Consumer<WatcherException> onClose) {
+    /**
+     * The constructor
+     *
+     * @param operator The operator to reconcile
+     * @param namespace The namespace
+     * @param onClose Callback called when the watch is closed.
+     */
+    public OperatorWatcher(Operator operator, String namespace, Consumer<WatcherException> onClose) {
         this.namespace = namespace;
         this.onClose = onClose;
         this.operator = operator;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Addresses #8060

Some of the operators do not recreate watches after they are closed with an error:

    AbstractConnectOperator
    KafkaRebalanceAssemblyOperator

This can lead to a custom resources not being watched and updated after the watch on that resource expires

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

