### PR TITLE
Add support for infinite auto-restarting of KafkaConnect connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Changes, deprecations and removals
 
 * **The default behavior of the Kafka Connect connector auto-restart has changed.**
-  When the auto-restart feature is enabled in `KafkaConnector` or `KafkaMirrorMaker2` custom resources, it will not continue to restart the connectors forever and not stop after 7 restarts.
+  When the auto-restart feature is enabled in `KafkaConnector` or `KafkaMirrorMaker2` custom resources, it will now continue to restart the connectors indefinitely rather than stopping after 7 restarts, as previously.
   If you want to use the original behaviour, use the `.spec.autoRestart.maxRestarts` option to configure the maximum number of restarts.
   For example:
   ```yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 ### Changes, deprecations and removals
 
 * **The default behavior of the Kafka Connect connector auto-restart has changed.**
-  When the auto-restart feature is enabled, it will not continue to restart the connectors forever and not stop after 7 restarts.
-  If you want to use the original behaviour, use the `.spec.autoRestart.maxRestarts` option to configure the maximal number of restarts.
+  When the auto-restart feature is enabled in `KafkaConnector` or `KafkaMirrorMaker2` custom resources, it will not continue to restart the connectors forever and not stop after 7 restarts.
+  If you want to use the original behaviour, use the `.spec.autoRestart.maxRestarts` option to configure the maximum number of restarts.
   For example:
   ```yaml
   apiVersion: kafka.strimzi.io/v1beta2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,28 @@
   * The `tracing.type: jaeger` configuration, in `KafkaConnect`, `KafkaMirrorMaker`, `KafkaMirrorMaker2` and `KafkaBridge` resources, is not supported anymore.
   * The OpenTelemetry based tracing is the only available by using `tracing.type: opentelemetry`.
 * Added version fields to the `Kafka` custom resource status to track install and upgrade state
+* Support for infinite auto-restart of Kafka Connect connectors
 
 ### Changes, deprecations and removals
+
+* **The default behavior of the Kafka Connect connector auto-restart has changed.**
+  When the auto-restart feature is enabled, it will not continue to restart the connectors forever and not stop after 7 restarts.
+  If you want to use the original behaviour, use the `.spec.autoRestart.maxRestarts` option to configure the maximal number of restarts.
+  For example:
+  ```yaml
+  apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaConnector
+  metadata:
+    labels:
+      strimzi.io/cluster: my-connect
+    name: echo-sink-connector
+  spec:
+    # ...
+    autoRestart:
+      enabled: true
+      maxRestarts: 7
+    # ...
+  ```
 * The automatic configuration of Cruise Control CPU capacity has been changed in this release:
   * There are three ways to configure Cruise Control CPU capacity values:
     * `.spec.cruiseControl.brokerCapacity` (for all brokers)

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -43,9 +43,9 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
         this.enabled = enabled;
     }
 
-    @Description("Maximum number of connector restarts that the operator will try. " +
-            "If the connector is still in failed state afterwards, it has to be restarted manually by the user. " +
-            "Defaults to unlimited number of restarts.")
+    @Description("The maximum number of connector restarts that the operator will try. " +
+            "If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. " +
+            "Defaults to an unlimited number of restarts.")
     public Integer getMaxRestarts() {
         return maxRestarts;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
@@ -23,11 +24,15 @@ import java.util.Map;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"enabled", "maxRestarts"})
 @EqualsAndHashCode
 public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
+
     private boolean enabled = true;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
+    private Integer maxRestarts;
+
+    private final Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Whether automatic restart for failed connectors and tasks should be enabled or disabled")
     public boolean isEnabled() {
@@ -36,6 +41,17 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    @Description("Maximal number of connector restarts that the operator will try. " +
+            "If the connector is still in failed state afterwards, it has to be restarted manually by the user. " +
+            "Defaults to unlimited number of restarts.")
+    public Integer getMaxRestarts() {
+        return maxRestarts;
+    }
+
+    public void setMaxRestarts(Integer maxRestarts) {
+        this.maxRestarts = maxRestarts;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AutoRestart.java
@@ -43,7 +43,7 @@ public class AutoRestart implements UnknownPropertyPreserving, Serializable {
         this.enabled = enabled;
     }
 
-    @Description("Maximal number of connector restarts that the operator will try. " +
+    @Description("Maximum number of connector restarts that the operator will try. " +
             "If the connector is still in failed state afterwards, it has to be restarted manually by the user. " +
             "Defaults to unlimited number of restarts.")
     public Integer getMaxRestarts() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -597,7 +597,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * {@code autoRestartBackOffInterval} and based on the {@code maxRestarts} parameter.
      *
      * @param autoRestartStatus     Status field with auto-restart status
-     * @param maxRestarts           Maximal number of restarts (or null for unlimited restarts)
+     * @param maxRestarts           Maximum number of restarts (or null for unlimited restarts)
      *
      * @return True if the connector should be auto-restarted right now. False otherwise.
      */
@@ -612,7 +612,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             var minutesSinceLastRestart = StatusUtils.minutesDifferenceUntilNow(StatusUtils.isoUtcDatetime(autoRestartStatus.getLastRestartTimestamp()));
 
             return (maxRestarts == null || count < maxRestarts)
-                    && minutesSinceLastRestart >= autoRestartBackOffInterval(count);
+                    && minutesSinceLastRestart >= nextAutoRestartBackOffIntervalInMinutes(count);
         }
     }
 
@@ -625,7 +625,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      *
      * @return  Number of minutes after which the next restart should happen
      */
-    private int autoRestartBackOffInterval(int restartCount)    {
+    private int nextAutoRestartBackOffIntervalInMinutes(int restartCount)    {
         return Math.min(restartCount * restartCount + restartCount, 60);
     }
 
@@ -645,7 +645,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             // There are previous auto-restarts => we check if it is time to reset the status
             long minutesSinceLastRestart = StatusUtils.minutesDifferenceUntilNow(StatusUtils.isoUtcDatetime(autoRestartStatus.getLastRestartTimestamp()));
 
-            return minutesSinceLastRestart > autoRestartBackOffInterval(autoRestartStatus.getCount());
+            return minutesSinceLastRestart > nextAutoRestartBackOffIntervalInMinutes(autoRestartStatus.getCount());
         } else {
             // There are no previous restarts => nothing to reset
             return false;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -594,7 +594,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
     /**
      * Checks whether it is time for another connector restart. The decision is made based on the timing provided by
-     * {@code autoRestartBackOffInterval} and based on the {@code maxRestarts} parameter.
+     * {@code autoRestartBackOffInterval} and the value specified for the {@code maxRestarts} parameter.
      *
      * @param autoRestartStatus     Status field with auto-restart status
      * @param maxRestarts           Maximum number of restarts (or null for unlimited restarts)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -529,7 +529,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
 
                      if (needsRestart)    {
                          // Connector or task failed and we should check it for auto-restart
-                         if (shouldAutoRestart(previousAutoRestartStatus))    {
+                         if (shouldAutoRestart(previousAutoRestartStatus, connectorSpec.getAutoRestart().getMaxRestarts()))    {
                              // There are failures, and it is a time to restart the connector now
                              metrics().connectorsAutoRestartsCounter(reconciliation.namespace()).increment();
                              return autoRestartConnector(reconciliation, host, apiClient, connectorName, status, previousAutoRestartStatus);
@@ -593,14 +593,15 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     /**
-     * Connector or tasks failed should only restart at minute 0, 2, 6, 12, 20, 30 and 42. This method checks if there
-     * is time for another restart.
+     * Checks whether it is time for another connector restart. The decision is made based on the timing provided by
+     * {@code autoRestartBackOffInterval} and based on the {@code maxRestarts} parameter.
      *
      * @param autoRestartStatus     Status field with auto-restart status
+     * @param maxRestarts           Maximal number of restarts (or null for unlimited restarts)
      *
-     * @return  True if the connector should be auto-restarted right now. False otherwise.
+     * @return True if the connector should be auto-restarted right now. False otherwise.
      */
-    /* test */ boolean shouldAutoRestart(AutoRestartStatus autoRestartStatus) {
+    /* test */ boolean shouldAutoRestart(AutoRestartStatus autoRestartStatus, Integer maxRestarts) {
         if (autoRestartStatus == null
                 || autoRestartStatus.getLastRestartTimestamp() == null) {
             // If there is no previous auto.restart status or timestamp, we always restart it
@@ -610,21 +611,22 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             var count = autoRestartStatus.getCount();
             var minutesSinceLastRestart = StatusUtils.minutesDifferenceUntilNow(StatusUtils.isoUtcDatetime(autoRestartStatus.getLastRestartTimestamp()));
 
-            return count < 7 && minutesSinceLastRestart >= autoRestartBackOffInterval(count);
+            return (maxRestarts == null || count < maxRestarts)
+                    && minutesSinceLastRestart >= autoRestartBackOffInterval(count);
         }
     }
 
     /**
      * Calculates the back-off interval for auto-restarting the connectors. It is calculated as (n^2 + n) where n is the
-     * number of previous restarts. As a result, the restarts should be done after 0, 2, 6, 12, 20, 30 and 42 minutes
-     * (there are always only up to 7 restarts).
+     * number of previous restarts, but is capped at max 60 minutes. As a result, the restarts should be done after 0,
+     * 2, 6, 12, 20, 30, 42, and 56 minutes and then every 60 minutes.
      *
      * @param restartCount  Number of restarts already applied to the connector
      *
      * @return  Number of minutes after which the next restart should happen
      */
     private int autoRestartBackOffInterval(int restartCount)    {
-        return restartCount * restartCount + restartCount;
+        return Math.min(restartCount * restartCount + restartCount, 60);
     }
 
     /**
@@ -707,11 +709,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     /**
-     * Return the ID of the connector task to be restarted if the provided KafkaConnector resource instance has the strimzio.io/restart-task annotation
+     * Return the ID of the connector task to be restarted if the provided KafkaConnector resource instance has the strimzi.io/restart-task annotation
      *
      * @param resource resource instance to check
      * @param connectorName KafkaConnector resource instance to check
-     * @return the ID of the task to be restarted if the provided KafkaConnector resource instance has the strimzio.io/restart-task annotation or -1 otherwise.
+     * @return the ID of the task to be restarted if the provided KafkaConnector resource instance has the strimzi.io/restart-task annotation or -1 otherwise.
      */
     @SuppressWarnings({ "rawtypes" })
     protected int getRestartTaskAnnotationTaskID(CustomResource resource, String connectorName) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
@@ -70,35 +70,56 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
             .withCount(1)
             .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(3).format(DateTimeFormatter.ISO_INSTANT))
             .build();
-        assertThat(op.shouldAutoRestart(autoRestartStatus), is(true));
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(true));
 
         // Should not restart before minute 2 when auto restart count is 1
         autoRestartStatus =  new AutoRestartStatusBuilder()
             .withCount(1)
             .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1).format(DateTimeFormatter.ISO_INSTANT))
             .build();
