### PR TITLE
Remove OkHttp logging configuration left-overs

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -138,11 +138,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-server</artifactId>
         </dependency>

--- a/cluster-operator/scripts/cluster_operator_run.sh
+++ b/cluster-operator/scripts/cluster_operator_run.sh
@@ -27,9 +27,6 @@ else
     echo "Configuration file log4j2.properties not found. Using default static logging setting. Dynamic updates of logging configuration will not work."
 fi
 
-# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
-export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-
 # Used to identify cluster operator instance when publishing events
 if [[ -z "$STRIMZI_OPERATOR_NAME" ]]; then
   STRIMZI_OPERATOR_NAME="$(cat /proc/sys/kernel/hostname)"

--- a/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
+++ b/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
@@ -17,8 +17,3 @@ logger.clients.additivity = false
 logger.streams.name = org.apache.kafka.streams
 logger.streams.level = INFO
 logger.streams.additivity = false
-
-# Keeps separate log level for OkHttp client
-logger.okhttp3.name = okhttp3
-logger.okhttp3.level = INFO
-logger.okhttp3.additivity = false

--- a/cluster-operator/src/main/resources/default-logging/EntityUserOperator.properties
+++ b/cluster-operator/src/main/resources/default-logging/EntityUserOperator.properties
@@ -14,8 +14,3 @@ rootLogger.additivity = false
 logger.jetty.name = org.eclipse.jetty
 logger.jetty.level = INFO
 logger.jetty.additivity = false
-
-# Keeps separate log level for OkHttp client
-logger.okhttp3.name = okhttp3
-logger.okhttp3.level = INFO
-logger.okhttp3.additivity = false

--- a/kafka-init/pom.xml
+++ b/kafka-init/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>

--- a/kafka-init/scripts/kafka_init_run.sh
+++ b/kafka-init/scripts/kafka_init_run.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
-export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-
 export JAVA_CLASSPATH=$JAVA_CLASSPATH:lib/io.strimzi.@project.build.finalName@.@project.packaging@:@project.dist.classpath@
 export JAVA_MAIN=io.strimzi.kafka.init.Main
 exec "${STRIMZI_HOME}/bin/launch_java.sh"

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -37,8 +37,4 @@ data:
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
-
-    # Keeps separate log level for OkHttp client
-    logger.okhttp3.name = okhttp3
-    logger.okhttp3.level = INFO
     {{- end }}

--- a/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -29,7 +29,3 @@ data:
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
-
-    # Keeps separate log level for OkHttp client
-    logger.okhttp3.name = okhttp3
-    logger.okhttp3.level = INFO

--- a/pom.xml
+++ b/pom.xml
@@ -413,12 +413,6 @@
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jul</artifactId>
-                <version>${log4j.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
@@ -1137,7 +1131,6 @@
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-jul</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.sundr:builder-annotations</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.sundr:sundr-codegen</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.projectlombok:lombok</ignoredUnusedDeclaredDependency>

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -27,9 +27,6 @@ rootLogger.additivity = false
 logger.clients.name = org.apache.kafka.clients
 logger.clients.level = info
 
-logger.okhttp.name = okhttp3
-logger.okhttp.level = INFO
-
 logger.fabric8.name = io.fabric8.kubernetes.client
 logger.fabric8.level = OFF
 logger.jayway.name = com.jayway.jsonpath.internal.path.CompiledPath

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -87,11 +87,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
@@ -276,7 +271,6 @@
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-client</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-jul</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>

--- a/topic-operator/scripts/topic_operator_run.sh
+++ b/topic-operator/scripts/topic_operator_run.sh
@@ -10,9 +10,6 @@ then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/topic-operator/custom-config/log4j2.properties"
 fi
 
-# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
-export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -65,11 +65,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <!-- Used because of OkHttp client which is using JUL (java.util.logging)-->
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/user-operator/scripts/user_operator_run.sh
+++ b/user-operator/scripts/user_operator_run.sh
@@ -10,9 +10,6 @@ then
     export JAVA_OPTS="${JAVA_OPTS} -Dlog4j2.configurationFile=file:/opt/user-operator/custom-config/log4j2.properties"
 fi
 
-# The java.util.logging.manager is set because of OkHttp client which is using JUL logging
-export JAVA_OPTS="${JAVA_OPTS} -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-
 if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
 fi


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes some leftovers from the use of OkHttp in the Fabric8 Kubernetes client -> the logging configurations and the integration between Log4j2 and JUL which is not needed anymore.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally