### PR TITLE
Update Docker version used in our CI and move `yq` instead of copying it

### DIFF
--- a/.azure/scripts/install_yq.sh
+++ b/.azure/scripts/install_yq.sh
@@ -6,4 +6,4 @@ if [ -z "$ARCH" ]; then
 fi
 
 curl -L https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_${ARCH} > yq && chmod +x yq
-sudo cp yq /usr/bin/
+sudo mv yq /usr/bin/

--- a/.azure/templates/steps/prerequisites/install_docker.yaml
+++ b/.azure/templates/steps/prerequisites/install_docker.yaml
@@ -2,7 +2,8 @@ steps:
   - task: DockerInstaller@0
     displayName: Install Docker
     inputs:
-      dockerVersion: 20.10.8
+      # Versions can be found from https://download.docker.com/linux/static/stable/x86_64/
+      dockerVersion: 24.0.5
       releaseType: stable
   - bash: |
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Docker version used in our CI. It also moves the `yq` binary instead of copying it to _save space_.

This is part of the work on container signing. But as these things are hard to test without merging, I decided to open a separate PR to minimize the risk of breaking the CI 😉.