### PR TITLE
docs(listeners): updates to names given to listeners

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -251,7 +251,7 @@ spec:
   kafka:
     #...
     listeners:
-      - name: externalclusterip
+      - name: clusterip
         type: cluster-ip
         tls: false
         port: 9096

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener.adoc
@@ -251,7 +251,7 @@ spec:
   kafka:
     #...
     listeners:
-      - name: external-cluster-ip
+      - name: externalclusterip
         type: cluster-ip
         tls: false
         port: 9096

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration.adoc
@@ -11,7 +11,7 @@ You can use the property to provide your own Kafka listener certificates.
 ----
 listeners:
   #...
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: true
@@ -44,7 +44,7 @@ When exposing Kafka outside of Kubernetes use source ranges, in addition to labe
 ----
 listeners:
   #...
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: false
@@ -68,7 +68,7 @@ You can configure the `Ingress` class using the `class` property.
 ----
 listeners:
   #...
-  - name: external
+  - name: external2
     port: 9094
     type: ingress
     tls: true
@@ -99,7 +99,7 @@ If the preferred address type is not found, Strimzi proceeds through the types i
 ----
 listeners:
   #...
-  - name: external
+  - name: external4
     port: 9094
     type: nodeport
     tls: false

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrap.adoc
@@ -12,7 +12,7 @@ The `alternativeNames` property is applicable to all types of listeners.
 ----
 listeners:
   #...
-  - name: external
+  - name: external1
     port: 9094
     type: route
     tls: true
@@ -40,7 +40,7 @@ Strimzi will not perform any validation that the requested hosts are available a
 ----
 listeners:
   #...
-  - name: external
+  - name: external2
     port: 9094
     type: ingress
     tls: true
@@ -71,7 +71,7 @@ You must ensure that they are free and can be used.
 # ...
 listeners:
   #...
-  - name: external
+  - name: external1
     port: 9094
     type: route
     tls: true
@@ -105,7 +105,7 @@ You must ensure that they are free and available for use.
 # ...
 listeners:
   #...
-  - name: external
+  - name: external4
     port: 9094
     type: nodeport
     tls: true
@@ -137,7 +137,7 @@ The `loadBalancerIP` field is ignored if the cloud provider does not support the
 # ...
 listeners:
   #...
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: true
@@ -168,7 +168,7 @@ You can use these annotations, for example, to instrument DNS tooling such as {K
 # ...
 listeners:
   #...
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: true

--- a/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker.adoc
@@ -16,7 +16,7 @@ Overriding the advertised host and ports is available for all types of listeners
 ----
 listeners:
   #...
-  - name: external
+  - name: external1
     port: 9094
     type: route
     tls: true

--- a/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-client-access.adoc
@@ -14,6 +14,8 @@ Otherwise, create listeners that provide client access within or outside the Kub
 include::../../modules/deploying/proc-deploy-example-clients.adoc[leveloffset=+1]
 //overview of listeners
 include::../../modules/overview/con-configuration-points-listeners.adoc[leveloffset=+1]
+//listener naming conventions
+include::../../modules/overview/con-configuration-points-listener-names.adoc[leveloffset=+1]
 //how to set up external clients that can access and use the deployment
 include::../../modules/deploying/proc-deploy-setup-external-clients.adoc[leveloffset=+1]
 //access through external listeners
@@ -24,3 +26,4 @@ ifdef::Section[]
 include::../../modules/security/proc-accessing-kafka-using-ingress.adoc[leveloffset=+1]
 endif::Section[]
 include::../../modules/security/proc-accessing-kafka-using-routes.adoc[leveloffset=+1]
+

--- a/documentation/modules/configuring/con-config-kafka.adoc
+++ b/documentation/modules/configuring/con-config-kafka.adoc
@@ -85,7 +85,7 @@ spec:
         tls: true
         authentication: # <14>
           type: tls
-      - name: external # <15>
+      - name: external1 # <15>
         port: 9094
         type: route
         tls: true

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -96,6 +96,10 @@ spec:
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLConfiguring}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].
 <8> Authorization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.
 <9> (Optional) Super users can access all brokers regardless of any access restrictions defined in ACLs.
