### PR TITLE
Sort node pool names in Kafka CR .status section

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -87,6 +87,7 @@ import org.apache.kafka.common.KafkaException;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -1047,7 +1048,7 @@ public class KafkaReconciler {
             }
 
             // Sets the list of used Node Pools in the Kafka CR status
-            kafkaStatus.setKafkaNodePools(statusesForKafka);
+            kafkaStatus.setKafkaNodePools(statusesForKafka.stream().sorted(Comparator.comparing(UsedNodePoolStatus::getName)).toList());
 
             List<Future<KafkaNodePool>> statusUpdateFutures = new ArrayList<>();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using Kafka Node Pools, we set a list of node pools used by a given Kafka cluster in the `.status.kafkaNodePools` section of the `Kafka` CR. However, right now we add it there as a list without any particular sorting. That can cause in some situations unnecessary updates to the status of the custom resource when the ordering changes. This then results in unnecessary reconciliations.

This PR orders the list of node pools based on their name to give it defined order and avoid the unnecessary changes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally