### PR TITLE
Improve `LeaderElectionManager` to release the lock at shutdown

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.operator.cluster.operator.assembly.AbstractConnectOperator;
@@ -46,7 +45,6 @@ public class ClusterOperator extends AbstractVerticle {
     private static final String NAME_SUFFIX = "-cluster-operator";
     private static final String CERTS_SUFFIX = NAME_SUFFIX + "-certs";
 
-    private final KubernetesClient client;
     private final String namespace;
     private final ClusterOperatorConfig config;
 
@@ -70,20 +68,18 @@ public class ClusterOperator extends AbstractVerticle {
     /**
      * Constructor
      *
-     * @param namespace                             Namespace which this operator instance manages
-     * @param config                                Cluster Operator configuration
-     * @param client                                Kubernetes client
-     * @param kafkaAssemblyOperator                 Kafka operator
-     * @param kafkaConnectAssemblyOperator          KafkaConnect operator
-     * @param kafkaMirrorMakerAssemblyOperator      KafkaMirrorMaker operator
-     * @param kafkaMirrorMaker2AssemblyOperator     KafkaMirrorMaker2 operator
-     * @param kafkaBridgeAssemblyOperator           KafkaBridge operator
-     * @param kafkaRebalanceAssemblyOperator        KafkaRebalance operator
-     * @param resourceOperatorSupplier              Resource operator supplier
+     * @param namespace                         Namespace which this operator instance manages
+     * @param config                            Cluster Operator configuration
+     * @param kafkaAssemblyOperator             Kafka operator
+     * @param kafkaConnectAssemblyOperator      KafkaConnect operator
+     * @param kafkaMirrorMakerAssemblyOperator  KafkaMirrorMaker operator
+     * @param kafkaMirrorMaker2AssemblyOperator KafkaMirrorMaker2 operator
+     * @param kafkaBridgeAssemblyOperator       KafkaBridge operator
+     * @param kafkaRebalanceAssemblyOperator    KafkaRebalance operator
+     * @param resourceOperatorSupplier          Resource operator supplier
      */
     public ClusterOperator(String namespace,
                            ClusterOperatorConfig config,
-                           KubernetesClient client,
                            KafkaAssemblyOperator kafkaAssemblyOperator,
                            KafkaConnectAssemblyOperator kafkaConnectAssemblyOperator,
                            KafkaMirrorMakerAssemblyOperator kafkaMirrorMakerAssemblyOperator,
@@ -94,7 +90,6 @@ public class ClusterOperator extends AbstractVerticle {
         LOGGER.info("Creating ClusterOperator for namespace {}", namespace);
         this.namespace = namespace;
         this.config = config;
-        this.client = client;
         this.kafkaAssemblyOperator = kafkaAssemblyOperator;
         this.kafkaConnectAssemblyOperator = kafkaConnectAssemblyOperator;
         this.kafkaMirrorMakerAssemblyOperator = kafkaMirrorMakerAssemblyOperator;
@@ -190,7 +185,6 @@ public class ClusterOperator extends AbstractVerticle {
         }
 
         strimziPodSetController.stop();
-        client.close();
         stop.complete();
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -241,11 +241,11 @@ public class Main {
                         // Not a leader anymore
                         if (!isShuttingDown) {
                             // Exit only if this isn't called as part of a shutdown
-                            LOGGER.info("Unexpectedly stopped being a leader => exiting");
+                            LOGGER.warn("Stopped being a leader => exiting");
                             // Has to run asynchronously to not block the leader election from shutting down (the exit call is synchronous)
                             CompletableFuture.runAsync(() -> System.exit(1));
                         } else {
-                            LOGGER.info("Stopped being a leader");
+                            LOGGER.info("Stopped being a leader during a shutdown");
                         }
                     },
                     s -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -59,6 +60,7 @@ public class Main {
     private static final Logger LOGGER = LogManager.getLogger(Main.class.getName());
 
     private static final int HEALTH_SERVER_PORT = 8080;
+    private static final long SHUTDOWN_TIMEOUT = 10_000L;
 
     /**
      * The main method used to run the Cluster Operator
@@ -75,6 +77,10 @@ public class Main {
         // setting DNS cache TTL
         Security.setProperty("networkaddress.cache.ttl", String.valueOf(config.getDnsCacheTtlSec()));
 
+        // Shutdown hook to register shutdown actions
+        ShutdownHook shutdownHook = new ShutdownHook();
+        Runtime.getRuntime().addShutdownHook(new Thread(shutdownHook));
+
         // setup Micrometer metrics options
         VertxOptions options = new VertxOptions().setMetricsOptions(
             new MicrometerMetricsOptions()
@@ -82,7 +88,7 @@ public class Main {
                 .setJvmMetricsEnabled(true)
                 .setEnabled(true));
         Vertx vertx = Vertx.vertx(options);
-        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(vertx)));
+        shutdownHook.register(() -> ShutdownHook.shutdownVertx(vertx, SHUTDOWN_TIMEOUT));
 
         // Setup Micrometer Metrics provider
         MetricsProvider metricsProvider = new MicrometerMetricsProvider();
@@ -90,9 +96,9 @@ public class Main {
 
         maybeCreateClusterRoles(vertx, config, client)
                 .compose(i -> startHealthServer(vertx, metricsProvider))
-                .compose(i -> leaderElection(client, config))
+                .compose(i -> leaderElection(client, config, shutdownHook))
                 .compose(i -> createPlatformFeaturesAvailability(vertx, client))
-                .compose(pfa -> deployClusterOperatorVerticles(vertx, client, metricsProvider, pfa, config))
+                .compose(pfa -> deployClusterOperatorVerticles(vertx, client, metricsProvider, pfa, config, shutdownHook))
                 .onComplete(res -> {
                     if (res.failed())   {
                         LOGGER.error("Unable to start operator for 1 or more namespace", res.cause());
@@ -135,10 +141,11 @@ public class Main {
      * @param metricsProvider   Metrics provider instance
      * @param pfa               PlatformFeaturesAvailability instance describing the Kubernetes cluster
      * @param config            Cluster Operator configuration
+     * @param shutdownHook      Shutdown hook to register leader election shutdown
      *
      * @return  Future which completes when all Cluster Operator verticles are started and running
      */
-    static CompositeFuture deployClusterOperatorVerticles(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config) {
+    static CompositeFuture deployClusterOperatorVerticles(Vertx vertx, KubernetesClient client, MetricsProvider metricsProvider, PlatformFeaturesAvailability pfa, ClusterOperatorConfig config, ShutdownHook shutdownHook) {
         ResourceOperatorSupplier resourceOperatorSupplier = new ResourceOperatorSupplier(
                 vertx,
                 client,
@@ -181,7 +188,6 @@ public class Main {
             futures.add(prom.future());
             ClusterOperator operator = new ClusterOperator(namespace,
                     config,
-                    client,
                     kafkaClusterOperations,
                     kafkaConnectClusterOperations,
                     kafkaMirrorMakerAssemblyOperator,
@@ -192,6 +198,8 @@ public class Main {
             vertx.deployVerticle(operator,
                 res -> {
                     if (res.succeeded()) {
+                        shutdownHook.register(() -> ShutdownHook.undeployVertxVerticle(vertx, res.result(), SHUTDOWN_TIMEOUT));
+
                         if (config.getCustomResourceSelector() != null) {
                             LOGGER.info("Cluster Operator verticle started in namespace {} with label selector {}", namespace, config.getCustomResourceSelector());
                         } else {
@@ -214,10 +222,11 @@ public class Main {
      *
      * When the leader election is disabled, it just completes the future without waiting for anything.
      *
-     * @param client    Kubernetes client
-     * @param config    Cluster Operator configuration
+     * @param client        Kubernetes client
+     * @param config        Cluster Operator configuration
+     * @param shutdownHook  Shutdown hook to register leader election shutdown
      */
-    private static Future<Void> leaderElection(KubernetesClient client, ClusterOperatorConfig config)    {
+    private static Future<Void> leaderElection(KubernetesClient client, ClusterOperatorConfig config, ShutdownHook shutdownHook)    {
         Promise<Void> leader = Promise.promise();
 
         if (config.getLeaderElectionConfig() != null) {
@@ -228,10 +237,16 @@ public class Main {
                         LOGGER.info("I'm the new leader");
                         leader.complete();
                     },
-                    () -> {
+                    isShuttingDown -> {
                         // Not a leader anymore
-                        LOGGER.info("Stopped being a leader => exiting");
-                        System.exit(0);
+                        if (!isShuttingDown) {
+                            // Exit only if this isn't called as part of a shutdown
+                            LOGGER.info("Unexpectedly stopped being a leader => exiting");
+                            // Has to run asynchronously to not block the leader election from shutting down (the exit call is synchronous)
+                            CompletableFuture.runAsync(() -> System.exit(1));
+                        } else {
+                            LOGGER.info("Stopped being a leader");
+                        }
                     },
                     s -> {
                         // Do nothing
@@ -239,6 +254,7 @@ public class Main {
 
             LOGGER.info("Waiting to become a leader");
             leaderElection.start();
+            shutdownHook.register(leaderElection::stop);
         } else {
             LOGGER.info("Leader election is not enabled");
             leader.complete();
@@ -259,7 +275,6 @@ public class Main {
      */
     /*test*/ static Future<Void> maybeCreateClusterRoles(Vertx vertx, ClusterOperatorConfig config, KubernetesClient client)  {
         if (config.isCreateClusterRoles()) {
-            @SuppressWarnings({ "rawtypes" })
             List<Future<ReconcileResult<ClusterRole>>> futures = new ArrayList<>();
             ClusterRoleOperator cro = new ClusterRoleOperator(vertx, client);
 
@@ -278,7 +293,6 @@ public class Main {
                                 StandardCharsets.UTF_8))) {
                     String yaml = br.lines().collect(Collectors.joining(System.lineSeparator()));
                     ClusterRole role = ClusterRoleOperator.convertYamlToClusterRole(yaml);
-                    @SuppressWarnings({ "rawtypes" })
                     Future<ReconcileResult<ClusterRole>> fut = cro.reconcile(new Reconciliation("start-cluster-operator", "Deployment", config.getOperatorNamespace(), "cluster-operator"), role.getMetadata().getName(), role);
                     futures.add(fut);
                 } catch (IOException e) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -592,6 +592,12 @@ public class StrimziPodSetController implements Runnable {
         LOGGER.infoOp("Requesting the StrimziPodSet controller to stop");
         this.stop = true;
         controllerThread.interrupt();
+        try {
+            controllerThread.join();
+        } catch (InterruptedException e)    {
+            LOGGER.warnOp("Interrupted while waiting for the StrimziPodSet controller thread to stop");
+        }
+        LOGGER.infoOp("StrimziPodSet controller stopped");
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
+import io.strimzi.operator.common.ShutdownHook;
 import io.strimzi.platform.KubernetesVersion;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -174,7 +175,7 @@ public class ClusterOperatorTest {
         CountDownLatch latch = new CountDownLatch(namespaceList.size() + 1);
 
         Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
-                    ClusterOperatorConfig.buildFromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
+                    ClusterOperatorConfig.buildFromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()), new ShutdownHook())
 
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(namespaceList.size()));
@@ -269,7 +270,7 @@ public class ClusterOperatorTest {
         CountDownLatch latch = new CountDownLatch(2);
 
         Main.deployClusterOperatorVerticles(VERTX, client, ResourceUtils.metricsProvider(), new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
-                ClusterOperatorConfig.buildFromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()))
+                ClusterOperatorConfig.buildFromMap(env, KafkaVersionTestUtils.getKafkaVersionLookup()), new ShutdownHook())
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(1));
                 for (String deploymentId: VERTX.deploymentIDs()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/leaderelection/LeaderElectionManagerMockTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -34,8 +35,8 @@ public class LeaderElectionManagerMockTest {
         CountDownLatch le2Leader = new CountDownLatch(1);
         CountDownLatch le2NotLeader = new CountDownLatch(1);
 
-        LeaderElectionManager le1 = createLeaderElectionManager("le-1", le1Leader::countDown, le1NotLeader::countDown);
-        LeaderElectionManager le2 = createLeaderElectionManager("le-2", le2Leader::countDown, le2NotLeader::countDown);
+        LeaderElectionManager le1 = createLeaderElectionManager("le-1", le1Leader::countDown, i -> le1NotLeader.countDown());
+        LeaderElectionManager le2 = createLeaderElectionManager("le-2", le2Leader::countDown, i -> le2NotLeader.countDown());
 
         // Start the first member => it should become a leader
         le1.start();
@@ -58,7 +59,7 @@ public class LeaderElectionManagerMockTest {
         assertThat(getLease().getSpec().getHolderIdentity(), anyOf(is(""), nullValue()));
     }
 
-    private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Runnable stopLeadershipCallback)   {
+    private LeaderElectionManager createLeaderElectionManager(String identity, Runnable startLeadershipCallback, Consumer<Boolean> stopLeadershipCallback)   {
         Map<String, String> envVars = new HashMap<>();
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAME.key(), LEASE_NAME);
         envVars.put(LeaderElectionManagerConfig.ENV_VAR_LEADER_ELECTION_LEASE_NAMESPACE.key(), NAMESPACE);

--- a/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
@@ -44,10 +44,10 @@ public class ShutdownHook implements Runnable {
     /**
      * Registers a lambda which should be called during the shutdown
      *
-     * @param c     Function which should be called when shutting down
+     * @param shutdownFunction  Function which should be called when shutting down
      */
-    public void register(Runnable c)    {
-        shutdownStack.push(c);
+    public void register(Runnable shutdownFunction)    {
+        shutdownStack.push(shutdownFunction);
     }
 
     /**
@@ -63,17 +63,17 @@ public class ShutdownHook implements Runnable {
 
         vertx.close(ar -> {
             if (!ar.succeeded()) {
-                LOGGER.error("Vertx close failed", ar.cause());
+                LOGGER.error("Vert.x close failed", ar.cause());
             }
             latch.countDown();
         });
 
         try {
             if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                LOGGER.error("Timed out while waiting for Vertx close");
+                LOGGER.error("Timed out while waiting for Vert.x close");
             }
         } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for Vertx close");
+            LOGGER.error("Interrupted while waiting for Vert.x close");
         }
 
         LOGGER.info("Shutdown of Vert.x is complete");
@@ -91,7 +91,7 @@ public class ShutdownHook implements Runnable {
         CountDownLatch latch = new CountDownLatch(1);
         vertx.undeploy(verticleId, ar -> {
             if (!ar.succeeded()) {
-                LOGGER.error("Vertx verticle failed to undeploy", ar.cause());
+                LOGGER.error("Vert.x verticle failed to undeploy", ar.cause());
             }
 
             latch.countDown();
@@ -99,10 +99,10 @@ public class ShutdownHook implements Runnable {
 
         try {
             if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                LOGGER.error("Timed out while waiting for Vertx verticle to undeploy");
+                LOGGER.error("Timed out while waiting for Vert.x verticle to undeploy");
             }
         } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for Vertx verticle to undeploy");
+            LOGGER.error("Interrupted while waiting for Vert.x verticle to undeploy");
         }
 
         LOGGER.info("Shutdown of Vert.x verticle {} is complete", verticleId);

--- a/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ShutdownHook.java
@@ -5,64 +5,106 @@
 package io.strimzi.operator.common;
 
 import io.vertx.core.Vertx;
-import static java.util.Objects.requireNonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This shutdown hook ensure that {@code Vertx.close()} is called on a clean shutdown,
- * which in turn calls the stop method of all running Verticles.
- * <p>
- * We add a fixed timeout because Vertx has none for stopping running Verticles.
+ * This shutdown hook executes the shutdown procedures. It allows shutdown procedures to be registered and executes
+ * them serially in the first-in last-out order. This allows us to build a hierarchy of steps executed in desired
+ * order (e.g. first stop the operators before releasing the leader election lock etc.). This is different from just
+ * registering multiple Java shutdown hooks because they would be executed in parallel / nondeterministic order.
  */
 public class ShutdownHook implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger(ShutdownHook.class);
 
-    private Vertx vertx;
-    private long timeoutMs;
+    private final Stack<Runnable> shutdownStack;
 
     /**
      * Constructs the shutdown hook
-     *
-     * @param vertx     Vert.x instance
      */
-    public ShutdownHook(Vertx vertx) {
-        this(vertx, 120_000);
-    }
-
-    /**
-     * Constructs the shutdown hook
-     *
-     * @param vertx         Vert.x instance
-     * @param timeoutMs     Timeout in milliseconds
-     */
-    public ShutdownHook(Vertx vertx, long timeoutMs) {
-        this.vertx = requireNonNull(vertx, "Vertx can't be null");
-        this.timeoutMs = timeoutMs;
+    public ShutdownHook() {
+        this.shutdownStack = new Stack<>();
     }
 
     @Override
     public void run() {
-        LOGGER.info("Shutdown started");
-        if (vertx.deploymentIDs().size() > 0) {
-            CountDownLatch latch = new CountDownLatch(1);
-            vertx.close(ar -> {
-                if (!ar.succeeded()) {
-                    LOGGER.error("Vertx close failed", ar.cause());
-                }
-                latch.countDown();
-            });
-            try {
-                if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                    LOGGER.error("Timed out while waiting for Vertx close");
-                }
-            } catch (InterruptedException e) {
-                LOGGER.error("Interrupted while waiting for Vertx close");
-            }
+        LOGGER.info("Shutdown hook started");
+
+        while (!shutdownStack.isEmpty()) {
+            shutdownStack.pop().run();
         }
-        LOGGER.info("Shutdown completed");
+
+        LOGGER.info("Shutdown hook completed");
+    }
+
+    /**
+     * Registers a lambda which should be called during the shutdown
+     *
+     * @param c     Function which should be called when shutting down
+     */
+    public void register(Runnable c)    {
+        shutdownStack.push(c);
+    }
+
+    /**
+     * Utility method which can be used to shut down Vert.x
+     *
+     * @param vertx         Vert.x instance
+     * @param timeoutMs     Timeout for the shutdown
+     */
+    public static void shutdownVertx(Vertx vertx, long timeoutMs) {
+        LOGGER.info("Shutting down Vert.x");
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        vertx.close(ar -> {
+            if (!ar.succeeded()) {
+                LOGGER.error("Vertx close failed", ar.cause());
+            }
+            latch.countDown();
+        });
+
+        try {
+            if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOGGER.error("Timed out while waiting for Vertx close");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error("Interrupted while waiting for Vertx close");
+        }
+
+        LOGGER.info("Shutdown of Vert.x is complete");
+    }
+
+    /**
+     * Utility method which can be used to undeploy verticle at shutdown
+     *
+     * @param vertx         Vert.x instance
+     * @param verticleId    ID of the verticle which should be undeployed
+     * @param timeoutMs     Timeout for the shutdown
+     */
+    public static void undeployVertxVerticle(Vertx vertx, String verticleId, long timeoutMs) {
+        LOGGER.info("Shutting down Vert.x verticle {}", verticleId);
+        CountDownLatch latch = new CountDownLatch(1);
+        vertx.undeploy(verticleId, ar -> {
+            if (!ar.succeeded()) {
+                LOGGER.error("Vertx verticle failed to undeploy", ar.cause());
+            }
+
+            latch.countDown();
+        });
+
+        try {
+            if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                LOGGER.error("Timed out while waiting for Vertx verticle to undeploy");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error("Interrupted while waiting for Vertx verticle to undeploy");
+        }
+
+        LOGGER.info("Shutdown of Vert.x verticle {} is complete", verticleId);
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Today, when one operator instance is shutdown, it does not release the leader election lock. That means that any other CO instance will need to wait for the lock to expire before it can take it and start operating.

This PR improves the `LeaderElectionManager` to release the lock at the shutdown. To do that, it does several changes:
* It stops running its own thread and instead is using the `CompletableFuture` of the Fabric8 Leader Elector. This allows to easily stop the elector and get it to release the lock.
* It reworks the shutdown hook which was previously shared between TO and CO and was solely focused on shutting down Vert.x. It was rewritten to be able to run several shutdown hooks in a serial fashion, so that we can shutdown things in the right order. For example, first the operator itself, then the Leader Election manager and finally Vert.x itself.

Thanks to these changes, when the operator instance now shuts down, it releases the lock and the other instance can take over immediately if it runs in parallel or right after it starts if it has to be freshly started.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally