### PR TITLE
docs(crds): updates the warning on deleting crds

### DIFF
--- a/documentation/assemblies/managing/assembly-uninstalling.adoc
+++ b/documentation/assemblies/managing/assembly-uninstalling.adoc
@@ -20,7 +20,15 @@ Such resources include:
 
 These are resources referenced by `Kafka`, `KafkaConnect`, `KafkaMirrorMaker`, or `KafkaBridge` configuration.
 
-WARNING: Deleting a `CustomResourceDefinition` results in the garbage collection of the corresponding custom resources (`Kafka`, `KafkaConnect`, `KafkaMirrorMaker`, or `KafkaBridge`) and dependent resources  (`Deployment`, `Pod`, `Service`, and so on).
+[WARNING]
+====
+*Deleting CRDs and related custom resources*
+
+When a `CustomResourceDefinition` is deleted, custom resources of that type are also deleted. 
+This includes the `Kafka`, `KafkaConnect`, `KafkaMirrorMaker`, and `KafkaBridge` resources managed by Strimzi, as well as the `StrimziPodSet` resource Strimzi uses to manage the pods of the Kafka components. 
+In addition, any Kubernetes resources created by these custom resources, such as `Deployment`, `Pod`, `Service`, and `ConfigMap` resources, are also removed.
+Always exercise caution when deleting these resources to avoid unintended data loss.
+====
 
 //Uninstall from command line
 include::../../modules/deploying/proc-uninstalling.adoc[leveloffset=+1]

--- a/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
+++ b/documentation/modules/deploying/con-deploy-custom-resources-example.adoc
@@ -5,6 +5,7 @@
 [id='con-custom-resources-example-{context}']
 = Strimzi custom resource example
 
+[role="_abstract"]
 CRDs require a one-time installation in a cluster to define the schemas used to instantiate and manage Strimzi-specific resources.
 
 After a new custom resource type is added to your cluster by installing a CRD, you can create instances of the resource based on its specification.
@@ -16,8 +17,6 @@ NOTE: Access to manage custom resources is limited to Strimzi administrators. Fo
 A CRD defines a new `kind` of resource, such as `kind:Kafka`, within a Kubernetes cluster.
 
 The Kubernetes API server allows custom resources to be created based on the `kind` and understands from the CRD how to validate and store the custom resource when it is added to the Kubernetes cluster.
-
-WARNING: When a `CustomResourceDefinition` is deleted, custom resources of that type are also deleted. Additionally, Kubernetes resources created by the custom resource are also deleted, such as `Deployment`, `Pod`, `Service` and `ConfigMap` resources.
 
 Each Strimzi-specific custom resource conforms to the schema defined by the CRD for the resource's `kind`.
 The custom resources for Strimzi components have common configuration properties, which are defined under `spec`.


### PR DESCRIPTION
**Documentation**

Updates the warning about deleting CRDs in the documentation describing how to uninstall Strimzi.
Removes a similar warning--not required-- from the overview of Strimzi custom resources.

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

