### PR TITLE
[DOC] Document manual rolling updates of Connect and MM2 clusters

### DIFF
--- a/documentation/assemblies/managing/assembly-rolling-updates.adoc
+++ b/documentation/assemblies/managing/assembly-rolling-updates.adoc
@@ -3,10 +3,10 @@
 // using/assembly-management-tasks.adoc
 
 [id='assembly-rolling-updates-{context}']
-= Starting rolling updates of Kafka, Connect, MirrorMaker 2, and ZooKeeper clusters using annotations
+= Starting rolling updates of Kafka and other operands using annotations
 
-Strimzi supports the use of annotations on resources to manually trigger a rolling update of Kafka, Connect, MirrorMaker 2, and ZooKeeper clusters through the Cluster Operator.
-Rolling updates restart the pods of the resource with new ones.
+Strimzi supports the use of annotations to manually trigger a rolling update of Kafka and other operands through the Cluster Operator.
+Use annotations to initiate rolling updates of Kafka, Kafka Connect, MirrorMaker 2, and ZooKeeper clusters.
 
 Manually performing a rolling update on a specific pod or set of pods is usually only required in exceptional circumstances.
 However, rather than deleting the pods directly, if you perform the rolling update through the Cluster Operator you ensure the following:

--- a/documentation/assemblies/managing/assembly-rolling-updates.adoc
+++ b/documentation/assemblies/managing/assembly-rolling-updates.adoc
@@ -3,9 +3,9 @@
 // using/assembly-management-tasks.adoc
 
 [id='assembly-rolling-updates-{context}']
-= Starting rolling updates of Kafka and ZooKeeper clusters using annotations
+= Starting rolling updates of Kafka, Connect, MirrorMaker 2, and ZooKeeper clusters using annotations
 
-Strimzi supports the use of annotations on resources to manually trigger a rolling update of Kafka and ZooKeeper clusters through the Cluster Operator.
+Strimzi supports the use of annotations on resources to manually trigger a rolling update of Kafka, Connect, MirrorMaker 2, and ZooKeeper clusters through the Cluster Operator.
 Rolling updates restart the pods of the resource with new ones.
 
 Manually performing a rolling update on a specific pod or set of pods is usually only required in exceptional circumstances.

--- a/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
@@ -5,12 +5,13 @@
 [id='proc-manual-rolling-update-pods-{context}']
 = Performing a rolling update using a pod annotation
 
-This procedure describes how to manually trigger a rolling update of an existing Kafka, Connect, MirrorMaker2, or ZooKeeper clusters using a Kubernetes `Pod` annotation.
+This procedure describes how to manually trigger a rolling update of existing Kafka, Kafka Connect, MirrorMaker 2, or ZooKeeper clusters using a Kubernetes `Pod` annotation.
 When multiple pods are annotated, consecutive rolling updates are performed within the same reconciliation run.
 
 .Prerequisites
 
-To perform a manual rolling update, you need a running Cluster Operator and Kafka, Connect, or MirrorMaker2 cluster.
+To perform a manual rolling update, you need a running Cluster Operator.
+The cluster for the component you are updating, whether it's Kafka, Kafka Connect, MirrorMaker 2, or ZooKeeper, must also be running.
 
 You can perform a rolling update on a Kafka cluster regardless of the topic replication factor used.
 But for Kafka to stay operational during the update, you'll need the following:
@@ -43,9 +44,9 @@ spec:
 . Find the name of the `Pod` you want to manually update.
 +
 For example, if your Kafka cluster is named _my-cluster_, the corresponding `Pod` names are _my-cluster-kafka-index_ and _my-cluster-zookeeper-index_.
-For Connect cluster named _my-connect_, the corresponding `Pod` name is _my-connect-connect-index_.
-And for MirrorMaker 2 cluster named _my-mm2_, the corresponding `Pod` name is _my-mm2-mirrormaker2-index_.
-The _index_ will be a number assigned to the `Pod`.
+For a Kafka Connect cluster named _my-connect-cluster_, the corresponding `Pod` name is _my-connect-cluster-connect-index_.
+And for a MirrorMaker 2 cluster named _my-mm2-cluster_, the corresponding `Pod` name is _my-mm2-cluster-mirrormaker2-index_.
+The _index_ is a number assigned to the `Pod`.
 
 . Annotate the `Pod` resource in Kubernetes.
 +
@@ -53,13 +54,13 @@ Use `kubectl annotate`:
 +
 [source,shell,subs=+quotes]
 ----
-kubectl annotate pod _cluster-name_-kafka-_index_ strimzi.io/manual-rolling-update=true
+kubectl annotate pod <cluster_name>-kafka-<index_number> strimzi.io/manual-rolling-update=true
 
-kubectl annotate pod _cluster-name_-zookeeper-_index_ strimzi.io/manual-rolling-update=true
+kubectl annotate pod <cluster_name>-zookeeper-<index_number> strimzi.io/manual-rolling-update=true
 
-kubectl annotate pod _cluster-name_-connect-_index_ strimzi.io/manual-rolling-update=true
+kubectl annotate pod <cluster_name>-connect-<index_number> strimzi.io/manual-rolling-update=true
 
-kubectl annotate pod _cluster-name_-mirrormaker2-_index_ strimzi.io/manual-rolling-update=true
+kubectl annotate pod <cluster_name>-mirrormaker2-<index_number> strimzi.io/manual-rolling-update=true
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).

--- a/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
@@ -5,12 +5,12 @@
 [id='proc-manual-rolling-update-pods-{context}']
 = Performing a rolling update using a pod annotation
 
-This procedure describes how to manually trigger a rolling update of an existing Kafka cluster or ZooKeeper cluster using a Kubernetes `Pod` annotation.
+This procedure describes how to manually trigger a rolling update of an existing Kafka, Connect, MirrorMaker2, or ZooKeeper clusters using a Kubernetes `Pod` annotation.
 When multiple pods are annotated, consecutive rolling updates are performed within the same reconciliation run.
 
 .Prerequisites
 
-To perform a manual rolling update, you need a running Cluster Operator and Kafka cluster.
+To perform a manual rolling update, you need a running Cluster Operator and Kafka, Connect, or MirrorMaker2 cluster.
 
 You can perform a rolling update on a Kafka cluster regardless of the topic replication factor used.
 But for Kafka to stay operational during the update, you'll need the following:
@@ -40,10 +40,12 @@ spec:
 
 .Procedure
 
-. Find the name of the Kafka or ZooKeeper `Pod` you want to manually update.
+. Find the name of the `Pod` you want to manually update.
 +
 For example, if your Kafka cluster is named _my-cluster_, the corresponding `Pod` names are _my-cluster-kafka-index_ and _my-cluster-zookeeper-index_.
-The _index_ starts at zero and ends at the total number of replicas minus one.
+For Connect cluster named _my-connect_, the corresponding `Pod` name is _my-connect-connect-index_.
+And for MirrorMaker 2 cluster named _my-mm2_, the corresponding `Pod` name is _my-mm2-mirrormaker2-index_.
+The _index_ will be a number assigned to the `Pod`.
 
 . Annotate the `Pod` resource in Kubernetes.
 +
@@ -54,8 +56,12 @@ Use `kubectl annotate`:
 kubectl annotate pod _cluster-name_-kafka-_index_ strimzi.io/manual-rolling-update=true
 
 kubectl annotate pod _cluster-name_-zookeeper-_index_ strimzi.io/manual-rolling-update=true
+
+kubectl annotate pod _cluster-name_-connect-_index_ strimzi.io/manual-rolling-update=true
+
+kubectl annotate pod _cluster-name_-mirrormaker2-_index_ strimzi.io/manual-rolling-update=true
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of the annotated `Pod` is triggered, as long as the annotation was detected by the reconciliation process.
-When the rolling update of a pod is complete, the annotation is removed from the `Pod`.
+When the rolling update of a pod is complete, the annotation is automatically removed from the `Pod`.

--- a/documentation/modules/managing/proc-manual-rolling-update-strimzipodset.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-strimzipodset.adoc
@@ -6,33 +6,34 @@
 = Performing a rolling update using a pod management annotation
 
 [role="_abstract"]
-This procedure describes how to trigger a rolling update of Kafka, Connect, MirrorMaker2, or ZooKeeper clusters.
+This procedure describes how to trigger a rolling update of Kafka, Kafka Connect, MirrorMaker 2, or ZooKeeper clusters.
 To trigger the update, you add an annotation to the `StrimziPodSet` that manages the pods running on the cluster.
 
 .Prerequisites
 
-To perform a manual rolling update, you need a running Cluster Operator and Kafka, Connect, or MirrorMaker2 cluster.
+To perform a manual rolling update, you need a running Cluster Operator.
+The cluster for the component you are updating, whether it's Kafka, Kafka Connect, MirrorMaker 2, or ZooKeeper, must also be running.
 
 .Procedure
 
 . Find the name of the resource that controls the pods you want to manually update.
 +
 For example, if your Kafka cluster is named _my-cluster_, the corresponding names are _my-cluster-kafka_ and _my-cluster-zookeeper_.
-For Connect cluster named _my-connect_, the corresponding name is _my-connect-connect_.
-And for MirrorMaker 2 cluster named _my-mm2_, the corresponding name is _my-mm2-mirrormaker2_.
+For a Kafka Connect cluster named _my-connect-cluster_, the corresponding name is _my-connect-cluster-connect_.
+And for a MirrorMaker 2 cluster named _my-mm2-cluster_, the corresponding name is _my-mm2-cluster-mirrormaker2_.
 
 . Use `kubectl annotate` to annotate the appropriate resource in Kubernetes.
 +
 .Annotating a StrimziPodSet
 [source,shell,subs=+quotes]
 ----
-kubectl annotate strimzipodset _<cluster_name>_-kafka strimzi.io/manual-rolling-update=true
+kubectl annotate strimzipodset <cluster_name>-kafka strimzi.io/manual-rolling-update=true
 
-kubectl annotate strimzipodset _<cluster_name>_-zookeeper strimzi.io/manual-rolling-update=true
+kubectl annotate strimzipodset <cluster_name>-zookeeper strimzi.io/manual-rolling-update=true
 
-kubectl annotate strimzipodset _<cluster_name>_-connect strimzi.io/manual-rolling-update=true
+kubectl annotate strimzipodset <cluster_name>-connect strimzi.io/manual-rolling-update=true
 
-kubectl annotate strimzipodset _<cluster_name>_-mirrormaker2 strimzi.io/manual-rolling-update=true
+kubectl annotate strimzipodset <cluster_name>-mirrormaker2 strimzi.io/manual-rolling-update=true
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).

--- a/documentation/modules/managing/proc-manual-rolling-update-strimzipodset.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-strimzipodset.adoc
@@ -6,18 +6,20 @@
 = Performing a rolling update using a pod management annotation
 
 [role="_abstract"]
-This procedure describes how to trigger a rolling update of a Kafka cluster or ZooKeeper cluster.
+This procedure describes how to trigger a rolling update of Kafka, Connect, MirrorMaker2, or ZooKeeper clusters.
 To trigger the update, you add an annotation to the `StrimziPodSet` that manages the pods running on the cluster.
 
 .Prerequisites
 
-To perform a manual rolling update, you need a running Cluster Operator and Kafka cluster.
+To perform a manual rolling update, you need a running Cluster Operator and Kafka, Connect, or MirrorMaker2 cluster.
 
 .Procedure
 
-. Find the name of the resource that controls the Kafka or ZooKeeper pods you want to manually update.
+. Find the name of the resource that controls the pods you want to manually update.
 +
 For example, if your Kafka cluster is named _my-cluster_, the corresponding names are _my-cluster-kafka_ and _my-cluster-zookeeper_.
+For Connect cluster named _my-connect_, the corresponding name is _my-connect-connect_.
+And for MirrorMaker 2 cluster named _my-mm2_, the corresponding name is _my-mm2-mirrormaker2_.
 
 . Use `kubectl annotate` to annotate the appropriate resource in Kubernetes.
 +
@@ -27,8 +29,12 @@ For example, if your Kafka cluster is named _my-cluster_, the corresponding name
 kubectl annotate strimzipodset _<cluster_name>_-kafka strimzi.io/manual-rolling-update=true
 
 kubectl annotate strimzipodset _<cluster_name>_-zookeeper strimzi.io/manual-rolling-update=true
+
+kubectl annotate strimzipodset _<cluster_name>_-connect strimzi.io/manual-rolling-update=true
+
+kubectl annotate strimzipodset _<cluster_name>_-mirrormaker2 strimzi.io/manual-rolling-update=true
 ----
 
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of all pods within the annotated resource is triggered, as long as the annotation was detected by the reconciliation process.
-When the rolling update of all the pods is complete, the annotation is removed from the resource.
+When the rolling update of all the pods is complete, the annotation is automatically removed from the resource.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR does the documentation for the PR #9153 / Issue #9142. It extends the existing docs for the manual rolling updates with mentions of Connect and MM2. It uses separate PR for the docs for easier review.

### Checklist

- [x] Update documentation