### PR TITLE
[DOC] Fix link to Entity Operator schema reference

### DIFF
--- a/documentation/modules/configuring/ref-kafka-entity-operator.adoc
+++ b/documentation/modules/configuring/ref-kafka-entity-operator.adoc
@@ -36,7 +36,7 @@ When this option is missing, the Entity Operator is deployed without the Topic O
 The `userOperator` property contains the configuration of the User Operator.
 When this option is missing, the Entity Operator is deployed without the User Operator.
 
-For more information on the properties used to configure the Entity Operator, see the link:{BookURLConfiguring}#type-EntityUserOperatorSpec-reference[`EntityUserOperatorSpec` schema reference^].
+For more information on the properties used to configure the Entity Operator, see the link:{BookURLConfiguring}#type-EntityOperatorSpec-reference[`EntityOperatorSpec` schema reference^].
 
 .Example of basic configuration enabling both operators
 [source,yaml,subs=attributes+]


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The documentation section about configuring Entity Operator has a paragraph which promises link to the Entity Operator schema reference which fits in with the context (chapter [Configuring the Entity Operator](https://strimzi.io/docs/operators/latest/full/deploying.html#ref-kafka-entity-operator-str)). But it actually links to the Entity User Operator schema. This PR fixes the link.

### Checklist

- [x] Update documentation