### PR TITLE
Fix ZooKeeper quorum port binding all interfaces with at least 3 nodes

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_config_generator.sh
@@ -44,9 +44,11 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 # Also check that Kafka version is greater-equal 3.4.1, because binding to 0.0.0.0 doesn't seem to work with previous version.
 # For single node case, we cannot set to 0.0.0.0 since ZooKeeper will fail when looking for next candidate in case of issue.
 # See: https://issues.apache.org/jira/browse/ZOOKEEPER-4708
+# For two nodes case (which is anyway a bad configuration), we cannot set to 0.0.0.0 because the two nodes seem to ping-pong
+# on leading and never reach a quorum. Without 0.0.0.0, it works just fine.
 NODE=1
 while [[ $NODE -le $ZOOKEEPER_NODE_COUNT ]]; do
-    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 1 ]] && [[ $(version "$KAFKA_VERSION") -ge $(version "3.4.1") ]]; then
+    if [[ $NODE -eq $ZOOKEEPER_ID ]] && [[ $ZOOKEEPER_NODE_COUNT -gt 2 ]] && [[ $(version "$KAFKA_VERSION") -ge $(version "3.4.1") ]]; then
       echo "server.${NODE}=0.0.0.0:2888:3888:participant;127.0.0.1:12181"
     else
       echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888:participant;127.0.0.1:12181"


### PR DESCRIPTION
From this discussion https://github.com/orgs/strimzi/discussions/8890 it turned out that when the ZooKeeper ensemble is made by just 2 nodes, the quorum port binding on all interfaces (by using 0.0.0.0) doesn't work properly.
The 2 nodes seem to ping-pong on leading and never reach a quorum.
This PR fixes the issue by using the 0.0.0.0 binding only if the ZooKeeper ensemble is made by at least 3 nodes.