### PR TITLE
Update Cruise Control & Kaniko and remove the SnakeYAML override

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.4.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.13.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.124</cruise-control.version>
+        <cruise-control.version>2.5.125</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.13.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.124</cruise-control.version>
+        <cruise-control.version>2.5.125</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.124</cruise-control.version>
+        <cruise-control.version>2.5.125</cruise-control.version>
     </properties>
 
     <repositories>
@@ -31,13 +31,6 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
-        </dependency>
-        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once swagger uses it out of the box -->
-        <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.14.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.15.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/pom.xml
+++ b/pom.xml
@@ -132,9 +132,6 @@
         <fasterxml.jackson-databind.version>2.15.2</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.15.2</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.15.2</fasterxml.jackson-annotations.version>
-        <!-- This is used to override CVE-2022-25857 and CVE-2022-41854 => should be removed once jackson-dataformat-yaml uses it out of the box -->
-        <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-        <snakeyaml.version>2.0</snakeyaml.version>
         <vertx.version>4.4.4</vertx.version>
         <vertx-junit5.version>4.4.4</vertx-junit5.version>
         <kafka.version>3.5.1</kafka.version>
@@ -527,13 +524,6 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${fasterxml.jackson-dataformat.version}</version>
-            </dependency>
-            <!-- This is used to override CVE-2022-25857 => should be removed once jackson-dataformat-yaml uses it out of the box -->
-            <!-- https://github.com/strimzi/strimzi-kafka-operator/issues/7261 covers the removal of this override -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <!-- transitive dep; override here to avoid buggy version -->


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR does yet another update of Cruise Control and Kaniko dependencies. The new Cruise Control version. finally gets rid of SnakeYAMl 1.33 so we can remove the overrides from our code.

This should close #7261.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging