### PR TITLE
[ST] addition of kafka version check in kafka status when upgrading kafka

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -109,6 +109,15 @@ public class KafkaUtils {
             });
     }
 
+    public static void waitUntilStatusKafkaVersionMatchesSpecificationKafkaVersion(String clusterName, String namespace) {
+        TestUtils.waitFor("Kafka version in Kafka cluster '" + clusterName + "' to match",
+            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
+                String kafkaVersionInSpec = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getSpec().getKafka().getVersion();
+                String kafkaVersionInStatus = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getKafkaVersion();
+                return kafkaVersionInSpec.equals(kafkaVersionInStatus);
+            });
+    }
+
     public static void waitUntilKafkaStatusConditionContainsMessage(String clusterName, String namespace, String pattern) {
         waitUntilKafkaStatusConditionContainsMessage(clusterName, namespace, pattern, Constants.GLOBAL_STATUS_TIMEOUT);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -109,12 +109,11 @@ public class KafkaUtils {
             });
     }
 
-    public static void waitUntilStatusKafkaVersionMatchesSpecificationKafkaVersion(String clusterName, String namespace) {
-        TestUtils.waitFor("Kafka version in Kafka cluster '" + clusterName + "' to match",
+    public static void waitUntilStatusKafkaVersionMatchesExpectedVersion(String clusterName, String namespace, String expectedKafkaVersion) {
+        TestUtils.waitFor("Kafka version '" + expectedKafkaVersion + "' in Kafka cluster '" + clusterName + "' to match",
             Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT, () -> {
-                String kafkaVersionInSpec = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getSpec().getKafka().getVersion();
                 String kafkaVersionInStatus = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getKafkaVersion();
-                return kafkaVersionInSpec.equals(kafkaVersionInStatus);
+                return expectedKafkaVersion.equals(kafkaVersionInStatus);
             });
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -366,6 +366,6 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
         }
 
         LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", Constants.CO_NAMESPACE, clusterName, newVersion.version());
-        KafkaUtils.waitUntilStatusKafkaVersionMatchesSpecificationKafkaVersion(clusterName, Constants.CO_NAMESPACE);
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(clusterName, Constants.CO_NAMESPACE, newVersion.version());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/KafkaUpgradeDowngradeST.java
@@ -263,8 +263,8 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Pre-change ZooKeeper version query returned: " + zkResult);
 
-        String kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(KafkaResource.getKafkaPodName(clusterName, 0));
-        LOGGER.info("Pre-change Kafka version query returned: " + kafkaVersionResult);
+        String kafkaVersionResult = KafkaResource.kafkaClient().inNamespace(Constants.CO_NAMESPACE).withName(clusterName).get().getStatus().getKafkaVersion();
+        LOGGER.info("Pre-change Kafka version: " + kafkaVersionResult);
 
         Map<String, String> zkPods = PodUtils.podSnapshot(Constants.CO_NAMESPACE, zkSelector);
         kafkaPods = PodUtils.podSnapshot(Constants.CO_NAMESPACE, kafkaSelector);
@@ -364,5 +364,8 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                         .get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version"), is(newVersion.protocolVersion()));
             }
         }
+
+        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", Constants.CO_NAMESPACE, clusterName, newVersion.version());
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesSpecificationKafkaVersion(clusterName, Constants.CO_NAMESPACE);
     }
 }


### PR DESCRIPTION


### Type of change

- Enhancement

### Description

Addition of check whether fields `spec.kafka.version` and `status.version` are matching after kafka version Upgrade. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles


