### PR TITLE
[systemtest] Add assumption for Kafka version to testKRaftMode test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -79,6 +79,7 @@ public class FeatureGatesIsolatedST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     public void testKRaftMode(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+        // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
         assumeTrue(TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
 
         final TestStorage testStorage = new TestStorage(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesIsolatedST.java
@@ -37,6 +37,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
@@ -60,6 +61,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Feature Gates should give us additional options on
@@ -77,6 +79,8 @@ public class FeatureGatesIsolatedST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     public void testKRaftMode(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+        assumeTrue(TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
+
         final TestStorage testStorage = new TestStorage(extensionContext);
 
         final String clusterName = testStorage.getClusterName();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds a simple assumption for `testKRaftMode` test for Kafka version -> the version needs to be `3.5.0` or higher for enabling the test. From Kafka version `3.5.0`, the SCRAM-SHA is available to use in KRaft.
When we enable auth (TLS/SCRAM-SHA) and we want to create a KafkaUser, it needs to create `ScramShaCredentialsCache` in UO. And because test is using TLS, it simply fails on older versions of Kafka:

```
  status:
    conditions:
    - lastTransitionTime: "2023-07-20T04:23:54.939921854Z"
      message: 'java.util.concurrent.CompletionException: java.lang.RuntimeException:
        ScramShaCredentialsCache is not ready!'
      reason: ExecutionException
      status: "True"
      type: NotReady
    observedGeneration: 1
```

### Checklist

- [ ] Make sure all tests pass

