### PR TITLE
[ST] Add ST for KafkaNodePool ID management

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -87,7 +87,7 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
 
         String nodePoolName = Constants.KAFKA_NODE_POOL_PREFIX + hashStub(resource.getMetadata().getName());
 
-        KafkaNodePoolBuilder builder = KafkaNodePoolTemplates.defaultKafkaNodePool(nodePoolName, resource.getMetadata().getName(), resource.getSpec().getKafka().getReplicas())
+        KafkaNodePoolBuilder builder = KafkaNodePoolTemplates.defaultKafkaNodePool(resource.getMetadata().getNamespace(), nodePoolName, resource.getMetadata().getName(), resource.getSpec().getKafka().getReplicas())
             .editOrNewMetadata()
                 .withNamespace(resource.getMetadata().getNamespace())
                 .addToLabels(resource.getMetadata().getLabels())

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -48,6 +48,7 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
     public void delete(KafkaNodePool resource) {
         String namespaceName = resource.getMetadata().getNamespace();
         String clusterName = resource.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        String podsetName = String.join("-", clusterName, resource.getMetadata().getName());
 
         kafkaNodePoolClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).delete();
 
@@ -55,7 +56,7 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
         // the Kafka pods will not be deleted during Kafka resource deletion -> so if we would delete PVCs during Kafka deletion
         // they will not be deleted too
         // additional deletion of pvcs with specification deleteClaim set to false which were not deleted prior this method
-        PersistentVolumeClaimUtils.deletePvcsByPrefixWithWait(namespaceName, clusterName);
+        PersistentVolumeClaimUtils.deletePvcsByPrefixWithWait(namespaceName, podsetName);
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -14,9 +14,10 @@ public class KafkaNodePoolTemplates {
 
     private KafkaNodePoolTemplates() {}
 
-    public static KafkaNodePoolBuilder defaultKafkaNodePool(String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+    public static KafkaNodePoolBuilder defaultKafkaNodePool(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
         return new KafkaNodePoolBuilder()
             .withNewMetadata()
+                .withNamespace(namespaceName)
                 .withName(nodePoolName)
                 .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, kafkaClusterName))
             .endMetadata()
@@ -25,16 +26,10 @@ public class KafkaNodePoolTemplates {
             .endSpec();
     }
 
-    public static KafkaNodePoolBuilder kafkaNodePoolBroker(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
-        return new KafkaNodePoolBuilder()
-            .withNewMetadata()
-                .withNamespace(namespaceName)
-                .withName(nodePoolName)
-                .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, kafkaClusterName))
-            .endMetadata()
-            .withNewSpec()
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRole(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
                 .addToRoles(ProcessRoles.BROKER)
-                .withReplicas(kafkaReplicas)
             .endSpec();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest.templates.crd;
 
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.model.Labels;
 
 import java.util.Map;
@@ -20,6 +21,19 @@ public class KafkaNodePoolTemplates {
                 .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, kafkaClusterName))
             .endMetadata()
             .withNewSpec()
+                .withReplicas(kafkaReplicas)
+            .endSpec();
+    }
+
+    public static KafkaNodePoolBuilder kafkaNodePoolBroker(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return new KafkaNodePoolBuilder()
+            .withNewMetadata()
+                .withNamespace(namespaceName)
+                .withName(nodePoolName)
+                .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, kafkaClusterName))
+            .endMetadata()
+            .withNewSpec()
+                .addToRoles(ProcessRoles.BROKER)
                 .withReplicas(kafkaReplicas)
             .endSpec();
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -5,12 +5,10 @@
 package io.strimzi.systemtest.utils.kafkaUtils;
 
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.operator.common.Annotations;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -29,57 +27,14 @@ public class KafkaNodePoolUtils {
         return getKafkaNodePool(namespaceName, resourceName).getStatus().getNodeIds();
     }
 
