### PR TITLE
Some trivial fixes to the documentation

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationCustom.adoc
@@ -1,6 +1,6 @@
 To configure custom authentication, set the `type` property to `custom`.
 
-Custom authentication allows for any type of kafka-supported authentication to be used.
+Custom authentication allows for any type of Kafka-supported authentication to be used.
 
 .Example custom OAuth authentication configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/overview/con-security-configuration-authentication.adoc
+++ b/documentation/modules/overview/con-security-configuration-authentication.adoc
@@ -19,4 +19,4 @@ For example, through the User Operator you can create a user representing a clie
 Using OAuth 2.0 token-based authentication, application clients can access Kafka brokers without exposing account credentials.
 An authorization server handles the granting of access and inquiries about access.
 
-Custom authentication allows for any type of kafka-supported authentication. It can provide more flexibility, but also adds complexity.
+Custom authentication allows for any type of Kafka-supported authentication. It can provide more flexibility, but also adds complexity.

--- a/documentation/modules/overview/con-security-configuration-encryption.adoc
+++ b/documentation/modules/overview/con-security-configuration-encryption.adoc
@@ -11,6 +11,7 @@ Communication is always encrypted for communication between:
 
 * Kafka brokers
 * ZooKeeper nodes
+* Kafka brokers and ZooKeeper nodes
 * Operators and Kafka brokers
 * Operators and ZooKeeper nodes
 * Kafka Exporter
@@ -28,5 +29,5 @@ Strimzi uses _Secrets_ to store the certificates and private keys required for m
 A TLS CA (certificate authority) issues certificates to authenticate the identity of a component.
 Strimzi verifies the certificates for the components against the CA certificate.
 
-* Strimzi components are verified against the _cluster CA_ CA
-* Kafka clients are verified against the _clients CA_ CA
+* Strimzi components are verified against the _cluster CA_
+* Kafka clients are verified against the _clients CA_

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -26,7 +26,7 @@ Supported authentication options:
 
 The authentication option you choose depends on how you wish to authenticate client access to Kafka brokers.
 
-NOTE: Try exploring the standard authentication options before using custom authentication. Custom authentication allows for any type of kafka-supported authentication. It can provide more flexibility, but also adds complexity.
+NOTE: Try exploring the standard authentication options before using custom authentication. Custom authentication allows for any type of Kafka-supported authentication. It can provide more flexibility, but also adds complexity.
 
 .Kafka listener authentication options
 image::listener-config-options.png[options for listener authentication configuration]


### PR DESCRIPTION
This PR "fixes" some documentation related stuff I thought was not right/clear.

* some lowercase "kafka-supported"
* a missing line to show encryption between Kafka brokers and ZooKeeper nodes as well
* a doubled "CA" when talking about components verification via TLS certs