### PR TITLE
Fix extra TF parameters in Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,7 +20,7 @@ jobs:
       - automation-check
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: smoke
   ###############################################################################################
 
@@ -36,7 +36,7 @@ jobs:
       - upgrade
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: upgrade
   ###############################################################################################
 
@@ -55,7 +55,7 @@ jobs:
       - ro
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: regression-operators
   ###############################################################################################
 
@@ -74,7 +74,7 @@ jobs:
       - rc
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: regression-components
   ###############################################################################################
 
@@ -93,7 +93,7 @@ jobs:
       - ko
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: kraft-operators
   ###############################################################################################
 
@@ -112,7 +112,7 @@ jobs:
       - kc
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: kraft-components
   ###############################################################################################
 
@@ -128,7 +128,7 @@ jobs:
       - acceptance
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: acceptance
   ###############################################################################################
 
@@ -144,5 +144,5 @@ jobs:
       - sanity
     tf_extra_params:
       test:
-        fmf:
+        tmt:
           name: sanity


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Testing Farm has deprecated ‹test.fmf› in favor of ‹test.tmt› and Packit has already switched to the ‹test.tmt› that is preferred by the Testing Farm.

Combination of both ‹test.tmt› and ‹test.fmf› results in broken TF runs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] n/a