-        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(false));
 
         // Should restart after minute 12 when auto restart count is 3
         autoRestartStatus =  new AutoRestartStatusBuilder()
             .withCount(3)
             .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(13).format(DateTimeFormatter.ISO_INSTANT))
             .build();
-        assertThat(op.shouldAutoRestart(autoRestartStatus), is(true));
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(true));
 
         // Should not restart before minute 12 when auto restart count is 3
         autoRestartStatus =  new AutoRestartStatusBuilder()
             .withCount(3)
             .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(DateTimeFormatter.ISO_INSTANT))
             .build();
-        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(false));
+
+        // Should restart after minute 61 when auto restart count is 25
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(25)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(61).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(true));
+
+        // Should not restart after 59 minutes when auto restart count is 25
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(25)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(59).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus, null), is(false));
 
         // Should not restart after 6 attempts
         autoRestartStatus =  new AutoRestartStatusBuilder()
             .withCount(7)
             .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusDays(1).format(DateTimeFormatter.ISO_INSTANT))
             .build();
-        assertThat(op.shouldAutoRestart(autoRestartStatus), is(false));
+        assertThat(op.shouldAutoRestart(autoRestartStatus, 7), is(false));
+
+        // Should restart after 6 attempts when maxRestarts set to higher number
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(7)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusDays(1).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldAutoRestart(autoRestartStatus, 8), is(true));
 
         context.completeNow();
     }
