### PR TITLE
Do not set Kafka.KafkaStatus.ListenerStatus.type property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.38.0
 
+### Changes, deprecations and removals
+
+* The `Kafka.KafkaStatus.ListenerStatus.type` property has been deprecated for a long time, and now we do not use it anymore.
+  The current plan is to completely remove this property in the next schema version.
+  If needed, you can use the `Kafka.KafkaStatus.ListenerStatus.name` property, which has the same value.
 
 ## 0.37.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/ListenerStatus.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -33,21 +34,23 @@ import static java.util.Collections.emptyMap;
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
+    private String type;
     private String name;
     private List<ListenerAddress> addresses;
     private String bootstrapServers;
     private List<String> certificates;
     private Map<String, Object> additionalProperties;
 
-    @Description("*The `type` property has been deprecated, and should now be configured using `name`.* " +
-            "The name of the listener.")
+    @Deprecated
+    @DeprecatedProperty(description = "The `type` property is deprecated and not used anymore.")
+    @Description("*The `type` property is deprecated and not used anymore. Use the `name` property.* The name of the listener.")
     public String getType() {
-        return name;
+        return type;
     }
 
     @Deprecated
-    public void setType(String name) {
-        this.name = name;
+    public void setType(String type) {
+        this.type = type;
     }
 
     @Description("The name of the listener.")

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaTest.java
@@ -200,8 +200,6 @@ public class KafkaTest extends AbstractCrdTest<Kafka> {
 
         List<ListenerStatus> listeners = model.getStatus().getListeners();
 
-        assertThat(listeners.get(0).getType(), is("plain"));
-        assertThat(listeners.get(1).getType(), is("external"));
         assertThat(listeners.get(0).getName(), is("plain"));
         assertThat(listeners.get(1).getName(), is("external"));
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-listener-name-and-status.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/Kafka-listener-name-and-status.yaml
@@ -25,14 +25,12 @@ status:
     status: "True"
   observedGeneration: 1
   listeners:
-  - type: "plain"
-    name: "plain"
+  - name: "plain"
     addresses:
     - host: "my-service.my-namespace.svc"
       port: 9092
     bootstrapServers: "my-service.my-namespace.svc:9092"
-  - type: "external"
-    name: "external"
+  - name: "external"
     addresses:
     - host: "my-route-address.domain.tld"
       port: 443

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -414,7 +414,6 @@ public class KafkaReconcilerStatusTest {
             // Check listener status
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
-            assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("5.124.16.8:31234,50.35.18.119:31234,55.36.78.115:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
 
@@ -519,7 +518,6 @@ public class KafkaReconcilerStatusTest {
             // Check listener status
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
-            assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("5.124.16.8:31234,my-address-0:31234,my-address-1:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
 
@@ -614,7 +612,6 @@ public class KafkaReconcilerStatusTest {
             // Check listener status
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
-            assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("node-0.my-kube:31234,node-1.my-kube:31234,node-3.my-kube:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(3));
 
@@ -706,7 +703,6 @@ public class KafkaReconcilerStatusTest {
             // Check listener status
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
-            assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("50.35.18.119:31234"));
             assertThat(status.getListeners().get(0).getAddresses().size(), is(1));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(31234));
@@ -795,7 +791,6 @@ public class KafkaReconcilerStatusTest {
             // Check listener status
             assertThat(status.getListeners().size(), is(1));
             assertThat(status.getListeners().get(0).getName(), is("external"));
-            assertThat(status.getListeners().get(0).getType(), is("external"));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is(nullValue()));
             assertThat(status.getListeners().get(0).getAddresses(), is(List.of()));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -139,12 +139,10 @@ public class KafkaStatusTest {
             KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
             assertThat(status.getListeners().size(), is(2));
-            assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(9092));
             assertThat(status.getListeners().get(0).getBootstrapServers(), is("my-service.my-namespace.svc:9092"));
-            assertThat(status.getListeners().get(1).getType(), is("external"));
             assertThat(status.getListeners().get(1).getName(), is("external"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getHost(), is("my-route-address.domain.tld"));
             assertThat(status.getListeners().get(1).getAddresses().get(0).getPort(), is(443));
@@ -295,7 +293,6 @@ public class KafkaStatusTest {
             KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
             assertThat(status.getListeners().size(), is(1));
-            assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(9092));
@@ -371,7 +368,6 @@ public class KafkaStatusTest {
             KafkaStatus status = kafkaCaptor.getValue().getStatus();
 
             assertThat(status.getListeners().size(), is(1));
-            assertThat(status.getListeners().get(0).getType(), is("plain"));
             assertThat(status.getListeners().get(0).getName(), is("plain"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getHost(), is("my-service.my-namespace.svc"));
             assertThat(status.getListeners().get(0).getAddresses().get(0).getPort(), is(9092));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1656,7 +1656,7 @@ Used in: xref:type-KafkaStatus-{context}[`KafkaStatus`]
 [options="header"]
 |====
 |Property                 |Description
-|type              1.2+<.<a|*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener.
+|type              1.2+<.<a|**The `type` property has been deprecated.** The `type` property is deprecated and not used anymore. *The `type` property is deprecated and not used anymore. Use the `name` property.* The name of the listener.
 |string
 |name              1.2+<.<a|The name of the listener.
 |string

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -93,7 +93,6 @@ status:
           port: 9092
       bootstrapServers: 'my-cluster-kafka-bootstrap.prm-project.svc:9092'
       name: plain
-      type: plain
     - addresses:
         - host: my-cluster-kafka-bootstrap.prm-project.svc
           port: 9093
@@ -104,7 +103,6 @@ status:
           
           -----END CERTIFICATE-----
       name: tls
-      type: tls
     - addresses:
         - host: >-
             2054284155.us-east-2.elb.amazonaws.com
@@ -117,7 +115,6 @@ status:
           
           -----END CERTIFICATE-----
       name: external3
-      type: external3
     - addresses:
         - host: ip-10-0-172-202.us-east-2.compute.internal
           port: 31644
@@ -128,7 +125,6 @@ status:
           
           -----END CERTIFICATE-----
       name: external4
-      type: external4
   observedGeneration: 3 # <5>
 ----
 <1> The Kafka cluster ID.

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -109,7 +109,6 @@ status:
           
           -----END CERTIFICATE-----
       name: external3
-      type: external3
   observedGeneration: 2
  # ...
 ----

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -101,7 +101,6 @@ status:
           
           -----END CERTIFICATE-----
       name: external4
-      type: external4
   observedGeneration: 2
  # ...
 ----

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -6269,7 +6269,7 @@ spec:
                     properties:
                       type:
                         type: string
-                        description: "*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener."
+                        description: '*The `type` property is deprecated and not used anymore. Use the `name` property.* The name of the listener.'
                       name:
                         type: string
                         description: The name of the listener.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6268,7 +6268,7 @@ spec:
                   properties:
                     type:
                       type: string
-                      description: "*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener."
+                      description: '*The `type` property is deprecated and not used anymore. Use the `name` property.* The name of the listener.'
                     name:
                       type: string
                       description: The name of the listener.

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeKafkaExternalListenersST.java
@@ -188,7 +188,7 @@ public class HttpBridgeKafkaExternalListenersST extends AbstractST {
         final String kafkaProducerExternalName = "kafka-producer-external" + new Random().nextInt(Integer.MAX_VALUE);
 
         final List<ListenerStatus> listenerStatusList = KafkaResource.kafkaClient().inNamespace(ts.getNamespaceName()).withName(ts.getClusterName()).get().getStatus().getListeners();
-        final String externalBootstrapServers = listenerStatusList.stream().filter(listener -> listener.getType().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME))
+        final String externalBootstrapServers = listenerStatusList.stream().filter(listener -> listener.getName().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME))
             .findFirst()
             .orElseThrow(RuntimeException::new)
             .getBootstrapServers();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -442,7 +442,7 @@ public class ListenersST extends AbstractST {
 
         // Check that Kafka status has correct addresses in NodePort external listener part
         for (ListenerStatus listenerStatus : KafkaResource.getKafkaStatus(clusterName, namespaceName).getListeners()) {
-            if (listenerStatus.getType().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)) {
+            if (listenerStatus.getName().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)) {
                 List<String> listStatusAddresses = listenerStatus.getAddresses().stream().map(ListenerAddress::getHost).collect(Collectors.toList());
                 listStatusAddresses.sort(Comparator.comparing(String::toString));
                 List<Integer> listStatusPorts = listenerStatus.getAddresses().stream().map(ListenerAddress::getPort).collect(Collectors.toList());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -476,7 +476,7 @@ class CustomResourceStatusST extends AbstractST {
         assertThat("Kafka cluster status has incorrect Observed Generation", observedGeneration, is(expectedObservedGeneration));
 
         for (ListenerStatus listener : kafkaStatus.getListeners()) {
-            switch (listener.getType()) {
+            switch (listener.getName()) {
                 case Constants.TLS_LISTENER_DEFAULT_NAME:
                     assertThat("TLS bootstrap has incorrect port", listener.getAddresses().get(0).getPort(), is(9093));
                     assertThat("TLS bootstrap has incorrect host", listener.getAddresses().get(0).getHost(), is(internalAddress));

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -182,7 +182,7 @@ public class TopicST extends AbstractST {
 
         properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaResource.kafkaClient().inNamespace(Constants.TEST_SUITE_NAMESPACE)
             .withName(clusterName).get().getStatus().getListeners().stream()
-            .filter(listener -> listener.getType().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME))
+            .filter(listener -> listener.getName().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME))
             .findFirst()
             .orElseThrow(RuntimeException::new)
             .getBootstrapServers());


### PR DESCRIPTION
This deprecated status property actually contains the listener's name, not the spec type. With this change, we do not set it anymore, and I'm also removing documentation references.

Example before:

```sh
status:
  listeners:
    - addresses:
       - host: my-cluster-kafka-bootstrap.test.svc
          port: 9092
      bootstrapServers: my-cluster-kafka-bootstrap.test.svc:9092
      name: plain
      type: plain
```

Example after:

```sh
status:
  listeners:
    - addresses:
       - host: my-cluster-kafka-bootstrap.test.svc
          port: 9092
      bootstrapServers: my-cluster-kafka-bootstrap.test.svc:9092
      name: plain
```
