### PR TITLE
Stop using `Optional<LabelSelector>` everywhere

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -262,7 +262,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
 
         if (scaledToZero)   {
-            return connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build()))
+            return connectorOperator.listAsync(namespace, new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())
                     .compose(connectors -> Future.join(
                             connectors.stream().map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
                                     .collect(Collectors.toList())
@@ -274,7 +274,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
         return Future.join(
                 apiClient.list(reconciliation, host, port),
-                connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())),
+                connectorOperator.listAsync(namespace, new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build()),
                 apiClient.listConnectorPlugins(reconciliation, host, port),
                 apiClient.updateConnectLoggers(reconciliation, host, port, desiredLogging, defaultLogging)
         ).compose(cf -> {
@@ -302,7 +302,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 Promise<Void> connectorStatuses = Promise.promise();
                 LOGGER.warnCr(reconciliation, "Failed to connect to the REST API => trying to update the connector status");
 
-                connectorOperator.listAsync(namespace, Optional.of(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build()))
+                connectorOperator.listAsync(namespace, new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())
                         .compose(connectors -> Future.join(
                                 connectors.stream().map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, error))
                                         .collect(Collectors.toList())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -84,7 +84,7 @@ public abstract class AbstractOperator<
     protected final O resourceOperator;
     private final String kind;
 
-    private final Optional<LabelSelector> selector;
+    private final LabelSelector selector;
 
     protected final OperatorMetricsHolder metrics;
 
@@ -105,7 +105,7 @@ public abstract class AbstractOperator<
         this.vertx = vertx;
         this.kind = kind;
         this.resourceOperator = resourceOperator;
-        this.selector = (selectorLabels == null || selectorLabels.toMap().isEmpty()) ? Optional.empty() : Optional.of(new LabelSelector(null, selectorLabels.toMap()));
+        this.selector = (selectorLabels == null || selectorLabels.toMap().isEmpty()) ? null : new LabelSelector(null, selectorLabels.toMap());
         this.metrics = metrics;
     }
 
@@ -218,7 +218,7 @@ public abstract class AbstractOperator<
             // and might not be really deleted. We have to filter these situations out and ignore the
             // reconciliation because such resource might be already operated by another instance (where the
             // same change triggered ADDED event).
-            LOGGER.debugCr(reconciliation, "{} {} in namespace {} does not match label selector {} and will be ignored", kind(), name, namespace, selector().get().getMatchLabels());
+            LOGGER.debugCr(reconciliation, "{} {} in namespace {} does not match label selector {} and will be ignored", kind(), name, namespace, selector().getMatchLabels());
             return Future.succeededFuture();
         }
 
