### PR TITLE
Use version variable in Cosign installation

### DIFF
--- a/.azure/scripts/install_cosign.sh
+++ b/.azure/scripts/install_cosign.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+readonly VERSION="2.2.0"
+
 ARCH=$1
 if [ -z "$ARCH" ]; then
     ARCH="amd64"
 fi
 
-curl -L https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-${ARCH} > cosign && chmod +x cosign
+curl -L https://github.com/sigstore/cosign/releases/download/v${VERSION}/cosign-linux-${ARCH} > cosign && chmod +x cosign
 sudo mv cosign /usr/bin/


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR implements the comment form https://github.com/strimzi/drain-cleaner/pull/98#discussion_r1332549079 that we should use a version variable in the cosign installation in the Operators repo as well to have things in sync and easier to copy around.