### PR TITLE
Add support for stopping connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.38.0
 
 * Sign containers using `cosign`
+* Add support for stopping connectors according to [Strimzi Proposal #54](https://github.com/strimzi/proposals/blob/main/054-stopping-kafka-connect-connectors.md)
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractConnectorSpec.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
@@ -23,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"pause", "tasksMax", "config"})
+@JsonPropertyOrder({"pause", "tasksMax", "config", "state"})
 @EqualsAndHashCode
 public abstract class AbstractConnectorSpec extends Spec {
     private static final long serialVersionUID = 1L;
@@ -36,6 +37,7 @@ public abstract class AbstractConnectorSpec extends Spec {
     private Integer tasksMax;
     private Boolean pause;
     private Map<String, Object> config = new HashMap<>(0);
+    private ConnectorState state;
 
     private AutoRestart autoRestart;
 
@@ -79,6 +81,8 @@ public abstract class AbstractConnectorSpec extends Spec {
      * @return  Flag indicating whether the connector should paused or not
      */
     @Description("Whether the connector should be paused. Defaults to false.")
+    @Deprecated
+    @DeprecatedProperty(description = "Deprecated in Strimzi 0.38.0, use state instead.")
     public Boolean getPause() {
         return pause;
     }
@@ -88,6 +92,7 @@ public abstract class AbstractConnectorSpec extends Spec {
      *
      * @param pause     Set to true to request the connector to be paused. False to have it running.
      */
+    @Deprecated
     public void setPause(Boolean pause) {
         this.pause = pause;
     }
@@ -109,4 +114,22 @@ public abstract class AbstractConnectorSpec extends Spec {
     public void setAutoRestart(AutoRestart autoRestart) {
         this.autoRestart = autoRestart;
     }
+
+    /**
+     * @return The state of the connector
+     */
+    @Description("The state the connector should be in. Defaults to running.")
+    public ConnectorState getState() {
+        return state;
+    }
+
+    /**
+     * Sets the connector state
+     *
+     * @param state The state of the connector
+     */
+    public void setState(ConnectorState state) {
+        this.state = state;
+    }
+
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/ConnectorState.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ConnectorState.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ConnectorState {
+    PAUSED,
+    STOPPED,
+    RUNNING;
+
+    @JsonCreator
+    public static ConnectorState forValue(String value) {
+        switch (value) {
+            case "paused":
+                return PAUSED;
+            case "stopped":
+                return STOPPED;
+            case "running":
+                return RUNNING;
+            default:
+                return null;
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        switch (this) {
+            case PAUSED:
+                return "paused";
+            case STOPPED:
+                return "stopped";
+            case RUNNING:
+                return "running";
+            default:
+                return null;
+        }
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/ConnectorState.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/ConnectorState.java
@@ -7,6 +7,9 @@ package io.strimzi.api.kafka.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * This defines values for the spec.state field of connectors
+ */
 public enum ConnectorState {
     PAUSED,
     STOPPED,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ConnectTimeoutException;
 import io.strimzi.api.kafka.KafkaConnectorList;
 import io.strimzi.api.kafka.model.AbstractKafkaConnectSpec;
+import io.strimzi.api.kafka.model.ConnectorState;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
 import io.strimzi.api.kafka.model.KafkaConnector;
 import io.strimzi.api.kafka.model.KafkaConnectorBuilder;
@@ -421,8 +422,8 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                 if (!needsReconfiguring(reconciliation, connectorName, connectorSpec, desiredConfig.asOrderedProperties().asMap(), currentConfig)) {
                     LOGGER.debugCr(reconciliation, "Connector {} exists and has desired config, {}=={}", connectorName, desiredConfig.asOrderedProperties().asMap(), currentConfig);
                     return apiClient.status(reconciliation, host, port, connectorName)
-                        .compose(status -> pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status))
-                        .compose(ignored -> maybeRestartConnector(reconciliation, host, apiClient, connectorName, resource, new ArrayList<>()))
+                        .compose(status -> updateState(reconciliation, host, apiClient, connectorName, connectorSpec, status, new ArrayList<>()))
+                        .compose(conditions -> maybeRestartConnector(reconciliation, host, apiClient, connectorName, resource, conditions))
                         .compose(conditions -> maybeRestartConnectorTask(reconciliation, host, apiClient, connectorName, resource, conditions))
                         .compose(conditions ->
                             apiClient.statusWithBackOff(reconciliation, new BackOff(200L, 2, 10), host, port, connectorName)
@@ -475,27 +476,64 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         return apiClient.createOrUpdatePutRequest(reconciliation, host, port, connectorName, asJson(connectorSpec, desiredConfig))
             .compose(ignored -> apiClient.statusWithBackOff(reconciliation, new BackOff(200L, 2, 10), host, port,
                     connectorName))
-            .compose(status -> pauseResume(reconciliation, host, apiClient, connectorName, connectorSpec, status))
+            .compose(status -> updateState(reconciliation, host, apiClient, connectorName, connectorSpec, status, new ArrayList<>()))
             .compose(ignored ->  apiClient.status(reconciliation, host, port, connectorName));
     }
 
-    private Future<Void> pauseResume(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, KafkaConnectorSpec connectorSpec, Map<String, Object> status) {
+    private Future<List<Condition>> updateState(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, KafkaConnectorSpec connectorSpec, Map<String, Object> status, List<Condition> conditions) {
         @SuppressWarnings({ "rawtypes" })
         Object path = ((Map) status.getOrDefault("connector", emptyMap())).get("state");
-        if (!(path instanceof String)) {
+        if (!(path instanceof String state)) {
             return Future.failedFuture("JSON response lacked $.connector.state");
         } else {
-            String state = (String) path;
-            boolean shouldPause = Boolean.TRUE.equals(connectorSpec.getPause());
-            if ("RUNNING".equals(state) && shouldPause) {
-                LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
-                return apiClient.pause(reconciliation, host, port, connectorName);
-            } else if ("PAUSED".equals(state) && !shouldPause) {
-                LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
-                return apiClient.resume(reconciliation, host, port, connectorName);
-            } else {
-                return Future.succeededFuture();
+            ConnectorState desiredState = connectorSpec.getState();
+            @SuppressWarnings("deprecation")
+            Boolean shouldPause = connectorSpec.getPause();
+            ConnectorState effectiveState = desiredState != null ? desiredState :
+                    Boolean.TRUE.equals(shouldPause) ? ConnectorState.PAUSED : ConnectorState.RUNNING;
+            if (desiredState != null && shouldPause != null) {
+                String message = "Both pause and state are set. Since pause is deprecated, state takes precedence " +
+                        "so the connector will be " + effectiveState.toValue();
+                LOGGER.warnCr(reconciliation, message);
+                conditions.add(StatusUtils.buildWarningCondition("UpdateState", message));
             }
+            Future<Void> future = Future.succeededFuture();
+            switch (state) {
+                case "RUNNING" -> {
+                    if (effectiveState == ConnectorState.PAUSED) {
+                        LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
+                        future = apiClient.pause(reconciliation, host, port, connectorName);
+                    } else if (effectiveState == ConnectorState.STOPPED) {
+                        LOGGER.debugCr(reconciliation, "Stopping connector {}", connectorName);
+                        future = apiClient.stop(reconciliation, host, port, connectorName);
+                    }
+                }
+                case "PAUSED" -> {
+                    if (effectiveState == ConnectorState.RUNNING) {
+                        LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
+                        future = apiClient.resume(reconciliation, host, port, connectorName);
+                    } else if (effectiveState == ConnectorState.STOPPED) {
+                        LOGGER.debugCr(reconciliation, "Stopping connector {}", connectorName);
+                        future = apiClient.stop(reconciliation, host, port, connectorName);
+                    }
+                }
+                case "STOPPED" -> {
+                    if (effectiveState == ConnectorState.RUNNING) {
+                        LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
+                        future = apiClient.resume(reconciliation, host, port, connectorName);
+                    } else if (effectiveState == ConnectorState.PAUSED) {
+                        LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
+                        future = apiClient.pause(reconciliation, host, port, connectorName);
+                    }
+                }
+                default -> {
+                    // Connectors can also be in the UNASSIGNED or RESTARTING state. We could transition directly
+                    // from these states to PAUSED or STOPPED but as these are transient, and typically lead to
+                    // RUNNING, we ignore them here.
+                    return Future.succeededFuture(conditions);
+                }
+            }
+            return future.compose(ignored -> Future.succeededFuture(conditions));
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -489,40 +489,40 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
             ConnectorState desiredState = connectorSpec.getState();
             @SuppressWarnings("deprecation")
             Boolean shouldPause = connectorSpec.getPause();
-            ConnectorState effectiveState = desiredState != null ? desiredState :
+            ConnectorState targetState = desiredState != null ? desiredState :
                     Boolean.TRUE.equals(shouldPause) ? ConnectorState.PAUSED : ConnectorState.RUNNING;
             if (desiredState != null && shouldPause != null) {
                 String message = "Both pause and state are set. Since pause is deprecated, state takes precedence " +
-                        "so the connector will be " + effectiveState.toValue();
+                        "so the connector will be " + targetState.toValue();
                 LOGGER.warnCr(reconciliation, message);
                 conditions.add(StatusUtils.buildWarningCondition("UpdateState", message));
             }
             Future<Void> future = Future.succeededFuture();
             switch (state) {
                 case "RUNNING" -> {
-                    if (effectiveState == ConnectorState.PAUSED) {
-                        LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
+                    if (targetState == ConnectorState.PAUSED) {
+                        LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = apiClient.pause(reconciliation, host, port, connectorName);
-                    } else if (effectiveState == ConnectorState.STOPPED) {
-                        LOGGER.debugCr(reconciliation, "Stopping connector {}", connectorName);
+                    } else if (targetState == ConnectorState.STOPPED) {
+                        LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
                         future = apiClient.stop(reconciliation, host, port, connectorName);
                     }
                 }
                 case "PAUSED" -> {
-                    if (effectiveState == ConnectorState.RUNNING) {
-                        LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
+                    if (targetState == ConnectorState.RUNNING) {
+                        LOGGER.infoCr(reconciliation, "Resuming connector {}", connectorName);
                         future = apiClient.resume(reconciliation, host, port, connectorName);
-                    } else if (effectiveState == ConnectorState.STOPPED) {
-                        LOGGER.debugCr(reconciliation, "Stopping connector {}", connectorName);
+                    } else if (targetState == ConnectorState.STOPPED) {
+                        LOGGER.infoCr(reconciliation, "Stopping connector {}", connectorName);
                         future = apiClient.stop(reconciliation, host, port, connectorName);
                     }
                 }
                 case "STOPPED" -> {
-                    if (effectiveState == ConnectorState.RUNNING) {
-                        LOGGER.debugCr(reconciliation, "Resuming connector {}", connectorName);
+                    if (targetState == ConnectorState.RUNNING) {
+                        LOGGER.infoCr(reconciliation, "Resuming connector {}", connectorName);
                         future = apiClient.resume(reconciliation, host, port, connectorName);
-                    } else if (effectiveState == ConnectorState.PAUSED) {
-                        LOGGER.debugCr(reconciliation, "Pausing connector {}", connectorName);
+                    } else if (targetState == ConnectorState.PAUSED) {
+                        LOGGER.infoCr(reconciliation, "Pausing connector {}", connectorName);
                         future = apiClient.pause(reconciliation, host, port, connectorName);
                     }
                 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -122,6 +122,16 @@ public interface KafkaConnectApi {
     Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
+     * Make a {@code PUT} request to {@code /connectors/${connectorName}/stop}.
+     * @param reconciliation The reconciliation
+     * @param host The host to make the request to.
+     * @param port The port to make the request to.
+     * @param connectorName The name of the connector to pause.
+     * @return A Future which completes with the result of the request.
+     */
+    Future<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName);
+
+    /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/resume}.
      * @param reconciliation The reconciliation
      * @param host The host to make the request to.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -277,15 +277,20 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
 
     @Override
     public Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
-        return pauseResume(reconciliation, host, port, "/connectors/" + connectorName + "/pause");
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/pause");
+    }
+
+    @Override
+    public Future<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/stop");
     }
 
     @Override
     public Future<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
-        return pauseResume(reconciliation, host, port, "/connectors/" + connectorName + "/resume");
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/resume");
     }
 
-    private Future<Void> pauseResume(Reconciliation reconciliation, String host, int port, String path) {
+    private Future<Void> updateState(Reconciliation reconciliation, String host, int port, String path) {
         LOGGER.debugCr(reconciliation, "Making PUT request to {} ", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.PUT, port, host, path, request -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -277,20 +277,20 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
 
     @Override
     public Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
-        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/pause");
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/pause", 202);
     }
 
     @Override
     public Future<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
-        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/stop");
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/stop", 204);
     }
 
     @Override
     public Future<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
-        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/resume");
+        return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/resume", 202);
     }
 
-    private Future<Void> updateState(Reconciliation reconciliation, String host, int port, String path) {
+    private Future<Void> updateState(Reconciliation reconciliation, String host, int port, String path, int expectedStatusCode) {
         LOGGER.debugCr(reconciliation, "Making PUT request to {} ", path);
         return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
                 httpClient.request(HttpMethod.PUT, port, host, path, request -> {
@@ -299,13 +299,13 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                 .putHeader("Accept", "application/json");
                         request.result().send(response -> {
                             if (response.succeeded()) {
-                                if (response.result().statusCode() == 202) {
+                                if (response.result().statusCode() == expectedStatusCode) {
                                     response.result().bodyHandler(body -> {
                                         result.complete();
                                     });
                                 } else {
                                     result.fail("Unexpected status code " + response.result().statusCode()
-                                            + " for GET request to " + host + ":" + port + path);
+                                            + " for PUT request to " + host + ":" + port + path);
                                 }
                             } else {
                                 result.tryFail(response.cause());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -384,6 +384,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         String className = MIRRORMAKER2_CONNECTOR_PACKAGE + entry.getKey();
 
                         KafkaMirrorMaker2ConnectorSpec mm2ConnectorSpec = entry.getValue().apply(mirror);
+                        @SuppressWarnings("deprecation")
                         KafkaConnectorSpec connectorSpec = new KafkaConnectorSpecBuilder()
                                 .withClassName(className)
                                 .withConfig(mm2ConnectorSpec.getConfig())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.Tags;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.netty.channel.ConnectTimeoutException;
 import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.ConnectorState;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.KafkaConnectResources;
@@ -100,12 +101,12 @@ public class ConnectorMockTest {
 
     private static final String NAMESPACE = "ns";
 
-    static class ConnectorState {
-        boolean paused;
+    static class ConnectorStatus {
+        ConnectorState state;
         JsonObject config;
 
-        public ConnectorState(boolean paused, JsonObject config) {
-            this.paused = paused;
+        public ConnectorStatus(ConnectorState state, JsonObject config) {
+            this.state = state;
             this.config = config;
         }
     }
@@ -120,7 +121,7 @@ public class ConnectorMockTest {
     private ReconnectingWatcher<KafkaConnect> connectWatch;
     private ReconnectingWatcher<KafkaConnector> connectorWatch;
     private KafkaConnectApi api;
-    private HashMap<String, ConnectorState> runningConnectors;
+    private HashMap<String, ConnectorStatus> connectors;
     private KafkaConnectAssemblyOperator kafkaConnectOperator;
     private MetricsProvider metricsProvider;
 
@@ -129,18 +130,18 @@ public class ConnectorMockTest {
     }
 
     private Future<Map<String, Object>> kafkaConnectApiStatusMock(String host, String connectorName)   {
-        ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
+        ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
         Map<String, Object> statusNode = new HashMap<>();
         statusNode.put("name", connectorName);
         Map<String, Object> connector = new HashMap<>();
         statusNode.put("connector", connector);
-        connector.put("state", connectorState.paused ? "PAUSED" : "RUNNING");
+        connector.put("state", connectorStatus.state.toString());
         connector.put("worker_id", "somehost0:8083");
         Map<String, Object> task = new HashMap<>();
         task.put("id", 0);
-        task.put("state", connectorState.paused ? "PAUSED" : "RUNNING");
+        task.put("state", connectorStatus.state.toString());
         task.put("worker_id", "somehost2:8083");
-        List<Map> tasks = singletonList(task);
+        List<Map<String, Object>> tasks = singletonList(task);
         statusNode.put("tasks", tasks);
 
         return Future.succeededFuture(statusNode);
@@ -202,14 +203,15 @@ public class ConnectorMockTest {
             }).onComplete(testContext.succeeding(v -> async.flag()));
     }
 
+    @SuppressWarnings({"checkstyle:JavaNCSS", "checkstyle:NPathComplexity"})
     private void setupMockConnectAPI() {
         api = mock(KafkaConnectApi.class);
-        runningConnectors = new HashMap<>();
+        connectors = new HashMap<>();
 
         when(api.list(any(), any(), anyInt())).thenAnswer(i -> {
             String host = i.getArgument(1);
             String matchingKeyPrefix = host + "##";
-            return Future.succeededFuture(runningConnectors.keySet().stream()
+            return Future.succeededFuture(connectors.keySet().stream()
                     .filter(s -> s.startsWith(matchingKeyPrefix))
                     .map(s -> s.substring(matchingKeyPrefix.length()))
                     .collect(Collectors.toList()));
@@ -226,11 +228,11 @@ public class ConnectorMockTest {
         when(api.getConnectorConfig(any(), any(), any(), anyInt(), any())).thenAnswer(invocation -> {
             String host = invocation.getArgument(2);
             String connectorName = invocation.getArgument(4);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState != null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus != null) {
                 Map<String, String> map = new HashMap<>();
                 map.put("name", connectorName);
-                for (Map.Entry<String, Object> entry : connectorState.config) {
+                for (Map.Entry<String, Object> entry : connectorStatus.config) {
                     if (entry.getValue() != null) {
                         map.put(entry.getKey(), entry.getValue().toString());
                     }
@@ -243,13 +245,13 @@ public class ConnectorMockTest {
         when(api.getConnector(any(), any(), anyInt(), any())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             String connectorName = invocation.getArgument(3);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("GET", String.format("/connectors/%s", connectorName), 404, "Not Found", ""));
             }
             return Future.succeededFuture(TestUtils.map(
                     "name", connectorName,
-                    "config", connectorState.config,
+                    "config", connectorStatus.config,
                     "tasks", emptyMap()));
         });
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
@@ -258,14 +260,14 @@ public class ConnectorMockTest {
             LOGGER.info("###### create " + host);
             String connectorName = invocation.getArgument(3);
             JsonObject connectorConfig = invocation.getArgument(4);
-            runningConnectors.putIfAbsent(key(host, connectorName), new ConnectorState(false, connectorConfig));
+            connectors.putIfAbsent(key(host, connectorName), new ConnectorStatus(ConnectorState.RUNNING, connectorConfig));
             return Future.succeededFuture();
         });
         when(api.delete(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             LOGGER.info("###### delete " + host);
             String connectorName = invocation.getArgument(3);
-            ConnectorState remove = runningConnectors.remove(key(host, connectorName));
+            ConnectorStatus remove = connectors.remove(key(host, connectorName));
             return remove != null ? Future.succeededFuture() : Future.failedFuture("No such connector " + connectorName);
         });
         when(api.statusWithBackOff(any(), any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
@@ -283,32 +285,44 @@ public class ConnectorMockTest {
         when(api.pause(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             String connectorName = invocation.getArgument(3);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
-            if (!connectorState.paused) {
-                runningConnectors.put(key(host, connectorName), new ConnectorState(true, connectorState.config));
+            if (!ConnectorState.PAUSED.equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.PAUSED, connectorStatus.config));
+            }
+            return Future.succeededFuture();
+        });
+        when(api.stop(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
+            String host = invocation.getArgument(1);
+            String connectorName = invocation.getArgument(3);
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
+                return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
+            }
+            if (!ConnectorState.STOPPED.equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.STOPPED, connectorStatus.config));
             }
             return Future.succeededFuture();
         });
         when(api.resume(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             String connectorName = invocation.getArgument(3);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
-            if (connectorState.paused) {
-                runningConnectors.put(key(host, connectorName), new ConnectorState(false, connectorState.config));
+            if (ConnectorState.STOPPED.equals(connectorStatus.state) || ConnectorState.PAUSED.equals(connectorStatus.state)) {
+                connectors.put(key(host, connectorName), new ConnectorStatus(ConnectorState.RUNNING, connectorStatus.config));
             }
             return Future.succeededFuture();
         });
         when(api.restart(any(), anyInt(), anyString(), anyBoolean(), anyBoolean())).thenAnswer(invocation -> {
             String host = invocation.getArgument(0);
             String connectorName = invocation.getArgument(2);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
             return Future.succeededFuture();
@@ -316,8 +330,8 @@ public class ConnectorMockTest {
         when(api.restartTask(any(), anyInt(), anyString(), anyInt())).thenAnswer(invocation -> {
             String host = invocation.getArgument(0);
             String connectorName = invocation.getArgument(2);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("PUT", "", 404, "Not found", "Connector name " + connectorName));
             }
             return Future.succeededFuture();
@@ -325,8 +339,8 @@ public class ConnectorMockTest {
         when(api.getConnectorTopics(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             String host = invocation.getArgument(1);
             String connectorName = invocation.getArgument(3);
-            ConnectorState connectorState = runningConnectors.get(key(host, connectorName));
-            if (connectorState == null) {
+            ConnectorStatus connectorStatus = connectors.get(key(host, connectorName));
+            if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("GET", String.format("/connectors/%s/topics", connectorName), 404, "Not Found", ""));
             }
             return Future.succeededFuture(List.of("my-topic"));
@@ -362,11 +376,11 @@ public class ConnectorMockTest {
 
     private static <T extends CustomResource<?, ? extends Status>> Predicate<T> ready() {
         return c -> c.getStatus() != null
-                && c.getStatus().getConditions().stream()
-                .anyMatch(condition ->
-                        "Ready".equals(condition.getType())
-                                && "True".equals(condition.getStatus())
-                );
+                    && c.getStatus().getConditions().stream()
+                    .anyMatch(condition ->
+                            "Ready".equals(condition.getType())
+                                    && "True".equals(condition.getStatus())
+                    );
     }
 
     private static <T extends CustomResource<?, ? extends Status>> Predicate<T> paused() {
@@ -670,12 +684,12 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         List<StatusDetails> connectorDeleted = Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
         assertThat(connectorDeleted.size(), is(1));
         waitFor("delete call on connect REST api", 1_000, 30_000,
-            () -> runningConnectors.isEmpty());
+            () -> connectors.isEmpty());
         // Verify connector is deleted from the connect via REST api
         verify(api).delete(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -710,7 +724,7 @@ public class ConnectorMockTest {
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(empty()));
+        assertThat(connectors.keySet(), is(empty()));
 
         // Create KafkaConnect cluster and wait till it's ready
         KafkaConnect connect = new KafkaConnectBuilder()
@@ -734,12 +748,12 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         List<StatusDetails> connectorDeleted = Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).delete();
         assertThat(connectorDeleted.size(), is(1));
         waitFor("delete call on connect REST api", 1_000, 30_000,
-            () -> runningConnectors.isEmpty());
+            () -> connectors.isEmpty());
         verify(api, atLeastOnce()).delete(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
@@ -797,7 +811,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         List<StatusDetails> connectDeleted = Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
         assertThat(connectDeleted.size(), is(1));
@@ -837,7 +851,7 @@ public class ConnectorMockTest {
         verify(api, never()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(empty()));
+        assertThat(connectors.keySet(), is(empty()));
 
         // Create KafkaConnect cluster and wait till it's ready
         KafkaConnect connect = new KafkaConnectBuilder()
@@ -861,7 +875,7 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         List<StatusDetails> connectDeleted = Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).withName(connectName).delete();
         assertThat(connectDeleted.size(), is(1));
@@ -979,7 +993,7 @@ public class ConnectorMockTest {
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any()))
             .thenAnswer(invocation -> Future.failedFuture(new ConnectRestException("GET", "/foo", 500, "Internal server error", "Bad stuff happened")));
         // NOTE: Clear runningConnectors as re-mocking it causes an entry to be added
-        runningConnectors.clear();
+        connectors.clear();
 
 
         // Create KafkaConnect cluster and wait till it's ready
@@ -1023,12 +1037,12 @@ public class ConnectorMockTest {
         verify(api, atLeastOnce()).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(empty()));
+        assertThat(connectors.keySet(), is(empty()));
     }
 
-    /** Create connect, create connector, pause connector, resume connector */
+    /** Create connect, create connector, pause connector via deprecated pause field, resume connector */
     @Test
-    public void testConnectorPauseResume() {
+    public void testConnectorDeprecatedPauseResume() {
         String connectName = "cluster";
         String connectorName = "connector";
 
@@ -1074,7 +1088,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         verify(api, never()).pause(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1112,6 +1126,227 @@ public class ConnectorMockTest {
         verify(api, times(1)).resume(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName));
+    }
+
+    /** Create connect, create connector, pause connector, resume connector */
+    @Test
+    public void testConnectorPauseResume() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(1)
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
+        verify(api, atLeastOnce()).list(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                .withName(connectorName)
+                .withNamespace(NAMESPACE)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .withTasksMax(1)
+                .withClassName("Dummy")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(2)).list(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(1)).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        verify(api, never()).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit(spec -> new KafkaConnectorBuilder(spec)
+                .editSpec()
+                .withState(ConnectorState.PAUSED)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "PAUSED");
+
+        verify(api, times(1)).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit(sp -> new KafkaConnectorBuilder(sp)
+                .editSpec()
+                .withState(ConnectorState.RUNNING)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(1)).pause(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, times(1)).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Create connect, create connector, stop connector, resume connector */
+    @Test
+    public void testConnectorStopResume() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        KafkaConnect connect = new KafkaConnectBuilder()
+                .withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(connectName)
+                .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(1)
+                .endSpec()
+                .build();
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).resource(connect).create();
+        waitForConnectReady(connectName);
+
+        // could be triggered twice (creation followed by status update) but waitForConnectReady could be satisfied with single
+        verify(api, atLeastOnce()).list(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, never()).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+
+        // Create KafkaConnector and wait till it's ready
+        KafkaConnector connector = new KafkaConnectorBuilder()
+                .withNewMetadata()
+                .withName(connectorName)
+                .withNamespace(NAMESPACE)
+                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName)
+                .endMetadata()
+                .withNewSpec()
+                .withTasksMax(1)
+                .withClassName("Dummy")
+                .endSpec()
+                .build();
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(connector).create();
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(2)).list(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT));
+        verify(api, times(1)).createOrUpdatePutRequest(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName), any());
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+
+        verify(api, never()).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit(spec -> new KafkaConnectorBuilder(spec)
+                .editSpec()
+                .withState(ConnectorState.STOPPED)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "STOPPED");
+
+        verify(api, times(1)).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, never()).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).withName(connectorName).edit(sp -> new KafkaConnectorBuilder(sp)
+                .editSpec()
+                .withState(ConnectorState.RUNNING)
+                .endSpec()
+                .build());
+
+        waitForConnectorState(connectorName, "RUNNING");
+
+        verify(api, times(1)).stop(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+        verify(api, times(1)).resume(any(),
+                eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
+                eq(connectorName));
+    }
+
+    /** Create connect, create connector, stop connector but Connect does no support it */
+    @Test
+    public void testConnectorBothStateAndPause() {
+        String connectName = "cluster";
+        String connectorName = "connector";
+
+        // Create KafkaConnect cluster and wait till it's ready
+        Crds.kafkaConnectOperation(client).inNamespace(NAMESPACE).resource(new KafkaConnectBuilder()
+                        .withNewMetadata()
+                        .withNamespace(NAMESPACE)
+                        .withName(connectName)
+                        .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                        .endMetadata()
+                        .withNewSpec()
+                        .withReplicas(1)
+                        .endSpec()
+                        .build())
+                .create();
+        waitForConnectReady(connectName);
+
+        String yaml = "apiVersion: kafka.strimzi.io/v1beta2\n" +
+                "kind: KafkaConnector\n" +
+                "metadata:\n" +
+                "  name: " + connectorName + "\n" +
+                "  namespace: " + NAMESPACE + "\n" +
+                "  labels:\n" +
+                "    strimzi.io/cluster: " + connectName + "\n" +
+                "spec:\n" +
+                "  class: EchoSink\n" +
+                "  tasksMax: 1\n" +
+                "  pause: true\n" +
+                "  state: \"stopped\"\n" +
+                "  config:\n" +
+                "    level: INFO\n" +
+                "    topics: timer-topic";
+
+        KafkaConnector kcr = TestUtils.fromYamlString(yaml, KafkaConnector.class);
+        Crds.kafkaConnectorOperation(client).inNamespace(NAMESPACE).resource(kcr).create();
+
+        waitForConnectorReady(connectorName);
+        waitForConnectorState(connectorName, "STOPPED");
+        waitForConnectorCondition(connectorName, "Warning", "DeprecatedFields");
+        waitForConnectorCondition(connectorName, "Warning", "UpdateState");
     }
 
     /** Create connect, create connector, restart connector */
@@ -1162,7 +1397,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1245,7 +1480,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1326,7 +1561,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1408,7 +1643,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
             eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         verify(api, never()).restart(
             eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
@@ -1489,7 +1724,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         when(api.list(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
@@ -1555,7 +1790,7 @@ public class ConnectorMockTest {
         verify(api, times(1)).createOrUpdatePutRequest(any(),
                 eq(KafkaConnectResources.qualifiedServiceName(connectName, NAMESPACE)), eq(KafkaConnectCluster.REST_API_PORT),
                 eq(connectorName), any());
-        assertThat(runningConnectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
+        assertThat(connectors.keySet(), is(Collections.singleton(key("cluster-connect-api.ns.svc", connectorName))));
 
         when(api.list(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));
         when(api.listConnectorPlugins(any(), any(), anyInt())).thenReturn(Future.failedFuture(new ConnectTimeoutException("connection timed out")));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -178,6 +178,12 @@ public class KafkaConnectApiIT {
             .compose(ignored -> client.resume(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
             .onComplete(context.succeeding(i -> { }))
 
+            .compose(ignored -> client.stop(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
+            .onComplete(context.succeeding(i -> { }))
+
+            .compose(ignored -> client.resume(Reconciliation.DUMMY_RECONCILIATION, "localhost", port, "test"))
+            .onComplete(context.succeeding(i -> { }))
+
             .compose(ignored -> client.restart("localhost", port, "test", true, true))
             .onComplete(context.succeeding(i -> { }))
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3097,8 +3097,10 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |xref:type-AutoRestart-{context}[`AutoRestart`]
 |config       1.2+<.<a|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |map
-|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|pause        1.2+<.<a|**The `pause` property has been deprecated.** Deprecated in Strimzi 0.38.0, use state instead. Whether the connector should be paused. Defaults to false.
 |boolean
+|state        1.2+<.<a|The state the connector should be in. Defaults to running.
+|string (one of [running, paused, stopped])
 |====
 
 [id='type-AutoRestart-{context}']
@@ -3301,8 +3303,10 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 |map
 |autoRestart  1.2+<.<a|Automatic restart of connector and tasks configuration.
 |xref:type-AutoRestart-{context}[`AutoRestart`]
-|pause        1.2+<.<a|Whether the connector should be paused. Defaults to false.
+|pause        1.2+<.<a|**The `pause` property has been deprecated.** Deprecated in Strimzi 0.38.0, use state instead. Whether the connector should be paused. Defaults to false.
 |boolean
+|state        1.2+<.<a|The state the connector should be in. Defaults to running.
+|string (one of [running, paused, stopped])
 |====
 
 [id='type-KafkaMirrorMaker2Status-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -77,6 +77,13 @@ spec:
                 pause:
                   type: boolean
                   description: Whether the connector should be paused. Defaults to false.
+                state:
+                  type: string
+                  enum:
+                    - paused
+                    - stopped
+                    - running
+                  description: The state the connector should be in. Defaults to running.
               description: The specification of the Kafka Connector.
             status:
               type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -270,6 +270,13 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 source connector.
                       heartbeatConnector:
                         type: object
@@ -295,6 +302,13 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                       checkpointConnector:
                         type: object
@@ -320,6 +334,13 @@ spec:
                           pause:
                             type: boolean
                             description: Whether the connector should be paused. Defaults to false.
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                       topicsPattern:
                         type: string

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -76,6 +76,13 @@ spec:
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.
+              state:
+                type: string
+                enum:
+                - paused
+                - stopped
+                - running
+                description: The state the connector should be in. Defaults to running.
             description: The specification of the Kafka Connector.
           status:
             type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -269,6 +269,13 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 source connector.
                     heartbeatConnector:
                       type: object
@@ -294,6 +301,13 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                     checkpointConnector:
                       type: object
@@ -319,6 +333,13 @@ spec:
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                     topicsPattern:
                       type: string


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This implements [Proposal 54](https://github.com/strimzi/proposals/blob/main/054-stopping-kafka-connect-connectors.md)

It adds a new field for connectors, state, that can be set to running (the default), paused or stopped. The existing pause field is now deprecated and if both fields are set, state takes precedence.

The proposal also mentions handling Kafka Connect < 3.5 and downgrade stop to pause in this case. From what I understand the next version of Strimzi will only support Kafka >= 3.5 so the `PUT /connector/<CONN>/stop` should be available. For that reason I've not added logic to handle Kafka Connect < 3.5.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

