### PR TITLE
Don't patch loadBalancerClass field in Service resources

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -90,6 +90,7 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
                     patchNodePorts(current, desired);
                     patchHealthCheckPorts(current, desired);
                     patchAnnotations(current, desired);
+                    patchLoadBalancerClass(current, desired);
                 }
 
                 patchDualStackNetworking(current, desired);
@@ -178,6 +179,20 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
 
         if (desired.getSpec().getIpFamilyPolicy() == null) {
             desired.getSpec().setIpFamilyPolicy(current.getSpec().getIpFamilyPolicy());
+        }
+    }
+
+    /**
+     * In some environments, the loadBalancerClass field of a LoadBalancer type service gets set automatically. When
+     * patching the service, we keep the original class set by the infrastructure instead of overriding it.
+     *
+     * @param current   Current Service
+     * @param desired   Desired Service
+     */
+    protected void patchLoadBalancerClass(Service current, Service desired) {
+        if (current.getSpec().getLoadBalancerClass() != null
+                && desired.getSpec().getLoadBalancerClass() == null) {
+            desired.getSpec().setLoadBalancerClass(current.getSpec().getLoadBalancerClass());
         }
     }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/ServiceOperatorTest.java
@@ -312,4 +312,45 @@ public class ServiceOperatorTest extends AbstractNamespacedResourceOperatorTest<
         assertThat(current2.getSpec().getIpFamilyPolicy(), is(not(desired2.getSpec().getIpFamilyPolicy())));
         assertThat(current2.getSpec().getIpFamilies(), is(desired2.getSpec().getIpFamilies()));
     }
+
+    @Test
+    public void testLoadBalancerClassPatching()  {
+        KubernetesClient client = mock(KubernetesClient.class);
+
+        Service current = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("LoadBalancer")
+                    .withPorts(new ServicePortBuilder()
+                            .withName("port1")
+                            .withPort(1234)
+                            .withTargetPort(new IntOrString(1234))
+                            .build())
+                    .withLoadBalancerClass("service.k8s.aws/nlb")
+                .endSpec()
+                .build();
+
+        Service desired = new ServiceBuilder()
+                .withNewMetadata()
+                    .withNamespace(NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("LoadBalancer")
+                    .withPorts(new ServicePortBuilder()
+                            .withName("port1")
+                            .withPort(1234)
+                            .withTargetPort(new IntOrString(1234))
+                            .build())
+                .endSpec()
+                .build();
+
+        ServiceOperator op = new ServiceOperator(vertx, client);
+        op.patchLoadBalancerClass(current, desired);
+
+        assertThat(current.getSpec().getLoadBalancerClass(), is(desired.getSpec().getLoadBalancerClass()));
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `loadBalancerClass` field might be in some environments set by the platform. In such case, we should reuse it instead of trying to patch it. This PR will patch it if it is set in the existing resource and not in the desired resource to avoid errors such as the one described in #8823.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging