### PR TITLE
Ignore default user quota in User Operator without error

### DIFF
--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/cache/QuotasCache.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/cache/QuotasCache.java
@@ -52,7 +52,10 @@ public class QuotasCache extends AbstractCache<KafkaUserQuotas> {
             ConcurrentHashMap<String, KafkaUserQuotas> map = new ConcurrentHashMap<>((int) (quotas.size() / 0.75f));
 
             for (Map.Entry<ClientQuotaEntity, Map<String, Double>> entry : quotas.entrySet()) {
-                if (entry.getKey().entries().containsKey(ClientQuotaEntity.USER)) {
+                // We have to check if the ClientQuotaEntity.USER value is not null, because the entries might contain
+                // the default user quota for which the key would exist but the value would be null. And that would
+                // throw and NPE when we try to insert it into the cache.
+                if (entry.getKey().entries().get(ClientQuotaEntity.USER) != null) {
                     map.put(entry.getKey().entries().get(ClientQuotaEntity.USER), QuotaUtils.fromClientQuota(entry.getValue()));
                 }
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #9096, when a user configures the default user quota, it breaks the QuotasCache in our User Operator. This PR fixes the USer OPerator to be able to ignore the default user quota. It does not handle or interact with it in any way, just ignores it. That way, users can use the Kafka Admin API to / `kafka-configs.sh` to set the default quota and User Operator to manage the quotas for the individual users.

This should close #9096.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging