### PR TITLE
Customize silent curl Kafka binaries download

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -35,6 +35,7 @@ jobs:
         displayName: "Build Java code"
         env:
           MVN_ARGS: "-DskipTests -e -V -B"
+          CURL_ARGS: "-s"
 
       # Run different checks on the code
       - bash: "make spotbugs"

--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -35,6 +35,7 @@ jobs:
         displayName: "Build Java code"
         env:
           MVN_ARGS: "-DskipTests -e -V -B"
+          RUN_ON_CI: "true"
 
       # Run different checks on the code
       - bash: "make spotbugs"

--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       # Get cached Maven repository
       - template: "../../steps/maven_cache.yaml"
-      - task: Cache@2
-        inputs:
-          key: '"kafka-binaries" | kafka-versions.yaml'
-          path: docker-images/artifacts/binaries/kafka/archives
-        displayName: Kafka binaries cache
+      #- task: Cache@2
+      #  inputs:
+      #    key: '"kafka-binaries" | kafka-versions.yaml'
+      #    path: docker-images/artifacts/binaries/kafka/archives
+      #  displayName: Kafka binaries cache
 
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_yq.yaml"

--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       # Get cached Maven repository
       - template: "../../steps/maven_cache.yaml"
-      #- task: Cache@2
-      #  inputs:
-      #    key: '"kafka-binaries" | kafka-versions.yaml'
-      #    path: docker-images/artifacts/binaries/kafka/archives
-      #  displayName: Kafka binaries cache
+      - task: Cache@2
+        inputs:
+          key: '"kafka-binaries" | kafka-versions.yaml'
+          path: docker-images/artifacts/binaries/kafka/archives
+        displayName: Kafka binaries cache
 
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_yq.yaml"

--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -35,7 +35,6 @@ jobs:
         displayName: "Build Java code"
         env:
           MVN_ARGS: "-DskipTests -e -V -B"
-          RUN_ON_CI: "true"
 
       # Run different checks on the code
       - bash: "make spotbugs"

--- a/docker-images/artifacts/build.sh
+++ b/docker-images/artifacts/build.sh
@@ -154,18 +154,13 @@ function download_kafka_binaries_from_cdn {
     local remote_path="${archive_url/https:\/\/archive.apache.org\/dist\//}"
     local cdn_url="https://dlcdn.apache.org/${remote_path}"
 
-    # curl command in silent mode if running on the CI
-    if [[ -n $RUN_ON_CI ]]; then
-        local curl_silent="s"
-    fi
-
     echo "Downloading from CDN: ${cdn_url}"
-    local cdn_code=$(curl -L"${curl_silent}" -o "${local_path}" -w %{http_code} "${cdn_url}")
+    local cdn_code=$(curl -L ${CURL_ARGS} -o "${local_path}" -w %{http_code} "${cdn_url}")
     echo "CDN HTTP code: ${cdn_code}"
 
     if [[ "${cdn_code}" != "200" ]]; then
         echo "Download from CDN failed. Retrying with archive: ${archive_url}"
-        local archive_code=$(curl -L"${curl_silent}" -o "${local_path}" -w %{http_code} "${archive_url}")
+        local archive_code=$(curl -L ${CURL_ARGS} -o "${local_path}" -w %{http_code} "${archive_url}")
         echo "Archive HTTP code: ${archive_code}"
     fi
 }

--- a/docker-images/artifacts/build.sh
+++ b/docker-images/artifacts/build.sh
@@ -153,14 +153,19 @@ function download_kafka_binaries_from_cdn {
     
     local remote_path="${archive_url/https:\/\/archive.apache.org\/dist\//}"
     local cdn_url="https://dlcdn.apache.org/${remote_path}"
-    
+
+    # curl command in silent mode if running on the CI
+    if [[ -n $RUN_ON_CI ]]; then
+        local curl_silent="s"
+    fi
+
     echo "Downloading from CDN: ${cdn_url}"
-    local cdn_code=$(curl -L -o "${local_path}" -w %{http_code} "${cdn_url}")
+    local cdn_code=$(curl -L"${curl_silent}" -o "${local_path}" -w %{http_code} "${cdn_url}")
     echo "CDN HTTP code: ${cdn_code}"
 
     if [[ "${cdn_code}" != "200" ]]; then
         echo "Download from CDN failed. Retrying with archive: ${archive_url}"
-        local archive_code=$(curl -L -o "${local_path}" -w %{http_code} "${archive_url}")
+        local archive_code=$(curl -L"${curl_silent}" -o "${local_path}" -w %{http_code} "${archive_url}")
         echo "Archive HTTP code: ${archive_code}"
     fi
 }

--- a/docker-images/artifacts/build.sh
+++ b/docker-images/artifacts/build.sh
@@ -155,12 +155,12 @@ function download_kafka_binaries_from_cdn {
     local cdn_url="https://dlcdn.apache.org/${remote_path}"
     
     echo "Downloading from CDN: ${cdn_url}"
-    local cdn_code=$(curl -Ls -o "${local_path}" -w %{http_code} "${cdn_url}")
+    local cdn_code=$(curl -L -o "${local_path}" -w %{http_code} "${cdn_url}")
     echo "CDN HTTP code: ${cdn_code}"
 
     if [[ "${cdn_code}" != "200" ]]; then
         echo "Download from CDN failed. Retrying with archive: ${archive_url}"
-        local archive_code=$(curl -Ls -o "${local_path}" -w %{http_code} "${archive_url}")
+        local archive_code=$(curl -L -o "${local_path}" -w %{http_code} "${archive_url}")
         echo "Archive HTTP code: ${archive_code}"
     fi
 }


### PR DESCRIPTION
When building the images and it comes to download the Kafka binaries, the curl command is executed in "silent" mode without providing any feedback to the user about the download progress.
Due to network issues, slow ISP connection, CDN or archives Apache site being slow, the user could have the following output for several minutes ...

```shell
Fetching Kafka 3.4.0 binaries from: https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz
Downloading from CDN: https://dlcdn.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz
CDN HTTP code: 404
Download from CDN failed. Retrying with archive: https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz
(cursor blinking)
```

He doesn't have any feedback about the download progress.
For example, because I have a very fast ISP connection and I am used to see the download to be pretty fast, I stopped the process after several minutes because I thought there were some problems.
After some checks, the reality was that the archive Apache site was slow instead.

This PR removes the "silent" mode on the curl commands to show the download progress to the user.

It replaces #9071 because GitHub had outage, my PR was not updated with commits I was pushing and wasting my time. New PR seems to work here.