### PR TITLE
Disable silent Kafka binaries download

### DIFF
--- a/docker-images/artifacts/build.sh
+++ b/docker-images/artifacts/build.sh
@@ -155,12 +155,12 @@ function download_kafka_binaries_from_cdn {
     local cdn_url="https://dlcdn.apache.org/${remote_path}"
     
     echo "Downloading from CDN: ${cdn_url}"
-    local cdn_code=$(curl -Ls -o "${local_path}" -w %{http_code} "${cdn_url}")
+    local cdn_code=$(curl -L -o "${local_path}" -w %{http_code} "${cdn_url}")
     echo "CDN HTTP code: ${cdn_code}"
 
     if [[ "${cdn_code}" != "200" ]]; then
         echo "Download from CDN failed. Retrying with archive: ${archive_url}"
-        local archive_code=$(curl -Ls -o "${local_path}" -w %{http_code} "${archive_url}")
+        local archive_code=$(curl -L -o "${local_path}" -w %{http_code} "${archive_url}")
         echo "Archive HTTP code: ${archive_code}"
     fi
 }


### PR DESCRIPTION
When building the images and it comes to download the Kafka binaries, the curl command is executed in "silent" mode without providing any feedback to the user about the download progress.
Due to network issues, slow ISP connection, CDN or archives Apache site being slow, the user could have the following output for several minutes ...

```shell
Fetching Kafka 3.4.0 binaries from: https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz
Downloading from CDN: https://dlcdn.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz
CDN HTTP code: 404
Download from CDN failed. Retrying with archive: https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz
(cursor blinking)
```

He doesn't have any feedback about the download progress.
For example, because I have a very fast ISP connection and I am used to see the download to be pretty fast, I stopped the process after several minutes because I thought there were some problems.
After some checks, the reality was that the archive Apache site was slow instead.

This PR removes the "silent" mode on the curl commands to show the download progress to the user.