### PR TITLE
This PR fixes the typo in the Syft installation script

### DIFF
--- a/.azure/scripts/install_syft.sh
+++ b/.azure/scripts/install_syft.sh
@@ -9,6 +9,6 @@ if [ -z "$ARCH" ]; then
 fi
 
 wget https://github.com/anchore/syft/releases/download/v${VERSION}/syft_${VERSION}_linux_${ARCH}.tar.gz -O syft.tar.gz
-tar xf syft.tar.xz -C /tmp
+tar xf syft.tar.gz -C /tmp
 chmod +x /tmp/syft
 sudo mv /tmp/syft /usr/bin


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There is a bug in the Syft installation guide caused by a typo that is currently breaking the CI for `main` branch runs. This PR tries to fix it.