### PR TITLE
Update list of KRaft limitations in Node Pool examples README

### DIFF
--- a/packaging/examples/kafka/nodepools/README.md
+++ b/packaging/examples/kafka/nodepools/README.md
@@ -25,6 +25,5 @@ _NOTE: To use this example, you have to enable the `UseKRaft` feature gate in ad
 
 Please be aware that ZooKeeper-less Kafka is still a work in progress and is still missing many features.
 For example:
-* The controller-only nodes are currently not rolled by Strimzi when their configuration changes due to the limitations of the Kafka Admin API. 
-* SCRAM-SHA-512 is not supported.
+* The controller-only nodes are currently not rolled by Strimzi when their configuration changes due to the limitations of the Kafka Admin API.
 * JBOD storage is not supported (you can use the `type: jbod` storage in the Strimzi custom resources, but it should contain only a single volume)


### PR DESCRIPTION
### Type of change

- Task

### Description

The README.md file in the KafkaNodePool examples folder lists the KRaft limitations and among them is also SCRAM-SHA support which now works with Kafka 3.5.0+. This PR updates the README file to remove it to avoid any confusion.