### PR TITLE
Make SharedEnvironmentProvider in AbstractModel class final

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -54,6 +54,7 @@ public abstract class AbstractModel {
     protected final String componentName;
     protected final OwnerReference ownerReference;
     protected final Labels labels;
+    protected final SharedEnvironmentProvider sharedEnvironmentProvider;
 
     // Docker image configuration
     protected String image;
@@ -78,11 +79,6 @@ public abstract class AbstractModel {
      */
     protected ResourceTemplate templateServiceAccount;
     protected ContainerTemplate templateContainer;
-
-    /**
-     * SharedEnvironmentProvider
-     */
-    protected SharedEnvironmentProvider sharedEnvironmentProvider;
 
     /**
      * Constructor


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `SharedEnvironmentProvider` in the `AbstractModel` class is set only form the constructor and can be marked as final variable.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally