### PR TITLE
[ST] Namespace deletion recovery Class, namespace usage fix

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -159,6 +159,9 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
         LOGGER.info("Recreating Kafka cluster without Topic Operator");
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
+            .editMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
             .editSpec()
                 .withNewEntityOperator()
                 .endEntityOperator()


### PR DESCRIPTION


### Type of change

- Refactoring

### Description
in Class `NamespaceDeletionRecoveryST` After refactor to usage of new constants for namespaces (i.e.,. `Constants.CO_NAMESPACE`, `Constants.TEST_SUITE_NAMESPACE`) namespace for re-creation of cluster operator was used incorrectly, causing CO to be created and watch different namespace. 

This PR fixes used namespace for CO re-creation. 
Additionally, there is switch to use `testStorage` in all manipulation with namespaces to promote usage of the same namespace in case of future changes/refactoring.  

