### PR TITLE
[systemtest] Remove TF's sanity check from push to main and enable it in PRs (per-command)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -133,13 +133,15 @@ jobs:
   ###############################################################################################
 
   - job: tests
-    trigger: commit
-    branch: main
+    trigger: pull_request
     identifier: "sanity"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
     skip_build: true
+    manual_trigger: true
+    labels:
+      - sanity
     tf_extra_params:
       test:
         fmf:


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR removes the Testing Farm's `sanity` check when pushing to `main` branch and enables it for running the `sanity` profile in PRs - using `/packit test --labels sanity` command (so the profile will not be executed automatically).
Currently, there are a few flaky tests, so for every push to main branch the TF's pipelines are failing.
We should firstly stabilize the STs and then we can enable it again. 

### Checklist

- [ ] Make sure all tests pass