### PR TITLE
[ST] Small change in getting pods when using nodepools for KafkaUpgradeDowngradeST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -260,7 +260,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Pre-change ZooKeeper version query returned: " + zkResult);
 
-        String kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0));
+        String kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResource.getKafkaPodName(clusterName, 0));
         LOGGER.info("Pre-change Kafka version query returned: " + kafkaVersionResult);
 
         Map<String, String> zkPods = PodUtils.podSnapshot(Constants.CO_NAMESPACE, zkSelector);
@@ -313,7 +313,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 " was expected", zkResult, is(newVersion.zookeeperVersion()));
 
         // Extract the Kafka version number from the jars in the lib directory
-        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0));
+        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResource.getKafkaPodName(clusterName, 0));
         LOGGER.info("Post-change Kafka version query returned: " + kafkaVersionResult);
 
         assertThat("Kafka container had version " + kafkaVersionResult + " where " + newVersion.version() +


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR changes the way kafka broker pods are returned to get correct kafkaVersion  when using node pools that have different pod name prefix. Getting the name using KafkaResources decides if node pools are used or not and based on this decision returns correct name prefix.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

