### PR TITLE
Fix docs about connecting to ZooKeeper

### DIFF
--- a/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
+++ b/documentation/modules/configuring/proc-connecting-to-zookeeper.adoc
@@ -5,10 +5,9 @@
 [id='proc-connnecting-to-zookeeper-{context}']
 = Connecting to ZooKeeper from a terminal
 
-Most Kafka CLI tools can connect directly to Kafka, so under normal circumstances you should not need to connect to ZooKeeper.
 ZooKeeper services are secured with encryption and authentication and are not intended to be used by external applications that are not part of Strimzi.
 
-However, if you want to use Kafka CLI tools that require a connection to ZooKeeper, you can use a terminal inside a ZooKeeper container and connect to `localhost:12181` as the ZooKeeper address.
+However, if you want to use CLI tools that require a connection to ZooKeeper, you can use a terminal inside a ZooKeeper pod and connect to `localhost:12181` as the ZooKeeper address.
 
 .Prerequisites
 
@@ -24,9 +23,7 @@ For example:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-kubectl exec -ti _my-cluster_-zookeeper-0 -- bin/kafka-topics.sh --list --zookeeper localhost:12181
+kubectl exec -ti _my-cluster_-zookeeper-0 -- bin/zookeeper-shell.sh localhost:12181 ls /
 ----
 +
 Be sure to use `localhost:12181`.
-+
-You can now run Kafka commands to ZooKeeper.


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Most of the Kafka CLI tools do not support direct connections to ZooKeeper anymore. This PR updates the docs about connecting to ZooKeeper from CLI tools to use the `zookeeper-shell.sh` in the example to make it still work and not mislead users.

### Checklist

- [x] Update documentation