### PR TITLE
Promote `StableConnectIdentities` feature gate to beta and enable it by default

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +21,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +34,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +47,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +60,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +73,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +86,6 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,+StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## 0.36.1
 
 * Add support for Apache Kafka 3.5.1
+* The `StableConnectIdentites` feature gate moves to beta stage.
+  By default, StrimziPodSets are used for Kafka Connect and Kafka Mirror Maker 2.
+  If needed, `StableConnectIdentites` can be disabled in the feature gates configuration in the Cluster Operator.
 
 ## 0.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # CHANGELOG
 
 ## 0.37.0
+
+* The `StableConnectIdentites` feature gate moves to beta stage.
+  By default, StrimziPodSets are used for Kafka Connect and Kafka Mirror Maker 2.
+  If needed, `StableConnectIdentites` can be disabled in the feature gates configuration in the Cluster Operator.
 * Support for the ppc64le platform
 
 ## 0.36.1
 
 * Add support for Apache Kafka 3.5.1
-* The `StableConnectIdentites` feature gate moves to beta stage.
-  By default, StrimziPodSets are used for Kafka Connect and Kafka Mirror Maker 2.
-  If needed, `StableConnectIdentites` can be disabled in the feature gates configuration in the Cluster Operator.
 
 ## 0.36.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -19,14 +19,12 @@ public class FeatureGates {
     private static final String USE_KRAFT = "UseKRaft";
     private static final String STABLE_CONNECT_IDENTITIES = "StableConnectIdentities";
     private static final String KAFKA_NODE_POOLS = "KafkaNodePools";
-
     private static final String UNIDIRECTIONAL_TOPIC_OPERATOR = "UnidirectionalTopicOperator";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, false);
-    private final FeatureGate stableConnectIdentities = new FeatureGate(STABLE_CONNECT_IDENTITIES, false);
+    private final FeatureGate stableConnectIdentities = new FeatureGate(STABLE_CONNECT_IDENTITIES, true);
     private final FeatureGate kafkaNodePools = new FeatureGate(KAFKA_NODE_POOLS, false);
-
     private final FeatureGate unidirectionalTopicOperator = new FeatureGate(UNIDIRECTIONAL_TOPIC_OPERATOR, false);
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -43,7 +43,7 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.OPERATOR_NAMESPACE.key(), "operator-namespace");
-        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+StableConnectIdentities");
+        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "-StableConnectIdentities");
         ENV_VARS.put(ClusterOperatorConfig.DNS_CACHE_TTL.key(), "10");
         ENV_VARS.put(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key(), "my.package.CustomPodSecurityProvider");
     }
@@ -65,7 +65,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getConnectBuildTimeoutMs(), is(Long.parseLong(ClusterOperatorConfig.CONNECT_BUILD_TIMEOUT_MS.defaultValue())));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
         assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
-        assertThat(config.featureGates().stableConnectIdentitiesEnabled(), is(false));
+        assertThat(config.featureGates().stableConnectIdentitiesEnabled(), is(true));
         assertThat(config.featureGates().useKRaftEnabled(), is(false));
         assertThat(config.isCreateClusterRoles(), is(false));
         assertThat(config.isNetworkPolicyGeneration(), is(true));
@@ -101,7 +101,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(30_000L));
         assertThat(config.getConnectBuildTimeoutMs(), is(40_000L));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
-        assertThat(config.featureGates().stableConnectIdentitiesEnabled(), is(true));
+        assertThat(config.featureGates().stableConnectIdentitiesEnabled(), is(false));
         assertThat(config.getDnsCacheTtlSec(), is(10));
         assertThat(config.getPodSecurityProviderClass(), is("my.package.CustomPodSecurityProvider"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -64,7 +64,7 @@ public class ClusterOperatorTest {
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
-        env.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,+StableConnectIdentities");
+        env.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,-StableConnectIdentities");
 
         if (podSetsOnly) {
             env.put(ClusterOperatorConfig.POD_SET_RECONCILIATION_ONLY.key(), "true");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
@@ -61,7 +61,7 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testFeatureGatesParsing() {
         assertThat(new FeatureGates("+UseKRaft,+KafkaNodePools").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("+StableConnectIdentities").stableConnectIdentitiesEnabled(), is(true));
+        assertThat(new FeatureGates("-StableConnectIdentities").stableConnectIdentitiesEnabled(), is(false));
         assertThat(new FeatureGates("+KafkaNodePools").kafkaNodePoolsEnabled(), is(true));
         assertThat(new FeatureGates("-UseKRaft,-StableConnectIdentities").useKRaftEnabled(), is(false));
         assertThat(new FeatureGates("-UseKRaft,-StableConnectIdentities").stableConnectIdentitiesEnabled(), is(false));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.KafkaConnectorList;
+import io.strimzi.api.kafka.model.KafkaConnector;
+import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.status.AutoRestartStatusBuilder;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.platform.KubernetesVersion;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
+    protected static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testShouldAutoRestartConnector(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+            supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        // Should restart after minute 2 when auto restart count is 1
+        var autoRestartStatus =  new AutoRestartStatusBuilder()
+            .withCount(1)
+            .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(3).format(DateTimeFormatter.ISO_INSTANT))
+            .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus), is(true));
+
+        // Should not restart before minute 2 when auto restart count is 1
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+            .withCount(1)
+            .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1).format(DateTimeFormatter.ISO_INSTANT))
+            .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+
+        // Should restart after minute 12 when auto restart count is 3
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+            .withCount(3)
+            .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(13).format(DateTimeFormatter.ISO_INSTANT))
+            .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus), is(true));
+
+        // Should not restart before minute 12 when auto restart count is 3
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+            .withCount(3)
+            .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(DateTimeFormatter.ISO_INSTANT))
+            .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+
+        // Should not restart after 6 attempts
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+            .withCount(7)
+            .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusDays(1).format(DateTimeFormatter.ISO_INSTANT))
+            .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+
+        context.completeNow();
+    }
+
+    @Test
+    public void testShouldResetAutoRestartStatus(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        // Should reset after minute 2 when auto restart count is 1
+        var autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(1)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(3).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+
+        // Should not reset before minute 2 when auto restart count is 1
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(1)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+
+        // Should reset after minute 12 when auto restart count is 3
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(3)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(13).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+
+        // Should not reset before minute 12 when auto restart count is 3
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(3)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+
+        context.completeNow();
+    }
+
+    @Test
+    public void testAutoRestartWhenDisabled(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .build();
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(nullValue()));
+
+                    verify(mockConnectApi, never()).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, never()).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartWhenEnabledAndNotFailed(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(nullValue()));
+
+                    verify(mockConnectApi, never()).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartWhenEnabledAndFailedFirstRestart(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(notNullValue()));
+                    assertThat(r.autoRestart.getCount(), is(1));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(notNullValue()));
+
+                    verify(mockConnectApi, times(1)).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartWhenEnabledAndFailedSecondRestart(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                    .withNewAutoRestart()
+                        .withCount(1)
+                        .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(3).format(DateTimeFormatter.ISO_INSTANT))
+                    .endAutoRestart()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(notNullValue()));
+                    assertThat(r.autoRestart.getCount(), is(2));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(notNullValue()));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(not(connector.getStatus().getAutoRestart().getLastRestartTimestamp()))); // Timestamp changed
+
+                    verify(mockConnectApi, times(1)).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartWhenEnabledAndFailedTooEarlyForSecondRestart(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                    .withNewAutoRestart()
+                        .withCount(1)
+                        .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1).format(DateTimeFormatter.ISO_INSTANT))
+                    .endAutoRestart()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(notNullValue()));
+                    assertThat(r.autoRestart.getCount(), is(1));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(notNullValue()));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(connector.getStatus().getAutoRestart().getLastRestartTimestamp())); // Timestamp changed
+
+                    verify(mockConnectApi, never()).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartReset(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                    .withNewAutoRestart()
+                        .withCount(2)
+                        .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(8).format(DateTimeFormatter.ISO_INSTANT))
+                    .endAutoRestart()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(nullValue()));
+
+                    verify(mockConnectApi, never()).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+
+    @Test
+    public void testAutoRestartTooEarlyForReset(VertxTestContext context) {
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                    .withName("my-connector")
+                    .withNamespace("my-namespace")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewAutoRestart()
+                        .withEnabled()
+                    .endAutoRestart()
+                    .withClassName("MyClass")
+                    .withTasksMax(3)
+                    .withConfig(Map.of("topic", "my-topic"))
+                .endSpec()
+                .withNewStatus()
+                    .withNewAutoRestart()
+                        .withCount(2)
+                        .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(5).format(DateTimeFormatter.ISO_INSTANT))
+                    .endAutoRestart()
+                .endStatus()
+                .build();
+
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperator = supplier.kafkaConnectorOperator;
+        when(connectorOperator.getAsync("my-namespace", "my-connector")).thenReturn(Future.succeededFuture(connector));
+
+        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
+                supplier, ResourceUtils.dummyClusterOperatorConfig());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        op.autoRestartFailedConnectorAndTasks(Reconciliation.DUMMY_RECONCILIATION, "my-connect-host", mockConnectApi, "my-connector", connector.getSpec(), statusAndConditions, connector)
+                .onComplete(context.succeeding(r -> context.verify(() -> {
+                    assertThat(r.autoRestart, is(notNullValue()));
+                    assertThat(r.autoRestart.getCount(), is(2));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(notNullValue()));
+                    assertThat(r.autoRestart.getLastRestartTimestamp(), is(connector.getStatus().getAutoRestart().getLastRestartTimestamp())); // Timestamp changed
+
+                    verify(mockConnectApi, never()).restart(any(), anyInt(), any(), anyBoolean(), anyBoolean());
+                    verify(supplier.kafkaConnectorOperator, times(1)).getAsync(any(), any());
+
+                    checkpoint.flag();
+                })));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -10,28 +10,22 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpec;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2ClusterSpecBuilder;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2MirrorSpec;
-import io.strimzi.api.kafka.model.KafkaMirrorMaker2MirrorSpecBuilder;
-import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
 import io.strimzi.api.kafka.model.KafkaJmxAuthenticationPasswordBuilder;
