### PR TITLE
Fixed getting CO log when multiple replicas are running

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -250,11 +250,13 @@ if [[ -n $CO_DEPLOY ]]; then
   echo "    $CO_DEPLOY"
   $KUBE_CLIENT get deploy strimzi-cluster-operator -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/deployments/cluster-operator.yaml
   $KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/pods/cluster-operator.yaml
-  CO_POD=$($KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o name -n "$NAMESPACE" --ignore-not-found)
-  if [[ -n $CO_POD ]]; then
-    echo "    $CO_POD"
-    CO_POD=$(echo "$CO_POD" | cut -d "/" -f 2) && readonly CO_POD
-    get_pod_logs "$CO_POD"
+  mapfile -t CO_PODS < <($KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o name -n "$NAMESPACE" --ignore-not-found)
+  if [[ ${#CO_PODS[@]} -ne 0 ]]; then
+    for pod in "${CO_PODS[@]}"; do
+      echo "    $pod"
+      CO_POD=$(echo "$pod" | cut -d "/" -f 2)
+      get_pod_logs "$CO_POD"
+    done
   fi
 fi
 


### PR DESCRIPTION
When the CO is running with multiple replicas (leader + standby(s)), the current `report.sh` tool is not able to get the logs from them. No one is returned in the zip file.
This PR fixes the issues, handling the CO pods as an array and looping across them to recover logs (the same way it works for ZooKeeper pods, Kafka pods and so on).