### PR TITLE
Bump BouncyCastle version used in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <javax.json.version>1.1.4</javax.json.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
-        <bouncycastle.version>1.69</bouncycastle.version>
+        <bouncycastle.version>1.76</bouncycastle.version>
         <kroxylicious-testing.version>0.4.0</kroxylicious-testing.version>
 
         <!-- properties to skip surefire tests during failsafe execution -->

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -209,12 +209,12 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Task

### Description

The BouncyCastle version used by system tests seems to be affected by CVE-2023-33201. While that should not have any impact on security of the operators or Kafka, it might come up in some security scanners. This PR tries to bump it to newer version.

### Checklist

- [x] Make sure all tests pass