### PR TITLE
feat: Kafka versions in status 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Removed support for OpenTracing:
   * The `tracing.type: jaeger` configuration, in `KafkaConnect`, `KafkaMirrorMaker`, `KafkaMirrorMaker2` and `KafkaBridge` resources, is not supported anymore.
   * The OpenTelemetry based tracing is the only available by using `tracing.type: opentelemetry`.
+* Added version fields to the `Kafka` custom resource status to track install and upgrade state
 
 ## 0.36.1
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -22,7 +22,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools", "clusterId", "operatorLastSuccessfulVersion", "kafkaVersion" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
@@ -32,6 +32,8 @@ public class KafkaStatus extends Status {
     private List<UsedNodePoolStatus> kafkaNodePools;
     
     private String clusterId;
+    private String operatorLastSuccessfulVersion;
+    private String kafkaVersion;
 
     @Description("Addresses of the internal and external listeners")
     public List<ListenerStatus> getListeners() {
@@ -58,5 +60,23 @@ public class KafkaStatus extends Status {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    @Description("The Last successful reconciliation was performed by an operator of this version.")
+    public String getOperatorLastSuccessfulVersion() {
+        return operatorLastSuccessfulVersion;
+    }
+
+    public void setOperatorLastSuccessfulVersion(String operatorLastSuccessfulVersion) {
+        this.operatorLastSuccessfulVersion = operatorLastSuccessfulVersion;
+    }
+
+    @Description("The version of Kafka currently deployed in the cluster.")
+    public String getKafkaVersion() {
+        return kafkaVersion;
+    }
+
+    public void setKafkaVersion(String kafkaVersion) {
+        this.kafkaVersion = kafkaVersion;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -62,7 +62,7 @@ public class KafkaStatus extends Status {
         this.clusterId = clusterId;
     }
 
-    @Description("The Last successful reconciliation was performed by an operator of this version.")
+    @Description("The version of the Strimzi Cluster Operator which performed the last successful reconciliation.")
     public String getOperatorLastSuccessfulVersion() {
         return operatorLastSuccessfulVersion;
     }

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -340,6 +340,11 @@
                 <directory>src/main/resources</directory>
             </resource>
             <resource>
+                <!-- separate folder for filtered resources so that non-filtered files don't have their ${} replaced -->
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
                 <directory>..</directory>
                 <includes>
                     <include>kafka-versions.yaml</include>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -76,6 +76,9 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaAssemblyOperator.class.getName());
 
     private static final Properties PROPERTIES = new Properties();
+    /**
+     * version of the operator, project.version in the pom.xml
+     */
     public static final String OPERATOR_VERSION;
 
     static {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -80,7 +80,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     /**
      * version of the operator, project.version in the pom.xml
      */
-    public static final String OPERATOR_VERSION;
+    /* test */ static final String OPERATOR_VERSION;
 
     static {
         InputStream propertiesFile = KafkaAssemblyOperator.class.getResourceAsStream("/.properties");
@@ -159,8 +159,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 status.setClusterId(kafkaAssembly.getStatus().getClusterId());
             }
 
-            if (status.getOperatorLastSuccessfulVersion() == null
-                    && kafkaAssembly.getStatus() != null
+            if (kafkaAssembly.getStatus() != null
                     && kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion() != null
             )  {
                 // If not set in the status prepared by reconciliation but set in the status previously, we copy the
@@ -168,7 +167,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 // reason before setting the cluster ID
                 status.setOperatorLastSuccessfulVersion(kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion());
             }
-
 
             if (status.getKafkaVersion() == null
                     && kafkaAssembly.getStatus() != null

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -56,6 +56,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
@@ -82,13 +83,23 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     public static final String OPERATOR_VERSION;
 
     static {
+        InputStream propertiesFile = KafkaAssemblyOperator.class.getResourceAsStream("/.properties");
         try {
-            PROPERTIES.load(KafkaAssemblyOperator.class.getResourceAsStream("/.properties"));
-            OPERATOR_VERSION = PROPERTIES.getProperty("version");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            try {
+                PROPERTIES.load(propertiesFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } finally {
+            try {
+                propertiesFile.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
+        OPERATOR_VERSION = PROPERTIES.getProperty("version");
     }
+
 
     /* test */ final ClusterOperatorConfig config;
     /* test */ final ResourceOperatorSupplier supplier;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -764,14 +764,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             status.setClusterId(kafka.getStatus().getClusterId());
         }
 
-        // We copy the versions if set
-        if (kafka.getStatus() != null && kafka.getStatus().getOperatorLastSuccessfulVersion() != null)  {
-            status.setOperatorLastSuccessfulVersion(kafka.getStatus().getOperatorLastSuccessfulVersion());
-        }
-        if (kafka.getStatus() != null && kafka.getStatus().getKafkaVersion() != null)  {
-            status.setKafkaVersion(kafka.getStatus().getKafkaVersion());
-        }
-
         return status;
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -278,7 +278,8 @@ public class KafkaReconciler {
                 .compose(i -> sharedKafkaConfigurationCleanup())
                 // This has to run after all possible rolling updates which might move the pods to different nodes
                 .compose(i -> nodePortExternalListenerStatus())
-                .compose(i -> addListenersToKafkaStatus(kafkaStatus));
+                .compose(i -> addListenersToKafkaStatus(kafkaStatus))
+                .compose(i -> updateKafkaVersion(kafkaStatus));
     }
 
     /**
@@ -1004,6 +1005,12 @@ public class KafkaReconciler {
     // Adds prepared Listener Statuses to the Kafka Status instance
     protected Future<Void> addListenersToKafkaStatus(KafkaStatus kafkaStatus) {
         kafkaStatus.setListeners(listenerReconciliationResults.listenerStatuses);
+        return Future.succeededFuture();
+    }
+
+    // Adds Kafka version to the Kafka Status instance
+    protected Future<Void> updateKafkaVersion(KafkaStatus kafkaStatus) {
+        kafkaStatus.setKafkaVersion(kafka.getKafkaVersion().version());
         return Future.succeededFuture();
     }
 

--- a/cluster-operator/src/main/resources-filtered/.properties
+++ b/cluster-operator/src/main/resources-filtered/.properties
@@ -1,0 +1,2 @@
+# properties file to store pom related metadata for consumption in java code
+version=${project.version}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -41,7 +41,6 @@ import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.status.KafkaStatus;
-import io.strimzi.api.kafka.model.status.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.storage.EphemeralStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
@@ -765,18 +764,6 @@ public class KafkaAssemblyOperatorTest {
     public void testUpdateClusterNoop(Params params, VertxTestContext context) {
         setFields(params);
         Kafka kafkaAssembly = getKafkaAssembly("bar");
-        updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
-    }
-
-    @ParameterizedTest
-    @MethodSource("data")
-    public void testUpdateClusterKafkaVersion(Params params, VertxTestContext context) {
-        setFields(params);
-        Kafka kafkaAssembly = getKafkaAssembly("bar");
-        kafkaAssembly.setStatus(new KafkaStatusBuilder()
-                .withKafkaVersion("3.4.0")
-                .withOperatorLastSuccessfulVersion("0.30.0")
-                .build());
         updateCluster(context, getKafkaAssembly("bar"), kafkaAssembly);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -202,7 +202,7 @@ public class KafkaReconcilerStatusTest {
         SecretOperator mockSecretOps = supplier.secretOperations;
         Secret secret = new Secret();
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
-        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconcilerStatusTasks(
@@ -242,7 +242,7 @@ public class KafkaReconcilerStatusTest {
         SecretOperator mockSecretOps = supplier.secretOperations;
         Secret secret = new Secret();
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.failedFuture("expected failure"));
-        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconcilerStatusTasks(
@@ -280,7 +280,7 @@ public class KafkaReconcilerStatusTest {
         SecretOperator mockSecretOps = supplier.secretOperations;
         Secret secret = new Secret();
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
-        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
         // Run the test
         KafkaReconciler reconciler = new MockKafkaReconcilerStatusTasks(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -171,6 +171,9 @@ public class KafkaReconcilerStatusTest {
             // Check ClusterID
             assertThat(status.getClusterId(), is("CLUSTERID"));
 
+            // Check kafka version
+            assertThat(status.getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
+
             // Check model warning conditions
             assertThat(status.getConditions().size(), is(1));
             assertThat(status.getConditions().get(0).getType(), is("Warning"));
@@ -178,6 +181,87 @@ public class KafkaReconcilerStatusTest {
 
             async.flag();
         }));
+    }
+
+    @Test
+    public void testKafkaReconcilerStatusUpdateVersion(VertxTestContext context) {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editOrNewSpec()
+                .editOrNewKafka()
+                .withReplicas(1)
+                .endKafka()
+                .endSpec()
+                .editOrNewStatus()
+                // supportedVersions is an ordered set, get the first element for the lowest kafka version
+                .withKafkaVersion(VERSIONS.supportedVersions().iterator().next())
+                .endStatus()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the secrets needed for Kafka client
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        Secret secret = new Secret();
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+
+        // Run the test
+        KafkaReconciler reconciler = new MockKafkaReconcilerStatusTasks(
+                new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
+                supplier,
+                kafka
+        );
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        reconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(v -> context.verify(() -> {
+
+            // Check kafka version updated to default
+            assertThat(status.getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
+
+            async.flag();
+        })));
+    }
+
+    @Test
+    public void testKafkaReconcilerStatusCustomKafkaVersion(VertxTestContext context) {
+        // supportedVersions is an ordered set, get the first element for the lowest kafka version
+        String lowestSupportedVersion = VERSIONS.supportedVersions().iterator().next();
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editOrNewSpec()
+                .editOrNewKafka()
+                .withVersion(lowestSupportedVersion)
+                .withReplicas(3)
+                .endKafka()
+                .endSpec()
+                .build();
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock the secrets needed for Kafka client
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        Secret secret = new Secret();
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(ClusterOperator.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
+
+        // Run the test
+        KafkaReconciler reconciler = new MockKafkaReconcilerStatusTasks(
+                new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
+                supplier,
+                kafka
+        );
+
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint async = context.checkpoint();
+        reconciler.reconcile(status, Clock.systemUTC())
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                // Check kafka version
+                assertThat(status.getKafkaVersion(), is(lowestSupportedVersion));
+
+                async.flag();
+            })));
     }
 
     @Test
@@ -754,6 +838,7 @@ public class KafkaReconcilerStatusTest {
                     .compose(i -> clusterId(kafkaStatus))
                     .compose(i -> nodePortExternalListenerStatus())
                     .compose(i -> addListenersToKafkaStatus(kafkaStatus))
+                    .compose(i -> updateKafkaVersion(kafkaStatus))
                     .recover(error -> {
                         LOGGER.errorCr(reconciliation, "Reconciliation failed", error);
                         return Future.failedFuture(error);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
@@ -122,10 +122,11 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
     @Test
     public void testWithAllVersionsInCR(VertxTestContext context) {
+        String kafkaVersion = VERSIONS.defaultVersion().version();
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editOrNewSpec()
                     .editOrNewKafka()
-                        .withVersion(VERSIONS.defaultVersion().version())
+                        .withVersion(kafkaVersion)
                         .addToConfig(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, "2.8")
                         .addToConfig(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, "2.8")
                     .endKafka()
@@ -154,7 +155,7 @@ public class KafkaReconcilerUpgradeDowngradeTest {
         KafkaStatus status = new KafkaStatus();
 
         Checkpoint async = context.checkpoint();
-        reconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(i -> context.verify(() -> {
+        reconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(v -> context.verify(() -> {
             assertThat(spsCaptor.getAllValues().size(), is(1));
 
             StrimziPodSet sps = spsCaptor.getValue();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
@@ -122,11 +122,10 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
     @Test
     public void testWithAllVersionsInCR(VertxTestContext context) {
-        String kafkaVersion = VERSIONS.defaultVersion().version();
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editOrNewSpec()
                     .editOrNewKafka()
-                        .withVersion(kafkaVersion)
+                        .withVersion(VERSIONS.defaultVersion().version())
                         .addToConfig(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, "2.8")
                         .addToConfig(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, "2.8")
                     .endKafka()
@@ -155,7 +154,7 @@ public class KafkaReconcilerUpgradeDowngradeTest {
         KafkaStatus status = new KafkaStatus();
 
         Checkpoint async = context.checkpoint();
-        reconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(v -> context.verify(() -> {
+        reconciler.reconcile(status, Clock.systemUTC()).onComplete(context.succeeding(i -> context.verify(() -> {
             assertThat(spsCaptor.getAllValues().size(), is(1));
 
             StrimziPodSet sps = spsCaptor.getValue();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -157,6 +157,7 @@ public class KafkaStatusTest {
             assertThat(status.getObservedGeneration(), is(2L));
             assertThat(status.getClusterId(), is("my-cluster-id"));
             assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+            assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
 
             async.flag();
         })));
@@ -196,6 +197,7 @@ public class KafkaStatusTest {
                 assertThat(status.getClusterId(), is("my-cluster-id"));
 
                 assertThat(status.getOperatorLastSuccessfulVersion(), is(nullValue()));
+                assertThat(status.getKafkaVersion(), is(nullValue()));
 
                 async.flag();
             })));
@@ -249,6 +251,7 @@ public class KafkaStatusTest {
             assertThat(kafkaCaptor.getAllValues().size(), is(0));
 
             assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+            assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
 
             async.flag();
         })));
@@ -308,7 +311,7 @@ public class KafkaStatusTest {
             assertThat(status.getClusterId(), is("my-cluster-id"));
 
             assertThat(status.getOperatorLastSuccessfulVersion(), is(nullValue()));
-
+            assertThat(status.getKafkaVersion(), is(nullValue()));
 
             async.flag();
         })));
@@ -342,7 +345,8 @@ public class KafkaStatusTest {
                                             .withPort(443)
                                             .build())
                                     .build())
-                    .withOperatorLastSuccessfulVersion("old-reconcile-version")
+                    .withKafkaVersion("old-kafka")
+                    .withOperatorLastSuccessfulVersion("old-operator")
                 .endStatus()
                 .build();
 
@@ -380,7 +384,8 @@ public class KafkaStatusTest {
             assertThat(status.getConditions().get(0).getMessage(), is("Something went wrong"));
 
             assertThat(status.getObservedGeneration(), is(2L));
-            assertThat(status.getOperatorLastSuccessfulVersion(), is("old-reconcile-version"));
+            assertThat(status.getKafkaVersion(), is("old-kafka"));
+            assertThat(status.getOperatorLastSuccessfulVersion(), is("old-operator"));
 
             async.flag();
         })));
@@ -480,6 +485,7 @@ public class KafkaStatusTest {
             listeners.add(ls2);
 
             reconcileState.kafkaStatus.setListeners(listeners);
+            reconcileState.kafkaStatus.setKafkaVersion(KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
 
             return Future.succeededFuture();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
@@ -210,12 +211,10 @@ public class KafkaUpgradeDowngradeMockTest {
         initialize(initialKafka)
                 .onComplete(context.succeeding(v -> {
                     context.verify(() -> {
-                        assertThat(
-                                Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
-                                        .getStatus()
-                                        .getKafkaVersion(),
-                                is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)
-                        );
+                        KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+                                .getStatus();
+                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
+                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -225,6 +224,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
                     assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -233,6 +233,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
                     assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -259,6 +260,10 @@ public class KafkaUpgradeDowngradeMockTest {
         initialize(initialKafka)
                 .onComplete(context.succeeding(v -> {
                     context.verify(() -> {
+                        KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+                                .getStatus();
+                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
+                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -266,14 +271,18 @@ public class KafkaUpgradeDowngradeMockTest {
                     });
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
                             KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -303,6 +312,10 @@ public class KafkaUpgradeDowngradeMockTest {
         initialize(initialKafka)
                 .onComplete(context.succeeding(v -> {
                     context.verify(() -> {
+                        KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+                                .getStatus();
+                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
+                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -310,14 +323,18 @@ public class KafkaUpgradeDowngradeMockTest {
                     });
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka1))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
                             KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka2))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -337,6 +354,10 @@ public class KafkaUpgradeDowngradeMockTest {
         Checkpoint reconciliation = context.checkpoint();
         initialize(initialKafka)
                 .onComplete(context.succeeding(v -> {
+                    KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+                            .getStatus();
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     context.verify(() -> {
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -345,14 +366,18 @@ public class KafkaUpgradeDowngradeMockTest {
                     });
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
                             KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -382,6 +407,10 @@ public class KafkaUpgradeDowngradeMockTest {
         initialize(initialKafka)
                 .onComplete(context.succeeding(v -> {
                     context.verify(() -> {
+                        KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
+                                .getStatus();
+                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
+                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -389,7 +418,9 @@ public class KafkaUpgradeDowngradeMockTest {
                     });
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
-                .onComplete(context.succeeding(v -> context.verify(() -> {
+                .onComplete(context.succeeding(status -> context.verify(() -> {
+                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
+                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeMockTest.java
@@ -175,6 +175,11 @@ public class KafkaUpgradeDowngradeMockTest {
                 .build();
     }
 
+    private void assertVersionsInKafkaStatus(KafkaStatus status, String operatorVersion, String kafkaVersion) {
+        assertThat(status.getOperatorLastSuccessfulVersion(), is(operatorVersion));
+        assertThat(status.getKafkaVersion(), is(kafkaVersion));
+    }
+
     private void assertVersionsInStrimziPodSet(String kafkaVersion, String messageFormatVersion, String protocolVersion, String image)  {
         StrimziPodSet sps = supplier.strimziPodSetOperator.client().inNamespace(NAMESPACE).withName(CLUSTER_NAME + "-kafka").get();
         assertThat(sps.getMetadata().getAnnotations().get(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION), is(kafkaVersion));
@@ -213,8 +218,7 @@ public class KafkaUpgradeDowngradeMockTest {
                     context.verify(() -> {
                         KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
                                 .getStatus();
-                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
-                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                        assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -223,8 +227,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -232,8 +235,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -262,8 +264,7 @@ public class KafkaUpgradeDowngradeMockTest {
                     context.verify(() -> {
                         KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
                                 .getStatus();
-                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
-                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                        assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -272,8 +273,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -281,8 +281,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -314,8 +313,7 @@ public class KafkaUpgradeDowngradeMockTest {
                     context.verify(() -> {
                         KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
                                 .getStatus();
-                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
-                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                        assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -356,8 +354,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 .onComplete(context.succeeding(v -> {
                     KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
                             .getStatus();
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
                     context.verify(() -> {
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
@@ -367,8 +364,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -376,8 +372,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 })))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                             KafkaVersionTestUtils.LATEST_FORMAT_VERSION,
                             KafkaVersionTestUtils.LATEST_PROTOCOL_VERSION,
@@ -409,8 +404,7 @@ public class KafkaUpgradeDowngradeMockTest {
                     context.verify(() -> {
                         KafkaStatus status = Crds.kafkaOperation(client).inNamespace(NAMESPACE).withName(CLUSTER_NAME).get()
                                 .getStatus();
-                        assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.LATEST_KAFKA_VERSION));
-                        assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                        assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
                         assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                                 KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,
@@ -419,8 +413,7 @@ public class KafkaUpgradeDowngradeMockTest {
                 }))
                 .compose(v -> operator.createOrUpdate(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME), updatedKafka))
                 .onComplete(context.succeeding(status -> context.verify(() -> {
-                    assertThat(status.getKafkaVersion(), is(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION));
-                    assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
+                    assertVersionsInKafkaStatus(status, KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION,
                             KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION,

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1609,16 +1609,20 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 
 [options="header"]
 |====
-|Property                   |Description
-|conditions          1.2+<.<a|List of status conditions.
+|Property                              |Description
+|conditions                     1.2+<.<a|List of status conditions.
 |xref:type-Condition-{context}[`Condition`] array
-|observedGeneration  1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
+|observedGeneration             1.2+<.<a|The generation of the CRD that was last reconciled by the operator.
 |integer
-|listeners           1.2+<.<a|Addresses of the internal and external listeners.
+|listeners                      1.2+<.<a|Addresses of the internal and external listeners.
 |xref:type-ListenerStatus-{context}[`ListenerStatus`] array
-|kafkaNodePools      1.2+<.<a|List of the KafkaNodePools used by this Kafka cluster.
+|kafkaNodePools                 1.2+<.<a|List of the KafkaNodePools used by this Kafka cluster.
 |xref:type-UsedNodePoolStatus-{context}[`UsedNodePoolStatus`] array
-|clusterId           1.2+<.<a|Kafka cluster Id.
+|clusterId                      1.2+<.<a|Kafka cluster Id.
+|string
+|operatorLastSuccessfulVersion  1.2+<.<a|The Last successful reconciliation was performed by an operator of this version.
+|string
+|kafkaVersion                   1.2+<.<a|The version of Kafka currently deployed in the cluster.
 |string
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1620,7 +1620,7 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |xref:type-UsedNodePoolStatus-{context}[`UsedNodePoolStatus`] array
 |clusterId                      1.2+<.<a|Kafka cluster Id.
 |string
-|operatorLastSuccessfulVersion  1.2+<.<a|The Last successful reconciliation was performed by an operator of this version.
+|operatorLastSuccessfulVersion  1.2+<.<a|The version of the Strimzi Cluster Operator which performed the last successful reconciliation.
 |string
 |kafkaVersion                   1.2+<.<a|The version of Kafka currently deployed in the cluster.
 |string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -6306,4 +6306,10 @@ spec:
                 clusterId:
                   type: string
                   description: Kafka cluster Id.
+                operatorLastSuccessfulVersion:
+                  type: string
+                  description: The Last successful reconciliation was performed by an operator of this version.
+                kafkaVersion:
+                  type: string
+                  description: The version of Kafka currently deployed in the cluster.
               description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -6308,7 +6308,7 @@ spec:
                   description: Kafka cluster Id.
                 operatorLastSuccessfulVersion:
                   type: string
-                  description: The Last successful reconciliation was performed by an operator of this version.
+                  description: The version of the Strimzi Cluster Operator which performed the last successful reconciliation.
                 kafkaVersion:
                   type: string
                   description: The version of Kafka currently deployed in the cluster.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6305,4 +6305,10 @@ spec:
               clusterId:
                 type: string
                 description: Kafka cluster Id.
+              operatorLastSuccessfulVersion:
+                type: string
+                description: The Last successful reconciliation was performed by an operator of this version.
+              kafkaVersion:
+                type: string
+                description: The version of Kafka currently deployed in the cluster.
             description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6307,7 +6307,7 @@ spec:
                 description: Kafka cluster Id.
               operatorLastSuccessfulVersion:
                 type: string
-                description: The Last successful reconciliation was performed by an operator of this version.
+                description: The version of the Strimzi Cluster Operator which performed the last successful reconciliation.
               kafkaVersion:
                 type: string
                 description: The version of Kafka currently deployed in the cluster.


### PR DESCRIPTION
Add new status fields
status.kafkaVersion
status.operatorLastSuccessfulVersion

Add project.version to resources
Edit pre-existing unit tests and add some more.
Note that operator version is reported as x.y.z-SNAPSHOT during development cycle

Contributes to: https://github.com/strimzi/strimzi-kafka-operator/issues/9002

Signed-off-by: Samuel Hawker <sam.b.hawker@gmail.com>
Signed-off-by: Samuel Hawker <samuel.hawker@ibm.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