@@ -135,6 +156,20 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(3)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+
+        // Should reset after 60 minutes when auto restart count is 25
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(25)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(61).format(DateTimeFormatter.ISO_INSTANT))
+                .build();
+        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+
+        // Should not reset after 59 minutes when auto restart count is 25
+        autoRestartStatus =  new AutoRestartStatusBuilder()
+                .withCount(25)
+                .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(59).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
         assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
 

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -3,8 +3,8 @@ Configures automatic restarts for connectors and tasks that are in a `FAILED` st
 When enabled, a back-off algorithm applies the automatic restart to each failed connector and its tasks.
 The back-off is calculated using the formula `n * n + n` where `n` is number of previous restarts and is capped at 60 minutes as a maximum.
 That means that the restarts will be done immediately and then after 2, 6, 12, 20, 30, 42, 56, and then every 60 minutes.
-By default, Strimzi will be restarting the connector and its tasks forever.
-If you want, you can use the `maxRestarts` field to set the maximal number of restarts.
+By default, Strimzi will restart the connector and its tasks forever.
+If you want, you can use the `maxRestarts` field to set the maximum number of restarts.
 When `maxRestarts` are used and the connector fails even after the final attempt, you will have to restart it manually.
 
 For Kafka Connect connectors, use the `autoRestart` property of the `KafkaConnector` resource to enable automatic restarts of failed connectors and tasks.
@@ -21,7 +21,7 @@ spec:
     enabled: true
 ----
 
-If desired, you can also set the maximal number of restarts.
+If desired, you can also set the maximum number of restarts.
 
 .Enabling automatic restarts of failed connectors for Kafka Connect with limited number of restarts
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,11 +1,12 @@
 Configures automatic restarts for connectors and tasks that are in a `FAILED` state.
 
 When enabled, a back-off algorithm applies the automatic restart to each failed connector and its tasks.
-The back-off is calculated using the formula `n * n + n` where `n` is number of previous restarts and is capped at 60 minutes as a maximum.
-That means that the restarts will be done immediately and then after 2, 6, 12, 20, 30, 42, 56, and then every 60 minutes.
-By default, Strimzi will restart the connector and its tasks forever.
-If you want, you can use the `maxRestarts` field to set the maximum number of restarts.
-When `maxRestarts` are used and the connector fails even after the final attempt, you will have to restart it manually.
+An incremental back-off interval is calculated using the formula `n * n + n` where `n` represents the number of previous restarts.
+This interval is capped at a maximum of 60 minutes.
+Consequently, a restart occurs immediately, followed by restarts after 2, 6, 12, 20, 30, 42, 56 minutes, and then at 60-minute intervals.
+By default, Strimzi initiates restarts of the connector and its tasks indefinitely.
+However, you can use the `maxRestarts` property to set a maximum on the number of restarts.
+If `maxRestarts` is configured and the connector still fails even after the final restart attempt, you must then restart the connector manually.
 
 For Kafka Connect connectors, use the `autoRestart` property of the `KafkaConnector` resource to enable automatic restarts of failed connectors and tasks.
 
