### PR TITLE
[systemtest] Add annotation for NodePools only mode in tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/NodePoolsOnly.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/NodePoolsOnly.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(NodePoolsOnlyCondition.class)
+public @interface NodePoolsOnly {
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/NodePoolsOnlyCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/NodePoolsOnlyCondition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.systemtest.Environment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class NodePoolsOnlyCondition implements ExecutionCondition {
+
+    private static final Logger LOGGER = LogManager.getLogger(NodePoolsOnlyCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (Environment.isKafkaNodePoolsEnabled()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("According to {} env variable with value: {}, the KafkaNodePools are not used, skipping this test because it should be executed only in KafkaNodePools mode",
+                Environment.STRIMZI_FEATURE_GATES_ENV,
+                Environment.STRIMZI_FEATURE_GATES);
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds annotation for NodePools only mode, with which we can annotate tests that should run only when we have NodePools enabled inside the `STRIMZI_FEATURE_GATES` env. variable.

It will be used as part of #8918 , but we will maybe find other places where we can use it.

### Checklist

- [ ] Make sure all tests pass

