### PR TITLE
Make simple authorization docs more clear about the classes and APIs it uses

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRule.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A representation of a single ACL rule for AclAuthorizer
+ * A representation of a single ACL rule for Kafka's built-in authorizer
  */
 @DescriptionFile
 @Buildable(

--- a/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AclRuleResource.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A representation of a single ACL rule for AclAuthorizer
+ * A representation of a single ACL rule for the Kafka's built-in authorizer
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.EXISTING_PROPERTY,

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaAuthorization.java
@@ -35,7 +35,7 @@ public abstract class KafkaAuthorization implements UnknownPropertyPreserving, S
 
     @Description("Authorization type. " +
             "Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. " +
-            "`simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization. " +
+            "`simple` authorization type uses Kafka's built-in authorizer for authorization. " +
             "`keycloak` authorization type uses Keycloak Authorization Services for authorization. " +
             "`opa` authorization type uses Open Policy Agent based authorization." +
             "`custom` authorization type uses user-provided implementation for authorization.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaUserAuthorization.java
@@ -30,7 +30,7 @@ public abstract class KafkaUserAuthorization implements UnknownPropertyPreservin
 
     @Description("Authorization type. " +
             "Currently the only supported type is `simple`. " +
-            "`simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.")
+            "`simple` authorization type uses the Kafka Admin API for managing the ACL rules.")
     public abstract String getType();
 
     @Override

--- a/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
@@ -1,4 +1,4 @@
-Configures access control rules for a `KafkaUser` when brokers are using the `AclAuthorizer`.
+Configures access control rules for a `KafkaUser` when brokers are using the `simple` authorization.
 
 .Example `KafkaUser` configuration with authorization
 [source,yaml,subs="attributes+"]
@@ -94,7 +94,7 @@ The following operations are supported:
 
 Only certain operations work with each resource.
 
-For more details about `AclAuthorizer`, ACLs and supported combinations of resources and operations, see link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
+For more details about `simple` authorization, ACLs and supported combinations of resources and operations, see link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
 
 [id='property-acl-host-{context}']
 = `host`

--- a/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.AclRule.adoc
@@ -1,4 +1,4 @@
-Configures access control rules for a `KafkaUser` when brokers are using the `simple` authorization.
+Configures access control rules for a `KafkaUser` when brokers are using `simple` authorization.
 
 .Example `KafkaUser` configuration with authorization
 [source,yaml,subs="attributes+"]
@@ -94,7 +94,7 @@ The following operations are supported:
 
 Only certain operations work with each resource.
 
-For more details about `simple` authorization, ACLs and supported combinations of resources and operations, see link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
+For more details about `simple` authorization, ACLs, and supported combinations of resources and operations, see link:http://kafka.apache.org/documentation/#security_authz[Authorization and ACLs^].
 
 [id='property-acl-host-{context}']
 = `host`

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
@@ -1,4 +1,4 @@
-Simple authorization in Strimzi uses the `AclAuthorizer` and `StandardAuthorizer` plugins, the default Access Control Lists (ACLs) authorization plugin provided with Apache Kafka.
+For simple authorization, Strimzi uses Kafka's built-in authorization plugins: the `StandardAuthorizer` for KRaft mode and the `AclAuthorizer` for ZooKeeper-based cluster management.
 ACLs allow you to define which users have access to which resources at a granular level.
 
 Configure the `Kafka` custom resource to use simple authorization.

--- a/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.KafkaAuthorizationSimple.adoc
@@ -1,4 +1,4 @@
-Simple authorization in Strimzi uses the `AclAuthorizer` plugin, the default Access Control Lists (ACLs) authorization plugin provided with Apache Kafka.
+Simple authorization in Strimzi uses the `AclAuthorizer` and `StandardAuthorizer` plugins, the default Access Control Lists (ACLs) authorization plugin provided with Apache Kafka.
 ACLs allow you to define which users have access to which resources at a granular level.
 
 Configure the `Kafka` custom resource to use simple authorization.

--- a/documentation/modules/configuring/con-config-kafka.adoc
+++ b/documentation/modules/configuring/con-config-kafka.adoc
@@ -195,7 +195,7 @@ spec:
 <14> Listener authentication mechanism specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0.
 <15> External listener configuration specifies how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`.
 <16> Optional configuration for a Kafka listener certificate managed by an external CA (certificate authority). The `brokerCertChainAndKey` specifies a `Secret` that contains a server certificate and a private key. You can configure Kafka listener certificates on any listener with enabled TLS encryption.
-<17> Authorization enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker. Simple authorization uses the `AclAuthorizer` Kafka plugin.
+<17> Authorization enables simple, OAUTH 2.0, or OPA authorization on the Kafka broker. Simple authorization uses the `AclAuthorizer` and `StandardAuthorizer` Kafka plugins.
 <18> Broker configuration. Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <19> Storage size for persistent volumes may be increased and additional volumes may be added to JBOD storage.
 <20> Persistent storage has additional configuration options, such as a storage `id` and `class` for dynamic volume provisioning.

--- a/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
@@ -13,7 +13,7 @@ Properties for the Kafka Connect cluster group ID and internal topics are config
 Alternatively, you can define them explicitly in the `spec` of the `KafkaConnect` resource. 
 This is useful when xref:con-config-kafka-connect-multiple-instances-{context}[configuring Kafka Connect for multiple instances], as the values for the group ID and topics must differ when running multiple Kafka Connect instances.
 
-Simple authorization uses ACL rules managed by the Kafka `AclAuthorizer` plugin to ensure appropriate access levels. 
+Simple authorization uses ACL rules managed by the Kafka `AclAuthorizer` and `StandardAuthorizer` plugins to ensure appropriate access levels.
 For more information on configuring a `KafkaUser` resource to use simple authorization, see the link:{BookURLConfiguring}#type-AclRule-reference[`AclRule` schema reference^].
 
 .Prerequisites

--- a/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
+++ b/documentation/modules/deploying/proc-deploy-setup-external-clients.adoc
@@ -94,7 +94,7 @@ spec:
 <5> Required. TLS encryption on the listener. For `route` and `ingress` type listeners it must be set to `true`. For mTLS authentication, also use the `authentication` property. 
 <6> Client authentication mechanism on the listener. For server and client authentication using mTLS, you specify `tls: true` and `authentication.type: tls`. 
 <7> (Optional) Depending on the requirements of the listener type, you can specify additional link:{BookURLConfiguring}#type-GenericKafkaListenerConfiguration-reference[listener configuration^].
-<8> Authorization specified as `simple`, which uses the `AclAuthorizer` Kafka plugin.
+<8> Authorization specified as `simple`, which uses the `AclAuthorizer` and `StandardAuthorizer` Kafka plugins.
 <9> (Optional) Super users can access all brokers regardless of any access restrictions defined in ACLs.
 +
 WARNING: An OpenShift route address comprises the Kafka cluster name, the listener name, the project name, and the domain of the router.

--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -15,10 +15,9 @@ Security policies and permissions defined in Keycloak are used to grant access t
 Users and clients are matched against policies that permit access to perform specific actions on Kafka brokers.
 
 Kafka allows all users full access to brokers by default,
-and also provides the `AclAuthorizer` plugin to configure authorization based on Access Control Lists (ACLs).
-
-ZooKeeper stores ACL rules that grant or deny access to resources based on _username_.
-However, OAuth 2.0 token-based authorization with  Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
+and also provides the `AclAuthorizer` and `StandardAuthorizer` plugins to configure authorization based on Access Control Lists (ACLs).
+The ACL rules used by these plugins and used to grant or deny access to resources based on _username_ are stored in the Kafka cluster itself.
+However, OAuth 2.0 token-based authorization with Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use OAuth 2.0 authorization and ACLs.
 
 [role="_additional-resources"]

--- a/documentation/modules/oauth/con-oauth-authorization-intro.adoc
+++ b/documentation/modules/oauth/con-oauth-authorization-intro.adoc
@@ -16,7 +16,7 @@ Users and clients are matched against policies that permit access to perform spe
 
 Kafka allows all users full access to brokers by default,
 and also provides the `AclAuthorizer` and `StandardAuthorizer` plugins to configure authorization based on Access Control Lists (ACLs).
-The ACL rules used by these plugins and used to grant or deny access to resources based on _username_ are stored in the Kafka cluster itself.
+The ACL rules managed by these plugins are used to grant or deny access to resources based on the _username_, and these rules are stored within the Kafka cluster itself.
 However, OAuth 2.0 token-based authorization with Keycloak offers far greater flexibility on how you wish to implement access control to Kafka brokers.
 In addition, you can configure your Kafka brokers to use OAuth 2.0 authorization and ACLs.
 

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -79,7 +79,7 @@ spec:
 When you configure token-based `oauth` authentication, you specify a `jwksEndpointUri` as the URI for local JWT validation.
 The hostname for the `tokenEndpointUri` URI must be the same.
 <3> The client ID of the OAuth 2.0 client definition in Keycloak that has Authorization Services enabled. Typically, `kafka` is used as the ID.
-<4> (Optional) Delegate authorization to Kafka `AclAuthorizer` if access is denied by Keycloak Authorization Services policies.
+<4> (Optional) Delegate authorization to Kafka `AclAuthorizer` and `StandardAuthorizer` if access is denied by Keycloak Authorization Services policies.
 Default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
 <6> (Optional) Designated super users.

--- a/documentation/modules/overview/con-security-configuration-authorization.adoc
+++ b/documentation/modules/overview/con-security-configuration-authorization.adoc
@@ -18,8 +18,8 @@ Supported authorization mechanisms:
 * Open Policy Agent (OPA) authorization
 * Custom authorization
 
-Simple authorization uses `AclAuthorizer`, the default Kafka authorization plugin.
-`AclAuthorizer` uses Access Control Lists (ACLs) to define which users have access to which resources.
+Simple authorization uses `AclAuthorizer` and `StandardAuthorizer` plugins that are part of Apache Kafka.
+It uses Access Control Lists (ACLs) to define which users have access to which resources.
 For custom authorization, you configure your own `Authorizer` plugin to enforce ACL rules. 
 
 OAuth 2.0 and OPA provide policy-based control from an authorization server.

--- a/documentation/modules/overview/con-security-configuration-authorization.adoc
+++ b/documentation/modules/overview/con-security-configuration-authorization.adoc
@@ -18,8 +18,8 @@ Supported authorization mechanisms:
 * Open Policy Agent (OPA) authorization
 * Custom authorization
 
-Simple authorization uses `AclAuthorizer` and `StandardAuthorizer` plugins that are part of Apache Kafka.
-It uses Access Control Lists (ACLs) to define which users have access to which resources.
+Simple authorization uses the`AclAuthorizer` and `StandardAuthorizer` Kafka plugins,
+which are responsible for managing Access Control Lists (ACLs) that specify user access to various resources.
 For custom authorization, you configure your own `Authorizer` plugin to enforce ACL rules. 
 
 OAuth 2.0 and OPA provide policy-based control from an authorization server.

--- a/documentation/modules/security/con-securing-client-authorization.adoc
+++ b/documentation/modules/security/con-securing-client-authorization.adoc
@@ -32,7 +32,7 @@ You can disable it using the `STRIMZI_ACLS_ADMIN_API_SUPPORTED` environment vari
 
 If no authorization is specified, the User Operator does not provision any access rights for the user.
 Whether such a `KafkaUser` can still access resources depends on the authorizer being used.
-For example, for the `simple` authorization, this is determined by the `allow.everyone.if.no.acl.found` configuration in the Kafka cluster.
+For example, for `simple` authorization, this is determined by the `allow.everyone.if.no.acl.found` configuration in the Kafka cluster.
 
 == ACL rules
 

--- a/documentation/modules/security/con-securing-client-authorization.adoc
+++ b/documentation/modules/security/con-securing-client-authorization.adoc
@@ -32,11 +32,11 @@ You can disable it using the `STRIMZI_ACLS_ADMIN_API_SUPPORTED` environment vari
 
 If no authorization is specified, the User Operator does not provision any access rights for the user.
 Whether such a `KafkaUser` can still access resources depends on the authorizer being used.
-For example, for the `AclAuthorizer` this is determined by its `allow.everyone.if.no.acl.found` configuration.
+For example, for the `simple` authorization, this is determined by the `allow.everyone.if.no.acl.found` configuration in the Kafka cluster.
 
 == ACL rules
 
-`AclAuthorizer` uses ACL rules to manage access to Kafka brokers.
+`simple` authorization uses ACL rules to manage access to Kafka brokers.
 
 ACL rules grant access rights to the user, which you specify in the `acls` property.
 

--- a/documentation/modules/security/proc-securing-kafka.adoc
+++ b/documentation/modules/security/proc-securing-kafka.adoc
@@ -50,7 +50,7 @@ spec:
   zookeeper:
     # ...
 ----
-<1> Authorization xref:con-securing-kafka-authorization-str[enables `simple` authorization on the Kafka broker using the `AclAuthorizer` Kafka plugin].
+<1> Authorization xref:con-securing-kafka-authorization-str[enables `simple` authorization on the Kafka broker using the `AclAuthorizer` and `StandardAuthorizer` Kafka plugins].
 <2> List of user principals with unlimited access to Kafka. _CN_ is the common name from the client certificate when mTLS authentication is used.
 <3> Listener authentication mechanisms may be configured for each listener, and xref:assembly-securing-kafka-brokers-{context}[specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0].
 +

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -654,7 +654,7 @@ spec:
                             - opa
                             - keycloak
                             - custom
-                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
+                          description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
                         url:
                           type: string
                           example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -162,7 +162,7 @@ spec:
                       type: string
                       enum:
                         - simple
-                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                   required:
                     - acls
                     - type
@@ -383,7 +383,7 @@ spec:
                       type: string
                       enum:
                         - simple
-                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                   required:
                     - acls
                     - type
@@ -604,7 +604,7 @@ spec:
                       type: string
                       enum:
                         - simple
-                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                      description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                   required:
                     - acls
                     - type

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -653,7 +653,7 @@ spec:
                         - opa
                         - keycloak
                         - custom
-                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
+                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
                       url:
                         type: string
                         example: http://opa:8181/v1/data/kafka/authz/allow

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -161,7 +161,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -382,7 +382,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -603,7 +603,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -161,7 +161,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -382,7 +382,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -603,7 +603,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/acl/SimpleAclRule.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.ArrayList;
 
 /**
- * Immutable class which represents a single ACL rule for AclAuthorizer.
+ * Immutable class which represents a single ACL rule for Kafka's built-in authorizer.
  * The main reason for not using directly the classes from the api module is that we need immutable objects for use in Sets.
  */
 public class SimpleAclRule {


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The current docs seem to in many places refer to the `simple` authorization as using the Kafka `AclAuthorizer`. But this can be confusing as it currently uses both `AclAuthorizer` (ZooKeeper mode) and `StandardAuthorizer` (KRaft mode). This PR tries to make it more clear. It uses both classes in the docs referring to the Kafka brokers configuration and tries to not refer to ny particular class in the User Operator docs as the User Operator really cares only about the Kafka Admin API support and not the actual authorizer class used by the brokers.

### Checklist

- [x] Update documentation