### PR TITLE
Validate if KafkaConnect spec image equals dockerOutput image

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectBuild.java
@@ -111,8 +111,13 @@ public class KafkaConnectBuild extends AbstractModel {
             // The additionalKanikoOptions are validated separately to avoid parsing the list twice
             if (spec.getBuild().getOutput() != null
                     && spec.getBuild().getOutput() instanceof DockerOutput dockerOutput) {
+
+                // Validation to check if KafkaConnect .spec.image equals .spec.build.output.image name
+                if (dockerOutput.getImage() != null && spec.getImage() != null && dockerOutput.getImage().equals(spec.getImage())) {
+                    throw new InvalidResourceException("KafkaConnect .spec.image cannot be the same as .spec.build.output.image");
+                }
                 if (dockerOutput.getAdditionalKanikoOptions() != null
-                        && !dockerOutput.getAdditionalKanikoOptions().isEmpty())  {
+                        && !dockerOutput.getAdditionalKanikoOptions().isEmpty()) {
                     validateAdditionalKanikoOptions(dockerOutput.getAdditionalKanikoOptions());
                     result.additionalKanikoOptions = dockerOutput.getAdditionalKanikoOptions();
                 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This should fix [#8990](https://github.com/strimzi/strimzi-kafka-operator/issues/8990)

This bugfix validates if `.spec.image` and `spec.build.output.image` are set to the same image and if so then fails the KafkaConnect build gracefully. The exception can be seen in the `status` section of the `kafkaconnect` resource output

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

