### PR TITLE
refactor: Add minor modifications to KafkaNodePools exception messages

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
@@ -122,7 +122,7 @@ public class NodePoolUtils {
         // If there are no node pools, the rest of the validation makes no sense, so we throw an exception right away
         if (nodePools.isEmpty()
                 || nodePools.stream().noneMatch(np -> np.getSpec().getReplicas() > 0))    {
-            throw new InvalidResourceException("KafkaNodePools are enabled, but the KafkaNodePool for Kafka cluster " + kafka.getMetadata().getName() + " either don't exists or have 0 replicas. " +
+            throw new InvalidResourceException("KafkaNodePools are enabled, but KafkaNodePools for Kafka cluster " + kafka.getMetadata().getName() + " either don't exist or have 0 replicas. " +
                     "Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource.");
         } else {
             List<String> errors = new ArrayList<>();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -545,7 +545,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         if (config.featureGates().kafkaNodePoolsEnabled()
                                 && ReconcilerUtils.nodePoolsEnabled(kafkaAssembly)
                                 && (nodePools == null || nodePools.isEmpty()))  {
-                            throw new InvalidConfigurationException("KafkaNodePools are enabled, but not pools found for Kafka cluster " + name);
+                            throw new InvalidConfigurationException("KafkaNodePools are enabled, but no KafkaNodePools found for Kafka cluster " + name);
                         }
 
                         Map<String, List<String>> currentPods = new HashMap<>();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/NodePoolUtilsTest.java
@@ -539,7 +539,7 @@ public class NodePoolUtilsTest {
                 .build();
 
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> NodePoolUtils.validateNodePools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(poolA), false));
-        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but the KafkaNodePool for Kafka cluster my-cluster either don't exists or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
+        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but KafkaNodePools for Kafka cluster my-cluster either don't exist or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
     }
 
     @Test
@@ -560,13 +560,13 @@ public class NodePoolUtilsTest {
     @Test
     public void testValidationOnlyPoolsWithZeroReplicas()   {
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> NodePoolUtils.validateNodePools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(), false));
-        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but the KafkaNodePool for Kafka cluster my-cluster either don't exists or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
+        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but KafkaNodePools for Kafka cluster my-cluster either don't exist or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
     }
 
     @Test
     public void testValidationIsCalledFromMainMethod()   {
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER));
-        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but the KafkaNodePool for Kafka cluster my-cluster either don't exists or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
+        assertThat(ex.getMessage(), is("KafkaNodePools are enabled, but KafkaNodePools for Kafka cluster my-cluster either don't exist or have 0 replicas. Please make sure at least one KafkaNodePool resource exists, is in the same namespace as the Kafka resource, has at least one replica, and has the strimzi.io/cluster label set to the name of the Kafka resource."));
     }
 
     @Test


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

- Add minor changes to KafkaNodePool InvalidConfiguration/Resource exception messages.
- Add a unit test to validate the exception thrown when no KafkaNodePool resource is found for a KafkaNodePool enabled Kafka cluster.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

