### PR TITLE
Validate number of JBOD disks in KafkaNodePools in KRaft mode

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -5,9 +5,7 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
-import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaSpec;
-import io.strimzi.api.kafka.model.storage.JbodStorage;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,7 +25,6 @@ public class KRaftUtils {
         Set<String> errors = new HashSet<>(0);
 
         if (kafkaSpec != null)  {
-            validateKafkaSpec(errors, kafkaSpec.getKafka());
             validateEntityOperatorSpec(errors, kafkaSpec.getEntityOperator(), utoEnabled);
         } else {
             errors.add("The .spec section of the Kafka custom resource is missing");
@@ -48,28 +45,6 @@ public class KRaftUtils {
     /* test */ static void validateEntityOperatorSpec(Set<String> errors, EntityOperatorSpec entityOperator, boolean utoEnabled) {
         if (entityOperator != null && entityOperator.getTopicOperator() != null && !utoEnabled) {
             errors.add("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.");
-        }
-    }
-
-    /**
-     * Checks whether the Kafka configuration contains any unsupported configurations
-     *
-     * @param errors    Set with detected errors to which any new errors should be added
-     * @param kafka     The Kafka spec which should be checked
-     */
-    /* test */ static void validateKafkaSpec(Set<String> errors, KafkaClusterSpec kafka) {
-        if (kafka != null) {
-            // Check number of disks in JBOD storage
-            if (kafka.getStorage() != null
-                    && JbodStorage.TYPE_JBOD.equals(kafka.getStorage().getType())) {
-                JbodStorage jbod = (JbodStorage) kafka.getStorage();
-
-                if (jbod.getVolumes().size() > 1) {
-                    errors.add("Using more than one disk in a JBOD storage is currently not supported when the UseKRaft feature gate is enabled");
-                }
-            }
-        } else {
-            errors.add("The .spec.kafka section of the Kafka custom resource is missing");
         }
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Apache Kafka in KRaft mode currently does not support JBOD storage (Strimzi's `type: jbod` itself is fine as long as it has only one disk). Right now, the validation for this is done only in the Kafka CR. But we force users to use KafkaNodePools for KRaft. So the actual storage used is int he KafkaNodePool resources. So the validation is currently not really working.

This PR removes the old validation of JBOD volume count for the Kafka CR which is not needed anymore. And it instead adds  a new validation for KafkaNodePools which causes an exception to be thrown when KRaft is used with more than one JBOD volume in any of the related node pools.

It also fixes some minor typos and indentation issues in the files which are already changed by this PR.

This should resolve #8955.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging