### PR TITLE
Bumped OpenTelemetry 1.19.0 for the Kafka 3rd party libs

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -29,8 +29,8 @@
         <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
-        <opentelemetry.version>1.18.0</opentelemetry.version>
-        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.19.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
     </properties>
 
     <repositories>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -29,8 +29,8 @@
         <jaeger-client.version>1.8.1</jaeger-client.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
-        <opentelemetry.version>1.18.0</opentelemetry.version>
-        <opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.19.0</opentelemetry.version>
+        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
     </properties>
 
     <repositories>

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -112,8 +112,8 @@
 //distributed tracing versions and links
 :JaegerClientVersion: 1.3.2
 :OpenTracingKafkaClient: 0.1.15
-:OpenTelemetryAlphaVersion: 1.18.0-alpha
-:OpenTelemetryVersion: 1.18.0
+:OpenTelemetryAlphaVersion: 1.19.0-alpha
+:OpenTelemetryVersion: 1.19.0
 
 :OpenTelemetryDocs: link:https://opentelemetry.io/docs/[OpenTelemetry documentation^]
 :OpenTracingDocs: link:https://opentracing.io/docs/[OpenTracing documentation^]


### PR DESCRIPTION
This trivial PR bumps OpenTelemetry to 1.19.0 in the Kafka 3rd party libs to align with what we have in the root pom and the Strimzi HTTP bridge.