### PR TITLE
docs(connectors): clarifies scope of autorestart when enabled

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -220,7 +220,7 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <16> Cluster alias for the target cluster used by the MirrorMaker 2 connectors.
 <17> Configuration for the `MirrorSourceConnector` that creates remote topics. The `config` overrides the default configuration options.
 <18> The maximum number of tasks that the connector may create. Tasks handle the data replication and run in parallel. If the infrastructure supports the processing overhead, increasing this value can improve throughput. Kafka Connect distributes the tasks between members of the cluster. If there are more tasks than workers, workers are assigned multiple tasks. For sink connectors, aim to have one task for each topic partition consumed. For source connectors, the number of tasks that can run in parallel may also depend on the external system. The connector creates fewer than the maximum number of tasks if it cannot achieve the parallelism.
-<19> Enables automatic restarts of failed connectors and tasks.
+<19> Enables automatic restarts of failed connectors and tasks. By default, the number of restarts is indefinite, but you can set a maximum on the number of automatic restarts using the `maxRestarts` property. 
 <20> Replication factor for mirrored topics created at the target cluster.
 <21> Replication factor for the `MirrorSourceConnector` `offset-syncs` internal topic that maps the offsets of the source and target clusters.
 <22> When ACL rules synchronization is enabled, ACLs are applied to synchronized topics. The default is `true`. This feature is not compatible with the User Operator. If you are using the User Operator, set this property to `false`.

--- a/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
+++ b/documentation/modules/configuring/proc-manual-restart-mirrormaker2-connector-task.adoc
@@ -2,7 +2,7 @@
 // assembly-management-tasks.adoc
 
 [id='proc-manual-restart-mirrormaker2-connector-task-{context}']
-= Performing restarts of MirrorMaker 2 connector task using annotations
+= Performing restarts of MirrorMaker 2 connector tasks using annotations
 
 This procedure describes how to manually trigger a restart of a Kafka MirrorMaker 2 connector task by using a Kubernetes annotation.
 

--- a/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
+++ b/documentation/modules/deploying/proc-deploying-kafkaconnector.adoc
@@ -15,8 +15,7 @@ You remove a connector by deleting its corresponding `KafkaConnector`.
 
 `KafkaConnector` resources must be deployed to the same namespace as the Kafka Connect cluster they link to.
 
-In the configuration shown in this procedure, the `autoRestart` features is enabled (`enabled: true`).
-This enables automatic restarts of failed connectors and tasks.
+In the configuration shown in this procedure, the `autoRestart` feature is enabled (`enabled: true`) for automatic restarts of failed connectors and tasks. 
 You can also annotate the `KafkaConnector` resource to xref:proc-manual-restart-connector-str[restart a connector] or xref:proc-manual-restart-connector-task-str[restart a connector task] manually.
 
 .Example connectors
@@ -65,33 +64,9 @@ With the `KafkaConnector` resources enabled, the Cluster Operator watches for th
 
 . Edit the `examples/connect/source-connector.yaml` file:
 +
-[source,yaml,subs="attributes+"]
-----
-apiVersion: {KafkaConnectorApiVersion}
-kind: KafkaConnector
-metadata:
-  name: my-source-connector # <1>
-  labels:
-    strimzi.io/cluster: my-connect-cluster # <2>
-spec:
-  class: org.apache.kafka.connect.file.FileStreamSourceConnector # <3>
-  tasksMax: 2 # <4>
-  autoRestart: # <5>
-    enabled: true
-  config: # <6>
-    file: "/opt/kafka/LICENSE" # <7>
-    topic: my-topic <8>
-    # ...
-----
-+
-<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
-<2> Name of the Kafka Connect cluster to create the connector instance in. Connectors must be deployed to the same namespace as the Kafka Connect cluster they link to.
-<3> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.
-<4> Maximum number of Kafka Connect tasks that the connector can create.
-<5> Enables automatic restarts of failed connectors and tasks.
-<6> xref:kafkaconnector-configs[Connector configuration] as key-value pairs.
-<7> This example source connector configuration reads data from the `/opt/kafka/LICENSE` file.
-<8> Kafka topic to publish the source data to.
+--
+include::../../shared/snip-example-source-connector-config.adoc[]
+--
 
 . Create the source `KafkaConnector` in your Kubernetes cluster:
 +
