### PR TITLE
[ST] Quick fix of logging resource creation

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -315,7 +315,7 @@ public class ResourceManager {
         if (StUtils.isParallelNamespaceTest(testContext)) {
             if (!Environment.isNamespaceRbacScope()) {
                 final String namespace = testContext.getStore(ExtensionContext.Namespace.GLOBAL).get(Constants.NAMESPACE_KEY).toString();
-                LOGGER.info("Using Namespace: {}", namespace);
+                LOGGER.info("Setting Namespace: {} to resource: {}/{}", namespace, resource.getKind(), resource.getMetadata().getName());
                 resource.getMetadata().setNamespace(namespace);
             }
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -166,6 +166,9 @@ public class ResourceManager {
     private final <T extends HasMetadata> void createResource(ExtensionContext testContext, boolean waitReady, T... resources) {
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
+
+            setNamespaceInResource(testContext, resource);
+
             if (resource.getMetadata().getNamespace() == null) {
                 LOGGER.info("Creating/Updating {} {}",
                         resource.getKind(), resource.getMetadata().getName());
@@ -173,8 +176,6 @@ public class ResourceManager {
                 LOGGER.info("Creating/Updating {} {}/{}",
                         resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName());
             }
-
-            setNamespaceInResource(testContext, resource);
 
             if (resource.getKind().equals(Kafka.RESOURCE_KIND)) {
                 // in case we want to run tests with KafkaNodePools enabled, we want to use it for all the Kafka resources


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is very simple, it changes in which order is the resource namespace is printed. Right now the additional namespace set is done after the LOGGER prints out its current namespace - When running in paralel and in case that no namespace is set for the resource or if it does not correspond with the testContext then the setNamespace method sets the metadata for the resource. So now if tests are run in parallel it might log wrong deployment namespace, this PR should fix it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

