### PR TITLE
Liveness / readiness probe for Kraft mode phase 1 and 2

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_controller_liveness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_controller_liveness.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-for proc in /proc/*[0-9];
-  do if readlink -f "$proc"/exe | grep -q java; then exit 0; fi;
-done
-
-exit 1

--- a/docker-images/kafka-based/kafka/scripts/kafka_liveness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_liveness.sh
@@ -2,8 +2,9 @@
 set -e
 
 if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
-  # Test KRaft controller process is running
-  . ./kafka_controller_liveness.sh
+  for proc in /proc/*[0-9];
+    do if readlink -f "$proc"/exe | grep -q java; then exit 0; fi;
+  done
 else
   # Test ZK-based broker liveness
   # We expect that either the broker is ready and listening on 9091 (replication port)

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness.sh
@@ -2,10 +2,8 @@
 set -e
 
 if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
-  # Test KRaft controller process is running
-  # This is the best check we can do in a combined node until KafkaRoller is updated
-  # See proposal 046 for more details
-  . ./kafka_controller_liveness.sh
+  # Test KRaft broker/controller readiness
+  . ./kafka_readiness_kraft.sh
 else
   # Test ZK-based broker readiness
   # The kafka-agent will create /var/opt/kafka/kafka-ready in the container when the broker

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+file=/tmp/strimzi.properties
+test -f $file
+roles=$(awk -F "process.roles=" '{print $2}' "$file")
+if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
+  # For controller only mode, check if it is listening on port 9090 (configured in controller.listener.names).
+  netstat -lnt | grep -E 'tcp?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090+[[:space:]]+[^ ]+[[:space:]]+LISTEN*'
+else
+  # For combined or broker only mode, check readiness via HTTP endpoint exposed by Kafka Agent.
+  # The endpoint returns 200 when broker state is 3 (RUNNING).
+  curl http://localhost:8080/v1/ready/ -v --fail
+fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
@@ -9,6 +9,6 @@ if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
   netstat -lnt | grep -E 'tcp?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090+[[:space:]]+[^ ]+[[:space:]]+LISTEN*'
 else
   # For combined or broker only mode, check readiness via HTTP endpoint exposed by Kafka Agent.
-  # The endpoint returns 200 when broker state is 3 (RUNNING).
+  # The endpoint returns 204 when broker state is 3 (RUNNING).
   curl http://localhost:8080/v1/ready/ --fail
 fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
@@ -10,5 +10,5 @@ if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
 else
   # For combined or broker only mode, check readiness via HTTP endpoint exposed by Kafka Agent.
   # The endpoint returns 200 when broker state is 3 (RUNNING).
-  curl http://localhost:8080/v1/ready/ -v --fail
+  curl http://localhost:8080/v1/ready/ --fail
 fi

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -52,7 +52,7 @@ import java.util.Map;
  *        }
  *      }</dd>
  *     <dt>{@code GET /v1/ready}</dt>
- *     <dd>Returns HTTP code 200 if broker state is RUNNING(3). Otherwise returns non successful HTTP code.
+ *     <dd>Returns HTTP code 204 if broker state is RUNNING(3). Otherwise returns non successful HTTP code.
  *     </dd>
  * </dl>
  */

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * A very simple Java agent which polls the value of the {@code kafka.server:type=KafkaServer,name=BrokerState}
  * Yammer Metric and once it reaches the value 3 (meaning "running as broker", see {@code kafka.server.BrokerState}),
  * creates a given file.
- * In zookeeper mode, the presence of this file is tested via a Kube "exec" readiness probe to determine when the broker is ready.
+ * In Zookeeper mode, the presence of this file is tested via a Kube "exec" readiness probe to determine when the broker is ready.
  * It also exposes a REST endpoint for broker metrics and readiness check used by KRaft mode.
  * <dl>
  *     <dt>{@code GET /v1/broker-state}</dt>
@@ -122,7 +122,7 @@ public class KafkaAgent {
         pollerThread.setDaemon(true);
 
         try {
-            startHTTPServer();
+            startHttpServer();
         } catch (Exception e) {
             LOGGER.error("Could not start the server for broker state: ", e);
             throw new RuntimeException(e);
@@ -216,7 +216,7 @@ public class KafkaAgent {
                 && "SessionExpireListener".equals(name.getType());
     }
 
-    private void startHTTPServer() throws Exception {
+    private void startHttpServer() throws Exception {
         Server server = new Server();
 
         HttpConfiguration https = new HttpConfiguration();
@@ -310,10 +310,10 @@ public class KafkaAgent {
                     boolean stateIsRunning = BROKER_RUNNING_STATE <= observedState && BROKER_UNKNOWN_STATE != observedState;
                     if (stateIsRunning) {
                         LOGGER.trace("Broker is in running according to {}. The current state is {}", brokerStateName, observedState);
-                        response.setStatus(HttpServletResponse.SC_OK);
+                        response.setStatus(HttpServletResponse.SC_NO_CONTENT);
                     } else {
                         LOGGER.trace("Broker is not running according to {}. The current state is {}", brokerStateName, observedState);
-                        response.setStatus(HttpServletResponse.SC_NOT_ACCEPTABLE);
+                        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
                         response.getWriter().print("Readiness failed: brokerState is " + observedState);
                     }
                 } else {

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -86,7 +86,7 @@ public class KafkaAgentTest {
         HttpResponse<String> response = HttpClient.newBuilder()
                 .build()
                 .send(req, HttpResponse.BodyHandlers.ofString());
-        assertEquals(response.statusCode(), HttpServletResponse.SC_OK);
+        assertEquals(HttpServletResponse.SC_OK, response.statusCode());
 
         String expectedResponse = "{\"brokerState\":2,\"recoveryState\":{\"remainingLogsToRecover\":10,\"remainingSegmentsToRecover\":100}}";
         assertEquals(expectedResponse, response.body());
@@ -103,6 +103,41 @@ public class KafkaAgentTest {
                 .build()
                 .send(req, HttpResponse.BodyHandlers.ofString());
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.statusCode());
+
+    }
+
+    @Test
+    public void testReadinessSuccess() throws Exception {
+        final Gauge brokerState = mock(Gauge.class);
+        when(brokerState.value()).thenReturn((byte) 3);
+
+        KafkaAgent agent = new KafkaAgent(brokerState, null, null);
+        context.setHandler(agent.getReadinessHandler());
+        server.setHandler(context);
+        server.start();
+
+        HttpResponse<String> response = HttpClient.newBuilder()
+                .build()
+                .send(req, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(HttpServletResponse.SC_OK, response.statusCode());
+    }
+
+    @Test
+    public void testReadinessFail() throws Exception {
+        final Gauge brokerState = mock(Gauge.class);
+        when(brokerState.value()).thenReturn((byte) 2);
+
+        KafkaAgent agent = new KafkaAgent(brokerState, null, null);
+        context.setHandler(agent.getReadinessHandler());
+        server.setHandler(context);
+        server.start();
+
+        HttpResponse<String> response = HttpClient.newBuilder()
+                .build()
+                .send(req, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(HttpServletResponse.SC_NOT_ACCEPTABLE, response.statusCode());
 
     }
 

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -120,7 +120,7 @@ public class KafkaAgentTest {
                 .build()
                 .send(req, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(HttpServletResponse.SC_OK, response.statusCode());
+        assertEquals(HttpServletResponse.SC_NO_CONTENT, response.statusCode());
     }
 
     @Test
@@ -137,7 +137,25 @@ public class KafkaAgentTest {
                 .build()
                 .send(req, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(HttpServletResponse.SC_NOT_ACCEPTABLE, response.statusCode());
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.statusCode());
+
+    }
+
+    @Test
+    public void testReadinessFailWithBrokerUnknownState() throws Exception {
+        final Gauge brokerState = mock(Gauge.class);
+        when(brokerState.value()).thenReturn((byte) 127);
+
+        KafkaAgent agent = new KafkaAgent(brokerState, null, null);
+        context.setHandler(agent.getReadinessHandler());
+        server.setHandler(context);
+        server.start();
+
+        HttpResponse<String> response = HttpClient.newBuilder()
+                .build()
+                .send(req, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.statusCode());
 
     }
 


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description

This PR implements  [proposal #046](https://github.com/strimzi/proposals/blob/main/046-kraft-liveness-readiness.md) for adding liveness/readiness checks for KRaft mode. 

As explained in https://github.com/strimzi/strimzi-kafka-operator/issues/8850, due to the change in upstream, the proposed liveness probe for broker only mode was changed from "broker is listening on the port 9091" to "the Java process in the container is running", which is consistent with the proposed liveness probe for controller only and combined modes. With this change, phase 2 and phase 3 end up with not much difference therefore both phases are being implemented in this PR. 

This PR is also blocked behind KafkaRoller's update to check controller nodes, otherwise if the pods are initially unschedulable the KafkaRoller won't be able to create the pods successfully once appropriate Kubernetes nodes are available as stated in the proposal. 

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/8850.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

