### PR TITLE
Enabling Kafka Agent to run when KRaft is enabled

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -70,12 +70,16 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
   fi
 
 else
-  rm -f /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-  KEY_STORE=/tmp/kafka/cluster.keystore.p12
-  TRUST_STORE=/tmp/kafka/cluster.truststore.p12
-  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected:$KEY_STORE:$CERTS_STORE_PASSWORD:$TRUST_STORE:$CERTS_STORE_PASSWORD"
-  export KAFKA_OPTS
+  KAFKA_READY=/var/opt/kafka/kafka-ready
+  ZK_CONNECTED=/var/opt/kafka/zk-connected
+  rm -f $KAFKA_READY $ZK_CONNECTED 2> /dev/null
 fi
+
+KEY_STORE=/tmp/kafka/cluster.keystore.p12
+TRUST_STORE=/tmp/kafka/cluster.truststore.p12
+# when in KRaft mode, the Kafka ready and ZooKeeper connected file paths are empty because not needed to the agent
+KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=$KAFKA_READY:$ZK_CONNECTED:$KEY_STORE:$CERTS_STORE_PASSWORD:$TRUST_STORE:$CERTS_STORE_PASSWORD"
+export KAFKA_OPTS
 
 # Configure Garbage Collection logging
 . ./set_kafka_gc_options.sh

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -69,7 +69,11 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     rm -f "$KRAFT_LOG_DIR/__cluster_metadata-0/quorum-state"
   fi
 
+  # when in KRaft mode, the Kafka ready and ZooKeeper connected file paths are empty because not needed to the agent
+  KAFKA_READY=
+  ZK_CONNECTED=
 else
+  # when in ZooKeeper mode, the Kafka ready and ZooKeeper connected file paths are defined because used by the agent
   KAFKA_READY=/var/opt/kafka/kafka-ready
   ZK_CONNECTED=/var/opt/kafka/zk-connected
   rm -f $KAFKA_READY $ZK_CONNECTED 2> /dev/null
@@ -77,7 +81,6 @@ fi
 
 KEY_STORE=/tmp/kafka/cluster.keystore.p12
 TRUST_STORE=/tmp/kafka/cluster.truststore.p12
-# when in KRaft mode, the Kafka ready and ZooKeeper connected file paths are empty because not needed to the agent
 KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=$KAFKA_READY:$ZK_CONNECTED:$KEY_STORE:$CERTS_STORE_PASSWORD:$TRUST_STORE:$CERTS_STORE_PASSWORD"
 export KAFKA_OPTS
 

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -54,7 +54,7 @@ public class KafkaAgentTest {
         final Gauge brokerState = mock(Gauge.class);
         when(brokerState.value()).thenReturn((byte) 3);
         KafkaAgent agent = new KafkaAgent(brokerState, null, null);
-        context.setHandler(agent.getServerHandler());
+        context.setHandler(agent.getBrokerStateHandler());
         server.setHandler(context);
         server.start();
 
@@ -79,7 +79,7 @@ public class KafkaAgentTest {
         when(remainingSegments.value()).thenReturn((byte) 100);
 
         KafkaAgent agent = new KafkaAgent(brokerState, remainingLogs, remainingSegments);
-        context.setHandler(agent.getServerHandler());
+        context.setHandler(agent.getBrokerStateHandler());
         server.setHandler(context);
         server.start();
 
@@ -95,7 +95,7 @@ public class KafkaAgentTest {
     @Test
     public void testBrokerMetricNotFound() throws Exception {
         KafkaAgent agent = new KafkaAgent(null, null, null);
-        context.setHandler(agent.getServerHandler());
+        context.setHandler(agent.getBrokerStateHandler());
         server.setHandler(context);
         server.start();
 


### PR DESCRIPTION
This PR enables the Kafka Agent to run when KRaft is anabled as well.
It's the base for future work about getting Kafka controller configuration via Kafka Agent (see https://github.com/strimzi/strimzi-kafka-operator/pull/8812) as well as improved liveness/readiness probes in KRaft mode (see https://github.com/strimzi/strimzi-kafka-operator/pull/8892).