+import io.strimzi.api.kafka.model.KafkaJmxOptionsBuilder;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.status.KafkaMirrorMaker2Status;
-import io.strimzi.operator.cluster.operator.resource.MockSharedEnvironmentProvider;
-import io.strimzi.operator.cluster.model.logging.LoggingModel;
-import io.strimzi.operator.cluster.model.logging.LoggingUtils;
-import io.strimzi.operator.cluster.model.metrics.MetricsModel;
-import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
-import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
-import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.KafkaMirrorMaker2Cluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.logging.LoggingUtils;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.operator.resource.MockSharedEnvironmentProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.SharedEnvironmentProvider;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
@@ -45,6 +39,8 @@ import io.strimzi.operator.common.operator.resource.PodDisruptionBudgetOperator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.strimzi.operator.common.operator.resource.ServiceOperator;
+import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
+import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -151,7 +147,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         KafkaMirrorMaker2Cluster mirrorMaker2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2, VERSIONS, sharedEnvironmentProvider);
 
@@ -257,7 +253,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name), kmm2)
@@ -371,7 +367,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name), kmm2)
@@ -472,7 +468,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockNetPolOps.reconcile(any(), eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"));
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name), kmm2)
@@ -532,7 +528,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name), kmm2)
@@ -594,7 +590,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         Checkpoint async = context.checkpoint();
         ops.createOrUpdate(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name), kmm2)
@@ -647,7 +643,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         Checkpoint async = context.checkpoint();
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS)) {
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities")) {
 
             @Override
             public Future<KafkaMirrorMaker2Status> createOrUpdate(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2Assembly) {
@@ -703,7 +699,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockMirrorMaker2Ops.updateStatusAsync(any(), mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS));
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"));
 
         Checkpoint async = context.checkpoint();
         ops.reconcile(new Reconciliation("test-trigger", KafkaMirrorMaker2.RESOURCE_KIND, kmm2Namespace, kmm2Name))
@@ -763,7 +759,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         KafkaMirrorMaker2Cluster mirrorMaker2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2, VERSIONS, sharedEnvironmentProvider);
 
@@ -863,7 +859,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-                supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
+                supplier, ResourceUtils.dummyClusterOperatorConfig("-StableConnectIdentities"), x -> mockConnectClient);
 
         KafkaMirrorMaker2Cluster mirrorMaker2 = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2, VERSIONS, sharedEnvironmentProvider);
 
@@ -916,150 +912,5 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
                     //assertThat(mirrorMaker2.isJmxAuthenticated(), is(true));
                     async.flag();
                 })));
-    }
-
-    @Test
-    public void testTopicsGroupsExclude(VertxTestContext context) {
-        String kmm2Name = "foo";
-        String sourceNamespace = "source-ns";
-        String targetNamespace = "target-ns";
-        String sourceClusterAlias = "my-cluster-src";
-        String targetClusterAlias = "my-cluster-tgt";
-        String excludedTopicList = "excludedTopic0,excludedTopic1";
-        String excludedGroupList = "excludedGroup0,excludedGroup1";
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMaker2 kmm2 = ResourceUtils.createEmptyKafkaMirrorMaker2(targetNamespace, kmm2Name);
-        ArgumentCaptor<KafkaMirrorMaker2> mirrorMaker2Captor = createMirrorMaker2CaptorMock(targetNamespace, kmm2Name, kmm2, supplier);
-        KafkaConnectApi mockConnectClient = createConnectClientMock();
-
-        KafkaMirrorMaker2ClusterSpec sourceCluster =
-            new KafkaMirrorMaker2ClusterSpecBuilder(true)
-                .withAlias(sourceClusterAlias)
-                .withBootstrapServers(sourceClusterAlias + "." + sourceNamespace + ".svc:9092")
-                .build();
-        KafkaMirrorMaker2ClusterSpec targetCluster =
-            new KafkaMirrorMaker2ClusterSpecBuilder(true)
-                .withAlias(targetClusterAlias)
-                .withBootstrapServers(targetClusterAlias + "." + targetNamespace + ".svc:9092")
-                .build();
-        kmm2.getSpec().setClusters(List.of(sourceCluster, targetCluster));
-
-        KafkaMirrorMaker2MirrorSpec deprecatedMirrorConnector = new KafkaMirrorMaker2MirrorSpecBuilder()
-            .withSourceCluster(sourceClusterAlias)
-            .withTargetCluster(targetClusterAlias)
-            .withTopicsExcludePattern(excludedTopicList)
-            .withGroupsExcludePattern(excludedGroupList)
-            .build();
-        kmm2.getSpec().setMirrors(List.of(deprecatedMirrorConnector));
-
-        KafkaMirrorMaker2AssemblyOperator mm2AssemblyOperator = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-            supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
-
-        Checkpoint async = context.checkpoint();
-        KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2, VERSIONS, sharedEnvironmentProvider);
-        mm2AssemblyOperator.reconcile(new Reconciliation("test-exclude", KafkaMirrorMaker2.RESOURCE_KIND, targetNamespace, kmm2Name))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                KafkaMirrorMaker2MirrorSpec capturedMirrorConnector = mirrorMaker2Captor.getAllValues().get(0).getSpec().getMirrors().get(0);
-                assertThat(capturedMirrorConnector.getTopicsExcludePattern(), is(excludedTopicList));
-                assertThat(capturedMirrorConnector.getGroupsExcludePattern(), is(excludedGroupList));
-                async.flag();
-            })));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void testTopicsGroupsBlacklist(VertxTestContext context) {
-        String kmm2Name = "foo";
-        String sourceNamespace = "source-ns";
-        String targetNamespace = "target-ns";
-        String sourceClusterAlias = "my-cluster-src";
-        String targetClusterAlias = "my-cluster-tgt";
-        String excludedTopicList = "excludedTopic0,excludedTopic1";
-        String excludedGroupList = "excludedGroup0,excludedGroup1";
-
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
-        KafkaMirrorMaker2 kmm2 = ResourceUtils.createEmptyKafkaMirrorMaker2(targetNamespace, kmm2Name);
-        ArgumentCaptor<KafkaMirrorMaker2> mirrorMaker2Captor = createMirrorMaker2CaptorMock(targetNamespace, kmm2Name, kmm2, supplier);
-        KafkaConnectApi mockConnectClient = createConnectClientMock();
-
-        KafkaMirrorMaker2ClusterSpec sourceCluster =
-            new KafkaMirrorMaker2ClusterSpecBuilder(true)
-                .withAlias(sourceClusterAlias)
-                .withBootstrapServers(sourceClusterAlias + "." + sourceNamespace + ".svc:9092")
-                .build();
-        KafkaMirrorMaker2ClusterSpec targetCluster =
-            new KafkaMirrorMaker2ClusterSpecBuilder(true)
-                .withAlias(targetClusterAlias)
-                .withBootstrapServers(targetClusterAlias + "." + targetNamespace + ".svc:9092")
-                .build();
-        kmm2.getSpec().setClusters(List.of(sourceCluster, targetCluster));
-
-        KafkaMirrorMaker2MirrorSpec deprecatedMirrorConnector = new KafkaMirrorMaker2MirrorSpecBuilder()
-            .withSourceCluster(sourceClusterAlias)
-            .withTargetCluster(targetClusterAlias)
-            .withTopicsBlacklistPattern(excludedTopicList)
-            .withGroupsBlacklistPattern(excludedGroupList)
-            .build();
-        kmm2.getSpec().setMirrors(List.of(deprecatedMirrorConnector));
-
-        KafkaMirrorMaker2AssemblyOperator mm2AssemblyOperator = new KafkaMirrorMaker2AssemblyOperator(vertx, new PlatformFeaturesAvailability(true, kubernetesVersion),
-            supplier, ResourceUtils.dummyClusterOperatorConfig(VERSIONS), x -> mockConnectClient);
-
-        Checkpoint async = context.checkpoint();
-        KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2, VERSIONS, sharedEnvironmentProvider);
-        mm2AssemblyOperator.reconcile(new Reconciliation("test-blacklist", KafkaMirrorMaker2.RESOURCE_KIND, targetNamespace, kmm2Name))
-            .onComplete(context.succeeding(v -> context.verify(() -> {
-                KafkaMirrorMaker2MirrorSpec capturedMirrorConnector = mirrorMaker2Captor.getAllValues().get(0).getSpec().getMirrors().get(0);
-                assertThat(capturedMirrorConnector.getTopicsBlacklistPattern(), is(excludedTopicList));
-                assertThat(capturedMirrorConnector.getGroupsBlacklistPattern(), is(excludedGroupList));
-                async.flag();
-            })));
-    }
-
-    private ArgumentCaptor<KafkaMirrorMaker2> createMirrorMaker2CaptorMock(String targetNamespace, String kmm2Name, KafkaMirrorMaker2 kmm2, ResourceOperatorSupplier supplier) {
-        CrdOperator mockMirrorMaker2Ops = supplier.mirrorMaker2Operator;
-        DeploymentOperator mockDcOps = supplier.deploymentOperations;
-        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
-        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
-        ConfigMapOperator mockCmOps = supplier.configMapOperations;
-        ServiceOperator mockServiceOps = supplier.serviceOperations;
-        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
-        SecretOperator mockSecretOps = supplier.secretOperations;
-
-        when(mockMirrorMaker2Ops.get(targetNamespace, kmm2Name)).thenReturn(kmm2);
-        when(mockMirrorMaker2Ops.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kmm2));
-
-        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
-        when(mockServiceOps.reconcile(any(), anyString(), anyString(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
-
-        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
-        when(mockDcOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture());
-        when(mockDcOps.reconcile(any(), anyString(), anyString(), dcCaptor.capture())).thenReturn(Future.succeededFuture());
-        when(mockDcOps.scaleUp(any(), anyString(), anyString(), anyInt(), anyLong())).thenReturn(Future.succeededFuture(42));
-        when(mockDcOps.scaleDown(any(), anyString(), anyString(), anyInt(), anyLong())).thenReturn(Future.succeededFuture(42));
-        when(mockDcOps.readiness(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockDcOps.waitForObserved(any(), anyString(), anyString(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
-        when(mockCmOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new ConfigMap())));
-        when(mockNetPolOps.reconcile(any(), eq(kmm2.getMetadata().getNamespace()), eq(KafkaMirrorMaker2Resources.deploymentName(
-            kmm2.getMetadata().getName())), any())).thenReturn(Future.succeededFuture(ReconcileResult.created(new NetworkPolicy())));
-        when(mockSecretOps.reconcile(any(), anyString(), any(), any())).thenReturn(Future.succeededFuture());
-
-        when(mockPodSetOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
-
-        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
-        when(mockPdbOps.reconcile(any(), anyString(), any(), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
-
-        ArgumentCaptor<KafkaMirrorMaker2> mirrorMaker2Captor = ArgumentCaptor.forClass(KafkaMirrorMaker2.class);
-        when(mockMirrorMaker2Ops.updateStatusAsync(any(), mirrorMaker2Captor.capture())).thenReturn(Future.succeededFuture());
-
-        return mirrorMaker2Captor;
-    }
-
-    private KafkaConnectApi createConnectClientMock() {
-        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
-        return mockConnectClient;
     }
 }

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -21,8 +21,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
 * The `UseStrimziPodSets` feature gate moved to GA stage in Strimzi 0.35 and the support for StatefulSets is completely removed. It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
-* The `StableConnectIdentities` feature gate is in alpha stage and is disabled by default.
-  It is expected to move to beta phase and be enabled by default from Strimzi 0.37.
+* The `StableConnectIdentities` feature gate is in beta stage and is enabled by default.
+  It is expected to move to GA phase and be always enabled from Strimzi 0.39.
 * The `KafkaNodePools` feature gate is in alpha stage and is disabled by default.
   It is expected to move to beta phase and be enabled by default from Strimzi 0.39.
 
@@ -59,8 +59,8 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 ¦`StableConnectIdentities`
 ¦0.34
-¦0.37 (planned)
-¦ -
+¦0.37
+¦0.39 (planned)
 
 ¦`KafkaNodePools`
 ¦0.36

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -91,14 +91,14 @@ To enable the `UseKRaft` feature gate, specify `+UseKRaft,+KafkaNodePools` in th
 [id='ref-operator-stable-connect-identities-feature-gate-{context}']
 == StableConnectIdentities feature gate
 
-The `StableConnectIdentities` feature gate has a default state of _disabled_.
+The `StableConnectIdentities` feature gate has a default state of _enabled_.
 
 The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes `Deployment` resources.
 `StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 
-.Enabling the `StableConnectIdentities` feature gate
-To enable the `StableConnectIdentities` feature gate, specify `+StableConnectIdentities` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+.Disabling the `StableConnectIdentities` feature gate
+To disable the `StableConnectIdentities` feature gate, specify `-StableConnectIdentities` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 IMPORTANT: The `StableConnectIdentities` feature gate must be disabled when downgrading to Strimzi 0.33 and earlier versions.
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -191,7 +191,7 @@ public interface Constants {
      * Feature gate related constants
      */
     String USE_KRAFT_MODE = "+UseKRaft";
-    String USE_STABLE_CONNECT_IDENTITIES = "+StableConnectIdentities";
+    String DONT_USE_STABLE_CONNECT_IDENTITIES = "-StableConnectIdentities";
     String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
     String UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -253,7 +253,7 @@ public class Environment {
     }
 
     public static boolean isStableConnectIdentitiesEnabled() {
-        return STRIMZI_FEATURE_GATES.contains(Constants.USE_STABLE_CONNECT_IDENTITIES);
+        return !STRIMZI_FEATURE_GATES.contains(Constants.DONT_USE_STABLE_CONNECT_IDENTITIES);
     }
 
     /**

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -47,7 +47,7 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   featureGatesBefore: "+StableConnectIdentities"
-  featureGatesAfter: ""
+  featureGatesAfter: "-StableConnectIdentities"
 - fromVersion: HEAD
   toVersion: 0.36.1
   fromExamples: HEAD

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -62,5 +62,5 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
-  featureGatesBefore: ""
+  featureGatesBefore: "-StableConnectIdentities"
   featureGatesAfter: "+StableConnectIdentities"


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR promotes the `StableConnectIdentities` feature gate which uses StirmziPodSets for Connect and Mirror Maker 2 to beta and thus enabled it by default. As part of this PR, it also updates the related documentation, system and unit tests. It does some refactoring of the unit tests to better split the tests unrelated to the Deployment to separate classes to make the removal easier in the future.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md