-    public static String annotateKafkaNodePool(String namespaceName, String resourceName, String annotationKey, String annotationValue) {
-        LOGGER.info("Annotating KafkaNodePool: {}/{} with annotation: {}", namespaceName, resourceName, annotationKey);
-        return ResourceManager.cmdKubeClient().namespace(namespaceName).execInCurrentNamespace("annotate", "kafkanodepool", resourceName, annotationKey + "=" + annotationValue).out().trim();
-    }
-
-    // This method takes into account all possible annotation formats [0, 1, 2, 10-20, 30].
-    public static String annotateKafkaNodePoolNextNodeIds(String namespaceName, String resourceName, String annotationValue) {
-        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, annotationValue);
-    }
-
-    // In case we want to set IDs for some reason in list of integers [0, 1, 2, 10, 30] format. This method does not represent all possibilities of this annotation.
-    public static String annotateKafkaNodePoolNextNodeIds(String namespaceName, String resourceName, List<Integer> annotationValue) {
-        return annotateKafkaNodePoolNextNodeIds(namespaceName, resourceName, annotationValue.toString());
-    }
-
-    // This method takes into account all possible annotation formats [0, 1, 2, 10-20, 30].
-    public static String annotateKafkaNodePoolRemoveNodeIds(String namespaceName, String resourceName, String annotationValue) {
-        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, annotationValue);
-    }
-
-    // In case we want to set IDs for some reason in list of integers [0, 1, 2, 10, 30] format. This method does not represent all possibilities of this annotation.
-    public static String annotateKafkaNodePoolRemoveNodeIds(String namespaceName, String resourceName, List<Integer> annotationValue) {
-        return annotateKafkaNodePoolRemoveNodeIds(namespaceName, resourceName, annotationValue.toString());
+    public static void setKafkaNodePoolAnnotation(String namespaceName, String resourceName,  Map<String, String> annotations) {
+        LOGGER.info("Annotating KafkaNodePool: {}/{} with annotation: {}", namespaceName, resourceName, annotations);
+        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(resourceName,
+            kafkaNodePool -> kafkaNodePool.getMetadata().setAnnotations(annotations),  namespaceName);
     }
 
     public static void scaleKafkaNodePool(String namespaceName, String kafkaNodePoolName, int scaleToReplicas) {
         LOGGER.info("Scaling KafkaNodePool: {}/{} to {} replicas", namespaceName, kafkaNodePoolName, scaleToReplicas);
-        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, nodePool -> {
-            nodePool.getSpec().setReplicas(scaleToReplicas);
-        }, namespaceName);
-    }
-
-    // Format for parsing must be similar to this -> "[2, 3, 50-52, 88]" then it can return a list of integers [2,3,50,51,52,88]
-    public static List<Integer> parseNodePoolIdsWithRangeStringToIntegerList(String inputString) {
-        List<Integer> outputList = new ArrayList<>();
-        inputString = inputString.replace("[", "").replace("]", "").replace(" ", "");
-        String[] ranges = inputString.split(",");
-
-        for (String range : ranges) {
-            if (range.contains("-")) {
-                String[] rangeValues = range.split("-");
-                int start = Integer.parseInt(rangeValues[0]);
-                int end = Integer.parseInt(rangeValues[1]);
-                for (int i = start; i <= end; i++) {
-                    outputList.add(i);
-                }
-            } else {
-                outputList.add(Integer.parseInt(range));
-            }
-        }
-
-        return outputList;
+        KafkaNodePoolResource.kafkaNodePoolClient().inNamespace(namespaceName).withName(kafkaNodePoolName).scale(scaleToReplicas);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -46,7 +46,7 @@ public class KafkaNodePoolUtils {
 
     // This method takes into account all possible annotation formats [0, 1, 2, 10-20, 30].
     public static String annotateKafkaNodePoolRemoveNodeIds(String namespaceName, String resourceName, String annotationValue) {
-        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, annotationValue.toString());
+        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, annotationValue);
     }
 
     // In case we want to set IDs for some reason in list of integers [0, 1, 2, 10, 30] format. This method does not represent all possibilities of this annotation.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.kafkaUtils;
+
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class KafkaNodePoolUtils {
+
+    private KafkaNodePoolUtils() {
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(PodUtils.class);
+
+    public static KafkaNodePool getKafkaNodePool(String namespaceName, String resourceName) {
+        return KafkaNodePoolResource.kafkaNodePoolClient().inNamespace(namespaceName).withName(resourceName).get();
+    }
+
+    public static List<Integer> getCurrentKafkaNodePoolIds(String namespaceName, String resourceName) {
+        return getKafkaNodePool(namespaceName, resourceName).getStatus().getNodeIds();
+    }
+
+    public static String annotateKafkaNodePool(String namespaceName, String resourceName, String annotationKey, String annotationValue) {
+        LOGGER.info("Annotating KafkaNodePool: {}/{} with annotation: {}", namespaceName, resourceName, annotationKey);
+        return ResourceManager.cmdKubeClient().namespace(namespaceName).execInCurrentNamespace("annotate", "kafkanodepool", resourceName, annotationKey + "=" + annotationValue).out().trim();
+    }
+
+    // This method takes into account all possible annotation formats [0, 1, 2, 10-20, 30].
+    public static String annotateKafkaNodePoolNextNodeIds(String namespaceName, String resourceName, String annotationValue) {
+        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, annotationValue);
+    }
+
+    // In case we want to set IDs for some reason in list of integers [0, 1, 2, 10, 30] format. This method does not represent all possibilities of this annotation.
+    public static String annotateKafkaNodePoolNextNodeIds(String namespaceName, String resourceName, List<Integer> annotationValue) {
+        return annotateKafkaNodePoolNextNodeIds(namespaceName, resourceName, annotationValue.toString());
+    }
+
+    // This method takes into account all possible annotation formats [0, 1, 2, 10-20, 30].
+    public static String annotateKafkaNodePoolRemoveNodeIds(String namespaceName, String resourceName, String annotationValue) {
+        return annotateKafkaNodePool(namespaceName, resourceName, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, annotationValue.toString());
+    }
+
+    // In case we want to set IDs for some reason in list of integers [0, 1, 2, 10, 30] format. This method does not represent all possibilities of this annotation.
+    public static String annotateKafkaNodePoolRemoveNodeIds(String namespaceName, String resourceName, List<Integer> annotationValue) {
+        return annotateKafkaNodePoolRemoveNodeIds(namespaceName, resourceName, annotationValue.toString());
+    }
+
+    public static void waitForKafkaNodePoolStablePodReplicasCount(TestStorage testStorage, int expectedReplicas) {
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), expectedReplicas);
+    }
+
+    public static void scaleKafkaNodePool(String namespaceName, String kafkaNodePoolName, int scaleToReplicas) {
+        LOGGER.info("Scaling KafkaNodePool: {}/{} to {} replicas", namespaceName, kafkaNodePoolName, scaleToReplicas);
+        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, nodePool -> {
+            nodePool.getSpec().setReplicas(scaleToReplicas);
+        }, namespaceName);
+    }
+
+    public static List<Integer> parseNodePoolIdWithRangeStringToIntegerList(String inputString) {
+        List<Integer> outputList = new ArrayList<>();
+        inputString = inputString.replace("[", "").replace("]", "").replace(" ","");
+        String[] ranges = inputString.split(",");
+
+        for (String range : ranges) {
+            if (range.contains("-")) {
+                String[] rangeValues = range.split("-");
+                int start = Integer.parseInt(rangeValues[0]);
+                int end = Integer.parseInt(rangeValues[1]);
+                for (int i = start; i <= end; i++) {
+                    outputList.add(i);
+                }
+            } else {
+                outputList.add(Integer.parseInt(range));
+            }
+        }
+
+        return outputList;
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -56,21 +56,11 @@ public class KafkaNodePoolUtils {
         return annotateKafkaNodePoolRemoveNodeIds(namespaceName, resourceName, annotationValue.toString());
     }
 
-    public static void waitForKafkaNodePoolStablePodReplicasCount(TestStorage testStorage, int expectedReplicas) {
-        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), expectedReplicas);
-    }
-
     public static void scaleKafkaNodePool(String namespaceName, String kafkaNodePoolName, int scaleToReplicas) {
         LOGGER.info("Scaling KafkaNodePool: {}/{} to {} replicas", namespaceName, kafkaNodePoolName, scaleToReplicas);
         KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, nodePool -> {
             nodePool.getSpec().setReplicas(scaleToReplicas);
         }, namespaceName);
