### PR TITLE
[ST] removal of duplicities and addition of checks into RollingUpdateST and KafkaRollerST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -18,7 +18,6 @@ import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
-import io.strimzi.systemtest.rollingupdate.KafkaRollerST;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
@@ -161,15 +160,10 @@ class RecoveryST extends AbstractST {
     }
 
     /**
-     * The main difference between this test and KafkaRollerST#testKafkaPodPending()
-     * is that in this test, we are deploying Kafka cluster with an impossible memory request,
-     * but in the KafkaRollerST#testKafkaPodPending()
-     * we first deploy Kafka cluster with a correct configuration, then change the configuration to an unschedulable one, waiting
-     * for one Kafka pod to be in the `Pending` phase. In this test, all 3 Kafka pods are `Pending`. After we
+     * We are deploying Kafka cluster with an impossible memory request, all 3 Kafka pods are `Pending`. After we
      * check that Kafka pods are stable in `Pending` phase (for one minute), we change the memory request so that the pods are again schedulable
      * and wait until the Kafka cluster recovers and becomes `Ready`.
      *
-     * @see {@link KafkaRollerST#testKafkaPodPending(ExtensionContext)}
      */
     @IsolatedTest("We need for each test case its own Cluster Operator")
     void testRecoveryFromImpossibleMemoryRequest() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -14,9 +14,6 @@ import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
@@ -49,7 +46,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -233,56 +229,6 @@ public class KafkaRollerST extends AbstractST {
         assertTrue(checkIfExactlyOneKafkaPodIsNotReady(namespaceName, clusterName));
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> kafka.getSpec().getKafka().setImage(kafkaImage), namespaceName);
-
-        // kafka should get back ready in some reasonable time frame.
-        // Current timeout for wait is set to 14 minutes, which should be enough.
-        // No additional checks are needed, because in case of wait failure, the test will not continue.
-        KafkaUtils.waitForKafkaReady(namespaceName, clusterName);
-    }
-
-    @ParallelNamespaceTest
-    public void testKafkaPodPending(ExtensionContext extensionContext) {
-        final TestStorage testStorage = storageMap.get(extensionContext);
-        final String namespaceName = StUtils.getNamespaceBasedOnRbac(Constants.TEST_SUITE_NAMESPACE, extensionContext);
-        final String clusterName = testStorage.getClusterName();
-
-        ResourceRequirements rr = new ResourceRequirementsBuilder()
-            .withRequests(Collections.emptyMap())
-            .build();
-
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
-            .editSpec()
-                .editKafka()
-                    .withResources(rr)
-                .endKafka()
-            .endSpec()
-            .build());
-
-        Map<String, Quantity> requests = new HashMap<>(2);
-        requests.put("cpu", new Quantity("123456"));
-        requests.put("memory", new Quantity("128Mi"));
-
-        if (Environment.isKafkaNodePoolsEnabled()) {
-            KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(KafkaResource.getNodePoolName(clusterName), knp ->
-                knp.getSpec().getResources().setRequests(requests), namespaceName);
-        } else {
-            KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka ->
-                kafka.getSpec().getKafka().getResources().setRequests(requests), namespaceName);
-        }
-
-        KafkaUtils.waitForKafkaNotReady(namespaceName, clusterName);
-
-        assertTrue(checkIfExactlyOneKafkaPodIsNotReady(namespaceName, clusterName));
-
-        requests.put("cpu", new Quantity("100m"));
-
-        if (Environment.isKafkaNodePoolsEnabled()) {
-            KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(KafkaResource.getNodePoolName(clusterName), knp ->
-                knp.getSpec().getResources().setRequests(requests), namespaceName);
-        } else {
-            KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka ->
-                kafka.getSpec().getKafka().getResources().setRequests(requests), namespaceName);
-        }
 
         // kafka should get back ready in some reasonable time frame.
         // Current timeout for wait is set to 14 minutes, which should be enough.

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -116,7 +116,7 @@ public class KafkaRollerST extends AbstractST {
         List<Event> events = kubeClient(namespaceName).listEventsByResourceUid(uid);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
 
-        // TODO scaling down of Kafka Cluster (with 4 replicas which has KafkaTopic with 4 replicas) can be forbidden in a future due to would-be Topic under-replication
+        // TODO scaling down of Kafka Cluster (with 4 replicas which has KafkaTopic with 4 replicas) can be forbidden in a future due to would-be Topic under-replication (https://github.com/strimzi/strimzi-kafka-operator/pull/9042)
         // scale down
         final int scaledDownReplicas = 3;
         LOGGER.info("Scaling down to {}", scaledDownReplicas);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -116,6 +116,7 @@ public class KafkaRollerST extends AbstractST {
         List<Event> events = kubeClient(namespaceName).listEventsByResourceUid(uid);
         assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
 
+        // TODO scaling down of Kafka Cluster (with 4 replicas which has KafkaTopic with 4 replicas) can be forbidden in a future due to would-be Topic under-replication
         // scale down
         final int scaledDownReplicas = 3;
         LOGGER.info("Scaling down to {}", scaledDownReplicas);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -534,6 +534,7 @@ class RollingUpdateST extends AbstractST {
         for (String cmName : StUtils.getKafkaConfigurationConfigMaps(clusterName, 3)) {
             ConfigMap configMap = kubeClient(namespaceName).getConfigMap(namespaceName, cmName);
             configMap.getData().put("new.kafka.config", "new.config.value");
+            configMap.getData().replace("listeners.config", "TLS_9095");
             kubeClient().updateConfigMapInNamespace(namespaceName, configMap);
         }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description
As Discussed in the ST triage, 
- Removal of redundant test  (`testKafkaPodPending`)
- Addition of change of data into Kafka Config Maps which are used by Operator and making sure it still does not trigger Rolling Update. 
- Investigation of warnings/logs when KafkaTopic become under-replicated due to not enough brokers being available


### Checklist

- [x] Write tests



