### PR TITLE
Remove deprecation in SystemTestCertAndKeyBuilder

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -74,15 +74,13 @@ public class SystemTestCertAndKeyBuilder {
     private X500Name issuer;
     private X500Name subject;
 
-    // Suppresses the deprecation warning about getSubjectDN()
-    @SuppressWarnings("deprecation")
     private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) {
         this.keyPair = keyPair;
         this.caCert = caCert;
         if (caCert != null) {
-            // getSubjectDN is deprecated, but BouncyCastle does not seem to work well with getSubjectX500Principal which replaces it
-            // The fix for this issue is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/7698
-            this.issuer = new X500Name(caCert.getCertificate().getSubjectDN().getName());
+            // getSubjectX500Principal().getName() applies additional formatting such as omitting spaces between DNs which would result
+            // in a breaking change instead of we use getSubjectX500Principal().toString()
+            this.issuer = new X500Name(caCert.getCertificate().getSubjectX500Principal().toString());
         }
         this.extensions = new ArrayList<>(extensions);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -76,16 +76,20 @@ public class SystemTestCertAndKeyBuilder {
     private X500Name issuer;
     private X500Name subject;
 
-    private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) throws CertificateEncodingException {
+    private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) {
         this.keyPair = keyPair;
         this.caCert = caCert;
         if (caCert != null) {
-            this.issuer = new JcaX509CertificateHolder(caCert.getCertificate()).getSubject();
+            try {
+                this.issuer = new JcaX509CertificateHolder(caCert.getCertificate()).getSubject();
+            } catch (CertificateEncodingException e) {
+                throw new RuntimeException(e);
+            }
         }
         this.extensions = new ArrayList<>(extensions);
     }
 
-    public static SystemTestCertAndKeyBuilder rootCaCertBuilder() throws CertificateEncodingException {
+    public static SystemTestCertAndKeyBuilder rootCaCertBuilder() {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -98,7 +102,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder intermediateCaCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
+    public static SystemTestCertAndKeyBuilder intermediateCaCertBuilder(SystemTestCertAndKey caCert) {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -112,7 +116,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder strimziCaCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
+    public static SystemTestCertAndKeyBuilder strimziCaCertBuilder(SystemTestCertAndKey caCert) {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -125,7 +129,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder endEntityCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
+    public static SystemTestCertAndKeyBuilder endEntityCertBuilder(SystemTestCertAndKey caCert) {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertAndKeyBuilder.java
@@ -17,6 +17,7 @@ import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -32,6 +33,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PublicKey;
 import java.security.Security;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -74,18 +76,16 @@ public class SystemTestCertAndKeyBuilder {
     private X500Name issuer;
     private X500Name subject;
 
-    private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) {
+    private SystemTestCertAndKeyBuilder(KeyPair keyPair, SystemTestCertAndKey caCert, List<Extension> extensions) throws CertificateEncodingException {
         this.keyPair = keyPair;
         this.caCert = caCert;
         if (caCert != null) {
-            // getSubjectX500Principal().getName() applies additional formatting such as omitting spaces between DNs which would result
-            // in a breaking change instead of we use getSubjectX500Principal().toString()
-            this.issuer = new X500Name(caCert.getCertificate().getSubjectX500Principal().toString());
+            this.issuer = new JcaX509CertificateHolder(caCert.getCertificate()).getSubject();
         }
         this.extensions = new ArrayList<>(extensions);
     }
 
-    public static SystemTestCertAndKeyBuilder rootCaCertBuilder() {
+    public static SystemTestCertAndKeyBuilder rootCaCertBuilder() throws CertificateEncodingException {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -98,7 +98,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder intermediateCaCertBuilder(SystemTestCertAndKey caCert) {
+    public static SystemTestCertAndKeyBuilder intermediateCaCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -112,7 +112,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder strimziCaCertBuilder(SystemTestCertAndKey caCert) {
+    public static SystemTestCertAndKeyBuilder strimziCaCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,
@@ -125,7 +125,7 @@ public class SystemTestCertAndKeyBuilder {
         );
     }
 
-    public static SystemTestCertAndKeyBuilder endEntityCertBuilder(SystemTestCertAndKey caCert) {
+    public static SystemTestCertAndKeyBuilder endEntityCertBuilder(SystemTestCertAndKey caCert) throws CertificateEncodingException {
         KeyPair keyPair = generateKeyPair();
         return new SystemTestCertAndKeyBuilder(
                 keyPair,


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR removes deprecation and fixes https://github.com/strimzi/strimzi-kafka-operator/issues/7698. 

### Checklist

- [x] Make sure all tests pass