### PR TITLE
docs(upgrade): adds note on rebuilding images

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-new-image-from-base.adoc
@@ -6,7 +6,7 @@
 = Building a new container image with connector plugins from the Kafka Connect base image
 
 [role="_abstract"]
-Create a custom Docker image with connector plugins from the Kafka Connect base image
+Create a custom Docker image with connector plugins from the Kafka Connect base image.
 Add the custom image to the `/opt/kafka/plugins` directory.
 
 You can use the Kafka container image on {DockerRepository} as a base image for creating your own custom image with additional connector plugins.

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -52,7 +52,7 @@ NOTE: The value of `log.message.format.version` and `inter.broker.protocol.versi
 +
 [NOTE]
 ====
-Changing the `kafka.version` ensures that all brokers in the cluster will be upgraded to start using the new broker binaries.
+Changing the `kafka.version` ensures that all brokers in the cluster are upgraded to start using the new broker binaries.
 During this process, some brokers are using the old binaries while others have already upgraded to the new ones.
 Leaving the `inter.broker.protocol.version` unchanged at the current setting ensures that the brokers can continue to communicate with each other throughout the upgrade.
 ====
@@ -78,7 +78,7 @@ spec:
 +
 WARNING: You cannot downgrade Kafka if the `inter.broker.protocol.version` for the new Kafka version changes. The inter-broker protocol version determines the schemas used for persistent metadata stored by the broker, including messages written to `__consumer_offsets`. The downgraded cluster will not understand the messages.
 
-. If the image for the Kafka cluster is defined in the Kafka custom resource, in `Kafka.spec.kafka.image`, update the `image` to point to a container image with the new Kafka version.
+. If the image for the Kafka cluster is defined in `Kafka.spec.kafka.image` of the `Kafka` custom resource, update the `image` to point to a container image with the new Kafka version.
 +
 See xref:con-versions-and-images-str[Kafka version and image mappings]
 
@@ -100,6 +100,11 @@ If required, set the `version` property for Kafka Connect and MirrorMaker as the
 .. For Kafka Connect, update `KafkaConnect.spec.version`.
 .. For MirrorMaker, update `KafkaMirrorMaker.spec.version`.
 .. For MirrorMaker 2, update `KafkaMirrorMaker2.spec.version`.
++
+NOTE: If you are using custom images that are built manually, you must rebuild those images to include the new version of the client binaries. 
+For example, if you xref:creating-new-image-from-base-str[created a Docker image from the base Kafka Connect image], update the Dockerfile to point to the latest base image and build configuration.
+
+. Verify that the upgraded client applications work correctly with the new Kafka brokers.
 
 . If configured, update the Kafka resource to use the new `inter.broker.protocol.version` version. Otherwise, go to step 9.
 +

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -101,7 +101,7 @@ If required, set the `version` property for Kafka Connect and MirrorMaker as the
 .. For MirrorMaker, update `KafkaMirrorMaker.spec.version`.
 .. For MirrorMaker 2, update `KafkaMirrorMaker2.spec.version`.
 +
-NOTE: If you are using custom images that are built manually, you must rebuild those images to include the new version of the client binaries. 
+NOTE: If you are using custom images that are built manually, you must rebuild those images to ensure that they are up-to-date with the latest Strimzi base image. 
 For example, if you xref:creating-new-image-from-base-str[created a Docker image from the base Kafka Connect image], update the Dockerfile to point to the latest base image and build configuration.
 
 . Verify that the upgraded client applications work correctly with the new Kafka brokers.


### PR DESCRIPTION
**Documentation**

Adds a note to the Kafka upgrade steps on rebuilding images for Kafka Connect when upgrading. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

