### PR TITLE
[ST] MirrorMaker2IsolatedST switch to manipulating kafkaUser instead …

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -218,5 +218,7 @@ public class KafkaUserUtils {
                     .build()
             );
         }, ns);
+
+        waitForKafkaUserReady(ns, kafkaUserResourceName);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUserUtils.java
@@ -192,19 +192,17 @@ public class KafkaUserUtils {
             });
     }
 
-    public static void modifyKafkaUserPasswordWithNewSecret(
-        String ns, String kafkaUserResourceName, String customSecretSource, String customPassword,
-        ResourceManager resourceManager, ExtensionContext extensionContext) {
+    public static void modifyKafkaUserPasswordWithNewSecret(String ns, String kafkaUserResourceName, String customSecretSource, String customPassword, ExtensionContext extensionContext) {
 
         Secret userDefinedSecret = new SecretBuilder()
             .withNewMetadata()
-            .withName(customSecretSource)
-            .withNamespace(ns)
+                .withName(customSecretSource)
+                .withNamespace(ns)
             .endMetadata()
             .addToData("password", customPassword)
             .build();
 
-        resourceManager.createResource(extensionContext, userDefinedSecret);
+        ResourceManager.getInstance().createResourceWithWait(extensionContext, userDefinedSecret);
 
         KafkaUserResource.replaceUserResourceInSpecificNamespace(kafkaUserResourceName, ku -> {
 
@@ -213,8 +211,9 @@ public class KafkaUserUtils {
                     .withPassword(
                         new PasswordBuilder()
                             .editOrNewValueFrom()
-                            .withNewSecretKeyRef("password", customSecretSource, false)
-                            .and().build()
+                                .withNewSecretKeyRef("password", customSecretSource, false)
+                            .endValueFrom()
+                            .build()
                     )
                     .build()
             );

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -974,40 +974,6 @@ class MirrorMaker2IsolatedST extends AbstractST {
         final String customSecretSource = "custom-secret-source";
         final String customSecretTarget = "custom-secret-target";
 
-        // Deploy source kafka with tls listener and SCRAM-SHA authentication
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withListeners(
-                        new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationScramSha512())
-                            .build()
-                    )
-                .endKafka()
-            .endSpec()
-            .build());
-
-        // Deploy target kafka with tls listeners with tls and SCRAM-SHA authentication
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaPersistent(kafkaClusterTargetName, 1, 1)
-            .editSpec()
-                .editKafka()
-                    .withListeners(
-                        new GenericKafkaListenerBuilder()
-                            .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
-                            .withPort(9093)
-                            .withType(KafkaListenerType.INTERNAL)
-                            .withTls(true)
-                            .withAuth(new KafkaListenerAuthenticationScramSha512())
-                            .build()
-                    )
-                .endKafka()
-            .endSpec()
-            .build());
-
         // Deploy source and target kafkas with tls listener and SCRAM-SHA authentication
         resourceManager.createResourceWithWait(extensionContext,
             KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1, 1)
@@ -1019,7 +985,8 @@ class MirrorMaker2IsolatedST extends AbstractST {
                                 .withPort(9093)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(true)
-                                .withAuth(new KafkaListenerAuthenticationScramSha512())
+                                .withNewKafkaListenerAuthenticationScramSha512Auth()
+                                .endKafkaListenerAuthenticationScramSha512Auth()
                                 .build()
                         )
                     .endKafka()
@@ -1034,7 +1001,8 @@ class MirrorMaker2IsolatedST extends AbstractST {
                                 .withPort(9093)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(true)
-                                .withAuth(new KafkaListenerAuthenticationScramSha512())
+                                .withNewKafkaListenerAuthenticationScramSha512Auth()
+                                .endKafkaListenerAuthenticationScramSha512Auth()
                                 .build()
                         )
                     .endKafka()
@@ -1121,11 +1089,11 @@ class MirrorMaker2IsolatedST extends AbstractST {
 
         LOGGER.info("Changing KafkaUser sha-password on MirrorMaker2 Source and make sure it rolled");
 
-        KafkaUserUtils.modifyKafkaUserPasswordWithNewSecret(testStorage.getNamespaceName(), kafkaUserSourceName, customSecretSource, "c291cmNlLXBhc3N3b3Jk", resourceManager, extensionContext);
+        KafkaUserUtils.modifyKafkaUserPasswordWithNewSecret(testStorage.getNamespaceName(), kafkaUserSourceName, customSecretSource, "c291cmNlLXBhc3N3b3Jk", extensionContext);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), mmSelector, 1, mmSnapshot);
         mmSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), mmSelector);
 
-        KafkaUserUtils.modifyKafkaUserPasswordWithNewSecret(testStorage.getNamespaceName(), kafkaUserTargetName, customSecretTarget, "dGFyZ2V0LXBhc3N3b3Jk", resourceManager, extensionContext);
+        KafkaUserUtils.modifyKafkaUserPasswordWithNewSecret(testStorage.getNamespaceName(), kafkaUserTargetName, customSecretTarget, "dGFyZ2V0LXBhc3N3b3Jk", extensionContext);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), mmSelector, 1, mmSnapshot);
 
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), mmSelector, 1, mmSnapshot);

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2IsolatedST.java
@@ -1008,6 +1008,40 @@ class MirrorMaker2IsolatedST extends AbstractST {
             .endSpec()
             .build());
 
+        // Deploy source and target kafkas with tls listener and SCRAM-SHA authentication
+        resourceManager.createResourceWithWait(extensionContext,
+            KafkaTemplates.kafkaPersistent(kafkaClusterSourceName, 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(
+                            new GenericKafkaListenerBuilder()
+                                .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                                .withPort(9093)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(true)
+                                .withAuth(new KafkaListenerAuthenticationScramSha512())
+                                .build()
+                        )
+                    .endKafka()
+                .endSpec()
+                .build(),
+            KafkaTemplates.kafkaPersistent(kafkaClusterTargetName, 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(
+                            new GenericKafkaListenerBuilder()
+                                .withName(Constants.TLS_LISTENER_DEFAULT_NAME)
+                                .withPort(9093)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(true)
+                                .withAuth(new KafkaListenerAuthenticationScramSha512())
+                                .build()
+                        )
+                    .endKafka()
+                .endSpec()
+                .build()
+        );
+
         resourceManager.createResourceWithWait(extensionContext,
             KafkaTopicTemplates.topic(kafkaClusterSourceName, testStorage.getTopicName(), testStorage.getNamespaceName()).build(),
             KafkaUserTemplates.scramShaUser(testStorage.getNamespaceName(), kafkaClusterSourceName, kafkaUserSourceName).build(),


### PR DESCRIPTION

### Type of change
- Refactoring


### Description
Testing of password change in mm2 by modifying KafkaUser instead of directly modifying secret managed by User Operator.
### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles

fixes https://github.com/strimzi/strimzi-kafka-operator/issues/8226
