### PR TITLE
[systemtest] Use UTO in KRaft tests

### DIFF
--- a/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'kraft-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'kraft-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'kraft-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'kraft-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'kraft-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'kraft-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'kraft-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools'
+      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -193,6 +193,7 @@ public interface Constants {
     String USE_KRAFT_MODE = "+UseKRaft";
     String USE_STABLE_CONNECT_IDENTITIES = "+StableConnectIdentities";
     String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
+    String UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
 
     /**
      * Default value which allows execution of tests with any tags

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -268,6 +268,10 @@ public class Environment {
         return STRIMZI_FEATURE_GATES.contains(Constants.USE_KAFKA_NODE_POOLS);
     }
 
+    public static boolean isUnidirectionalTopicOperatorEnabled() {
+        return STRIMZI_FEATURE_GATES.contains(Constants.UNIDIRECTIONAL_TOPIC_OPERATOR);
+    }
+
     /**
      * Provides boolean information, if testing environment support shared memory (i.e., environment, where all
      * components share memory). In general, we use {@link Environment#RESOURCE_ALLOCATION_STRATEGY_DEFAULT} if env {@link Environment#RESOURCE_ALLOCATION_STRATEGY_ENV}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/KRaftWithoutUTONotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/KRaftWithoutUTONotSupported.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(KRaftWithoutUTONotSupportedCondition.class)
+public @interface KRaftWithoutUTONotSupported {
+
+    String value() default "KRaft mode without UTO is not supported with configuration in this test case.";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/KRaftWithoutUTONotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/KRaftWithoutUTONotSupportedCondition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.systemtest.Environment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class KRaftWithoutUTONotSupportedCondition implements ExecutionCondition {
+
+    private static final Logger LOGGER = LogManager.getLogger(KRaftWithoutUTONotSupportedCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (!Environment.isKRaftModeEnabled() || Environment.isUnidirectionalTopicOperatorEnabled()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("According to {} env variable with value: {}, the KRaft mode is used, skipping this test because is not KRaft mode without UTO compliant",
+                Environment.STRIMZI_FEATURE_GATES_ENV,
+                Environment.STRIMZI_FEATURE_GATES);
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/UTONotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/UTONotSupported.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(UTONotSupportedCondition.class)
+public @interface UTONotSupported {
+
+    String value() default "UTO is not working with scenario in this test case.";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/UTONotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/UTONotSupportedCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.systemtest.Environment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class UTONotSupportedCondition implements ExecutionCondition {
+    private static final Logger LOGGER = LogManager.getLogger(UTONotSupportedCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (!Environment.isUnidirectionalTopicOperatorEnabled()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("According to {} env variable with value: {}, the UnidirectionalTopicOperator is used, skipping this test because the scenario will not work with UTO",
+                Environment.STRIMZI_FEATURE_GATES_ENV,
+                Environment.STRIMZI_FEATURE_GATES);
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/enums/ConditionStatus.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/enums/ConditionStatus.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.enums;
+
+/**
+ * Status of the CR, found inside .status.conditions.*.status
+ */
+public enum ConditionStatus {
+    True,
+    False
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -7,7 +7,9 @@ package io.strimzi.systemtest.utils.kafkaUtils;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
+import io.strimzi.systemtest.enums.ConditionStatus;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceOperation;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
@@ -126,11 +128,15 @@ public class KafkaTopicUtils {
      * Wait until KafkaTopic is in desired status
      * @param namespaceName Namespace name
      * @param topicName name of KafkaTopic
-     * @param state desired state
+     * @param conditionType desired state
      */
-    public static boolean waitForKafkaTopicStatus(String namespaceName, String topicName, Enum<?> state) {
+    public static boolean waitForKafkaTopicStatus(String namespaceName, String topicName, Enum<?> conditionType) {
+        return waitForKafkaTopicStatus(namespaceName, topicName, conditionType, ConditionStatus.True);
+    }
+
+    public static boolean waitForKafkaTopicStatus(String namespaceName, String topicName, Enum<?> conditionType, ConditionStatus conditionStatus) {
         return ResourceManager.waitForResourceStatus(KafkaTopicResource.kafkaTopicClient(), KafkaTopic.RESOURCE_KIND,
-            namespaceName, topicName, state, ResourceOperation.getTimeoutForResourceReadiness(KafkaTopic.RESOURCE_KIND));
+            namespaceName, topicName, conditionType, conditionStatus, ResourceOperation.getTimeoutForResourceReadiness(KafkaTopic.RESOURCE_KIND));
     }
 
     public static boolean waitForKafkaTopicReady(String namespaceName, String topicName) {
@@ -138,6 +144,9 @@ public class KafkaTopicUtils {
     }
 
     public static boolean waitForKafkaTopicNotReady(final String namespaceName, String topicName) {
+        if (Environment.isUnidirectionalTopicOperatorEnabled()) {
+            return waitForKafkaTopicStatus(namespaceName, topicName, Ready, ConditionStatus.False);
+        }
         return waitForKafkaTopicStatus(namespaceName, topicName, NotReady);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -16,7 +16,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
@@ -110,7 +110,7 @@ public class CruiseControlConfigurationST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
     void testConfigurationDiskChangeDoNotTriggersRollingUpdateOfKafkaPods(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
@@ -145,7 +145,10 @@ public class CruiseControlConfigurationST extends AbstractST {
         assertThat(KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec()
             .getCruiseControl().getBrokerCapacity().getOutboundNetwork(), is("20KB/s"));
 
-        CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(namespaceName);
+        // https://github.com/strimzi/strimzi-kafka-operator/issues/8864
+        if (!Environment.isUnidirectionalTopicOperatorEnabled()) {
+            CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(namespaceName);
+        }
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -27,7 +27,9 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.annotations.UTONotSupported;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -80,7 +82,8 @@ public class CruiseControlST extends AbstractST {
     private static final String CRUISE_CONTROL_PARTITION_METRICS_SAMPLES_TOPIC = "strimzi.cruisecontrol.partitionmetricsamples"; // partitions 32 , rf - 2
 
     @IsolatedTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
+    @UTONotSupported("https://github.com/strimzi/strimzi-kafka-operator/issues/8864")
     void testAutoCreationOfCruiseControlTopicsWithResources(ExtensionContext extensionContext) {
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
 
@@ -235,7 +238,7 @@ public class CruiseControlST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
     void testCruiseControlTopicExclusion(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -25,7 +25,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
@@ -257,7 +257,7 @@ class LoggingChangeST extends AbstractST {
 
     @ParallelNamespaceTest
     @Tag(ROLLING_UPDATE)
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
     @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:CyclomaticComplexity"})
     void testDynamicallySetEOloggingLevels(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -13,7 +13,8 @@ import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
+import io.strimzi.systemtest.annotations.UTONotSupported;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
@@ -54,7 +55,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
  * These tests does not have to be run every time with PRs and so on, the nature of the tests is sufficient for recovery profile only.
  */
 @Tag(RECOVERY)
-@KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+@KRaftWithoutUTONotSupported
 class NamespaceDeletionRecoveryST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(NamespaceDeletionRecoveryST.class);
     private String storageClassName = "retain";
@@ -66,6 +67,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
      */
     @IsolatedTest("We need for each test case its own Cluster Operator")
     @Tag(INTERNAL_CLIENTS_USED)
+    @UTONotSupported("https://github.com/strimzi/strimzi-kafka-operator/issues/8864")
     void testTopicAvailable(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
@@ -117,7 +119,8 @@ class NamespaceDeletionRecoveryST extends AbstractST {
      */
     @IsolatedTest("We need for each test case its own Cluster Operator")
     @Tag(INTERNAL_CLIENTS_USED)
-    void testTopicNotAvailable(ExtensionContext extensionContext) throws InterruptedException {
+    @UTONotSupported("https://github.com/strimzi/strimzi-kafka-operator/issues/8864")
+    void testTopicNotAvailable(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 
         final List<String> topicsToRemove = List.of("__strimzi-topic-operator-kstreams-topic-store-changelog", "__strimzi_store_topic");

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/ReconciliationST.java
@@ -16,7 +16,9 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.annotations.UTONotSupported;
 import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaConnectorResource;
@@ -132,7 +134,8 @@ public class ReconciliationST extends AbstractST {
 
     @ParallelNamespaceTest
     @Tag(CRUISE_CONTROL)
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
+    @UTONotSupported("strimzi.io/pause-reconciliation is not supported in UTO, we should use strimzi.io/managed")
     void testPauseReconciliationInKafkaRebalanceAndTopic(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -10,8 +10,9 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBui
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.annotations.UTONotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.AdminClientOperation;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaAdminClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaAdminClientsBuilder;
@@ -52,7 +53,8 @@ public class ThrottlingQuotaST extends AbstractST {
     private String scraperPodName = "";
 
     @ParallelTest
-    @KRaftNotSupported("TopicOperator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
+    @UTONotSupported("https://github.com/strimzi/strimzi-kafka-operator/issues/8864")
     void testThrottlingQuotasDuringAllTopicOperations(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, clusterOperator.getDeploymentNamespace());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -68,7 +68,6 @@ import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourceNotNull;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourceState;
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourcesHigherThanOrEqualTo;
-import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricValueHigherThan;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static java.util.Collections.singletonList;
@@ -523,7 +522,8 @@ public class TopicST extends AbstractST {
         assertKafkaTopicStatus(topicName, clusterOperator.getDeploymentNamespace(), Ready, True, 6);
 
         // Check failed reconciliations
-        assertMetricValueHigherThan(toMetricsCollector, "strimzi_reconciliations_failed_total{kind=\"" + KafkaTopic.RESOURCE_KIND + ",}", 3);
+        // This is currently doesn't work properly and will be changed in UTO implementation - https://github.com/strimzi/proposals/pull/76
+        // assertMetricValueHigherThan(toMetricsCollector, "strimzi_reconciliations_failed_total{kind=\"" + KafkaTopic.RESOURCE_KIND + ",}", 3);
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -26,7 +26,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
@@ -75,7 +75,7 @@ public class KafkaRollerST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaRollerST.class);
 
     @ParallelNamespaceTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
     void testKafkaRollsWhenTopicIsUnderReplicated(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());
@@ -143,7 +143,7 @@ public class KafkaRollerST extends AbstractST {
     }
 
     @ParallelNamespaceTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test class")
+    @KRaftWithoutUTONotSupported
     void testKafkaTopicRFLowerThanMinInSyncReplicas(ExtensionContext extensionContext) {
         final String namespaceName = StUtils.getNamespaceBasedOnRbac(clusterOperator.getDeploymentNamespace(), extensionContext);
         final String clusterName = mapWithClusterNames.get(extensionContext.getDisplayName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
@@ -15,7 +15,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -135,7 +135,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
      *  - topic-operator-watcher
      */
     @ParallelTest
-    @KRaftNotSupported("Topic Operator is not supported by KRaft mode and is used in this test case")
+    @KRaftWithoutUTONotSupported
     final void testTopicOperatorWatchingOtherNamespace(ExtensionContext extensionContext) {
 
         LOGGER.info("Topic Operator in Kafka: {}/{} watches KafkaTopics in (different) Namespace: {}", MAIN_TEST_NAMESPACE, PRIMARY_KAFKA_NAME, PRIMARY_KAFKA_WATCHED_NAMESPACE);


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR enables few tests that were disabled when running in KRaft mode -> and which contain usage of TO.
For enabling the test, I added few annotations, where we are checking, if the UTO is enabled with KRaft or not.

Because the UTO is creating KafkaTopics in one way -> so from KafkaTopic CR to Kafka -> I had to disable few tests (using `@UTONotSupported`). Also there are few changes to the KafkaTopic's status and exceptions + messages, that are in the KafkaTopic's status.

There are also testcases, that will need few more changes and also few tests that are checking TO's metrics (will be implemented in future PRs). For tracking these tests, I created two issues:

https://github.com/strimzi/strimzi-kafka-operator/issues/8863
https://github.com/strimzi/strimzi-kafka-operator/issues/8864

Finally, I added UTO FG to the KRaft pipelines in AZP.

### Checklist

- [ ] Make sure all tests pass
