### PR TITLE
docs(node pools): describes the role of reserved.broker-max.id in managing ids

### DIFF
--- a/documentation/modules/configuring/con-config-security-providers.adoc
+++ b/documentation/modules/configuring/con-config-security-providers.adoc
@@ -41,7 +41,7 @@ For more information on the Kubernetes security profiles, see {K8sSecurityStanda
 In the following example, security context is configured for Kafka brokers in the `template` configuration of the `Kafka` resource.  
 Security context is specified at the pod and container level.
 
-[source,yaml]
+[source,yaml,subs="+attributes"]
 .Example `template` configuration for security context
 ----
 apiVersion: {KafkaApiVersion}

--- a/documentation/modules/configuring/proc-managing-node-pools-ids.adoc
+++ b/documentation/modules/configuring/proc-managing-node-pools-ids.adoc
@@ -51,6 +51,27 @@ The default approach is also applied if the assigned range of IDs is misformatte
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* (Optional) Use the `reserved.broker-max.id` configuration property to extend the allowable range for node IDs within your node pools. 
+
+By default, Apache Kafka restricts node IDs to numbers ranging from 0 to 999. 
+To use node ID values greater than 999, add the `reserved.broker-max.id` configuration property to the `Kafka` custom resource and specify the required maximum node ID value.
+
+In this example, the maximum node ID is set at 10000.
+Node IDs can then be assigned up to that value. 
+
+[source,yaml,subs="+attributes"]
+.Example configuration for the maximum node ID number
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    config:
+      reserved.broker.max.id: 10000
+  # ...      
+----
 
 .Procedure
 
@@ -75,6 +96,8 @@ kubectl annotate kafkanodepool pool-b strimzi.io/remove-node-ids="[60-50,9,8,7]"
 ----
 +
 The highest available ID from this range is removed when scaling down `pool-b`.
++
+NOTE: If you want to remove a specific node, you can assign a single node ID to the scaling down annotation: `kubectl annotate kafkanodepool pool-b strimzi.io/remove-node-ids="[3]"`. 
 
 . You can now scale the node pool.
 +
@@ -87,3 +110,17 @@ For more information, see the following:
 --
 +
 On reconciliation, a warning is given if the annotations are misformatted. 
+
+. After you have performed the scaling operation, you can remove the annotation if it's no longer needed.
++
+.Removing the annotation for scaling up 
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafkanodepool pool-a strimzi.io/next-node-ids-
+----
++
+.Removing the annotation for  scaling down 
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafkanodepool pool-b strimzi.io/remove-node-ids-
+----

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -28,9 +28,10 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* (Optional) For scale down operations, xref:proc-managing-node-pools-ids-{context}[you can specify the range of node IDs to use in the operation].
+* (Optional) For scale down operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use in the operation].
 +
-If you have assigned a range of node IDs for the operation, the ID of the node being removed is determined by the sequence of nodes given. 
+If you have assigned a range of node IDs for the operation, the ID of the node being removed is determined by the sequence of nodes given.
+If you have assigned a single node ID, the node with the specified ID is removed.  
 Otherwise, the node with the highest available ID in the node pool is removed.  
 
 .Procedure

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -27,7 +27,7 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* (Optional) For scale up operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use].
+* (Optional) For scale up operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use in the operation].
 +
 If you have assigned a range of node IDs for the operation, the ID of the node being added is determined by the sequence of nodes given. 
 If you have assigned a single node ID, a node is added with the specified ID.

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -27,9 +27,10 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* (Optional) For scale up operations, xref:proc-managing-node-pools-ids-{context}[you can specify the range of node IDs to use].
+* (Optional) For scale up operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use].
 +
 If you have assigned a range of node IDs for the operation, the ID of the node being added is determined by the sequence of nodes given. 
+If you have assigned a single node ID, a node is added with the specified ID.
 Otherwise, the lowest available node ID across the cluster is used.  
 
 .Procedure


### PR DESCRIPTION
**Documentation**

If you set `reserved.broker.max.id` to greater than the default (999), you can then add bigger number ranges when assigning node ID ranges to node pools.

This PR describes in the documentation the role this property plays when managing node IDs for node pools.
The PR also mentions in the node pool scaling procedure that you can remove the annotation when the operation is complete. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

