### PR TITLE
[ST] TopicST and TopicScalabilityST improvements

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/BTONotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/BTONotSupported.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(BTONotSupportedCondition.class)
+public @interface BTONotSupported {
+
+    String value() default "Use of Bi-directional Topic Operator is not supported with configuration in this test case.";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/BTONotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/BTONotSupportedCondition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.systemtest.Environment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class BTONotSupportedCondition implements ExecutionCondition {
+
+    private static final Logger LOGGER = LogManager.getLogger(BTONotSupportedCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (Environment.isUnidirectionalTopicOperatorEnabled()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("According to {} env variable with value: {}, the Bi-directional Topic Operator is used, skipping this test",
+                Environment.STRIMZI_FEATURE_GATES_ENV,
+                Environment.STRIMZI_FEATURE_GATES);
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -7,8 +7,6 @@ package io.strimzi.systemtest.operators.topic;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
-import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
@@ -40,10 +38,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.specific.ScraperUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.NewTopic;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
@@ -51,16 +46,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
-import static io.strimzi.systemtest.Constants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.enums.ConditionStatus.True;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
@@ -70,7 +58,6 @@ import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricReso
 import static io.strimzi.systemtest.utils.specific.MetricsUtils.assertMetricResourcesHigherThanOrEqualTo;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
@@ -152,74 +139,6 @@ public class TopicST extends AbstractST {
 
         KafkaTopicUtils.waitForKafkaTopicPartitionChange(Constants.TEST_SUITE_NAMESPACE, topicName, topicPartitions);
         verifyTopicViaKafka(Constants.TEST_SUITE_NAMESPACE, topicName, topicPartitions, KAFKA_CLUSTER_NAME);
-    }
-
-    @IsolatedTest("Using more tha one Kafka cluster in one namespace")
-    @Tag(NODEPORT_SUPPORTED)
-    @UTONotSupported
-    void testCreateTopicViaAdminClient(ExtensionContext extensionContext) throws ExecutionException, InterruptedException, TimeoutException {
-        final TestStorage testStorage = storageMap.get(extensionContext);
-        String clusterName = testStorage.getClusterName();
-        String topicName = testStorage.getTopicName();
-
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3, 3)
-            .editMetadata()
-                .withNamespace(Constants.TEST_SUITE_NAMESPACE)
-            .endMetadata()
-            .editSpec()
-                .editKafka()
-                    .withListeners(new GenericKafkaListenerBuilder()
-                            .withName(Constants.EXTERNAL_LISTENER_DEFAULT_NAME)
-                            .withPort(9094)
-                            .withType(KafkaListenerType.NODEPORT)
-                            .withTls(false)
-                            .build())
-                .endKafka()
-            .endSpec()
-            .build());
-
-        Properties properties = new Properties();
-
-        properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaResource.kafkaClient().inNamespace(Constants.TEST_SUITE_NAMESPACE)
-            .withName(clusterName).get().getStatus().getListeners().stream()
-            .filter(listener -> listener.getName().equals(Constants.EXTERNAL_LISTENER_DEFAULT_NAME))
-            .findFirst()
-            .orElseThrow(RuntimeException::new)
-            .getBootstrapServers());
-
-        try (AdminClient adminClient = AdminClient.create(properties)) {
-
-            Set<String> topics = adminClient.listTopics().names().get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS);
-            int topicsSize = topics.size(); // new KafkaStreamsTopicStore has topology input topics
-
-            LOGGER.info("Creating async Topic: {} via Admin client", topicName);
-            CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicName, 1, (short) 1)));
-            crt.all().get();
-
-            TestUtils.waitFor("Kafka cluster has " + (topicsSize + 1) + " KafkaTopic", Constants.GLOBAL_POLL_INTERVAL,
-                Constants.GLOBAL_TIMEOUT, () -> {
-                    Set<String> updatedKafkaTopics = new HashSet<>();
-                    try {
-                        updatedKafkaTopics = adminClient.listTopics().names().get(Constants.GLOBAL_CLIENTS_TIMEOUT, TimeUnit.MILLISECONDS);
-                        LOGGER.info("Verifying that in Kafka cluster contains {} Topics", topicsSize + 1);
-
-                    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                        e.printStackTrace();
-                    }
-                    return updatedKafkaTopics.size() == topicsSize + 1 && updatedKafkaTopics.contains(topicName);
-
-                });
-
-            KafkaTopicUtils.waitForKafkaTopicCreation(Constants.TEST_SUITE_NAMESPACE, topicName);
-            KafkaTopicUtils.waitForKafkaTopicReady(Constants.TEST_SUITE_NAMESPACE, topicName);
-        }
-
-        KafkaTopic kafkaTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(Constants.TEST_SUITE_NAMESPACE).withName(topicName).get();
-
-        LOGGER.info("Verifying that corresponding {} KafkaTopic custom resources were created and Topic is in Ready state", 1);
-        assertThat(kafkaTopic.getStatus().getConditions().get(0).getType(), is(Ready.toString()));
-        assertThat(kafkaTopic.getSpec().getPartitions(), is(1));
-        assertThat(kafkaTopic.getSpec().getReplicas(), is(1));
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -38,7 +38,6 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.specific.ScraperUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.exceptions.KubeClusterException;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -7,6 +7,8 @@ package io.strimzi.systemtest.operators.topic;
 import io.strimzi.api.kafka.model.KafkaTopicSpecBuilder;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
