### PR TITLE
Remove Ready column from the KafkaNodePool CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -55,12 +55,7 @@ import java.util.Map;
                                 name = "Desired replicas",
                                 description = "The desired number of replicas",
                                 jsonPath = ".spec.replicas",
-                                type = "integer"),
-                    @Crd.Spec.AdditionalPrinterColumn(
-                                name = "Ready",
-                                description = "The state of the custom resource",
-                                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
-                                type = "string")
+                                type = "integer")
                 }
         )
 )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -34,10 +34,6 @@ spec:
       description: The desired number of replicas
       jsonPath: .spec.replicas
       type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -34,10 +34,6 @@ spec:
       description: The desired number of replicas
       jsonPath: .spec.replicas
       type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The KafkaNodePool CRD has the _Ready_ column in the _additional printer columns_. But it does not use the Ready state. So the column is always empty. This PR removes it from the CRD definition.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally