### PR TITLE
docs(upgrade):  Add new version fields to examples showing Kafka status

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade.adoc
@@ -30,4 +30,7 @@ include::assembly-upgrade-cluster-operator.adoc[leveloffset=+1]
 
 include::assembly-upgrade-kafka-versions.adoc[leveloffset=+1]
 
+//checking the status of an upgrade
+include::../../modules/upgrading/con-upgrade-status.adoc[leveloffset=+1]
+
 include::../../modules/upgrading/proc-switching-to-FIPS-mode-when-upgrading-Strimzi.adoc[leveloffset=+1]

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -63,10 +63,13 @@ The `status.conditions` and `status.observedGeneration` properties are common to
 
 `status.conditions`:: Status conditions describe the _current state_ of a resource. Status condition properties are useful for tracking progress related to the resource achieving its _desired state_, as defined by the configuration specified in its `spec`. Status condition properties provide the time and reason the state of the resource changed, and details of events preventing or delaying the operator from realizing the desired state.
 
-`status.observedGeneration`:: Last observed generation denotes the latest reconciliation of the resource by the Cluster Operator. If the value of `observedGeneration` is different from the value of `metadata.generation` ((the current version of the deployment), the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
+`status.observedGeneration`:: Last observed generation denotes the latest reconciliation of the resource by the Cluster Operator. If the value of `observedGeneration` is different from the value of `metadata.generation` (the current version of the deployment), the operator has not yet processed the latest update to the resource. If these values are the same, the status information reflects the most recent changes to the resource.
 
 The `status` properties also provide resource-specific information.
 For example, `KafkaStatus` provides information on listener addresses, and the ID of the Kafka cluster.
+
+`KafkaStatus` also provides information on the Kafka and Strimzi versions being used.
+You can check the values of `operatorLastSuccessfulVersion` and `kafkaVersion` to determine whether an upgrade of Strimzi or Kafka has completed  
 
 Strimzi creates and maintains the status of custom resources, periodically evaluating the current state of the custom resource and updating its status accordingly.
 When performing an update on a custom resource using `kubectl edit`, for example, its `status` is not editable. Moreover, changing the `status` would not affect the configuration of the Kafka cluster.
@@ -87,7 +90,8 @@ status:
     - lastTransitionTime: '2023-01-20T17:56:29.396588Z'
       status: 'True'
       type: Ready # <3>
-  listeners: # <4>
+  kafkaVersion: {DefaultKafkaVersion} # <4>
+  listeners: # <5>
     - addresses:
         - host: my-cluster-kafka-bootstrap.prm-project.svc
           port: 9092
@@ -125,13 +129,16 @@ status:
           
           -----END CERTIFICATE-----
       name: external4
-  observedGeneration: 3 # <5>
+  observedGeneration: 3 # <6>
+  operatorLastSuccessfulVersion: {ProductVersion} # <7>
 ----
 <1> The Kafka cluster ID.
 <2> Status `conditions` describe the current state of the Kafka cluster.
 <3> The `Ready` condition indicates that the Cluster Operator considers the Kafka cluster able to handle traffic.
-<4> The `listeners` describe Kafka bootstrap addresses by type.
-<5> The `observedGeneration` value indicates the last reconciliation of the `Kafka` custom resource by the Cluster Operator.
+<4> The version of Kafka being used by the Kafka cluster.
+<5> The `listeners` describe Kafka bootstrap addresses by type.
+<6> The `observedGeneration` value indicates the last reconciliation of the `Kafka` custom resource by the Cluster Operator.
+<7> The version of the operator that successfully completed the last reconciliation. 
 
 NOTE: The Kafka bootstrap addresses listed in the status do not signify that those endpoints or the Kafka cluster is in a `Ready` state.
 

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -87,7 +87,7 @@ my-cluster-kafka-external3-bootstrap  a8d4a6fb363bf447fb6e475fc3040176-36312313.
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
 +
 .Example status for the bootstrap address
-[source,yaml]
+[source,yaml,subs="+attributes"]
 ----
 status:
   clusterId: Y_RJQDGKRXmNF7fEcWldJQ
@@ -95,6 +95,7 @@ status:
     - lastTransitionTime: '2023-01-31T14:59:37.113630Z'
       status: 'True'
       type: Ready
+  kafkaVersion: {DefaultKafkaVersion}    
   listeners:
     # ...
     - addresses:
@@ -110,6 +111,7 @@ status:
           -----END CERTIFICATE-----
       name: external3
   observedGeneration: 2
+  operatorLastSuccessfulVersion: {ProductVersion}
  # ...
 ----
 +

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -81,7 +81,7 @@ my-cluster-kafka-external4-bootstrap  NodePort  172.30.30.23    9094:32650/TCP
 The bootstrap address used for client connection is propagated to the `status` of the `Kafka` resource.
 +
 .Example status for the bootstrap address
-[source,yaml]
+[source,yaml,subs="+attributes"]
 ----
 status:
   clusterId: Y_RJQDGKRXmNF7fEcWldJQ
@@ -89,6 +89,7 @@ status:
     - lastTransitionTime: '2023-01-31T14:59:37.113630Z'
       status: 'True'
       type: Ready
+  kafkaVersion: {DefaultKafkaVersion}
   listeners:
     # ...
     - addresses:
@@ -102,6 +103,7 @@ status:
           -----END CERTIFICATE-----
       name: external4
   observedGeneration: 2
+  operatorLastSuccessfulVersion: {ProductVersion}
  # ...
 ----
 

--- a/documentation/modules/upgrading/con-upgrade-status.adoc
+++ b/documentation/modules/upgrading/con-upgrade-status.adoc
@@ -1,0 +1,31 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-upgrade.adoc
+
+[id='con-upgrade-status-{context}']
+= Checking the status of an upgrade
+
+[role="_abstract"]
+When performing an upgrade, you can check it completed successfully in the status of the `Kafka` custom resource.
+The status provides information on the Strimzi and Kafka versions being used.
+
+To ensure that you have the correct versions after completing an upgrade, verify the `kafkaVersion` and `operatorLastSuccessfulVersion` values in the Kafka status.  
+
+* `operatorLastSuccessfulVersion` is the version of the Strimzi operator that last performed a successful reconciliation.
+* `kafkaVersion` is the the version of Kafka being used by the Kafka cluster.
+
+You can use these values to check an upgrade of Strimzi or Kafka has completed.
+
+.Checking an upgrade from the Kafka status
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+spec:
+  # ...
+status:
+  # ...
+  kafkaVersion: {DefaultKafkaVersion} 
+  operatorLastSuccessfulVersion: {ProductVersion}
+----

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -52,6 +52,7 @@ Wait for the rolling updates to complete.
 kubectl get pod my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
-The image tag shows the new Strimzi version followed by the Kafka version. For example, `_NEW-STRIMZI-VERSION_-kafka-_CURRENT-KAFKA-VERSION_`.
-
-Your Cluster Operator was downgraded to the previous version.
+The image tag shows the new Strimzi version followed by the Kafka version. 
+For example, `<strimzi_version>-kafka-<kafka_version>`.
++
+You can also xref:con-upgrade-status-{context}[check the downgrade has completed successfully from the status of the `Kafka` resource].

--- a/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-brokers-newer-kafka.adoc
@@ -148,5 +148,4 @@ IMPORTANT: From Kafka 3.0.0, when the `inter.broker.protocol.version` is set to 
 
 . Wait for the Cluster Operator to update the cluster.
 +
-* The Kafka cluster and clients are now using the new Kafka version.
-* The brokers are configured to send messages using the inter-broker protocol version and message format version of the new version of Kafka.
+You can xref:con-upgrade-status-{context}[check the upgrade has completed successfully from the status of the `Kafka` resource].

--- a/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-cluster-operator.adoc
@@ -63,13 +63,14 @@ You will upgrade the Kafka version later.
 kubectl get pods my-cluster-kafka-0 -o jsonpath='{.spec.containers[0].image}'
 ----
 +
-The image tag shows the new Operator version. For example:
+The image tag shows the new Strimzi version followed by the Kafka version:
 +
 [source,shell,subs="+quotes,attributes"]
 ----
 {ExampleImageTagUpgrades}
 ----
++
+You can also xref:con-upgrade-status-{context}[check the upgrade has completed successfully from the status of the `Kafka` resource].
 
-Your Cluster Operator was upgraded to version {ProductVersion} but the version of Kafka running in the cluster it manages is unchanged.
-
-Following the Cluster Operator upgrade, you must perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].
+The Cluster Operator is upgraded to version {ProductVersion}, but the version of Kafka running in the cluster it manages is unchanged.
+Following a Cluster Operator upgrade, you must perform a xref:assembly-upgrading-kafka-versions-str[Kafka upgrade].


### PR DESCRIPTION
**Documentation**

Kafka and Strimzi versions are now listed in the `.status section` of the Kafka custom resource.
This PR updates docs so that these properties are present on any examples of the Kafka resource status.
Also explains how the properties can be used in the upgrade section.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