++
+WARNING: An OpenShift route address comprises the Kafka cluster name, the listener name, the project name, and the domain of the router.
+For example, `my-cluster-kafka-external1-bootstrap-my-project.domain.com` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>.<domain>). 
+Each DNS label (between periods "`.`") must not exceed 63 characters, and the total length of the address must not exceed 255 characters.
 
 . Create or update the `Kafka` resource.
 +

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -73,8 +73,8 @@ spec:
   kafka:
     # ...
     listeners: # <1>
-    - name: external # <2>
-      port: 9094 <3>
+    - name: external1 # <2>
+      port: 9094 # <3>
       type: _<listener_type>_ # <4>
       tls: true # <5>
       authentication:
@@ -96,10 +96,6 @@ spec:
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLConfiguring}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].
 <8> Authorization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.
 <9> (Optional) Super users can access all brokers regardless of any access restrictions defined in ACLs.
-+
-WARNING: An OpenShift Route address comprises the name of the Kafka cluster, the name of the listener, and the name of the namespace it is created in.
-For example, `my-cluster-kafka-listener1-bootstrap-myproject` (_CLUSTER-NAME_-kafka-_LISTENER-NAME_-bootstrap-_NAMESPACE_).
-If you are using a `route` listener type, be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
 
 . Create or update the `Kafka` resource.
 +

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -116,8 +116,8 @@ status:
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external2
-      type: external2
+      name: external3
+      type: external3
     - addresses:
         - host: ip-10-0-172-202.us-east-2.compute.internal
           port: 31644
@@ -127,8 +127,8 @@ status:
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external1
-      type: external1
+      name: external4
+      type: external4
   observedGeneration: 3 # <5>
 ----
 <1> The Kafka cluster ID.

--- a/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
+++ b/documentation/modules/metrics/proc-metrics-kafka-deploy-options.adoc
@@ -202,7 +202,7 @@ spec:
   kafka:
     # ...
     listeners:
-    - name: external
+    - name: external3
       port: 9094
       type: loadbalancer
       tls: true

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -56,7 +56,7 @@ You configure an `external` listener with `type: oauth` for a secure transport l
 ----
 # ...
 listeners:
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: true

--- a/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authentication-broker-config.adoc
@@ -51,7 +51,7 @@ The examples here show the configuration options as configured for external list
 [source,yaml,subs="+quotes,attributes"]
 ----
 #...
-- name: external
+- name: external3
   port: 9094
   type: loadbalancer
   tls: true
@@ -84,7 +84,7 @@ The examples here show the configuration options as configured for external list
 .Example 2: Configuring token validation using an introspection endpoint
 [source,yaml,subs="+quotes,attributes"]
 ----
-- name: external
+- name: external3
   port: 9094
   type: loadbalancer
   tls: true

--- a/documentation/modules/overview/con-configuration-points-listener-names.adoc
+++ b/documentation/modules/overview/con-configuration-points-listener-names.adoc
@@ -6,14 +6,19 @@
 = Listener naming conventions
 
 [role="_abstract"]
-From the listener configuration, the resulting listener bootstrap and broker names are structured according to the following naming conventions:
+From the listener configuration, the resulting listener bootstrap and per-broker service names are structured according to the following naming conventions:
 
 .Listener naming conventions
 [cols="2a,4,4", options="header"]
 |===
-| Listener type | Bootstrap name | Broker name
+| Listener type | Bootstrap service name | Per-Broker service name
 | `internal` | <cluster_name>-kafka-bootstrap | _Not applicable_
-| `external` | <cluster_name>-kafka-<listener-name>-bootstrap | <cluster_name>-kafka-<listener-name>-<idx>
+| `loadbalancer` + 
+  `nodeport` +
+  `ingress` +
+  `route` +
+  `cluster-ip`
+ | <cluster_name>-kafka-<listener-name>-bootstrap | <cluster_name>-kafka-<listener-name>-<idx>
 |===  
 
 For example, `my-cluster-kafka-bootstrap`, `my-cluster-kafka-external1-bootstrap`, and `my-cluster-kafka-external1-0`.
@@ -26,7 +31,7 @@ These specific combinations of listener name and port configuration values are b
 .Backwards compatible listener name and port combinations
 [cols="2a,2a,4,4", options="header"]
 |===
-| Listener name | Port | Bootstrap name | Broker name
+| Listener name | Port | Bootstrap service name | Per-Broker service name
 | `plain` | `9092` | <cluster_name>-kafka-bootstrap |  _Not applicable_
 | `tls` | `9093` | <cluster-name>-kafka-bootstrap |  _Not applicable_
 | `external` | `9094` | <cluster_name>-kafka-bootstrap | <cluster_name>-kafka-bootstrap-<idx>

--- a/documentation/modules/overview/con-configuration-points-listener-names.adoc
+++ b/documentation/modules/overview/con-configuration-points-listener-names.adoc
@@ -1,0 +1,33 @@
+// This module is included in:
+//
+// assembly-deploy-client-access.adoc
+
+[id="con-configuration-points-listener-names-{context}"]
+= Listener naming conventions
+
+[role="_abstract"]
+From the listener configuration, the resulting listener bootstrap and broker names are structured according to the following naming conventions:
+
+.Listener naming conventions
+[cols="2a,4,4", options="header"]
+|===
+| Listener type | Bootstrap name | Broker name
+| `internal` | <cluster_name>-kafka-bootstrap | _Not applicable_
+| `external` | <cluster_name>-kafka-<listener-name>-bootstrap | <cluster_name>-kafka-<listener-name>-<idx>
+|===  
+
+For example, `my-cluster-kafka-bootstrap`, `my-cluster-kafka-external1-bootstrap`, and `my-cluster-kafka-external1-0`.
+The names are assigned to the services, routes, load balancers, and ingresses created through the listener configuration.
+
+You can use certain backwards compatible names and port numbers to transition listeners initially configured under the retired `KafkaListeners` schema.
+The resulting external listener naming convention varies slightly. 
+These specific combinations of listener name and port configuration values are backwards compatible:
+
+.Backwards compatible listener name and port combinations
+[cols="2a,2a,4,4", options="header"]
+|===
+| Listener name | Port | Bootstrap name | Broker name
+| `plain` | `9092` | <cluster_name>-kafka-bootstrap |  _Not applicable_
+| `tls` | `9093` | <cluster-name>-kafka-bootstrap |  _Not applicable_
+| `external` | `9094` | <cluster_name>-kafka-bootstrap | <cluster_name>-kafka-bootstrap-<idx>
+|===

--- a/documentation/modules/overview/con-configuration-points-listeners.adoc
+++ b/documentation/modules/overview/con-configuration-points-listeners.adoc
@@ -64,7 +64,7 @@ spec:
         tls: true
         authentication:
           type: tls
-      - name: external
+      - name: external1
         port: 9094
         type: route
         tls: true

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -73,7 +73,7 @@ spec:
         tls: true
         authentication:
           type: tls
-      - name: external
+      - name: external3
         port: 9094
         type: loadbalancer
         tls: true

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -43,7 +43,7 @@ For more information about enabling TLS passthrough, see the {NginxIngressContro
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external`.
+The name of the listener is `external2`.
 
 .Procedure
 
@@ -67,7 +67,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external
+      - name: external2
         port: 9094
         type: ingress
         tls: true # <1>
@@ -107,11 +107,11 @@ An `ingress` is also created for each service, with a DNS address to expose them
 .Ingresses created for the bootstrap and brokers
 [source,shell]
 ----
-NAME                        CLASS  HOSTS                    ADDRESS               PORTS
-my-cluster-kafka-0          nginx  broker-0.myingress.com   external.ingress.com  80,443
-my-cluster-kafka-1          nginx  broker-1.myingress.com   external.ingress.com  80,443
-my-cluster-kafka-2          nginx  broker-2.myingress.com   external.ingress.com  80,443
-my-cluster-kafka-bootstrap  nginx  bootstrap.myingress.com  external.ingress.com  80,443
+NAME                                  CLASS  HOSTS                    ADDRESS       PORTS
+my-cluster-kafka-external2-0          nginx  broker-0.myingress.com   192.168.49.2  80,443
+my-cluster-kafka-external2-1          nginx  broker-1.myingress.com   192.168.49.2  80,443
+my-cluster-kafka-external2-2          nginx  broker-2.myingress.com   192.168.49.2  80,443
+my-cluster-kafka-external2-bootstrap  nginx  bootstrap.myingress.com  192.168.49.2  80,443
 ----
 +
 The DNS addresses used for client connection are propagated to the `status` of each ingress.
@@ -122,7 +122,7 @@ The DNS addresses used for client connection are propagated to the `status` of e
 status:
   loadBalancer:
     ingress:
-      - hostname: external.ingress.com
+    - ip: 192.168.49.2
  # ...
 ----
 

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -26,7 +26,7 @@ For more information on listener configuration, see the link:{BookURLConfiguring
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external`.
+The name of the listener is `external3`.
 
 .Procedure
 
@@ -47,8 +47,8 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external
-        port: 9095
+      - name: external3
+        port: 9094
         type: loadbalancer
         tls: true
         authentication:
@@ -72,16 +72,16 @@ A cluster CA certificate to verify the identity of the kafka brokers is also cre
 [source,shell]
 ----
 NAME                                  TYPE            CLUSTER-IP      PORT(S)
-my-cluster-kafka-external-0          LoadBalancer     172.30.204.234  9095:30011/TCP
-my-cluster-kafka-external-1          LoadBalancer     172.30.164.89   9095:32544/TCP 
-my-cluster-kafka-external-2          LoadBalancer     172.30.73.151   9095:32504/TCP
-my-cluster-kafka-external-bootstrap  LoadBalancer     172.30.30.228   9095:30371/TCP
+my-cluster-kafka-external3-0          LoadBalancer    172.30.204.234  9094:30011/TCP
+my-cluster-kafka-external3-1          LoadBalancer    172.30.164.89   9094:32544/TCP 
+my-cluster-kafka-external3-2          LoadBalancer    172.30.73.151   9094:32504/TCP
+my-cluster-kafka-external3-bootstrap  LoadBalancer    172.30.30.228   9094:30371/TCP
 
-NAME                                 EXTERNAL-IP (loadbalancer)
-my-cluster-kafka-external-0          a8a519e464b924000b6c0f0a05e19f0d-1132975133.us-west-2.elb.amazonaws.com
-my-cluster-kafka-external-1          ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com 
-my-cluster-kafka-external-2          a9173e8ccb1914778aeb17eca98713c0-777597560.us-west-2.elb.amazonaws.com
-my-cluster-kafka-external-bootstrap  a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
+NAME                                  EXTERNAL-IP (loadbalancer)
+my-cluster-kafka-external3-0          a8a519e464b924000b6c0f0a05e19f0d-1132975133.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external3-1          ab6adc22b556343afb0db5ea05d07347-611832211.us-west-2.elb.amazonaws.com 
+my-cluster-kafka-external3-2          a9173e8ccb1914778aeb17eca98713c0-777597560.us-west-2.elb.amazonaws.com
+my-cluster-kafka-external3-bootstrap  a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
 ----
 +
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
@@ -100,16 +100,16 @@ status:
     - addresses:
         - host: >-
             a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com
-          port: 9095
+          port: 9094
       bootstrapServers: >-
-        a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095
+        a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9094
       certificates:
         - |
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external
-      type: external
+      name: external3
+      type: external3
   observedGeneration: 2
  # ...
 ----
@@ -131,9 +131,9 @@ status:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external3")].bootstrapServers}{"\n"}'
 
-a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095
+a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9094
 ----
 
 . Extract the cluster CA certificate.
@@ -145,7 +145,7 @@ kubectl get secret my-cluster-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | ba
 
 . Configure your client to connect to the brokers.
 
-.. Specify the bootstrap host and port in your Kafka client as the bootstrap address to connect to the Kafka cluster. For example, `a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9095`.
+.. Specify the bootstrap host and port in your Kafka client as the bootstrap address to connect to the Kafka cluster. For example, `a8d4a6fb363bf447fb6e475fc3040176-36312313.us-west-2.elb.amazonaws.com:9094`.
 
 .. Add the extracted certificate to the truststore of your Kafka client to configure a TLS connection.
 +

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -26,7 +26,7 @@ For more information on listener configuration, see the link:{BookURLConfiguring
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external`.
+The name of the listener is `external4`.
 
 .Procedure
 
@@ -47,7 +47,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external
+      - name: external4
         port: 9094
         type: nodeport
         tls: true
@@ -71,11 +71,11 @@ A cluster CA certificate to verify the identity of the kafka brokers is created 
 .Node port services created for the bootstrap and brokers
 [source,shell]
 ----
-NAME                                 TYPE      CLUSTER-IP      PORT(S)               
-my-cluster-kafka-external-0          NodePort  172.30.55.13    9094:31789/TCP
-my-cluster-kafka-external-1          NodePort  172.30.250.248  9094:30028/TCP
-my-cluster-kafka-external-2          NodePort  172.30.115.81   9094:32650/TCP
-my-cluster-kafka-external-bootstrap  NodePort  172.30.30.23    9094:32650/TCP
+NAME                                  TYPE      CLUSTER-IP      PORT(S)               
+my-cluster-kafka-external4-0          NodePort  172.30.55.13    9094:31789/TCP
+my-cluster-kafka-external4-1          NodePort  172.30.250.248  9094:30028/TCP
+my-cluster-kafka-external4-2          NodePort  172.30.115.81   9094:32650/TCP
+my-cluster-kafka-external4-bootstrap  NodePort  172.30.30.23    9094:32650/TCP
 ----
 +
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
@@ -100,8 +100,8 @@ status:
           -----BEGIN CERTIFICATE-----
           
           -----END CERTIFICATE-----
-      name: external
-      type: external
+      name: external4
+      type: external4
   observedGeneration: 2
  # ...
 ----
@@ -110,7 +110,7 @@ status:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external4")].bootstrapServers}{"\n"}'
 
 ip-10-0-224-199.us-west-2.compute.internal:32650
 ----

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -16,8 +16,9 @@ Per-broker connections are then established using DNS names, which route traffic
 To connect to a broker, you specify a hostname for the route bootstrap address, as well as the certificate used for TLS encryption.
 For access using routes, the port is always 443.
 
-WARNING: An OpenShift route address comprises the name of the Kafka cluster, the name of the listener, and the name of the project it is created in.
-For example, `my-cluster-kafka-external-bootstrap-myproject` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>). Be careful that the whole length of the address does not exceed a maximum limit of 63 characters.
+WARNING: An OpenShift route address comprises the Kafka cluster name, the listener name, the project name, and the domain of the router.
+For example, `my-cluster-kafka-external1-bootstrap-my-project.domain.com` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>.<domain>). 
+Each DNS label (between periods (`.`) must not exceed 63 characters, and the total length of the address must not exceed 255 characters.
 
 The procedure shows basic listener configuration.
 TLS encryption (`tls`) must be enabled.
@@ -43,7 +44,7 @@ To configure listeners to use your own listener certificates, xref:proc-installi
 * A running Cluster Operator
 
 In this procedure, the Kafka cluster name is `my-cluster`.
-The name of the listener is `external`.
+The name of the listener is `external1`.
 
 .Procedure
 
@@ -64,7 +65,7 @@ spec:
   kafka:
     # ...
     listeners:
-      - name: external
+      - name: external1
         port: 9094
         type: route
         tls: true # <1>
@@ -95,11 +96,11 @@ The routes are preconfigured with TLS passthrough.
 .Routes created for the bootstraps and brokers
 [source,shell]
 ----
-NAME                                  HOST/PORT                                                   SERVICES                              PORT  TERMINATION
-my-cluster-kafka-external-0          my-cluster-kafka-external-0-my-project.router.com          my-cluster-kafka-external-0          9094  passthrough
-my-cluster-kafka-external-1          my-cluster-kafka-external-1-my-project.router.com          my-cluster-kafka-external-1          9094  passthrough
-my-cluster-kafka-external-2          my-cluster-kafka-external-2-my-project.router.com          my-cluster-kafka-external-2          9094  passthrough
-my-cluster-kafka-external-bootstrap  my-cluster-kafka-external-bootstrap-my-project.router.com  my-cluster-kafka-external-bootstrap  9094  passthrough
+NAME                                  HOST/PORT                                                  SERVICES                              PORT  TERMINATION
+my-cluster-kafka-external1-0          my-cluster-kafka-external1-0-my-project.router.com         my-cluster-kafka-external1-0          9094  passthrough
+my-cluster-kafka-external1-1          my-cluster-kafka-external1-1-my-project.router.com         my-cluster-kafka-external1-1          9094  passthrough
+my-cluster-kafka-external1-2          my-cluster-kafka-external1-2-my-project.router.com         my-cluster-kafka-external1-2          9094  passthrough
+my-cluster-kafka-external1-bootstrap  my-cluster-kafka-external1-bootstrap-my-project.router.com my-cluster-kafka-external1-bootstrap  9094  passthrough
 ----
 +
 The DNS addresses used for client connection are propagated to the `status` of each route.
@@ -110,7 +111,7 @@ The DNS addresses used for client connection are propagated to the `status` of e
 status:
   ingress:
     - host: >-
-        my-cluster-kafka-external-bootstrap-my-project.router.com
+        my-cluster-kafka-external1-bootstrap-my-project.router.com
  # ...
 ----
 
@@ -118,10 +119,10 @@ status:
 +
 [source,shell]
 ----
-openssl s_client -connect my-cluster-kafka-external-0-my-project.router.com:443 -servername my-cluster-kafka-external-0-my-project.router.com -showcerts
+openssl s_client -connect my-cluster-kafka-external1-0-my-project.router.com:443 -servername my-cluster-kafka-external1-0-my-project.router.com -showcerts
 ----
 +
-The server name is the SNI for passing the connection to the broker. 
+The server name is the Server Name Indication (SNI) for passing the connection to the broker. 
 +
 If the connection is successful, the certificates for the broker are returned.
 +
@@ -137,12 +138,12 @@ Certificate chain
 +
 [source,shell,subs=+quotes]
 ----
-kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external")].bootstrapServers}{"\n"}'
+kubectl get kafka my-cluster -o=jsonpath='{.status.listeners[?(@.name=="external1")].bootstrapServers}{"\n"}'
 
-my-cluster-kafka-external-bootstrap-my-project.router.com:443
+my-cluster-kafka-external1-bootstrap-my-project.router.com:443
 ----
 +
-The address comprises the cluster name, the listener name, the project name and the domain of the router (`router.com` in this example).
+The address comprises the Kafka cluster name, the listener name, the project name and the domain of the router (`router.com` in this example).
 
 . Extract the cluster CA certificate.
 +

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -18,7 +18,7 @@ For access using routes, the port is always 443.
 
 WARNING: An OpenShift route address comprises the Kafka cluster name, the listener name, the project name, and the domain of the router.
 For example, `my-cluster-kafka-external1-bootstrap-my-project.domain.com` (<cluster_name>-kafka-<listener_name>-bootstrap-<namespace>.<domain>). 
-Each DNS label (between periods (`.`) must not exceed 63 characters, and the total length of the address must not exceed 255 characters.
+Each DNS label (between periods "`.`") must not exceed 63 characters, and the total length of the address must not exceed 255 characters.
 
 The procedure shows basic listener configuration.
 TLS encryption (`tls`) must be enabled.

--- a/documentation/modules/security/proc-installing-certs-per-listener.adoc
+++ b/documentation/modules/security/proc-installing-certs-per-listener.adoc
@@ -63,7 +63,7 @@ listeners:
     port: 9092
     type: internal
     tls: false
-  - name: external
+  - name: external3
     port: 9094
     type: loadbalancer
     tls: true


### PR DESCRIPTION
**Documentation**

Some of the name/port combinations shown as example external listener configuration in the documentation reflected the backwards compatible special cases for transition of listeners originally configured using the `KafkaListeners` schema, which was retired.

Listener names have been updated so that the example names/ports of the external listeners are not these special cases.
A new section has also been created  that describes the naming of services, routes, ingresses and load balances based on the listener names given, as well as explaining the special cases.

Names given:

- name: external1
  type: route
- name: external2
  type: ingress
- name: external3
  type: loadbalancer
- name: external4
  type: nodeport

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

