### PR TITLE
[ST] SecurityST testCaRenewalBreakInMiddle fix clients and broker configuration

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1095,6 +1095,7 @@ class SecurityST extends AbstractST {
     void testCaRenewalBreakInMiddle(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext, Constants.TEST_SUITE_NAMESPACE);
 
+        // Extra Kafka configuration ensures that topic created automatically (by producer) will have data available on more than just single replica once one of broker fails
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
             .editSpec()
                 .withNewClusterCa()
@@ -1117,6 +1118,7 @@ class SecurityST extends AbstractST {
                 .build()
         );
 
+        // Configuration `acks=all` paired with Kafka's `min.insync.replicas=2` enforces there are at least 2 replicas with all produced data before test continues.
         String producerAdditionConfiguration = "acks=all\n";
         KafkaClients kafkaClients = new KafkaClientsBuilder()
             .withTopicName(testStorage.getTopicName())


### PR DESCRIPTION


### Type of change

- Refactoring

### Description

Configuration of broker, topic, and producer is updated to handle situation with 1 (out of 3) brokers being down, specific configuration is:
1. producer `acks=all` 
2. topic `replication=3`
3. broker `min.insync.replicas=2`   `default.replication.factor=3`

This will prevent frequent failures due to only 1 replica which is often present in broker which is actually down. 

### Checklist


- [x] Write tests
- [x] Make sure all tests pass

