### PR TITLE
[ST] Correct assumption for KRaft tests and Kafka 3.5.0 version

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -38,7 +38,7 @@ import java.util.Random;
 import static io.strimzi.systemtest.Constants.BRIDGE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(INTERNAL_CLIENTS_USED)
 @Tag(BRIDGE)
@@ -109,7 +109,7 @@ class HttpBridgeScramShaST extends AbstractST {
     @BeforeAll
     void setUp(ExtensionContext extensionContext) {
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
 
         clusterOperator = clusterOperator.defaultInstallation(extensionContext)
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -51,7 +51,7 @@ public class KafkaVersionsST extends AbstractST {
     @MethodSource("io.strimzi.systemtest.utils.TestKafkaVersion#getSupportedKafkaVersions")
     void testKafkaWithVersion(final TestKafkaVersion testKafkaVersion, ExtensionContext extensionContext) {
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", testKafkaVersion.version()) == 1);
 
         final TestStorage testStorage = new TestStorage(extensionContext);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.strimzi.systemtest.Constants.KAFKA_SMOKE;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(KAFKA_SMOKE)
 public class KafkaVersionsST extends AbstractST {
@@ -51,7 +51,7 @@ public class KafkaVersionsST extends AbstractST {
     @MethodSource("io.strimzi.systemtest.utils.TestKafkaVersion#getSupportedKafkaVersions")
     void testKafkaWithVersion(final TestKafkaVersion testKafkaVersion, ExtensionContext extensionContext) {
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", testKafkaVersion.version()) != 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
 
         final TestStorage testStorage = new TestStorage(extensionContext);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 
 @Tag(REGRESSION)
@@ -154,7 +154,7 @@ class UserST extends AbstractST {
     @ParallelTest
     void testTlsUserWithQuotas(ExtensionContext extensionContext) {
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
 
         KafkaUser user = KafkaUserTemplates.tlsUser(Constants.TEST_SUITE_NAMESPACE, userClusterName, "encrypted-arnost").build();
 
@@ -165,7 +165,7 @@ class UserST extends AbstractST {
     void testTlsExternalUserWithQuotas(ExtensionContext extensionContext) {
         final TestStorage testStorage = storageMap.get(extensionContext);
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
 
         final String kafkaUserName = testStorage.getKafkaUsername();
         final KafkaUser tlsExternalUser = KafkaUserTemplates.tlsExternalUser(Constants.TEST_SUITE_NAMESPACE, userClusterName, kafkaUserName).build();
@@ -415,7 +415,7 @@ class UserST extends AbstractST {
     @ParallelTest
     void testUOListeningOnlyUsersInSameCluster(ExtensionContext extensionContext) {
         // skip test if KRaft mode is enabled and Kafka version is lower than 3.5.0 - https://github.com/strimzi/strimzi-kafka-operator/issues/8806
-        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) != 1);
+        assumeFalse(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions("3.5.0", Environment.ST_KAFKA_VERSION) == 1);
 
         final TestStorage testStorage = new TestStorage(extensionContext, Constants.TEST_SUITE_NAMESPACE);
         final String userListeningClusterName = "user-listening-cluster";


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In few STs we have assumption for checking if the KRaft is used and also if Kafka version is >= than 3.5.0 - because of the SCRAM-SHA support that was bringed in Kafka 3.5.0.
However, the assumption we had there was wrong -> the tests were executed only when the KRaft mode was enabled and the Kafka version was 3.5.0 -> not in cases when we didn't use KRaft. So the test coverage was actually lower than it should be.

This PR fixes this issue.

(thanks for finding the issue @henryZrncik )

### Checklist

- [ ] Make sure all tests pass

