### PR TITLE
Remove un-necessary encoding and replace it with inputEncoding parameter in checkstyle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -975,7 +975,6 @@
                             <configLocation>.checkstyle/checkstyle.xml</configLocation>
                             <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <propertyExpansion>importControlFile=${strimziRootDirectory}/.checkstyle/import-control.xml</propertyExpansion>

--- a/pom.xml
+++ b/pom.xml
@@ -975,6 +975,7 @@
                             <configLocation>.checkstyle/checkstyle.xml</configLocation>
                             <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <inputEncoding>UTF-8</inputEncoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <propertyExpansion>importControlFile=${strimziRootDirectory}/.checkstyle/import-control.xml</propertyExpansion>

--- a/pom.xml
+++ b/pom.xml
@@ -975,7 +975,6 @@
                             <configLocation>.checkstyle/checkstyle.xml</configLocation>
                             <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                            <inputEncoding>UTF-8</inputEncoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <propertyExpansion>importControlFile=${strimziRootDirectory}/.checkstyle/import-control.xml</propertyExpansion>


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR removes an `encoding` parameter from checkstyle plugin, which is not present anymore for some technical reasons (i.e., in the 3.1.2 version it was present). Furthermore the 3.3.0 version introduced the `inputEncoding` parameter, which should be equivalent to the `encoding` parameter (based on documentation).

Checkstyle 3.1.2 `encoding` DOC
```
The file encoding to use when reading the source files. If the property project.build.sourceEncoding;
is not set, the platform default encoding is used. Note: This parameter always overrides the
property charset from Checkstyle&apos;s &lt;code&gt;TreeWalker&lt; module.
```

Checkstyle 3.3.0 `inputEncoding` DOC
```
The file encoding to use when reading the source files. If the property project.build.sourceEncoding is not set, the platform default encoding is used. Note: This parameter always overrides the property charset from Checkstyle&apos;s TreeWalker module.
```

More can be found here:

[MCHECKSTYLE-417](https://issues.apache.org/jira/browse/MCHECKSTYLE-417).
[Git Commit](https://github.com/apache/maven-checkstyle-plugin/commit/627fa4f684866a579f2c105fcc1dbf3ed776daa8).

Removes unnecessary warning during build:

```java
[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.0:check (validate)'[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.0:check (validate)'
```

Update:

We decided to go with the approach, where we remove `encoding` parameter and now encoding uses the `<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>` property by default so there is no need to use the `inputEncoding`, which was introduced in 3.3.0.

### Checklist

- [x] Make sure all tests pass