@@ -118,11 +93,11 @@ metadata:
   labels:
     strimzi.io/cluster: my-connect
 spec:
-  class: org.apache.kafka.connect.file.FileStreamSinkConnector <1>
+  class: org.apache.kafka.connect.file.FileStreamSinkConnector # <1>
   tasksMax: 2
-  config: <2>
-    file: "/tmp/my-file" <3>
-    topics: my-topic <4>
+  config: # <2>
+    file: "/tmp/my-file" # <3>
+    topics: my-topic # <4>
 ----
 +
 <1> Full name or alias of the connector class. This should be present in the image being used by the Kafka Connect cluster.

--- a/documentation/modules/overview/con-configuration-points-connect.adoc
+++ b/documentation/modules/overview/con-configuration-points-connect.adoc
@@ -183,30 +183,7 @@ You can also specify where the data should sit in Kafka by specifying a target t
 Use `tasksMax` to specify the maximum number of tasks.
 For example, a source connector with `tasksMax: 2` might split the import of source data into two tasks.
 
-.Example KafkaConnector source connector configuration
-[source,yaml,subs="attributes+"]
-----
-apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnector
-metadata:
-  name: my-source-connector  <1>
-  labels:
-    strimzi.io/cluster: my-connect-cluster <2>
-spec:
-  class: org.apache.kafka.connect.file.FileStreamSourceConnector <3>
-  tasksMax: 2 <4>
-  config: <5>
-    file: "/opt/kafka/LICENSE" <6>
-    topic: my-topic <7>
-    # ...
-----
-<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
-<2> Name of the Kafka Connect cluster to create the connector instance in. Connectors must be deployed to the same namespace as the Kafka Connect cluster they link to.
-<3> Full name of the connector class. This should be present in the image being used by the Kafka Connect cluster.
-<4> Maximum number of Kafka Connect tasks that the connector can create.
-<5> link:{BookURLDeploying}#kafkaconnector-configs[Connector configuration^] as key-value pairs.
-<6> Location of the external data file. In this example, we're configuring the `FileStreamSourceConnector` to read from the `/opt/kafka/LICENSE` file.
-<7> Kafka topic to publish the source data to.
+include::../../shared/snip-example-source-connector-config.adoc[]
 
 NOTE: You can link:{BookURLDeploying}#assembly-loading-config-with-providers-str[load confidential configuration values for a connector^] from external sources, such as Kubernetes Secrets or ConfigMaps.
 

--- a/documentation/shared/snip-example-source-connector-config.adoc
+++ b/documentation/shared/snip-example-source-connector-config.adoc
@@ -1,0 +1,28 @@
+//source connector example
+.Example KafkaConnector source connector configuration
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  name: my-source-connector  # <1>
+  labels:
+    strimzi.io/cluster: my-connect-cluster # <2>
+spec:
+  class: org.apache.kafka.connect.file.FileStreamSourceConnector # <3>
+  tasksMax: 2 # <4>
+  autoRestart: # <5>
+    enabled: true
+  config: # <6>
+    file: "/opt/kafka/LICENSE" # <7>
+    topic: my-topic # <8>
+    # ...
+----
+<1> Name of the `KafkaConnector` resource, which is used as the name of the connector. Use any name that is valid for a Kubernetes resource.
+<2> Name of the Kafka Connect cluster to create the connector instance in. Connectors must be deployed to the same namespace as the Kafka Connect cluster they link to.
+<3> Full name of the connector class. This should be present in the image being used by the Kafka Connect cluster.
+<4> Maximum number of Kafka Connect tasks that the connector can create.
+<5> Enables automatic restarts of failed connectors and tasks. By default, the number of restarts is indefinite, but you can set a maximum on the number of automatic restarts using the `maxRestarts` property. 
+<6> link:{BookURLDeploying}#kafkaconnector-configs[Connector configuration^] as key-value pairs.
+<7> Location of the external data file. In this example, we're configuring the `FileStreamSourceConnector` to read from the `/opt/kafka/LICENSE` file.
+<8> Kafka topic to publish the source data to.


### PR DESCRIPTION
**Documentation**

Updates the Kafka Connect and MirorMaker 2 configuration examples to explain scope when enabling automatic restarts.
Property descriptions now say that the restarts are indefinite unless specifying the `maxRestarts` property.
Also creates a single source connector example that's used in the deploying and overview guides. 

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