-    }
-
-    public static boolean kafkaNodePoolIdsContainOnly(String namespaceName, String kafkaNodePoolName, List<Integer> expectedNodePoolIds) {
-        LOGGER.info("Checking that KafkaNodePool: {}/{} contains IDs: {}", namespaceName, kafkaNodePoolName, expectedNodePoolIds);
-        List<Integer> currentIds = getCurrentKafkaNodePoolIds(namespaceName, kafkaNodePoolName);
-        return  currentIds.containsAll(expectedNodePoolIds) && currentIds.size() == expectedNodePoolIds.size();
     }
 
     // Format for parsing must be similar to this -> "[2, 3, 50-52, 88]" then it can return a list of integers [2,3,50,51,52,88]

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -67,9 +67,10 @@ public class KafkaNodePoolUtils {
         }, namespaceName);
     }
 
-    public static List<Integer> parseNodePoolIdWithRangeStringToIntegerList(String inputString) {
+    // Format for parsing must be similar to this -> "[2, 3, 50-52, 88]" then it can return a list of integers [2,3,50,51,52,88]
+    public static List<Integer> parseNodePoolIdsWithRangeStringToIntegerList(String inputString) {
         List<Integer> outputList = new ArrayList<>();
-        inputString = inputString.replace("[", "").replace("]", "").replace(" ","");
+        inputString = inputString.replace("[", "").replace("]", "").replace(" ", "");
         String[] ranges = inputString.split(",");
 
         for (String range : ranges) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -67,6 +67,12 @@ public class KafkaNodePoolUtils {
         }, namespaceName);
     }
 
+    public static boolean kafkaNodePoolIdsContainOnly(String namespaceName, String kafkaNodePoolName, List<Integer> expectedNodePoolIds) {
+        LOGGER.info("Checking that KafkaNodePool: {}/{} contains IDs: {}", namespaceName, kafkaNodePoolName, expectedNodePoolIds);
+        List<Integer> currentIds = getCurrentKafkaNodePoolIds(namespaceName, kafkaNodePoolName);
+        return  currentIds.containsAll(expectedNodePoolIds) && currentIds.size() == expectedNodePoolIds.size();
+    }
+
     // Format for parsing must be similar to this -> "[2, 3, 50-52, 88]" then it can return a list of integers [2,3,50,51,52,88]
     public static List<Integer> parseNodePoolIdsWithRangeStringToIntegerList(String inputString) {
         List<Integer> outputList = new ArrayList<>();

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -4,12 +4,10 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
-import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import java.util.ArrayList;
 import java.util.List;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -253,7 +253,7 @@ public class KafkaNodePoolST extends AbstractST {
         KafkaNodePoolUtils.annotateKafkaNodePoolNextNodeIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), nodePoolAnnoIdsWithRange);
         // Scale-down
         KafkaNodePoolUtils.scaleKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), originalReplicaCount);
-        KafkaNodePoolUtils.waitForKafkaNodePoolStablePodReplicasCount(testStorage, scaledReplicaCount);
+        KafkaNodePoolUtils.waitForKafkaNodePoolStablePodReplicasCount(testStorage, originalReplicaCount);
         assertTrue(KafkaNodePoolUtils.getCurrentKafkaNodePoolIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName()).containsAll(originalNodePoolIds));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -243,19 +243,21 @@ public class KafkaNodePoolST extends AbstractST {
         KafkaNodePoolUtils.annotateKafkaNodePoolNextNodeIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), nodePoolAnnoIdsWithRange);
         // Scale-up
         KafkaNodePoolUtils.scaleKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), scaledReplicaCount);
