### PR TITLE
Gather logs correctly for all namespaces in STs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -217,7 +217,7 @@ public class SetupClusterOperator {
         LOGGER.debug("Cluster Operator installation configuration:\n{}", this::toString);
 
         this.testClassName = this.extensionContext.getRequiredTestClass() != null ? this.extensionContext.getRequiredTestClass().getName() : "";
-        this.testMethodName = this.extensionContext.getDisplayName() != null ? this.extensionContext.getDisplayName() : "";
+        this.testMethodName = this.extensionContext.getRequiredTestMethod() != null ? this.extensionContext.getRequiredTestMethod().getName() : "";
 
         if (Environment.isOlmInstall()) {
             runOlmInstallation();
@@ -389,7 +389,12 @@ public class SetupClusterOperator {
                         this.namespaceToWatch += "," + Constants.TEST_SUITE_NAMESPACE;
                     }
                 }
-                cluster.createNamespaces(CollectorElement.createCollectorElement(testClassName, testMethodName), namespaceInstallTo, bindingsNamespaces);
+
+                final CollectorElement collectorElement = this.testMethodName == null || this.testMethodName.isEmpty() ?
+                    CollectorElement.createCollectorElement(this.testClassName) :
+                    CollectorElement.createCollectorElement(this.testClassName, this.testMethodName);
+
+                cluster.createNamespaces(collectorElement, namespaceInstallTo, bindingsNamespaces);
                 StUtils.copyImagePullSecrets(namespaceInstallTo);
 
                 this.extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(Constants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, true);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -48,6 +48,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.PreconditionViolationException;
 
 import java.io.File;
 import java.io.IOException;
@@ -217,7 +218,16 @@ public class SetupClusterOperator {
         LOGGER.debug("Cluster Operator installation configuration:\n{}", this::toString);
 
         this.testClassName = this.extensionContext.getRequiredTestClass() != null ? this.extensionContext.getRequiredTestClass().getName() : "";
-        this.testMethodName = this.extensionContext.getRequiredTestMethod() != null ? this.extensionContext.getRequiredTestMethod().getName() : "";
+
+        try {
+            if (this.extensionContext.getRequiredTestMethod() != null) {
+                this.testMethodName = this.extensionContext.getRequiredTestMethod().getName();
+            }
+        } catch (PreconditionViolationException e) {
+            LOGGER.debug("Test method is not present: {}\n{}", e.getMessage(), e.getCause());
+            // getRequiredTestMethod() is not present, in @BeforeAll scope so we're avoiding PreconditionViolationException exception
+            this.testMethodName = "";
+        }
 
         if (Environment.isOlmInstall()) {
             runOlmInstallation();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Refactoring

### Description

This PR fixes the way how we collect logs. Currently, we have in-consistencies and use both `extensionContext.getRequiredTestClass().getSimpleName()` and `extensionContext.getRequiredTestClass().getName()`. But this ends up that when we get a specific CollectorElement in `HashMap` it clearly does not retrieve the correct namespaces, which should be collector. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass