### PR TITLE
Update Kubernetes Config Provider to 1.1.2

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -21,7 +21,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -21,7 +21,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Strimzi Kubernetes Config Provider to a new version 1.1.2 which fixes logging in case of Kubernetes client errors.

_This is currently a Draft PR based on the RC1 used to run the tests._

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally