### PR TITLE
Add ppc64le support to multi-arch images on Azure CI

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -53,7 +53,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
 
   # Push Strimzi containers -> run only on main branch
   - stage: push_containers
@@ -73,7 +73,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
 
   # Publish Strimzi docs to the website -> run only on main branch
   - stage: public_docs

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -37,7 +37,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn:
@@ -52,7 +52,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn:
@@ -87,4 +87,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -48,7 +48,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
@@ -63,7 +63,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   # Publishes the Strimzi Helm Chart as an OCI artifact to Quay.io
   - stage: helm_as_oci_publish
     displayName: Publish Helm Chart as OCI artifact

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -38,7 +38,7 @@ def buildKeycloakAndOpa_ppc64le(String workspace) {
 def buildStrimziImages() {
     sh(script: """
         eval \$(minikube docker-env)
-        MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make all TESTCONTAINERS_RYUK_DISABLED=TRUE TESTCONTAINERS_CHECKS_DISABLE=TRUE
+        MVN_ARGS='-DskipTests -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make all TESTCONTAINERS_RYUK_DISABLED=TRUE TESTCONTAINERS_CHECKS_DISABLE=TRUE
     """)
 }
 

--- a/.jenkins/jenkins.groovy
+++ b/.jenkins/jenkins.groovy
@@ -38,7 +38,7 @@ def buildKeycloakAndOpa_ppc64le(String workspace) {
 def buildStrimziImages() {
     sh(script: """
         eval \$(minikube docker-env)
-        MVN_ARGS='-DskipTests -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make all TESTCONTAINERS_RYUK_DISABLED=TRUE TESTCONTAINERS_CHECKS_DISABLE=TRUE
+        MVN_ARGS='-Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=2' make all TESTCONTAINERS_RYUK_DISABLED=TRUE TESTCONTAINERS_CHECKS_DISABLE=TRUE
     """)
 }
 


### PR DESCRIPTION
Passing ppc64le job by skipping UT/ITs : http://140.211.168.45:8080/job/strimzi-kafka-operator/job/strimzi-kafka-operator-vnfork/41/

As per discussion https://github.com/orgs/strimzi/discussions/8804 we are facing some flaky failures with UT/ITs so we have skipped them using `-DskipTests` in forked branch https://github.com/Vaibhav-Nazare/strimzi-kafka-operator


All system tests are passing.