### PR TITLE
docs(typos): corrects asciidoc `subs`  in examples

### DIFF
--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -17,7 +17,7 @@ Finalizers ensure orderly and controlled deletion of `KafkaTopic` resources.
 A finalizer for the Topic Operator is added to the metadata of the `KafkaTopic` resource:
 
 .Finalizer to control topic deletion
-[source,shell,subs="+quotes"]
+[source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
 kind: KafkaTopic
@@ -35,7 +35,7 @@ The finalizer prevents the topic from being fully deleted until the finalization
 If you then delete the topic using `kubectl delete kafkatopic my-topic-1`, a timestamp is added to the metadata:
 
 .Finalizer timestamp on deletion
-[source,shell,subs="+quotes"]
+[source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
 kind: KafkaTopic

--- a/documentation/modules/operators/proc-converting-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-managed-topics.adoc
@@ -42,7 +42,7 @@ oc get kafkatopics my-topic-1 -o yaml
 ----
 +
 .Example topic with a `Ready` status
-[source,shell,subs="+quotes"]
+[source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
 kind: KafkaTopic

--- a/documentation/modules/operators/proc-converting-non-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-non-managed-topics.adoc
@@ -62,7 +62,7 @@ oc get kafkatopics my-topic-1 -o yaml
 ----
 +
 .Example topic with a `Ready` status
-[source,shell,subs="+quotes"]
+[source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
 kind: KafkaTopic


### PR DESCRIPTION
**Documentation**

Corrects from "+quotes" to "+attributes"  in examples so that API version is picked up

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

