### PR TITLE
Adding thread name to the bridge logging layout pattern

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaBridgeCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaBridgeCluster.properties
@@ -3,7 +3,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -520,7 +520,7 @@ class LoggingChangeST extends AbstractST {
                     "appender.console.type = Console\n" +
                     "appender.console.name = STDOUT\n" +
                     "appender.console.layout.type = PatternLayout\n" +
-                    "appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n\n" +
+                    "appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n\n" +
                     "\n" +
                     "rootLogger.level = OFF\n" +
                     "rootLogger.appenderRefs = console\n" +


### PR DESCRIPTION
This trivial PR just adds the thread name to the logging layout pattern for the bridge as already done on the Strimzi HTTP bridge repo as well with this PR https://github.com/strimzi/strimzi-kafka-bridge/pull/818