### PR TITLE
[systemtest] Update scalibility profile - add recovery group

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -546,11 +546,12 @@
         </profile>
 
         <profile>
-            <id>scalability</id>
+            <id>scalability_recovery</id>
             <properties>
                 <skipTests>false</skipTests>
                 <groups>
-                    all,scalability
+                    scalability,
+                    recovery
                 </groups>
             </properties>
         </profile>


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds `recovery` group into `scalability` profile and renames the profile to `scalability_recovery`.
The profile is used in our automation, where we are running these two groups together, so I'm adding this change to handle it on a profile level.

### Checklist

- [ ] Make sure all tests pass

