### PR TITLE
Fix `make all` command to execute all tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,14 @@ docu_htmlnoheaderclean:
 docu_pdfclean:
 	rm -rf documentation/pdf
 
-helm_install: packaging/helm-charts/helm3
+helm_install:
+	$(MAKE) -C packaging/helm-charts/helm3 helm_install
 
-crd_install: packaging/install
+crd_install:
+	$(MAKE) -C packaging/install crd_install
 
-dashboard_install: packaging/examples
+dashboard_install:
+	$(MAKE) -C packaging/examples dashboard_install
 
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `make all` command should execute a bunch of different targets / tasks. But it seems that it ignores some of them. This PR updates them to make new `make` call to make them execute properly when `make all` is called.

While this was not a direct cause of #8891, it helped to make it unnoticed since the relevant tasks were not being executed when building the project locally.