@@ -21,7 +22,7 @@ spec:
     enabled: true
 ----
 
-If desired, you can also set the maximum number of restarts.
+If you prefer, you can also set a maximum limit on the number of restarts.
 
 .Enabling automatic restarts of failed connectors for Kafka Connect with limited number of restarts
 [source,yaml,subs="attributes+"]

--- a/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AutoRestart.adoc
@@ -1,14 +1,11 @@
 Configures automatic restarts for connectors and tasks that are in a `FAILED` state.
 
 When enabled, a back-off algorithm applies the automatic restart to each failed connector and its tasks.
-
-The operator attempts an automatic restart on reconciliation. 
-If the first attempt fails, the operator makes up to six more attempts. 
-The duration between each restart attempt increases from 2 to 30 minutes.
-After each restart, failed connectors and tasks transit from `FAILED` to `RESTARTING`.
-If the restart fails after the final attempt, there is likely to be a problem with the connector configuration. 
-The connector and tasks remain in a `FAILED` state and you have to restart them manually.
-You can do this by annotating the `KafKaConnector` custom resource with `strimzi.io/restart: "true"`.
+The back-off is calculated using the formula `n * n + n` where `n` is number of previous restarts and is capped at 60 minutes as a maximum.
+That means that the restarts will be done immediately and then after 2, 6, 12, 20, 30, 42, 56, and then every 60 minutes.
+By default, Strimzi will be restarting the connector and its tasks forever.
+If you want, you can use the `maxRestarts` field to set the maximal number of restarts.
+When `maxRestarts` are used and the connector fails even after the final attempt, you will have to restart it manually.
 
 For Kafka Connect connectors, use the `autoRestart` property of the `KafkaConnector` resource to enable automatic restarts of failed connectors and tasks.
 
@@ -22,6 +19,21 @@ metadata:
 spec:
   autoRestart:
     enabled: true
+----
+
+If desired, you can also set the maximal number of restarts.
+
+.Enabling automatic restarts of failed connectors for Kafka Connect with limited number of restarts
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaConnectorApiVersion}
+kind: KafkaConnector
+metadata:
+  name: my-source-connector
+spec:
+  autoRestart:
+    enabled: true
+    maxRestarts: 10
 ----
 
 For MirrorMaker 2, use the `autoRestart` property of connectors in the `KafkaMirrorMaker2` resource to enable automatic restarts of failed connectors and tasks.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3119,7 +3119,7 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 |Property            |Description
 |enabled      1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled.
 |boolean
-|maxRestarts  1.2+<.<a|Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts.
+|maxRestarts  1.2+<.<a|Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3119,7 +3119,7 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 |Property            |Description
 |enabled      1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled.
 |boolean
-|maxRestarts  1.2+<.<a|Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts.
+|maxRestarts  1.2+<.<a|The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts.
 |integer
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3116,9 +3116,11 @@ include::../api/io.strimzi.api.kafka.model.AutoRestart.adoc[leveloffset=+1]
 
 [options="header"]
 |====
-|Property        |Description
-|enabled  1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+|Property            |Description
+|enabled      1.2+<.<a|Whether automatic restart for failed connectors and tasks should be enabled or disabled.
 |boolean
+|maxRestarts  1.2+<.<a|Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts.
+|integer
 |====
 
 [id='type-KafkaConnectorStatus-{context}']

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -221,7 +221,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <16> Cluster alias for the target cluster used by the MirrorMaker 2 connectors.
 <17> Configuration for the `MirrorSourceConnector` that creates remote topics. The `config` overrides the default configuration options.
 <18> The maximum number of tasks that the connector may create. Tasks handle the data replication and run in parallel. If the infrastructure supports the processing overhead, increasing this value can improve throughput. Kafka Connect distributes the tasks between members of the cluster. If there are more tasks than workers, workers are assigned multiple tasks. For sink connectors, aim to have one task for each topic partition consumed. For source connectors, the number of tasks that can run in parallel may also depend on the external system. The connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
-<19> Enables automatic restarts of failed connectors and tasks. Up to seven restart attempts are made, after which restarts must be made manually.
+<19> Enables automatic restarts of failed connectors and tasks.
 <20> Replication factor for mirrored topics created at the target cluster.
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When ACL rules synchronization is enabled, ACLs are applied to synchronized topics. The default is `true`. This feature is not compatible with the User Operator. If you are using the User Operator, set this property to `false`.

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -15,10 +15,9 @@ You remove a connector by deleting its corresponding `KafkaConnector`.
 
 `KafkaConnector` resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
-In the configuration shown in this procedure, the `autoRestart` property is set to `true`.
-This enables automatic restarts of failed connectors and tasks. 
-Up to seven restart attempts are made, after which restarts must be made manually.
-You annotate the `KafkaConnector` resource to xref:proc-manual-restart-connector-str[restart a connector] or xref:proc-manual-restart-connector-task-str[restart a connector task] manually.
+In the configuration shown in this procedure, the `autoRestart` features is enabled (`enabled: true`).
+This enables automatic restarts of failed connectors and tasks.
+You can also annotate the `KafkaConnector` resource to xref:proc-manual-restart-connector-str[restart a connector] or xref:proc-manual-restart-connector-task-str[restart a connector task] manually.
 
 .Example connectors
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -68,7 +68,7 @@ spec:
                       description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                     maxRestarts:
                       type: integer
-                      description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                      description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                   description: Automatic restart of connector and tasks configuration.
                 config:
                   x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -68,7 +68,7 @@ spec:
                       description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                     maxRestarts:
                       type: integer
-                      description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                      description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                   description: Automatic restart of connector and tasks configuration.
                 config:
                   x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -66,6 +66,9 @@ spec:
                     enabled:
                       type: boolean
                       description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                    maxRestarts:
+                      type: integer
+                      description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                   description: Automatic restart of connector and tasks configuration.
                 config:
                   x-kubernetes-preserve-unknown-fields: true

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -265,7 +265,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -290,7 +290,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -315,7 +315,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -265,7 +265,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -290,7 +290,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -315,7 +315,7 @@ spec:
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                               maxRestarts:
                                 type: integer
-                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                                description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -263,6 +263,9 @@ spec:
                               enabled:
                                 type: boolean
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                              maxRestarts:
+                                type: integer
+                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -285,6 +288,9 @@ spec:
                               enabled:
                                 type: boolean
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                              maxRestarts:
+                                type: integer
+                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean
@@ -307,6 +313,9 @@ spec:
                               enabled:
                                 type: boolean
                                 description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                              maxRestarts:
+                                type: integer
+                                description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
                           pause:
                             type: boolean

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -65,6 +65,9 @@ spec:
                   enabled:
                     type: boolean
                     description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                  maxRestarts:
+                    type: integer
+                    description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -67,7 +67,7 @@ spec:
                     description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                   maxRestarts:
                     type: integer
-                    description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                    description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -67,7 +67,7 @@ spec:
                     description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                   maxRestarts:
                     type: integer
-                    description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                    description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -264,7 +264,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -289,7 +289,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -314,7 +314,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -264,7 +264,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -289,7 +289,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -314,7 +314,7 @@ spec:
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
                             maxRestarts:
                               type: integer
-                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
+                              description: "Maximum number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -262,6 +262,9 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -284,6 +287,9 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
@@ -306,6 +312,9 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "Maximal number of connector restarts that the operator will try. If the connector is still in failed state afterwards, it has to be restarted manually by the user. Defaults to unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [Strimzi Proposal #55](https://github.com/strimzi/proposals/blob/main/055-infinite-auto-restart-of-Kafka-connectors.md) which adds support for infinite auto-restarts of KafkaConnectors and KafkaMirrorMaker2 connectors.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md