### PR TITLE
 [ST] Fix for MetricsIsolatedST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsIsolatedST.java
@@ -732,7 +732,7 @@ public class MetricsIsolatedST extends AbstractST {
                     .endEntityOperator()
                 .endSpec()
                 .build(),
-            KafkaTemplates.kafkaWithMetrics(kafkaClusterSecondName, namespaceSecond, 1, 1).build(),
+            KafkaTemplates.kafkaWithMetrics(kafkaClusterSecondName, namespaceSecond, 3, 3).build(),
             ScraperTemplates.scraperPod(clusterOperator.getDeploymentNamespace(), coScraperName).build(),
             ScraperTemplates.scraperPod(namespaceFirst, scraperName).build(),
             ScraperTemplates.scraperPod(namespaceSecond, secondScraperName).build()


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR should fix problem with not ready ZooKeeper connection in MetricsIsolatedSTs.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

