### PR TITLE
Allow running ZooKeeper and KRaft based clusters in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@
 * Make sure brokers are empty before scaling them down
 * Update Cruise Control to 2.5.128
 * Add support for pausing `KafkaTopic` reconciliations with the UnidirectionalTopicOperator
+* Allow running ZooKeeper and KRaft based Apache Kafka clusters in parallel when the `+UseKRaft` feature gate is enabled
 
 ### Changes, deprecations and removals
 
 * The `Kafka.KafkaStatus.ListenerStatus.type` property has been deprecated for a long time, and now we do not use it anymore.
   The current plan is to completely remove this property in the next schema version.
   If needed, you can use the `Kafka.KafkaStatus.ListenerStatus.name` property, which has the same value.
+* Added `strimzi.io/kraft` annotation to be applied on `Kafka` custom resource, together with the `+UseKRaft` feature gate enabled, to declare a ZooKeeper or KRaft based cluster.
+  * if `enabled` the `Kafka` resource defines a KRaft-based cluster.
+  * if `disabled`, missing or any other value, the operator handle the `Kafka` resource as a ZooKeeper-based cluster.
 
 ## 0.37.0
 

--- a/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
+++ b/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
@@ -107,4 +107,10 @@ public class ResourceAnnotations {
      */
     public static final String ANNO_STRIMZI_IO_SKIP_BROKER_SCALEDOWN_CHECK = STRIMZI_DOMAIN + "skip-broker-scaledown-check";
 
+    /**
+     * Annotation for defining a cluster as KRaft (enabled) or ZooKeeper (disabled) based.
+     * This annotation is used on the Kafka CR
+     * If missing or with an invalid value, the cluster is assumed to be ZooKeeper-based
+     */
+    public static final String ANNO_STRIMZI_IO_KRAFT = STRIMZI_DOMAIN + "kraft";
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -181,6 +181,11 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     public static final String ENABLED_VALUE_STRIMZI_IO_NODE_POOLS = "enabled";
 
     /**
+     * The annotation value which indicates that the KRaft mode is enabled
+     */
+    public static final String ENABLED_VALUE_STRIMZI_IO_KRAFT = "enabled";
+
+    /**
      * Key under which the broker configuration is stored in Config Map
      */
     public static final String BROKER_CONFIGURATION_FILENAME = "server.config";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -372,4 +372,14 @@ public class ReconcilerUtils {
     public static boolean nodePoolsEnabled(Kafka kafka) {
         return KafkaCluster.ENABLED_VALUE_STRIMZI_IO_NODE_POOLS.equals(Annotations.stringAnnotation(kafka, Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "disabled").toLowerCase(Locale.ENGLISH));
     }
+
+    /**
+     * Checks whether the KRaft mode is enabled for given Kafka custom resource using the strimzi.io/kraft annotation
+     *
+     * @param kafka Tha Kafka custom resource which might have the node-pools annotation
+     * @return True when the KRaft mode is enabled. False otherwise (using ZooKeeper mode).
+     */
+    public static boolean kraftEnabled(Kafka kafka) {
+        return KafkaCluster.ENABLED_VALUE_STRIMZI_IO_KRAFT.equals(Annotations.stringAnnotation(kafka, Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled").toLowerCase(Locale.ENGLISH));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
@@ -79,7 +79,10 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(NAMESPACE)
-                    .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled"))
+                    .withAnnotations(Map.of(
+                            Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled",
+                            Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"
+                    ))
                 .endMetadata()
                 .withNewSpec()
                     .withNewKafka()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -1318,7 +1318,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
     public void testKRaftClusterWithoutNodePools(VertxTestContext context)  {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
-                .withAnnotations(Map.of())
+                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"))
                 .endMetadata()
                 .build();
 
@@ -1364,7 +1364,12 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(Collections.emptyList()));
 
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
-        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(KAFKA));
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                        .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                .endMetadata()
+                .build();
+        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(kafka));
         when(mockKafkaOps.updateStatusAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         StatefulSetOperator mockStsOps = supplier.stsOperations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -1364,12 +1364,12 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(Collections.emptyList()));
 
         CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
-        Kafka kafka = new KafkaBuilder(KAFKA)
+        Kafka kraftEnabledKafka = new KafkaBuilder(KAFKA)
                 .editMetadata()
                         .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .endMetadata()
                 .build();
-        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(kafka));
+        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(kraftEnabledKafka));
         when(mockKafkaOps.updateStatusAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         StatefulSetOperator mockStsOps = supplier.stsOperations;

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -67,8 +67,9 @@ IMPORTANT: **KRaft mode is not ready for production in Apache Kafka or in Strimz
 Enabling the `UseKRaft` feature gate requires the `KafkaNodePools` feature gate to be enabled as well.
 To deploy a Kafka cluster in KRaft mode, you must use the `KafkaNodePool` resources.
 For more details and examples, see xref:deploying-kafka-node-pools-{context}[].
+The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
 
-When the `UseKRaft` feature gate is enabled, the Kafka cluster is deployed without ZooKeeper.
+When the `UseKRaft` feature gate is enabled and such annotation is set, the Kafka cluster is deployed without ZooKeeper.
 *The `.spec.zookeeper` properties in the `Kafka` custom resource are ignored, but still need to be present.*
 The `UseKRaft` feature gate provides an API that configures Kafka cluster nodes and their roles.
 The API is still in development and is expected to change before the KRaft mode is production-ready.
@@ -87,6 +88,8 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 
 .Enabling the UseKRaft feature gate
 To enable the `UseKRaft` feature gate, specify `+UseKRaft,+KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
+If such annotation is set to `disabled`, missing or any other value, the operator will handle the `Kafka` custom resource as using ZooKeeper mode.
 
 [id='ref-operator-stable-connect-identities-feature-gate-{context}']
 == StableConnectIdentities feature gate

--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -24,6 +24,7 @@ metadata:
   name: my-cluster
   annotations:
     strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 3.5.1

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
@@ -32,6 +32,7 @@ metadata:
   name: my-cluster
   annotations:
     strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 3.5.1

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -42,6 +42,7 @@ metadata:
   name: my-cluster
   annotations:
     strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 3.5.1

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -182,6 +182,10 @@ public class ResourceManager {
                 if (Environment.isKafkaNodePoolsEnabled()) {
                     Map<String, String> annotations = resource.getMetadata().getAnnotations();
                     annotations.put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled");
+                    // if the tests are running with UseKRaft enabled, the corresponding annotation is needed for all the Kafka resources
+                    if (Environment.isKRaftModeEnabled()) {
+                        annotations.put(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled");
+                    }
                     resource.getMetadata().setAnnotations(annotations);
                 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -109,6 +109,7 @@ public class FeatureGatesST extends AbstractST {
         Kafka kafka = KafkaTemplates.kafkaPersistent(clusterName, kafkaReplicas)
             .editOrNewMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .editSpec()


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements proposal being still discussed here https://github.com/strimzi/proposals/pull/93.
It adds a new annotation `strimzi.io/kraft` to be applied on a `Kafka` custom resource in order to distinguish between ZooKeeper and KRaft based clusters.
It actually changes the behaviour of the `+UseKRaft` feature gate.
With this change, it's not enough enabling the feature gate to create a KRaft based cluster but it's also needed to apply the `strimzi.io/kraft: enabled` annotation.
The `disabled`, missing or any other values identify the cluster as ZooKeeper based and the operator reconciles it in the proper way.

This PR fixes #9108 as well.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md
