### PR TITLE
Add container signing with cosign

### DIFF
--- a/.azure/scripts/install_cosign.sh
+++ b/.azure/scripts/install_cosign.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ARCH=$1
+if [ -z "$ARCH" ]; then
+    ARCH="amd64"
+fi
+
+curl -L https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-${ARCH} > cosign && chmod +x cosign
+sudo mv cosign /usr/bin/

--- a/.azure/templates/jobs/build/push_containers.yaml
+++ b/.azure/templates/jobs/build/push_containers.yaml
@@ -11,6 +11,7 @@ jobs:
       # Install Prerequisites
       - template: "../../steps/prerequisites/install_docker.yaml"
       - template: "../../steps/prerequisites/install_yq.yaml"
+      - template: "../../steps/prerequisites/install_cosign.yaml"
 
       # Get the container archives
       - ${{ each arch in parameters.architectures }}:
@@ -64,3 +65,15 @@ jobs:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
           DOCKER_TAG: '${{ parameters.dockerTag }}'
+      - bash: "make docker_sign_manifest"
+        displayName: "Sign container manifests"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          BUILD_ID: $(Build.BuildId)
+          BUILD_COMMIT: $(Build.SourceVersion)
+          DOCKER_REGISTRY: "quay.io"
+          DOCKER_ORG: "strimzi"
+          DOCKER_TAG: '${{ parameters.dockerTag }}'
+          COSIGN_PASSWORD: $(COSIGN_PASSWORD)
+          COSIGN_PRIVATE_KEY: $(COSIGN_PRIVATE_KEY)

--- a/.azure/templates/steps/prerequisites/install_cosign.yaml
+++ b/.azure/templates/steps/prerequisites/install_cosign.yaml
@@ -1,0 +1,3 @@
+steps:
+  - bash: ".azure/scripts/install_cosign.sh"
+    displayName: "Install cosign"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.38.0
 
+* Sign containers using `cosign`
+
 ### Changes, deprecations and removals
 
 * The `Kafka.KafkaStatus.ListenerStatus.type` property has been deprecated for a long time, and now we do not use it anymore.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init systemtest docker-images/artifacts packaging/helm-charts/helm3 packaging/install packaging/examples
 DOCKERDIRS=docker-images/base docker-images/operator docker-images/kafka-based docker-images/maven-builder docker-images/kaniko-executor
-DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_delete_manifest docker_delete_archive
+DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_sign_manifest docker_delete_manifest docker_delete_archive
 JAVA_TARGETS=java_build java_install java_clean
 
 all: prerequisites_check $(SUBDIRS) $(DOCKERDIRS) crd_install dashboard_install helm_install shellcheck docu_versions docu_check

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -14,6 +14,8 @@ DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
 BUILD_TAG          ?= latest
+BUILD_ID           ?= n/a
+BUILD_COMMIT       ?= n/a
 RELEASE_VERSION    ?= $(shell cat $(TOPDIR)/release.version)
 
 ifdef DOCKER_ARCHITECTURE
@@ -65,6 +67,14 @@ docker_amend_manifest_default:
 docker_push_manifest_default:
 	# Push the manifest to the registry
 	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+
+.PHONY: docker_sign_manifest_default
+docker_sign_manifest_default:
+	# Signs the manifest and its images
+	@echo $$COSIGN_PRIVATE_KEY | base64 -d > cosign.key
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign --recursive --tlog-upload=false -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) --key cosign.key $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
+	@rm cosign.key
 
 .PHONY: docker_delete_manifest_default
 docker_delete_manifest_default:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ If you want to get in touch with us first before contributing, you can use:
 ## License
 Strimzi is licensed under the [Apache License](./LICENSE), Version 2.0
 
+## Container signatures
+
+From the 0.38.0 release, Strimzi containers are signed using the [`cosign` tool](https://github.com/sigstore/cosign).
+Strimzi currently does not use the keyless signing and the transparency log.
+To verify the container, you can copy the following public key into a file:
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET3OleLR7h0JqatY2KkECXhA9ZAkC
+TRnbE23Wb5AzJPnpevvQ1QUEQQ5h/I4GobB7/jkGfqYkt6Ct5WOU2cc6HQ==
+-----END PUBLIC KEY-----
+```
+
+And use it to verify the signature:
+
+```
+cosign verify --key strimzi.pub quay.io/strimzi/operator:latest --insecure-ignore-tlog=true
+```
+
 ---
 
 Strimzi is a <a href="http://cncf.io">Cloud Native Computing Foundation</a> sandbox project.

--- a/docker-images/base/Makefile
+++ b/docker-images/base/Makefile
@@ -12,4 +12,7 @@ docker_amend_manifest:
 docker_push_manifest:
 	# Do nothing
 
+docker_sign_manifest:
+	# Do nothing
+
 .PHONY: build clean release

--- a/docker-images/kafka-based/Makefile
+++ b/docker-images/kafka-based/Makefile
@@ -29,6 +29,9 @@ docker_amend_manifest:
 docker_push_manifest:
 	./build.sh docker_push_manifest
 
+docker_sign_manifest:
+	./build.sh docker_sign_manifest
+
 docker_delete_manifest:
 	./build.sh docker_delete_manifest
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds container signing using our own keyset and the `cosign` tool. The signing is done only in the CI and should not affect any local builds done by the developers. The README.md is updated with the information about how to verify the containers if needed.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md