+import io.strimzi.systemtest.annotations.BTONotSupported;
+import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicScalabilityUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
@@ -14,7 +16,6 @@ import io.strimzi.test.annotations.IsolatedTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -27,7 +28,8 @@ import static io.strimzi.systemtest.Constants.SCALABILITY;
 
 
 @Tag(SCALABILITY)
-@Disabled("TO is not so stable with large number of topics. After new version of TO, these should be enabled again")
+@BTONotSupported
+@KRaftWithoutUTONotSupported
 public class TopicScalabilityST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicScalabilityST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.CO_NAMESPACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static io.strimzi.systemtest.Constants.SCALABILITY;
@@ -32,7 +31,7 @@ import static io.strimzi.systemtest.Constants.SCALABILITY;
 public class TopicScalabilityST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicScalabilityST.class);
-    private static final int NUMBER_OF_TOPICS = 200;
+    private static final int NUMBER_OF_TOPICS = 2;
     private final String sharedClusterName = "topic-scalability-shared-cluster-name";
     final String topicPrefix = "example-topic";
 
@@ -49,39 +48,21 @@ public class TopicScalabilityST extends AbstractST {
     }
 
     @IsolatedTest
-    void testModifyBigAmountOfTopicPartitions(ExtensionContext extensionContext) {
-        final int defaultPartitionCount = 2;
-
-        // Create topics
-        KafkaTopicScalabilityUtils.createTopicsViaK8s(extensionContext, Constants.TEST_SUITE_NAMESPACE, sharedClusterName, topicPrefix,
-                NUMBER_OF_TOPICS, defaultPartitionCount, 1, 1);
-        KafkaTopicScalabilityUtils.waitForTopicsReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
-
-        // Decrease partitions and expect not ready status
-        KafkaTopicScalabilityUtils.modifyBigAmountOfTopics(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS,
-                new KafkaTopicSpecBuilder().withPartitions(defaultPartitionCount - 1).build());
-        KafkaTopicScalabilityUtils.waitForTopicsNotReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
-
-        // Set back to default and check if topic becomes ready
-        KafkaTopicScalabilityUtils.modifyBigAmountOfTopics(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS,
-                new KafkaTopicSpecBuilder().withPartitions(defaultPartitionCount).build());
-        KafkaTopicScalabilityUtils.waitForTopicsReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
-    }
-
-    @IsolatedTest
-    void testModifyBigAmountOfTopicConfigs(ExtensionContext extensionContext) {
+    void testModifyBigAmountOfTopics(ExtensionContext extensionContext) {
         Map<String, Object> modifiedConfig = new HashMap<>();
+        final int defaultPartitionCount = 1;
+        final int modifiedPartitionCount = defaultPartitionCount + 1;
 
         // Create topics
         KafkaTopicScalabilityUtils.createTopicsViaK8s(extensionContext, Constants.TEST_SUITE_NAMESPACE, sharedClusterName, topicPrefix,
-                NUMBER_OF_TOPICS, 2, 3, 2);
+                NUMBER_OF_TOPICS, defaultPartitionCount, 3, 1);
         KafkaTopicScalabilityUtils.waitForTopicsReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
 
         // Add set of configs and expect topics to have ready status
         modifiedConfig.put("compression.type", "gzip");
         modifiedConfig.put("cleanup.policy", "delete");
         modifiedConfig.put("message.timestamp.type", "LogAppendTime");
-        modifiedConfig.put("min.insync.replicas", 6);
+        modifiedConfig.put("min.insync.replicas", 2);
 
         KafkaTopicScalabilityUtils.modifyBigAmountOfTopics(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS,
                 new KafkaTopicSpecBuilder().withConfig(modifiedConfig).build());
@@ -99,7 +80,6 @@ public class TopicScalabilityST extends AbstractST {
                 new KafkaTopicSpecBuilder().withConfig(modifiedConfig).build());
         KafkaTopicScalabilityUtils.waitForTopicsContainConfig(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS, modifiedConfig);
 
-
         // Set size configs
         modifiedConfig.clear();
         modifiedConfig.put("retention.bytes", 9876543);
@@ -111,21 +91,30 @@ public class TopicScalabilityST extends AbstractST {
                 new KafkaTopicSpecBuilder().withConfig(modifiedConfig).build());
         KafkaTopicScalabilityUtils.waitForTopicsContainConfig(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS, modifiedConfig);
 
-
         // Set back to default state
         modifiedConfig.clear();
         KafkaTopicScalabilityUtils.modifyBigAmountOfTopics(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS,
                 new KafkaTopicSpecBuilder().withConfig(modifiedConfig).build());
         KafkaTopicScalabilityUtils.waitForTopicsReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
+
+        // Try increasing partitions as this should create more load
+        KafkaTopicScalabilityUtils.modifyBigAmountOfTopics(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS,
+                new KafkaTopicSpecBuilder().withPartitions(modifiedPartitionCount).build());
+        KafkaTopicScalabilityUtils.waitForTopicsPartitions(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS, modifiedPartitionCount);
+        KafkaTopicScalabilityUtils.waitForTopicsReady(Constants.TEST_SUITE_NAMESPACE, topicPrefix, NUMBER_OF_TOPICS);
     }
 
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
-        clusterOperator.defaultInstallation(extensionContext).createInstallation().runInstallation();
+        clusterOperator.defaultInstallation(extensionContext)
+            .createInstallation()
+            .runInstallation();
+
         LOGGER.info("Deploying shared Kafka across all test cases in Namespace: {}", Constants.TEST_SUITE_NAMESPACE);
+        cluster.createNamespace(Constants.TEST_SUITE_NAMESPACE);
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(sharedClusterName, 3, 1)
             .editMetadata()
-                .withNamespace(CO_NAMESPACE)
+                .withNamespace(Constants.TEST_SUITE_NAMESPACE)
             .endMetadata()
             .build());
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -31,7 +31,7 @@ import static io.strimzi.systemtest.Constants.SCALABILITY;
 public class TopicScalabilityST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicScalabilityST.class);
-    private static final int NUMBER_OF_TOPICS = 2;
+    private static final int NUMBER_OF_TOPICS = 200;
     private final String sharedClusterName = "topic-scalability-shared-cluster-name";
     final String topicPrefix = "example-topic";
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR should improve tests testModifyBigAmountOfTopics which is merged from two tests that are very similar and deleted testCreateTopicViaAdminClient which seems to be duplicate.

### Checklist


- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

