### PR TITLE
[ST] Small changes in OLM examples and OLM installation

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -270,6 +270,7 @@ public class SetupClusterOperator {
             .withEnvVars(extraEnvVars)
             .withOperationTimeout(operationTimeout)
             .withReconciliationInterval(reconciliationInterval)
+            .withNamespaceToWatch(this.namespaceInstallTo)
             .build();
 
         olmResource = new OlmResource(olmConfiguration);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/OlmResource.java
@@ -63,8 +63,7 @@ public class OlmResource implements SpecificResourceType {
 
         // Manual installation needs to be approved with a patch
         if (olmConfiguration.getOlmInstallationStrategy() == OlmInstallationStrategy.Manual) {
-            OlmUtils.waitUntilNonUsedInstallPlanIsPresent(olmConfiguration.getNamespaceName());
-            approveNotApprovedInstallPlan();
+            OlmUtils.waitUntilNonUsedInstallPlanWithSpecificCsvIsPresentAndApprove(olmConfiguration.getNamespaceName(), olmConfiguration.getCsvName());
         }
 
         // Make sure that operator will be created

--- a/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/olm/OlmAbstractST.java
@@ -87,8 +87,8 @@ public class OlmAbstractST extends AbstractST {
     void doTestDeployExampleKafkaMirrorMaker2() {
         JsonObject kafkaMirrorMaker2Resource = OlmResource.getExampleResources().get(KafkaMirrorMaker2.RESOURCE_KIND);
         cmdKubeClient().applyContent(kafkaMirrorMaker2Resource.toString()
-                .replace("my-cluster-source-kafka-bootstrap", "my-cluster-kafka-bootstrap")
-                .replace("my-cluster-target-kafka-bootstrap", "my-cluster-kafka-bootstrap"));
+                .replace("cluster-a-kafka-bootstrap", "my-cluster-kafka-bootstrap")
+                .replace("cluster-b-kafka-bootstrap", "my-cluster-kafka-bootstrap"));
         KafkaMirrorMaker2Utils.waitForKafkaMirrorMaker2Ready(Constants.TEST_SUITE_NAMESPACE, kafkaMirrorMaker2Resource.getJsonObject("metadata").getString("name"));
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/OlmUpgradeST.java
@@ -101,7 +101,7 @@ public class OlmUpgradeST extends AbstractUpgradeST {
         KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
             .withProducerName(testStorage.getProducerName())
             .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+            .withNamespaceName(Constants.CO_NAMESPACE)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
             .withTopicName(topicUpgradeName)
             .withMessageCount(testStorage.getMessageCount())

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -14,7 +14,7 @@
 #  --- Prerequisites ---
 
 fromVersion: 0.36.1
-fromOlmChannelName: strimzi-0.36.1
+fromOlmChannelName: strimzi-0.36.x
 fromExamples: strimzi-0.36.1
 fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.36.1/strimzi-0.36.1.zip
 fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.36.1/kafka-versions.yaml


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR consists of 2 different changes with OLM. First change makes sure that strimzi installed via OLM will watch namespace of it's installation - this should fix error with OLM installation in STs (when operator group is deployed it fails as there is no target namespace to watch). Second change is about OLM examples where target and source kafka cluster changed names to cluster-a and cluster-b.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

