### PR TITLE
docs(uto): command to remove finalizers from topics

### DIFF
--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -54,15 +54,14 @@ If the deletion fails, it is shown in the status of the resource.
 
 When the finalization tasks are successfully executed, the finalizer is removed from the metadata, and the resource is fully deleted.  
 
-Finalizers also prevent related resources from being deleted. 
+Finalizers also serve to prevent related resources from being deleted. 
 If the unidirectional Topic Operator is not running, it won't be able to remove the `metadata.finalizer`. 
-Consequently, an attempt to delete the namespace that contains the `KafkaTopic` resource won't complete until either the operator is restarted, or the finalizer is otherwise removed (for example using `kubectl edit`). 
+And any attempt to delete the `KafkaTopic` resources directly or by deleting the namespace will result in failure or timeout. 
 
 == Removing finalizers
 
-If you want to bypass the finalization process when deleting topics, you can remove the finalizers.   
-You might want to do this to delete topics more quickly; or to handle certain topics without invoking cleanup operations.
-Perhaps the cleanup operation associated with the finalization process is not completing as expected.
+If you want to bypass the finalization process when deleting topics, you have to remove the finalizers.   
+You can do this manually by editing the resources directly or by using a command.
 
 To remove finalizers on all topics, use the following command:
 

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -55,7 +55,7 @@ If the deletion fails, it is shown in the status of the resource.
 When the finalization tasks are successfully executed, the finalizer is removed from the metadata, and the resource is fully deleted.  
 
 Finalizers also serve to prevent related resources from being deleted. 
-If the unidirectional Topic Operator is not running, it won't be able to remove the `metadata.finalizer`. 
+If the unidirectional Topic Operator is not running, it won't be able to remove its finalizer from the `metadata.finalizers`. 
 And any attempt to delete the `KafkaTopic` resources directly or by deleting the namespace will result in failure or timeout. 
 
 == Removing finalizers
@@ -81,5 +81,7 @@ kubectl get kt <topic_name> -o=json | jq '.metadata.finalizers = null' | kubectl
 ----
 
 After running the command, you can go ahead and delete the topics.
+Alternatively, if the topics were already being deleted but were blocked due to outstanding finalizers then their deletion should complete.
 
-WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed.
+WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed. 
+For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related topic in Kafka won't be deleted.  

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -24,8 +24,8 @@ kind: KafkaTopic
 metadata:
   generation: 1
   name: my-topic-1
-  finalizer: 
-    strimzi.io/topic-operator
+  finalizers: 
+    - strimzi.io/topic-operator
   labels:
     strimzi.io/cluster: my-cluster
 ----
@@ -42,8 +42,8 @@ kind: KafkaTopic
 metadata:
   generation: 1
   name: my-topic-1
-  finalizer: 
-    strimzi.io/topic-operator
+  finalizers: 
+    - strimzi.io/topic-operator
   labels:
     strimzi.io/cluster: my-cluster
   deletionTimestamp: 20230301T000000.000  
@@ -56,11 +56,11 @@ When the finalization tasks are successfully executed, the finalizer is removed 
 
 Finalizers also serve to prevent related resources from being deleted. 
 If the unidirectional Topic Operator is not running, it won't be able to remove its finalizer from the `metadata.finalizers`. 
-And any attempt to delete the `KafkaTopic` resources directly or by deleting the namespace will result in failure or timeout. 
+And any attempt to directly delete the `KafkaTopic` resources or the namespace will fail or timeout, leaving the namespace in a stuck terminating state.
 
 == Removing finalizers
 
-If you want to bypass the finalization process when deleting topics, you have to remove the finalizers.   
+If the Topic Operator is not running, and you want to bypass the finalization process when deleting topics, you have to remove the finalizers.   
 You can do this manually by editing the resources directly or by using a command.
 
 To remove finalizers on all topics, use the following command:
@@ -84,4 +84,4 @@ After running the command, you can go ahead and delete the topics.
 Alternatively, if the topics were already being deleted but were blocked due to outstanding finalizers then their deletion should complete.
 
 WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed. 
-For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related topic in Kafka won't be deleted.  
+For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related Kafka topic won't be deleted.  

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 Unidirectional topic management supports the deletion of topics managed through the `KafkaTopic` resource with or without Kubernetes finalizers.
-This is controlled by the `STRIMZI_USE_FINALIZERS` Topic Operator environment variable.
+This is determined by the `STRIMZI_USE_FINALIZERS` Topic Operator environment variable.
 By default, this is set to `true`, though it can be set to `false` in the Topic Operator `env` configuration if you do not want the Topic Operator to add finalizers.
 
 NOTE: Unidirectional topic management is available as a preview. 
@@ -57,3 +57,30 @@ When the finalization tasks are successfully executed, the finalizer is removed 
 Finalizers also prevent related resources from being deleted. 
 If the unidirectional Topic Operator is not running, it won't be able to remove the `metadata.finalizer`. 
 Consequently, an attempt to delete the namespace that contains the `KafkaTopic` resource won't complete until either the operator is restarted, or the finalizer is otherwise removed (for example using `kubectl edit`). 
+
+== Removing finalizers
+
+If you want to bypass the finalization process when deleting topics, you can remove the finalizers.   
+You might want to do this to delete topics more quickly; or to handle certain topics without invoking cleanup operations.
+Perhaps the cleanup operation associated with the finalization process is not completing as expected.
+
+To remove finalizers on all topics, use the following command:
+
+.Removing finalizers on topics
+[source,shell]
+----
+kubectl get kt -o=json | jq '.items[].metadata.finalizers = null' | kubectl apply -f -
+----
+
+The command uses the `jq` tool to modify the `KafkaTopic` (`kt`) resources by setting the finalizers to `null`.
+You can also use the command for a specific topic:
+
+.Removing a finalizer on a specific topic
+[source,shell]
+----
+kubectl get kt <topic_name> -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -
+----
+
+After running the command, you can go ahead and delete the topics.
+
+WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed.


### PR DESCRIPTION
**Documentation**

Adds a *Removing finalizers* section to the UTO content related to deleting managed topics.
Clarifies the reasons for removing finalizers (with caution) and shows the command to remove finalizers. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

