### PR TITLE
Removed direct jna dependency not needed with new test-container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -798,14 +798,6 @@
                 <version>${strimzi-test-container.version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
-            <!-- Can be removed once the Strimzi Test Container is using new Test Container version -->
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>5.8.0</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
As commented in the pom file, this PR removes the jna dependency because we already moved to use test-container 0.104.0.
This was already done on the bridge via https://github.com/strimzi/strimzi-kafka-bridge/pull/827.