@@ -480,7 +480,7 @@ public abstract class AbstractOperator<
      * and {@linkplain #allResourceNames(String) query}.
      * @return A selector.
      */
-    public Optional<LabelSelector> selector() {
+    public LabelSelector selector() {
         return selector;
     }
 
@@ -492,7 +492,7 @@ public abstract class AbstractOperator<
      * @return  A future which completes when the watcher has been created
      */
     public Future<ReconnectingWatcher<T>> createWatch(String namespace) {
-        return VertxUtil.async(vertx, () -> new ReconnectingWatcher<>(resourceOperator, kind(), namespace, selector().orElse(null), this::eventHandler));
+        return VertxUtil.async(vertx, () -> new ReconnectingWatcher<>(resourceOperator, kind(), namespace, selector(), this::eventHandler));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -53,7 +53,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -315,7 +314,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         super.reconcileThese(trigger, desiredNames, namespace, ignore -> {
             List<String> connects = desiredNames.stream().map(NamespaceAndName::getName).collect(Collectors.toList());
             LabelSelectorRequirement requirement = new LabelSelectorRequirement(Labels.STRIMZI_CLUSTER_LABEL, "In", connects);
-            Optional<LabelSelector> connectorsSelector = Optional.of(new LabelSelector(List.of(requirement), null));
+            LabelSelector connectorsSelector = new LabelSelector(List.of(requirement), null);
             connectorOperator.listAsync(namespace, connectorsSelector)
                     .onComplete(ar -> {
                         if (ar.succeeded()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/Operator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/Operator.java
@@ -14,7 +14,6 @@ import io.vertx.core.Handler;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -107,7 +106,7 @@ public interface Operator {
      * A selector for narrowing the resources which this operator instance consumes to those whose labels match this selector.
      * @return A selector.
      */
-    default Optional<LabelSelector> selector() {
-        return Optional.empty();
+    default LabelSelector selector() {
+        return null;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.client.WatcherException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.operator.resource.AbstractWatchableNamespacedResourceOperator;
 
-import java.util.Optional;
 import java.util.function.BiConsumer;
 
 /**
@@ -67,7 +66,7 @@ public class ReconnectingWatcher<T extends HasMetadata> implements Watcher<T> {
      * @return  The created watch
      */
     private Watch createWatch() {
-        return resourceOperator.watch(namespace, Optional.ofNullable(selector), this);
+        return resourceOperator.watch(namespace, selector, this);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -65,7 +65,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -1927,7 +1926,7 @@ public class ConnectorMockTest {
         String connectorName1 = "connector1";
         String connectorName2 = "connector2";
 
-        when(kafkaConnectOperator.selector()).thenReturn(Optional.of(new LabelSelector(null, Map.of("foo", "bar"))));
+        when(kafkaConnectOperator.selector()).thenReturn(new LabelSelector(null, Map.of("foo", "bar")));
 
         KafkaConnect kafkaConnect = new KafkaConnectBuilder()
                 .withNewMetadata()
@@ -1995,7 +1994,7 @@ public class ConnectorMockTest {
         String connectorName1 = "connector1";
         String connectorName2 = "connector2";
 
-        when(kafkaConnectOperator.selector()).thenReturn(Optional.of(new LabelSelector(null, Map.of("foo", "bar"))));
+        when(kafkaConnectOperator.selector()).thenReturn(new LabelSelector(null, Map.of("foo", "bar")));
 
         KafkaConnect kafkaConnect1 = new KafkaConnectBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNodePoolWatcherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorNodePoolWatcherTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -91,7 +90,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.empty(), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(null, supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(1));
@@ -106,7 +105,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "matching")).build()), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "matching")).build(), supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(1));
@@ -121,7 +120,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "not-matching")).build()), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "not-matching")).build(), supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(0));
@@ -133,7 +132,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(null);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "not-matching")).build()), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(new LabelSelectorBuilder().withMatchLabels(Map.of("selector", "not-matching")).build(), supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(0));
@@ -151,7 +150,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(kafka);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.empty(), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(null, supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, POOL);
 
         assertThat(mockKao.reconciliations.size(), is(0));
@@ -169,7 +168,7 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.empty(), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(null, supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, pool);
 
         assertThat(mockKao.reconciliations.size(), is(0));
@@ -187,24 +186,24 @@ public class KafkaAssemblyOperatorNodePoolWatcherTest {
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
         when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
 
-        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(Optional.empty(), supplier);
+        MockKafkaAssemblyOperator mockKao = new MockKafkaAssemblyOperator(null, supplier);
         mockKao.nodePoolEventHandler(Watcher.Action.ADDED, pool);
 
         assertThat(mockKao.reconciliations.size(), is(0));
     }
 
     static class MockKafkaAssemblyOperator extends KafkaAssemblyOperator  {
-        private final Optional<LabelSelector> selector;
+        private final LabelSelector selector;
 
         public List<Reconciliation> reconciliations = new ArrayList<>();
 
-        public MockKafkaAssemblyOperator(Optional<LabelSelector> selector, ResourceOperatorSupplier supplier) {
+        public MockKafkaAssemblyOperator(LabelSelector selector, ResourceOperatorSupplier supplier) {
             super(Vertx.vertx(), null, null, null, supplier, ResourceUtils.dummyClusterOperatorConfig());
             this.selector = selector;
         }
 
         @Override
-        public Optional<LabelSelector> selector() {
+        public LabelSelector selector() {
             return selector;
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -110,7 +111,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
@@ -132,6 +132,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
@@ -1233,7 +1234,6 @@ public class KafkaAssemblyOperatorTest {
             })));
     }
 
-    @SuppressWarnings("unchecked")
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
@@ -1253,7 +1253,7 @@ public class KafkaAssemblyOperatorTest {
 
         Kafka foo = getKafkaAssembly("foo");
         Kafka bar = getKafkaAssembly("bar");
-        when(mockKafkaOps.listAsync(eq(kafkaNamespace), any(Optional.class))).thenReturn(
+        when(mockKafkaOps.listAsync(eq(kafkaNamespace), isNull(LabelSelector.class))).thenReturn(
             Future.succeededFuture(asList(foo, bar))
         );
         // when requested Custom Resource for a specific Kafka cluster
@@ -1287,7 +1287,6 @@ public class KafkaAssemblyOperatorTest {
         ops.reconcileAll("test", kafkaNamespace, context.succeeding(v -> completeTest.flag()));
     }
 
-    @SuppressWarnings("unchecked")
     @ParameterizedTest
     @MethodSource("data")
     @Timeout(value = 2, timeUnit = TimeUnit.MINUTES)
@@ -1303,7 +1302,7 @@ public class KafkaAssemblyOperatorTest {
         foo.getMetadata().setNamespace("namespace1");
         Kafka bar = getKafkaAssembly("bar");
         bar.getMetadata().setNamespace("namespace2");
-        when(mockKafkaOps.listAsync(eq("*"), any(Optional.class))).thenReturn(
+        when(mockKafkaOps.listAsync(eq("*"), isNull(LabelSelector.class))).thenReturn(
                 Future.succeededFuture(asList(foo, bar))
         );
         // when requested Custom Resource for a specific Kafka cluster

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
@@ -60,7 +61,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -76,6 +76,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -576,7 +577,6 @@ public class KafkaBridgeAssemblyOperatorTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testReconcileCallsCreateOrUpdate(VertxTestContext context) {
         // Must create all checkpoints before flagging any to avoid premature test success
         Checkpoint async = context.checkpoint();
@@ -596,7 +596,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         KafkaBridge bar = ResourceUtils.createKafkaBridge(kbNamespace, "bar", image, 1,
                 BOOTSTRAP_SERVERS, KAFKA_BRIDGE_PRODUCER_SPEC, KAFKA_BRIDGE_CONSUMER_SPEC, KAFKA_BRIDGE_HTTP_SPEC, true);
 
-        when(mockBridgeOps.listAsync(eq(kbNamespace), any(Optional.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
+        when(mockBridgeOps.listAsync(eq(kbNamespace), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
         when(mockBridgeOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(bar));
         when(mockBridgeOps.updateStatusAsync(any(), any(KafkaBridge.class))).thenReturn(Future.succeededFuture());
         // when requested ConfigMap for a specific Kafka Bridge cluster

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
@@ -68,7 +69,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -86,13 +86,14 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"unchecked", "ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
+@SuppressWarnings({"ClassFanOutComplexity", "checkstyle:ClassDataAbstractionCoupling"})
 @ExtendWith(VertxExtension.class)
 public class KafkaConnectAssemblyOperatorTest {
 
@@ -129,7 +130,7 @@ public class KafkaConnectAssemblyOperatorTest {
         SecretOperator mockSecretOps = supplier.secretOperations;
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectOps.get(kc.getMetadata().getNamespace(), kc.getMetadata().getName())).thenReturn(kc);
         when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
 
@@ -274,7 +275,7 @@ public class KafkaConnectAssemblyOperatorTest {
 
         KafkaConnect kc = ResourceUtils.createEmptyKafkaConnect(kcNamespace, kcName);
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS, SHARED_ENV_PROVIDER);
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectOps.get(kcNamespace, kcName)).thenReturn(kc);
         when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
         when(mockConnectOps.updateStatusAsync(any(), any(KafkaConnect.class))).thenReturn(Future.succeededFuture());
@@ -373,7 +374,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnect kc = ResourceUtils.createEmptyKafkaConnect(kcNamespace, kcName);
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS, SHARED_ENV_PROVIDER);
         kc.getSpec().setImage("some/different:image"); // Change the image to generate some diff
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectOps.get(kcNamespace, kcName)).thenReturn(kc);
         when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
         when(mockConnectOps.updateStatusAsync(any(), any(KafkaConnect.class))).thenReturn(Future.succeededFuture());
@@ -584,7 +585,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS, SHARED_ENV_PROVIDER);
         kc.getSpec().setReplicas(scaleTo); // Change replicas to create ScaleUp
 
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectOps.get(kcNamespace, kcName)).thenReturn(kc);
         when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
         when(mockConnectOps.updateStatusAsync(any(), any(KafkaConnect.class))).thenReturn(Future.succeededFuture());
@@ -660,7 +661,7 @@ public class KafkaConnectAssemblyOperatorTest {
         KafkaConnectCluster connect = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kc, VERSIONS, SHARED_ENV_PROVIDER);
         kc.getSpec().setReplicas(scaleTo); // Change replicas to create ScaleDown
 
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectOps.get(kcNamespace, kcName)).thenReturn(kc);
         when(mockConnectOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kc));
         when(mockConnectOps.updateStatusAsync(any(), any(KafkaConnect.class))).thenReturn(Future.succeededFuture());
@@ -727,12 +728,12 @@ public class KafkaConnectAssemblyOperatorTest {
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
 
-        when(mockConnectorOps.listAsync(any(), any(Optional.class))).thenReturn(Future.succeededFuture(List.of()));
+        when(mockConnectorOps.listAsync(any(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(List.of()));
         String kcNamespace = "test";
 
         KafkaConnect foo = ResourceUtils.createEmptyKafkaConnect(kcNamespace, "foo");
         KafkaConnect bar = ResourceUtils.createEmptyKafkaConnect(kcNamespace, "bar");
-        when(mockConnectOps.listAsync(eq(kcNamespace), any(Optional.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
+        when(mockConnectOps.listAsync(eq(kcNamespace), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
         // when requested ConfigMap for a specific Kafka Connect cluster
         when(mockConnectOps.getAsync(eq(kcNamespace), eq("foo"))).thenReturn(Future.succeededFuture(foo));
         when(mockConnectOps.getAsync(eq(kcNamespace), eq("bar"))).thenReturn(Future.succeededFuture(bar));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorKubeTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -64,7 +65,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
@@ -150,7 +150,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -319,7 +319,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -459,7 +459,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -646,7 +646,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -835,7 +835,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1031,7 +1031,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1231,7 +1231,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1417,7 +1417,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1562,7 +1562,7 @@ public class KafkaConnectBuildAssemblyOperatorKubeTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectBuildAssemblyOperatorOpenShiftTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -64,7 +65,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiPredicate;
 
 import static java.util.Collections.emptyList;
@@ -149,7 +149,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -302,7 +302,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -440,7 +440,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -622,7 +622,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -789,7 +789,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -928,7 +928,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1108,7 +1108,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1312,7 +1312,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);
@@ -1518,7 +1518,7 @@ public class KafkaConnectBuildAssemblyOperatorOpenShiftTest {
         CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
 
         // Mock KafkaConnector ops
-        when(mockConnectorOps.listAsync(anyString(), any(Optional.class))).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Mock KafkaConnect ops
         when(mockConnectOps.get(NAMESPACE, NAME)).thenReturn(kc);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
@@ -58,7 +59,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -73,6 +73,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -613,7 +614,7 @@ public class KafkaMirrorMaker2AssemblyOperatorTest {
 
         KafkaMirrorMaker2 foo = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "foo");
         KafkaMirrorMaker2 bar = ResourceUtils.createEmptyKafkaMirrorMaker2(kmm2Namespace, "bar");
-        when(mockMirrorMaker2Ops.listAsync(eq(kmm2Namespace), any(Optional.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
+        when(mockMirrorMaker2Ops.listAsync(eq(kmm2Namespace), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
         // when requested ConfigMap for a specific Kafka MirrorMaker 2 cluster
         when(mockMirrorMaker2Ops.getAsync(eq(kmm2Namespace), eq("foo"))).thenReturn(Future.succeededFuture(foo));
         when(mockMirrorMaker2Ops.getAsync(eq(kmm2Namespace), eq("bar"))).thenReturn(Future.succeededFuture(bar));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker;
@@ -55,7 +56,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -68,6 +68,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -578,7 +579,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         KafkaMirrorMaker foo = ResourceUtils.createKafkaMirrorMaker(kmmNamespace, "foo", image, producer, consumer, include);
         KafkaMirrorMaker bar = ResourceUtils.createKafkaMirrorMaker(kmmNamespace, "bar", image, producer, consumer, include);
 
-        when(mockMirrorOps.listAsync(eq(kmmNamespace), any(Optional.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
+        when(mockMirrorOps.listAsync(eq(kmmNamespace), isNull(LabelSelector.class))).thenReturn(Future.succeededFuture(asList(foo, bar)));
         // when requested ConfigMap for a specific Kafka Mirror Maker cluster
         when(mockMirrorOps.getAsync(anyString(), eq("foo"))).thenReturn(Future.succeededFuture(foo));
         when(mockMirrorOps.getAsync(anyString(), eq("bar"))).thenReturn(Future.succeededFuture(bar));

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -37,7 +37,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
@@ -443,12 +442,12 @@ public class Util {
      *
      * @return              True if the resource contains all labels from the LabelSelector or if the LabelSelector is empty
      */
-    public static boolean matchesSelector(Optional<LabelSelector> labelSelector, HasMetadata cr) {
-        if (labelSelector.isPresent()) {
+    public static boolean matchesSelector(LabelSelector labelSelector, HasMetadata cr) {
+        if (labelSelector != null && labelSelector.getMatchLabels() != null) {
             if (cr.getMetadata().getLabels() != null) {
-                return cr.getMetadata().getLabels().entrySet().containsAll(labelSelector.get().getMatchLabels().entrySet());
+                return cr.getMetadata().getLabels().entrySet().containsAll(labelSelector.getMatchLabels().entrySet());
             } else {
-                return labelSelector.get().getMatchLabels().isEmpty();
+                return labelSelector.getMatchLabels().isEmpty();
             }
         }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -28,7 +28,6 @@ import io.vertx.core.Vertx;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
@@ -358,7 +357,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      *
      * @return A Future with a list of matching resources.
      */
-    public Future<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
+    public Future<List<T>> listAsync(String namespace, LabelSelector selector) {
         return listAsync(applySelector(applyNamespace(namespace), selector));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractResourceOperator.java
@@ -19,7 +19,6 @@ import io.vertx.core.Vertx;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -145,9 +144,9 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      *
      * @return  Filtered operation
      */
-    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Optional<LabelSelector> selector)  {
-        if (selector.isPresent()) {
-            return filterable.withLabelSelector(selector.get());
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, LabelSelector selector)  {
+        if (selector != null) {
+            return filterable.withLabelSelector(selector);
         } else {
             return filterable;
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractWatchableNamespacedResourceOperator.java
@@ -14,8 +14,6 @@ import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.vertx.core.Vertx;
 
-import java.util.Optional;
-
 /**
  * Abstract class for resources which can be watched.
  *
@@ -74,11 +72,11 @@ public abstract class AbstractWatchableNamespacedResourceOperator<
      *
      * @return  A Kubernetes watch instance
      */
-    public Watch watch(String namespace, Optional<LabelSelector> selector, Watcher<T> watcher) {
+    public Watch watch(String namespace, LabelSelector selector, Watcher<T> watcher) {
         FilterWatchListDeletable<T, L, R> operation
                 = ANY_NAMESPACE.equals(namespace) ? operation().inAnyNamespace() : operation().inNamespace(namespace);
-        if (selector.isPresent()) {
-            operation = operation.withLabelSelector(selector.get());
+        if (selector != null) {
+            operation = operation.withLabelSelector(selector);
         }
         return operation.watch(watcher);
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.common.operator.resource.concurrent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -385,7 +384,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      *
      * @return A CompletionStage with a list of matching resources.
      */
-    public CompletionStage<List<T>> listAsync(String namespace, Optional<LabelSelector> selector) {
+    public CompletionStage<List<T>> listAsync(String namespace, LabelSelector selector) {
         return listAsync(applySelector(applyNamespace(namespace), selector));
     }
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractResourceOperator.java
@@ -6,7 +6,6 @@ package io.strimzi.operator.common.operator.resource.concurrent;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
@@ -149,9 +148,9 @@ public abstract class AbstractResourceOperator<C extends KubernetesClient,
      *
      * @return  Filtered operation
      */
-    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, Optional<LabelSelector> selector)  {
-        if (selector.isPresent()) {
-            return filterable.withLabelSelector(selector.get());
+    protected FilterWatchListDeletable<T, L, R> applySelector(FilterWatchListDeletable<T, L, R> filterable, LabelSelector selector)  {
+        if (selector != null) {
+            return filterable.withLabelSelector(selector);
         } else {
             return filterable;
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractWatchableNamespacedResourceOperator.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.common.operator.resource.concurrent;
 
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -74,11 +73,11 @@ public abstract class AbstractWatchableNamespacedResourceOperator<
      *
      * @return  A Kubernetes watch instance
      */
-    public Watch watch(String namespace, Optional<LabelSelector> selector, Watcher<T> watcher) {
+    public Watch watch(String namespace, LabelSelector selector, Watcher<T> watcher) {
         FilterWatchListDeletable<T, L, R> operation
                 = ANY_NAMESPACE.equals(namespace) ? operation().inAnyNamespace() : operation().inNamespace(namespace);
-        if (selector.isPresent()) {
-            operation = operation.withLabelSelector(selector.get());
+        if (selector != null) {
+            operation = operation.withLabelSelector(selector);
         }
         return operation.watch(watcher);
     }

--- a/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/UtilTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static io.strimzi.operator.common.Util.matchesSelector;
 import static io.strimzi.operator.common.Util.parseMap;
@@ -46,8 +45,6 @@ public class UtilTest {
 
     @Test
     public void testParseMapEmptyString() {
-        String stringMap = "";
-
         Map<String, String> m = parseMap(null);
         assertThat(m, aMapWithSize(0));
     }
@@ -122,7 +119,8 @@ public class UtilTest {
 
         assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, overrides2), is(expected));
         assertThat(Util.mergeLabelsOrAnnotations(base, overrides1, null, overrides2), is(expected));
-        assertThat(Util.mergeLabelsOrAnnotations(base, null), is(base));
+        assertThat(Util.mergeLabelsOrAnnotations(base, (Map<String, String>) null), is(base));
+        assertThat(Util.mergeLabelsOrAnnotations(base, (Map<String, String>[]) null), is(base));
         assertThat(Util.mergeLabelsOrAnnotations(base), is(base));
         assertThat(Util.mergeLabelsOrAnnotations(null, overrides2), is(overrides2));
         assertThrows(InvalidResourceException.class, () -> Util.mergeLabelsOrAnnotations(base, forbiddenOverrides));
@@ -156,37 +154,37 @@ public class UtilTest {
                 .build();
 
         // Resources without any labels
-        Optional<LabelSelector> selector = Optional.empty();
+        LabelSelector selector = null;
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(emptyMap()).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(emptyMap()).build();
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build();
         assertThat(matchesSelector(selector, testResource), is(false));
 
         // Resources with Labels
         testResource.getMetadata().setLabels(Map.of("label1", "value1", "label2", "value2"));
 
-        selector = Optional.empty();
+        selector = null;
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(emptyMap()).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(emptyMap()).build();
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2")).build();
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1")).build();
         assertThat(matchesSelector(selector, testResource), is(true));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value1")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value1")).build();
         assertThat(matchesSelector(selector, testResource), is(false));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label3", "value3")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label3", "value3")).build();
         assertThat(matchesSelector(selector, testResource), is(false));
 
-        selector = Optional.of(new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1", "label3", "value3")).build());
+        selector = new LabelSelectorBuilder().withMatchLabels(Map.of("label2", "value2", "label1", "value1", "label3", "value3")).build();
         assertThat(matchesSelector(selector, testResource), is(false));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In our code, we seem to be passing through various layers of the code `Optional<LabelSelector>`. We use it in method parameters and class fields. That does not seem to be the generally recommended use of the Optional class so it produces a lot of warnings in IDEs such as IntelliJ. The use of `Optional` in this way should also lead to increased resource consumption. I do not think it also adds anything to our code - as a matter of fact, in many places where we use it we know for sure that there is always a `LabelSelector` specified (e.g. with connectors or node pools). And in places where it might be empty, we can easily replace it with a null check without loosing any functionality. So this PR removes it and uses simple `LabelSelector` instead -> if nothing else the code is simpler, easier to read and with less noise in the IDE warnings.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally