### PR TITLE
Update CHANGELOG.md to reflect the 0.36.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.37.0
 
+
+## 0.36.1
+
 * Add support for Apache Kafka 3.5.1
 
 ## 0.36.0


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the CHANGELOG.md to make it more clear that Kafka 3.5.1 is already in the 0.36.1 release and there is no need to wait for 0.37.

### Checklist

- [x] Update CHANGELOG.md