### PR TITLE
Add support for Software Bills of Materials (SBOMs) to Strimzi CI

### DIFF
--- a/.azure/scripts/install_syft.sh
+++ b/.azure/scripts/install_syft.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+readonly VERSION="0.90.0"
+
+ARCH=$1
+if [ -z "$ARCH" ]; then
+    ARCH="amd64"
+fi
+
+wget https://github.com/anchore/syft/releases/download/v${VERSION}/syft_${VERSION}_linux_${ARCH}.tar.gz -O syft.tar.gz
+tar xf syft.tar.xz -C /tmp
+chmod +x /tmp/syft
+sudo mv /tmp/syft /usr/bin

--- a/.azure/templates/jobs/build/push_containers.yaml
+++ b/.azure/templates/jobs/build/push_containers.yaml
@@ -12,6 +12,7 @@ jobs:
       - template: "../../steps/prerequisites/install_docker.yaml"
       - template: "../../steps/prerequisites/install_yq.yaml"
       - template: "../../steps/prerequisites/install_cosign.yaml"
+      - template: "../../steps/prerequisites/install_syft.yaml"
 
       # Get the container archives
       - ${{ each arch in parameters.architectures }}:
@@ -77,3 +78,35 @@ jobs:
           DOCKER_TAG: '${{ parameters.dockerTag }}'
           COSIGN_PASSWORD: $(COSIGN_PASSWORD)
           COSIGN_PRIVATE_KEY: $(COSIGN_PRIVATE_KEY)
+      # SBOMs generation, packaging, and signing
+      - ${{ each arch in parameters.architectures }}:
+          - bash: make docker_sbom
+            displayName: "Generate SBOMs for ${{ arch }} containers"
+            env:
+              BUILD_REASON: $(Build.Reason)
+              BRANCH: $(Build.SourceBranch)
+              DOCKER_REGISTRY: "quay.io"
+              DOCKER_ORG: "strimzi"
+              DOCKER_TAG: '${{ parameters.dockerTag }}'
+              DOCKER_ARCHITECTURE: ${{ arch }}
+              COSIGN_PASSWORD: $(COSIGN_PASSWORD)
+              COSIGN_PRIVATE_KEY: $(COSIGN_PRIVATE_KEY)
+      - bash: tar -z -C ./sbom/ -cvpf sbom.tar.gz ./
+        displayName: "Tar the SBOM files"
+      - publish: $(System.DefaultWorkingDirectory)/sbom.tar.gz
+        artifact: SBOMs
+        displayName: "Publish the SBOM files"
+      # push the SBOMs to container registry only for releases
+      - ${{ each arch in parameters.architectures }}:
+          - bash: make docker_push_sbom
+            displayName: "Push SBOMs for ${{ arch }} containers"
+            condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+            env:
+              BUILD_REASON: $(Build.Reason)
+              BRANCH: $(Build.SourceBranch)
+              DOCKER_REGISTRY: "quay.io"
+              DOCKER_ORG: "strimzi"
+              DOCKER_TAG: '${{ parameters.dockerTag }}'
+              DOCKER_ARCHITECTURE: ${{ arch }}
+              COSIGN_PASSWORD: $(COSIGN_PASSWORD)
+              COSIGN_PRIVATE_KEY: $(COSIGN_PRIVATE_KEY)

--- a/.azure/templates/steps/prerequisites/install_syft.yaml
+++ b/.azure/templates/steps/prerequisites/install_syft.yaml
@@ -1,0 +1,3 @@
+steps:
+  - bash: ".azure/scripts/install_syft.sh"
+    displayName: "Install Syft"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.38.0
 
 * Sign containers using `cosign`
+* Generate and publish Software Bill of Materials (SBOMs) of Strimzi containers
 * Add support for stopping connectors according to [Strimzi Proposal #54](https://github.com/strimzi/proposals/blob/main/054-stopping-kafka-connect-connectors.md)
 
 ### Changes, deprecations and removals

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 SUBDIRS=kafka-agent mirror-maker-agent tracing-agent crd-annotations test crd-generator api mockkube certificate-manager operator-common config-model config-model-generator cluster-operator topic-operator user-operator kafka-init systemtest docker-images/artifacts packaging/helm-charts/helm3 packaging/install packaging/examples
 DOCKERDIRS=docker-images/base docker-images/operator docker-images/kafka-based docker-images/maven-builder docker-images/kaniko-executor
-DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_sign_manifest docker_delete_manifest docker_delete_archive
+DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_sign_manifest docker_delete_manifest docker_delete_archive docker_sbom docker_push_sbom
 JAVA_TARGETS=java_build java_install java_clean
 
 all: prerequisites_check $(SUBDIRS) $(DOCKERDIRS) crd_install dashboard_install helm_install shellcheck docu_versions docu_check

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -7,6 +7,7 @@
 # the registry where the image will be pushed (default is Docker Hub).
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 ARCHIVE_DIR=$(TOPDIR)docker-images/container-archives
+SBOM_DIR=$(TOPDIR)sbom
 
 DOCKERFILE_DIR     ?= ./
 DOCKER_CMD         ?= docker
@@ -21,6 +22,7 @@ RELEASE_VERSION    ?= $(shell cat $(TOPDIR)/release.version)
 ifdef DOCKER_ARCHITECTURE
   DOCKER_PLATFORM = --platform linux/$(DOCKER_ARCHITECTURE)
   DOCKER_PLATFORM_TAG_SUFFIX = -$(DOCKER_ARCHITECTURE)
+  SBOM_DIR=$(TOPDIR)sbom/$(DOCKER_ARCHITECTURE)
 endif
 
 all: docker_build docker_push
@@ -80,6 +82,34 @@ docker_sign_manifest_default:
 docker_delete_manifest_default:
 	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
 	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true
+
+.PHONY: docker_sbom_default
+docker_sbom_default:
+	# Saves the SBOM of the image
+	test -d $(SBOM_DIR) || mkdir -p $(SBOM_DIR)
+	# Generate the text format
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	syft packages $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST --output syft-table --file $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt
+	# Generate the SPDX JSON format for machine processing
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	syft packages $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST --output spdx-json --file $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json
+	# Sign the TXT and SPDX-JSON SBOM
+	@echo $$COSIGN_PRIVATE_KEY | base64 -d > cosign.key
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign-blob --tlog-upload=false --key cosign.key --bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt.bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.txt
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign-blob --tlog-upload=false --key cosign.key --bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json.bundle $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json
+	@rm cosign.key
+
+.PHONY: docker_push_sbom_default
+docker_push_sbom_default:
+	# Push the SBOMto the container registry and sign it
+	@echo $$COSIGN_PRIVATE_KEY | base64 -d > cosign.key
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign attach sbom --sbom $(SBOM_DIR)/$(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)/$(DOCKER_TAG)/$$MANIFEST_DIGEST.json $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+	MANIFEST_DIGEST=$(shell docker buildx imagetools inspect $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) --format '{{ json . }}' | jq -r .manifest.digest); \
+	cosign sign --tlog-upload=false -a author=StrimziCI -a BuildID=$(BUILD_ID) -a Commit=$(BUILD_COMMIT) --key cosign.key --attachment sbom $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME)@$$MANIFEST_DIGEST
+	@rm cosign.key
 
 docker_%: docker_%_default
 	@  true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ And use it to verify the signature:
 cosign verify --key strimzi.pub quay.io/strimzi/operator:latest --insecure-ignore-tlog=true
 ```
 
+## Software Bill of Materials (SBOM)
+
+From the 0.38.0 release, Strimzi publishes the software bill of materials (SBOM) of our containers.
+The SBOMs are published as an archive with `SPDX-JSON` and `Syft-Table` formats signed using cosign.
+For releases, they are also pushed into the container registry.
+To verify the SBOM signatures, please use the Strimzi public key:
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET3OleLR7h0JqatY2KkECXhA9ZAkC
+TRnbE23Wb5AzJPnpevvQ1QUEQQ5h/I4GobB7/jkGfqYkt6Ct5WOU2cc6HQ==
+-----END PUBLIC KEY-----
+```
+
+You can use it to verify the signature of the SBOM files with the following command:
+
+```
+cosign verify-blob --key cosign.pub --bundle <SBOM-file>.bundle --insecure-ignore-tlog=true <SBOM-file>
+```
+
 ---
 
 Strimzi is a <a href="http://cncf.io">Cloud Native Computing Foundation</a> sandbox project.

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,7 +1,7 @@
 TOPDIR=$(dir $(lastword $(MAKEFILE_LIST)))
 
 DOCKERDIRS=base operator kafka-based maven-builder kaniko-executor
-DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_delete_manifest docker_delete_archive
+DOCKER_TARGETS=docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_delete_manifest docker_delete_archive docker_sbom docker_push_sbom
 
 all: $(DOCKERDIRS)
 $(DOCKER_TARGETS): $(DOCKERDIRS)

--- a/docker-images/base/Makefile
+++ b/docker-images/base/Makefile
@@ -15,4 +15,10 @@ docker_push_manifest:
 docker_sign_manifest:
 	# Do nothing
 
+docker_sbom:
+	# Do nothing
+
+docker_push_sbom:
+	# Do nothing
+
 .PHONY: build clean release

--- a/docker-images/kafka-based/Makefile
+++ b/docker-images/kafka-based/Makefile
@@ -1,6 +1,6 @@
 TOPDIR = $(dir $(lastword $(MAKEFILE_LIST)))
 RELEASE_VERSION ?= $(shell cat $(TOPDIR)/release.version)
-DOCKER_TARGETS = docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_delete_manifest docker_delete_archive
+DOCKER_TARGETS = docker_build docker_push docker_tag docker_load docker_save docker_amend_manifest docker_push_manifest docker_delete_manifest docker_delete_archive docker_sbom docker_push_sbom
 DOCKER_TAG ?= latest
 
 .PHONY: build clean release all $(DOCKER_TARGETS)
@@ -37,6 +37,12 @@ docker_delete_manifest:
 
 docker_delete_archive:
 	./build.sh docker_delete_archive
+
+docker_sbom:
+	./build.sh docker_sbom
+
+docker_push_sbom:
+	./build.sh docker_push_sbom
 
 all: docker_build docker_push
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for Software Bills of Materials (SBOMs) to Strimzi CI and Strimzi build. It uses Sysft to generate the SBOMs and publishes them in two ways:
* For all release builds, the SBOMs are pushed to Quay.io in SPDX-JSON format and signed with Cosign (same as our containers)
* For all release and `main` branch builds, the Azure CI produces an archive with the SBOMs in SPDX-JSON and Syft-Table formats signed with Cosign

The reason for not pushing the SBOMs for `main` branch to Quay.io is that it would create lot of records without much value (The SBOMs are pushed under the image digest and not under the tag). We might add it in the future if we see some demand.

The reason for including the SyftTable format is that it is easy for humans to read it:

```
NAME                                              VERSION                                    TYPE         
accessors-smart                                   2.4.9                                      java-archive  
acl                                               2.2.53-1.el8                               rpm           
activation                                        1.1.1                                      java-archive  
alsa-lib                                          1.2.8-2.el8                                rpm           
animal-sniffer-annotations                        1.14                                       java-archive 
...
```

_Testing CI changes affecting only the main branch or release is non-trivial. There is a chance that something will not work. But the logic here is executed at the end of the pipeline, so if there are some issues, we can fix them in follow-up PRs without any real impact other then the pipeline failing after it did everyting it does today._

This should have no impact on Strimzi developers as the changes to the build are not trigger by any of the other commands. There should be also no impact on any users who do not care about SBOMs, they can just ignore all of this.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md
