### PR TITLE
feat: Add missing backtick from IPV6 string in crd docs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfiguration.java
@@ -217,7 +217,7 @@ public class GenericKafkaListenerConfiguration implements Serializable, UnknownP
     }
 
     @Description("Specifies the IP Families used by the service. " +
-            "Available options are `IPv4` and `IPv6. " +
+            "Available options are `IPv4` and `IPv6`. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @PresentInVersions("v1beta2+")

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/InternalServiceTemplate.java
@@ -64,7 +64,7 @@ public class InternalServiceTemplate implements HasMetadataTemplate, Serializabl
     }
 
     @Description("Specifies the IP Families used by the service. " +
-            "Available options are `IPv4` and `IPv6. " +
+            "Available options are `IPv4` and `IPv6`. " +
             "If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @PresentInVersions("v1beta2+")

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -342,7 +342,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |xref:type-GenericKafkaListenerConfigurationBroker-{context}[`GenericKafkaListenerConfigurationBroker`] array
 |ipFamilyPolicy                1.2+<.<a|Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.
 |string (one of [RequireDualStack, SingleStack, PreferDualStack])
-|ipFamilies                    1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.
+|ipFamilies                    1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.
 |string (one or more of [IPv6, IPv4]) array
 |createBootstrapService        1.2+<.<a|Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
 |boolean
@@ -987,7 +987,7 @@ Used in: xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`], xre
 |xref:type-MetadataTemplate-{context}[`MetadataTemplate`]
 |ipFamilyPolicy  1.2+<.<a|Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.
 |string (one of [RequireDualStack, SingleStack, PreferDualStack])
-|ipFamilies      1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.
+|ipFamilies      1.2+<.<a|Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.
 |string (one or more of [IPv6, IPv4]) array
 |====
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -364,7 +364,7 @@ spec:
                                   enum:
                                     - IPv4
                                     - IPv6
-                                description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                                description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                               createBootstrapService:
                                 type: boolean
                                 description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
@@ -1340,7 +1340,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                           description: Template for Kafka bootstrap `Service`.
                         brokersService:
                           type: object
@@ -1371,7 +1371,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                           description: Template for Kafka broker `Service`.
                         externalBootstrapService:
                           type: object
@@ -2474,7 +2474,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                           description: Template for ZooKeeper client `Service`.
                         nodesService:
                           type: object
@@ -2505,7 +2505,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                           description: Template for ZooKeeper nodes `Service`.
                         persistentVolumeClaim:
                           type: object
@@ -4617,7 +4617,7 @@ spec:
                                 enum:
                                   - IPv4
                                   - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                           description: Template for Cruise Control API `Service`.
                         podDisruptionBudget:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -910,7 +910,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                       description: Template for Kafka Connect API `Service`.
                     headlessService:
                       type: object
@@ -941,7 +941,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                       description: Template for Kafka Connect headless `Service`.
                     connectContainer:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -918,7 +918,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                       description: Template for Kafka Bridge API `Service`.
                     podDisruptionBudget:
                       type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1025,7 +1025,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                       description: Template for Kafka Connect API `Service`.
                     headlessService:
                       type: object
@@ -1056,7 +1056,7 @@ spec:
                             enum:
                               - IPv4
                               - IPv6
-                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                          description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                       description: Template for Kafka Connect headless `Service`.
                     connectContainer:
                       type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -363,7 +363,7 @@ spec:
                                 enum:
                                 - IPv4
                                 - IPv6
-                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                              description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                             createBootstrapService:
                               type: boolean
                               description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
@@ -1339,7 +1339,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                         description: Template for Kafka bootstrap `Service`.
                       brokersService:
                         type: object
@@ -1370,7 +1370,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                         description: Template for Kafka broker `Service`.
                       externalBootstrapService:
                         type: object
@@ -2473,7 +2473,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                         description: Template for ZooKeeper client `Service`.
                       nodesService:
                         type: object
@@ -2504,7 +2504,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                         description: Template for ZooKeeper nodes `Service`.
                       persistentVolumeClaim:
                         type: object
@@ -4616,7 +4616,7 @@ spec:
                               enum:
                               - IPv4
                               - IPv6
-                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                            description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                         description: Template for Cruise Control API `Service`.
                       podDisruptionBudget:
                         type: object

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -909,7 +909,7 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                     description: Template for Kafka Connect API `Service`.
                   headlessService:
                     type: object
@@ -940,7 +940,7 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                     description: Template for Kafka Connect headless `Service`.
                   connectContainer:
                     type: object

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -917,7 +917,7 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                     description: Template for Kafka Bridge API `Service`.
                   podDisruptionBudget:
                     type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1024,7 +1024,7 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                     description: Template for Kafka Connect API `Service`.
                   headlessService:
                     type: object
@@ -1055,7 +1055,7 @@ spec:
                           enum:
                           - IPv4
                           - IPv6
-                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
+                        description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                     description: Template for Kafka Connect headless `Service`.
                   connectContainer:
                     type: object


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