-        KafkaNodePoolUtils.waitForKafkaNodePoolStablePodReplicasCount(testStorage, scaledReplicaCount);
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), scaledReplicaCount);
 
-        // Check correct IDs
-        assertTrue(KafkaNodePoolUtils.kafkaNodePoolIdsContainOnly(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), expectedNodePoolIds));
+        // Check correct IDS
+        LOGGER.info("Checking that KafkaNodePool contains IDs: {}", expectedNodePoolIds);
+        assertTrue(KafkaNodePoolUtils.getCurrentKafkaNodePoolIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName()).containsAll(expectedNodePoolIds));
 
         // Annotate NodePool for scale-down
         KafkaNodePoolUtils.annotateKafkaNodePoolNextNodeIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), nodePoolAnnoIdsWithRange);
         // Scale-down
         KafkaNodePoolUtils.scaleKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), originalReplicaCount);
-        KafkaNodePoolUtils.waitForKafkaNodePoolStablePodReplicasCount(testStorage, originalReplicaCount);
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), originalReplicaCount);
 
-        // Check correct IDs
-        assertTrue(KafkaNodePoolUtils.kafkaNodePoolIdsContainOnly(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), originalNodePoolIds));
+        // Check correct IDS
+        LOGGER.info("Checking that KafkaNodePool contains IDs: {}", originalNodePoolIds);
+        assertTrue(KafkaNodePoolUtils.getCurrentKafkaNodePoolIds(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName()).containsAll(originalNodePoolIds));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -249,7 +249,6 @@ public class KafkaNodePoolST extends AbstractST {
             .endSpec()
             .build();
 
-        // Create in order NodePool A, B and then Kafka
         resourceManager.createResourceWithWait(extensionContext, poolA, poolB, kafka);
         PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), nodePoolNameA), 1);
         PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), nodePoolNameB), 2);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -106,7 +106,7 @@ public class KafkaNodePoolST extends AbstractST {
             .endMetadata()
             .build();
 
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(kafkaNodePoolName, testStorage.getClusterName(), 3)
+        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
@@ -226,7 +226,7 @@ public class KafkaNodePoolST extends AbstractST {
 
         LOGGER.info("Testing deployment of NodePools with pre-configured annotation: {} is creating Brokers with correct IDs", Annotations.ANNO_STRIMZI_IO_NODE_POOLS);
         // Deploy NodePool A with only 1 replica and give it annotation with 1 ID
-        KafkaNodePool poolA =  KafkaNodePoolTemplates.kafkaNodePoolBroker(testStorage.getNamespaceName(), nodePoolNameA, testStorage.getClusterName(), 1)
+        KafkaNodePool poolA =  KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRole(testStorage.getNamespaceName(), nodePoolNameA, testStorage.getClusterName(), 1)
             .editOrNewMetadata()
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[5]"))
             .endMetadata()
@@ -238,7 +238,7 @@ public class KafkaNodePoolST extends AbstractST {
             .build();
 
         // Deploy NodePool B with 2 replicas and give it annotation with only  1 ID
-        KafkaNodePool poolB =  KafkaNodePoolTemplates.kafkaNodePoolBroker(testStorage.getNamespaceName(), nodePoolNameB, testStorage.getClusterName(), 2)
+        KafkaNodePool poolB =  KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRole(testStorage.getNamespaceName(), nodePoolNameB, testStorage.getClusterName(), 2)
             .editOrNewMetadata()
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[6]"))
             .endMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -327,7 +327,7 @@ public class FeatureGatesST extends AbstractST {
             .endMetadata()
             .build();
 
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getKafkaNodePoolName(), testStorage.getClusterName(), 3)
+        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), testStorage.getClusterName(), 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds a basic ST that sets annotation to the deployed KafkaNodePool resource. Then scales it's replicas up and down and checks that correct brokers pods with IDs specified in the annotation are created or deleted. This PR also adds some KafkaNodePoolUtils for ST usage.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

