### PR TITLE
[systemtest] Disable whole NamespaceDeletionRecoveryIsolatedST for KRaft (and currently also for regression)

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -52,6 +53,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
  */
 @Tag(RECOVERY)
 @Tag(REGRESSION)
+@Disabled("Tests are not working on Minikube at the moment")
 @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
 class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(NamespaceDeletionRecoveryIsolatedST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryIsolatedST.java
@@ -52,6 +52,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
  */
 @Tag(RECOVERY)
 @Tag(REGRESSION)
+@KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
 class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(NamespaceDeletionRecoveryIsolatedST.class);
     private String storageClassName = "retain";
@@ -116,7 +117,6 @@ class NamespaceDeletionRecoveryIsolatedST extends AbstractST {
      */
     @IsolatedTest("We need for each test case its own Cluster Operator")
     @Tag(INTERNAL_CLIENTS_USED)
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
     void testTopicNotAvailable(ExtensionContext extensionContext) throws InterruptedException {
         final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR disables whole `NamespaceDeletionRecoveryIsolatedST` when running in KRaft mode, as both of the tests need TopicOperator, which is not available in KRaft (UTO is not yet tested, but if the scenario will work, we should enable it back with usage of it).

### Checklist

- [ ] Make sure all tests pass

