### PR TITLE
Delete `ClusterRoleBinding` when Mirror Maker 2 with rack awareness is deleted

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -678,4 +678,16 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         return resourceOperator.patchAsync(reconciliation, patchedKafkaMirrorMaker2)
             .compose(ignored -> Future.succeededFuture());
     }
+
+    /**
+     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
+     * <p>
+     * @param reconciliation    The Reconciliation identification
+     * @return                  Future indicating the result of the deletion
+     */
+    @Override
+    protected Future<Boolean> delete(Reconciliation reconciliation) {
+        return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, KafkaMirrorMaker2Resources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null)
+                .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
+    }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When Mirror Maker 2 resource with enabled rack awareness is deleted, we currently don't delete the ClusterRoleBinding which belongs to it. This PR adds the deletion tot he `KafkaMirrorMaker2AssemblyOperator` class. It also moved the original deletion method from the `AbstractConnectOperator` which was updating the status of KafkaConnector resources to `KafkaConnectAssemblyOperator`. The KafkaConnector resources are used only in Kafka Connect, so it makes no sense to delete it in `AbstractConnectOperator` which is shared with Mirror Maker 2.

This was raised in #8966 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging