### PR TITLE
[ST] ThrottlingQuotaST test ThrottlingQuotasDuringAllTopicOperations modifications

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/AdminClientOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/AdminClientOperation.java
@@ -8,7 +8,7 @@ public enum AdminClientOperation {
     CREATE_TOPICS("create"),
     DELETE_TOPICS("delete"),
     LIST_TOPICS("list"),
-    UPDATE_TOPICS("update"),
+    ALTER_TOPICS("alter"),
     HELP("help");
 
     private final String operation;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -166,7 +166,7 @@ public class ClientUtils {
             }
         }
     }
-    public static void waitForClientContainsAllMessages(String jobName, String namespace, List<String> messages) {
+    public static void waitForClientContainsAllMessages(String jobName, String namespace, List<String> messages, boolean deleteAfterSuccess) {
         String jobPodName = PodUtils.getPodNameByPrefix(namespace, jobName);
         List<String> notReadyMessages = messages;
         TestUtils.waitFor("client Job to contain all messages: [" + messages.toString() + "]", Constants.GLOBAL_POLL_INTERVAL, Constants.THROTTLING_EXCEPTION_TIMEOUT, () -> {
@@ -175,6 +175,11 @@ public class ClientUtils {
                     notReadyMessages.remove(message);
                 }
             }
+
+            if (deleteAfterSuccess && notReadyMessages.isEmpty()) {
+                JobUtils.deleteJobWithWait(namespace, jobName);
+            }
+
             return notReadyMessages.isEmpty();
         });
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -10,6 +10,7 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.WaitException;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -164,6 +165,18 @@ public class ClientUtils {
                 throw e;
             }
         }
+    }
+    public static void waitForClientContainsAllMessages(String jobName, String namespace, List<String> messages) {
+        String jobPodName = PodUtils.getPodNameByPrefix(namespace, jobName);
+        List<String> notReadyMessages = messages;
+        TestUtils.waitFor("client Job to contain all messages: [" + messages.toString() + "]", Constants.GLOBAL_POLL_INTERVAL, Constants.THROTTLING_EXCEPTION_TIMEOUT, () -> {
+            for (String message : messages) {
+                if (kubeClient().logsInSpecificNamespace(namespace, jobPodName).contains(message)) {
+                    notReadyMessages.remove(message);
+                }
+            }
+            return notReadyMessages.isEmpty();
+        });
     }
 
     public static void waitForClientContainsMessage(String jobName, String namespace, String message) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -22,7 +22,6 @@ import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import java.util.ArrayList;
 import java.util.List;

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -114,7 +114,7 @@ public class ThrottlingQuotaST extends AbstractST {
             topicNames.add(testStorage.getTopicName() + "-" + i);
         }
 
-        ClientUtils.waitForClientContainsAllMessages(listAdminName, testStorage.getNamespaceName(), topicNames);
+        ClientUtils.waitForClientContainsAllMessages(listAdminName, testStorage.getNamespaceName(), topicNames, true);
 
         int partitionAlter = 25;
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In this PR there are a few changes that could improve the overall test. One of them is renaming anything related to the alter operation to update as the client uses update instead of alter. Second is adding a check to verify that admin is able to list all topics not just the last one. 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

