### PR TITLE
Allow disabling leader election in Helm chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -104,6 +104,7 @@ the documentation for more details.
 | `image.imagePullPolicy`                     | Image pull policy for all pods deployed by Cluster Operator                     | `IfNotPresent`               |
 | `image.imagePullSecrets`                    | List of Docker registry pull secrets                                            | `[]`                         |
 | `fullReconciliationIntervalMs`              | Full reconciliation interval in milliseconds                                    | 120000                       |
+| `leaderElection.enable`                     | Whether to enable leader election                                               | `true`                       |
 | `operationTimeoutMs`                        | Operation timeout in milliseconds                                               | 300000                       |
 | `operatorNamespaceLabels`                   | Labels of the namespace where the operator runs                                 | `nil`                        |
 | `podSecurityContext`                        | Cluster Operator pod's security context                                         | `nil`                        |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -141,7 +141,11 @@ spec:
 {{ toYaml .Values.extraEnvs | indent 12 }}
             {{- end }}
             - name: STRIMZI_LEADER_ELECTION_ENABLED
+              {{- if .Values.leaderElection.enable }}
               value: "true"
+              {{- else }}
+              value: "false"
+              {{- end }}
             - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
               value: "strimzi-cluster-operator"
             - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -50,6 +50,9 @@ rbac:
 serviceAccountCreate: yes
 serviceAccount: strimzi-cluster-operator
 
+leaderElection:
+  enable: true
+
 # If you are using the grafana dashboard sidecar,
 # you can import some default dashboards here
 dashboards:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

As proposed in #8893, this PR adds the option to set the `STRIMZI_LEADER_ELECTION_ENABLED` in the Helm chart.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

