### PR TITLE
[systemtest] Remove the workaround for OpenTelemetry and TLS on OCP

### DIFF
--- a/systemtest/src/test/resources/tracing/jaeger-instance.yaml
+++ b/systemtest/src/test/resources/tracing/jaeger-instance.yaml
@@ -10,10 +10,6 @@ spec:
       log-level: debug
       query:
         base-path: /jaeger
-      # explicitly disable TLS, because tracing on some platforms automatically enables TLS, which for us is not supported
-      # until this is resolved (https://github.com/strimzi/strimzi-kafka-operator/issues/7570)
-      collector.grpc.tls.enabled: false
-      reporter.grpc.tls.enabled: false
   ingress:
     openshift: {}
     resources: {}


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR removes the `*.tls.enabled: false` configuration from the `jaeger-instance.yaml`. Previously, we used these because of the issue with TLS connection to the Jaeger endpoint. Now, because we are using OTLP endpoint which is not TLS protected by default, we can remove the workaround.

### Checklist

- [x] Make sure all tests pass