### PR TITLE
Add Unidirectional Topic Operator metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 * Allow manual rolling of Kafka Connect and Kafka Mirror Maker 2 pods using the `strimzi.io/manual-rolling-update` annotation (supported only when `StableConnectIdentities` feature gate is enabled) 
 * Make sure brokers are empty before scaling them down
 * Update Cruise Control to 2.5.128
-* Add support for pausing `KafkaTopic` reconciliations with the UnidirectionalTopicOperator
+* Add support for pausing reconciliations to the Unidirectional Topic Operator
 * Allow running ZooKeeper and KRaft based Apache Kafka clusters in parallel when the `+UseKRaft` feature gate is enabled
+* Add support for metrics to the Unidirectional Topic Operator
 
 ### Changes, deprecations and removals
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/BatchOperatorMetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/BatchOperatorMetricsHolder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.metrics;
+
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.model.Labels;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A metrics holder for batch operators.
+ */
+public class BatchOperatorMetricsHolder extends MetricsHolder {
+    private final Map<String, AtomicInteger> reconciliationsMaxQueueMap = new ConcurrentHashMap<>(1);
+    private final Map<String, AtomicInteger> reconciliationsMaxBatchMap = new ConcurrentHashMap<>(1);
+
+    /**
+     * Constructs the operator metrics holder
+     *
+     * @param kind              Kind of the resources for which these metrics apply
+     * @param selectorLabels    Selector labels to select the controller resources
+     * @param metricsProvider   Metrics provider
+     */
+    public BatchOperatorMetricsHolder(String kind, Labels selectorLabels, MetricsProvider metricsProvider) {
+        super(kind, selectorLabels, metricsProvider);
+    }
+
+    /**
+     * Gauge metric for the max size recorded for the event queue.
+     *
+     * @param namespace Namespace of the resources being reconciled
+     *
+     * @return Metrics gauge
+     */
+    public AtomicInteger reconciliationsMaxQueueSize(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.queue.size",
+            metricsProvider, selectorLabels, reconciliationsMaxQueueMap, "Max size recorded for the shared event queue");
+    }
+
+    /**
+     * Gauge metric for the max size recorded for the event batch.
+     *
+     * @param namespace Namespace of the resources being reconciled
+     *
+     * @return Metrics gauge
+     */
+    public AtomicInteger reconciliationsMaxBatchSize(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.batch.size",
+            metricsProvider, selectorLabels, reconciliationsMaxBatchMap, "Max size recorded for a single event batch");
+    }
+}

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
@@ -35,8 +35,6 @@ public abstract class MetricsHolder {
     private final Map<String, Counter> successfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private final Map<String, Counter> lockedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private final Map<String, Timer> reconciliationsTimerMap = new ConcurrentHashMap<>(1);
-    private final Map<String, AtomicInteger> reconciliationsMaxQueueMap = new ConcurrentHashMap<>(1);
-    private final Map<String, AtomicInteger> reconciliationsMaxBatchMap = new ConcurrentHashMap<>(1);
 
     /**
      * Constructs the metrics holder
@@ -161,30 +159,6 @@ public abstract class MetricsHolder {
     public Counter lockedReconciliationsCounter(String namespace) {
         return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.locked", metricsProvider, selectorLabels, lockedReconciliationsCounterMap,
                 "Number of reconciliations skipped because another reconciliation for the same resource was still running");
-    }
-
-    /**
-     * Gauge metric for the max size recorded for the event queue.
-     *
-     * @param namespace Namespace of the resources being reconciled
-     *
-     * @return Metrics gauge
-     */
-    public AtomicInteger reconciliationsMaxQueueSize(String namespace) {
-        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.queue.size",
-            metricsProvider, selectorLabels, reconciliationsMaxQueueMap, "Max size recorded for the shared event queue");
-    }
-
-    /**
-     * Gauge metric for the max size recorded for the event batch.
-     *
-     * @param namespace Namespace of the resources being reconciled
-     *
-     * @return Metrics gauge
-     */
-    public AtomicInteger reconciliationsMaxBatchSize(String namespace) {
-        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.batch.size",
-            metricsProvider, selectorLabels, reconciliationsMaxBatchMap, "Max size recorded for a single event batch");
     }
 
     ////////////////////

--- a/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/metrics/MetricsHolder.java
@@ -35,6 +35,8 @@ public abstract class MetricsHolder {
     private final Map<String, Counter> successfulReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private final Map<String, Counter> lockedReconciliationsCounterMap = new ConcurrentHashMap<>(1);
     private final Map<String, Timer> reconciliationsTimerMap = new ConcurrentHashMap<>(1);
+    private final Map<String, AtomicInteger> reconciliationsMaxQueueMap = new ConcurrentHashMap<>(1);
+    private final Map<String, AtomicInteger> reconciliationsMaxBatchMap = new ConcurrentHashMap<>(1);
 
     /**
      * Constructs the metrics holder
@@ -159,6 +161,30 @@ public abstract class MetricsHolder {
     public Counter lockedReconciliationsCounter(String namespace) {
         return getCounter(namespace, kind, METRICS_PREFIX + "reconciliations.locked", metricsProvider, selectorLabels, lockedReconciliationsCounterMap,
                 "Number of reconciliations skipped because another reconciliation for the same resource was still running");
+    }
+
+    /**
+     * Gauge metric for the max size recorded for the event queue.
+     *
+     * @param namespace Namespace of the resources being reconciled
+     *
+     * @return Metrics gauge
+     */
+    public AtomicInteger reconciliationsMaxQueueSize(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.queue.size",
+            metricsProvider, selectorLabels, reconciliationsMaxQueueMap, "Max size recorded for the shared event queue");
+    }
+
+    /**
+     * Gauge metric for the max size recorded for the event batch.
+     *
+     * @param namespace Namespace of the resources being reconciled
+     *
+     * @return Metrics gauge
+     */
+    public AtomicInteger reconciliationsMaxBatchSize(String namespace) {
+        return getGauge(namespace, kind, METRICS_PREFIX + "reconciliations.max.batch.size",
+            metricsProvider, selectorLabels, reconciliationsMaxBatchMap, "Max size recorded for a single event batch");
     }
 
     ////////////////////

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.client.informers.cache.ItemStore;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.metrics.MetricsHolder;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -43,6 +44,8 @@ class BatchingLoop {
     private final ItemStore<KafkaTopic> itemStore;
     private final Runnable stop;
     private final int maxQueueSize;
+    private final MetricsHolder metrics;
+    private final String namespace;
 
     public BatchingLoop(
             int maxQueueSize,
@@ -51,7 +54,9 @@ class BatchingLoop {
             int maxBatchSize,
             long maxBatchLingerMs,
             ItemStore<KafkaTopic> itemStore,
-            Runnable stop) {
+            Runnable stop,
+            MetricsHolder metrics,
+            String namespace) {
         this.maxQueueSize = maxQueueSize;
         this.queue = new LinkedBlockingDeque<>(maxQueueSize);
         this.controller = controller;
@@ -63,6 +68,8 @@ class BatchingLoop {
         this.maxBatchLingerMs = maxBatchLingerMs;
         this.itemStore = itemStore;
         this.stop = stop;
+        this.metrics = metrics;
+        this.namespace = namespace;
     }
 
     /**
@@ -93,7 +100,8 @@ class BatchingLoop {
      */
     public void offer(TopicEvent event) {
         if (queue.offerFirst(event)) {
-            LOGGER.debugOp("Item {} push onto the deque tail", event);
+            LOGGER.debugOp("Item {} push onto the deque head", event);
+            metrics.reconciliationsMaxQueueSize(namespace).getAndUpdate(size -> size < queue.size() ? queue.size() : size);
         } else {
             LOGGER.errorOp("Queue length {} exceeded, stopping operator. Please increase {} environment variable.",
                     maxQueueSize,
@@ -257,16 +265,13 @@ class BatchingLoop {
                 addToBatch(batchId, batch, rejected, topicEvent);
             }
             LOGGER.traceOp("[Batch #{}] Filled with {} topics", batchId, batch.size());
+            metrics.reconciliationsMaxBatchSize(namespace).getAndUpdate(size -> size < batch.size() ? batch.size() : size);
 
             // here we need a deque and can push `rejected` back on the front of the queue
             //      where they can be taken by the next thread.
             for (int i = rejected.size() - 1; i >= 0; i--) {
                 TopicEvent item = rejected.get(i);
-                if (queue.offerFirst(item)) {
-                    LOGGER.traceOp("[Batch #{}] Item {} returned to deque head", batchId, item);
-                } else {
-                    LOGGER.warnOp("[Batch #{}] Item {} couldn't be pushed onto the deque head after rejection from batch", batchId, item);
-                }
+                offer(item);
             }
         }
 
@@ -288,6 +293,7 @@ class BatchingLoop {
             } else {
                 LOGGER.debugOp("[Batch #{}] Rejecting item {}, already inflight", batchId, topicEvent);
                 rejected.add(topicEvent);
+                metrics.lockedReconciliationsCounter(namespace).increment();
             }
         }
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/ReconcilableTopic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/ReconcilableTopic.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.topic.v2;
 import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.metrics.MetricsHolder;
 
 /**
  * A topic to be reconciled
@@ -54,23 +53,18 @@ public class ReconcilableTopic {
     }
 
     /**
-     * Start the reconciliation timer.
-     * @param metrics Metrics holder
+     * @return The timer sample
      */
-    public void startTimer(MetricsHolder metrics) {
-        if (sample == null) {
-            sample = Timer.start(metrics.metricsProvider().meterRegistry());
-        }
+    public Timer.Sample reconciliationTimerSample() {
+        return sample;
     }
 
     /**
-     * Stop the reconciliation timer if present.
-     * @param metrics Metrics holder
+     * Store the timer sample
+     * @param sample The timer sample
      */
-    public void stopTimer(MetricsHolder metrics) {
-        if (sample != null) {
-            sample.stop(metrics.reconciliationsTimer(reconciliation.namespace()));
-        }
+    public void reconciliationTimerSample(Timer.Sample sample) {
+        this.sample = sample;
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/ReconcilableTopic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/ReconcilableTopic.java
@@ -4,16 +4,74 @@
  */
 package io.strimzi.operator.topic.v2;
 
+import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.metrics.MetricsHolder;
 
 /**
  * A topic to be reconciled
- * @param reconciliation The reconciliation
- * @param kt The topic
- * @param topicName The name of the topic in Kafka (spec.topicName, or metadata.name)
  */
-record ReconcilableTopic(Reconciliation reconciliation, KafkaTopic kt, String topicName) {
+public class ReconcilableTopic {
+    private Reconciliation reconciliation;
+    private KafkaTopic kt;
+    private String topicName;
+    private Timer.Sample sample;
+
+    /**
+     * @param reconciliation The reconciliation
+     * @param kt The topic
+     * @param topicName The name of the topic in Kafka (spec.topicName, or metadata.name)
+     */
+    public ReconcilableTopic(Reconciliation reconciliation, KafkaTopic kt, String topicName) {
+        this.reconciliation = reconciliation;
+        this.kt = kt;
+        this.topicName = topicName;
+    }
+
+    /**
+     * Returns the reconciliation.
+     * @return Reconciliation.
+     */
+    public Reconciliation reconciliation() {
+        return reconciliation;
+    }
+
+    /**
+     * Returns the Kafka topic.
+     * @return Kafka topic.
+     */
+    public KafkaTopic kt() {
+        return kt;
+    }
+
+    /**
+     * Returns the topic name.
+     * @return Topic name
+     */
+    public String topicName() {
+        return topicName;
+    }
+
+    /**
+     * Start the reconciliation timer.
+     * @param metrics Metrics holder
+     */
+    public void startTimer(MetricsHolder metrics) {
+        if (sample == null) {
+            sample = Timer.start(metrics.metricsProvider().meterRegistry());
+        }
+    }
+
+    /**
+     * Stop the reconciliation timer if present.
+     * @param metrics Metrics holder
+     */
+    public void stopTimer(MetricsHolder metrics) {
+        if (sample != null) {
+            sample.stop(metrics.reconciliationsTimer(reconciliation.namespace()));
+        }
+    }
 
     @Override
     public String toString() {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorMain.java
@@ -26,7 +26,7 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.http.HealthCheckAndMetricsServer;
 import io.strimzi.operator.common.http.Liveness;
 import io.strimzi.operator.common.http.Readiness;
-import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
+import io.strimzi.operator.common.metrics.BatchOperatorMetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import org.apache.kafka.clients.admin.Admin;
 
@@ -67,7 +67,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
         this.resyncIntervalMs = config.fullReconciliationIntervalMs();
         this.admin = admin;
         MetricsProvider metricsProvider = createMetricsProvider();
-        OperatorMetricsHolder metrics = new OperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);
+        BatchOperatorMetricsHolder metrics = new BatchOperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);
         this.controller = new BatchingTopicController(selector, admin, client, config.useFinalizer(), metrics, namespace);
         this.itemStore = new BasicItemStore<KafkaTopic>(Cache::metaNamespaceKeyFunc);
         this.queue = new BatchingLoop(config.maxQueueSize(), controller, 1, config.maxBatchSize(), config.maxBatchLingerMs(), itemStore, this::stop, metrics, namespace);
@@ -159,7 +159,6 @@ public class TopicOperatorMain implements Liveness, Readiness {
                     TopicOperatorMain.class.getPackage().getImplementationVersion())
                 .build();
     }
-
 
     @Override
     public boolean isAlive() {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorMain.java
@@ -9,16 +9,29 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.BasicItemStore;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.http.HealthCheckAndMetricsServer;
 import io.strimzi.operator.common.http.Liveness;
 import io.strimzi.operator.common.http.Readiness;
+import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
+import io.strimzi.operator.common.model.Labels;
 import org.apache.kafka.clients.admin.Admin;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -47,15 +60,19 @@ public class TopicOperatorMain implements Liveness, Readiness {
                       Admin admin,
                       KubernetesClient client,
                       TopicOperatorConfig config) throws ExecutionException, InterruptedException {
+        Objects.requireNonNull(namespace);
+        Objects.requireNonNull(selector);
         this.namespace = namespace;
         this.client = client;
         this.resyncIntervalMs = config.fullReconciliationIntervalMs();
         this.admin = admin;
-        this.controller = new BatchingTopicController(selector, admin, client, config.useFinalizer());
+        MetricsProvider metricsProvider = createMetricsProvider();
+        OperatorMetricsHolder metrics = new OperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);
+        this.controller = new BatchingTopicController(selector, admin, client, config.useFinalizer(), metrics, namespace);
         this.itemStore = new BasicItemStore<KafkaTopic>(Cache::metaNamespaceKeyFunc);
-        this.queue = new BatchingLoop(config.maxQueueSize(),  controller, 1, config.maxBatchSize(), config.maxBatchLingerMs(), itemStore, this::stop);
-        this.handler = new TopicOperatorEventHandler(queue, config.useFinalizer());
-        this.healthAndMetricsServer = new HealthCheckAndMetricsServer(8080, this, this, null);
+        this.queue = new BatchingLoop(config.maxQueueSize(), controller, 1, config.maxBatchSize(), config.maxBatchLingerMs(), itemStore, this::stop, metrics, namespace);
+        this.handler = new TopicOperatorEventHandler(queue, config.useFinalizer(), metrics, namespace);
+        this.healthAndMetricsServer = new HealthCheckAndMetricsServer(8080, this, this, metricsProvider);
     }
 
     synchronized void start() {
@@ -170,5 +187,21 @@ public class TopicOperatorMain implements Liveness, Readiness {
         } else {
             return queue.isReady();
         }
+    }
+
+    /**
+     * Creates the MetricsProvider instance based on a PrometheusMeterRegistry
+     * and binds the JVM metrics to it.
+     *
+     * @return MetricsProvider instance
+     */
+    private static MetricsProvider createMetricsProvider()  {
+        MeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        return new MicrometerMetricsProvider(registry);
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
@@ -9,10 +9,15 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.metrics.MetricsHolder;
+import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
@@ -44,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static io.strimzi.api.kafka.model.KafkaTopic.RESOURCE_KIND;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -67,10 +73,7 @@ class BatchingTopicControllerTest {
 
     private Admin[] admin = new Admin[] {null};
 
-    @BeforeEach
-    public void createKubeClient() {
-        this.client = new KubernetesClientBuilder().build();
-    }
+    private MetricsHolder metrics;
 
     private static <T> KafkaFuture<T> interruptedFuture() throws ExecutionException, InterruptedException {
         var future = mock(KafkaFuture.class);
@@ -97,12 +100,19 @@ class BatchingTopicControllerTest {
 
     @BeforeAll
     public static void setupKubeCluster() {
-        TopicOperatorTestUtil.setupKubeCluster();
+        TopicOperatorTestUtil.setupKubeCluster(NAMESPACE);
     }
 
     @AfterAll
     public static void teardownKubeCluster() {
-        TopicOperatorTestUtil.teardownKubeCluster2();
+        TopicOperatorTestUtil.teardownKubeCluster2(NAMESPACE);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        this.client = new KubernetesClientBuilder().build();
+        MetricsProvider metricsProvider = new MicrometerMetricsProvider(new SimpleMeterRegistry());
+        this.metrics = new OperatorMetricsHolder(RESOURCE_KIND, null, metricsProvider);
     }
 
     @AfterEach
@@ -120,7 +130,7 @@ class BatchingTopicControllerTest {
     }
 
     private void assertOnUpdateThrowsInterruptedException(KubernetesClient client, Admin admin, KafkaTopic kt) throws ExecutionException, InterruptedException {
-        controller = new BatchingTopicController(Map.of("key", "VALUE"), admin, client, true);
+        controller = new BatchingTopicController(Map.of("key", "VALUE"), admin, client, true, metrics, NAMESPACE);
         List<ReconcilableTopic> batch = List.of(new ReconcilableTopic(new Reconciliation("test", "KafkaTopic", NAMESPACE, NAME), kt, BatchingTopicController.topicName(kt)));
         assertThrows(InterruptedException.class, () -> controller.onUpdate(batch));
     }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -96,6 +96,7 @@ class TopicControllerIT {
 
     private static final Logger LOGGER = LogManager.getLogger(TopicControllerIT.class);
     public static final Map<String, String> SELECTOR = Map.of("foo", "FOO", "bar", "BAR");
+    private static final String NAMESPACE = "ns";
 
     KubernetesClient client;
 
@@ -110,12 +111,12 @@ class TopicControllerIT {
 
     @BeforeAll
     public static void setupKubeCluster() {
-        TopicOperatorTestUtil.setupKubeCluster();
+        TopicOperatorTestUtil.setupKubeCluster(NAMESPACE);
     }
 
     @AfterAll
     public static void teardownKubeCluster() {
-        TopicOperatorTestUtil.teardownKubeCluster2();
+        TopicOperatorTestUtil.teardownKubeCluster2(NAMESPACE);
     }
 
     @BeforeEach

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -16,7 +16,6 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.KafkaTopicStatus;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -78,6 +77,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
+import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 import static io.strimzi.operator.topic.v2.BatchingTopicController.isPaused;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -460,7 +460,7 @@ class TopicControllerIT {
         var current = Crds.topicOperation(client).inNamespace(namespace).withName(topicName).get();
         var paused = Crds.topicOperation(client).resource(new KafkaTopicBuilder(current)
             .editMetadata()
-                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "True"))
+                .withAnnotations(Map.of(ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true"))
             .endMetadata()
             .build()).update();
         LOGGER.info("Test paused KafkaTopic {} with resourceVersion {}",
@@ -1964,7 +1964,7 @@ class TopicControllerIT {
         KafkaTopic kt = createTopic(
             kafkaCluster,
             kafkaTopic(namespace, topicName, SELECTOR,
-                Map.of(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "True"),
+                Map.of(ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true"),
                 true, topicName, 1, 1, Map.of()),
             pausedIsTrue()
         );

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic.v2;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.informers.cache.ItemStore;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.RequiredSearch;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+import io.strimzi.operator.common.MetricsProvider;
+import io.strimzi.operator.common.MicrometerMetricsProvider;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.metrics.MetricsHolder;
+import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static io.strimzi.api.kafka.model.KafkaTopic.RESOURCE_KIND;
+import static io.strimzi.operator.topic.v2.BatchingTopicController.topicName;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(KafkaClusterExtension.class)
+public class TopicOperatorMetricsTest {
+    private static final String NAMESPACE = "ns";
+    private static final int KT_RESOURCES = 100;
+    private static final int MAX_QUEUE_SIZE = 200;
+    private static final int MAX_BATCH_SIZE = 10;
+    private static final int MAX_THREADS = 2;
+    private static final long MAX_BATCH_LINGER_MS = 10_000;
+
+    private static KubernetesClient client;
+    private static MetricsHolder metrics;
+
+    @BeforeAll
+    public static void beforeAll() {
+        TopicOperatorTestUtil.setupKubeCluster(NAMESPACE);
+        client = new KubernetesClientBuilder().build();
+
+        MetricsProvider metricsProvider = new MicrometerMetricsProvider(new SimpleMeterRegistry());
+        metrics = new OperatorMetricsHolder(RESOURCE_KIND, null, metricsProvider);
+    }
+
+    @AfterAll
+    public static void afterAll(TestInfo testInfo) {
+        TopicOperatorTestUtil.cleanupNamespace(client, testInfo, NAMESPACE);
+        TopicOperatorTestUtil.teardownKubeCluster2(NAMESPACE);
+        client.close();
+    }
+
+    @Test
+    public void shouldHaveMetricsAfterSomeEvents() {
+        BatchingLoop mockQueue = mock(BatchingLoop.class);
+        TopicOperatorEventHandler eventHandler = new TopicOperatorEventHandler(mockQueue, true, metrics, NAMESPACE);
+        for (int i = 0; i < KT_RESOURCES; i++) {
+            KafkaTopic kt = new KafkaTopic();
+            kt.getMetadata().setNamespace(NAMESPACE);
+            kt.getMetadata().setName("t" + i);
+            kt.getMetadata().setResourceVersion("100100");
+            eventHandler.onAdd(kt);
+        }
+        String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
+        assertGaugeMatches("strimzi.resources", is(Double.valueOf(KT_RESOURCES)), tags);
+
+        for (int i = 0; i < KT_RESOURCES; i++) {
+            KafkaTopic kt = new KafkaTopic();
+            kt.getMetadata().setNamespace(NAMESPACE);
+            kt.getMetadata().setName("t" + i);
+            kt.getMetadata().setResourceVersion("1");
+            eventHandler.onDelete(kt, false);
+        }
+        assertGaugeMatches("strimzi.resources", is(0.0), tags);
+    }
+
+    @Test
+    public void shouldHaveMetricsAfterSomeUpserts() throws InterruptedException {
+        BatchingLoop batchingLoop = createAndStartBatchingLoop();
+        for (int i = 0; i < KT_RESOURCES; i++) {
+            if (i < KT_RESOURCES / 2) {
+                batchingLoop.offer(new TopicUpsert(0, NAMESPACE, "t0", "10010" + i));
+            } else {
+                batchingLoop.offer(new TopicUpsert(0, NAMESPACE, "t" + i, "100100"));
+            }
+        }
+
+        String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
+        assertGaugeMatches("strimzi.reconciliations.max.queue.size", greaterThan(0.0), tags);
+        assertGaugeMatches("strimzi.reconciliations.max.queue.size", lessThanOrEqualTo(Double.valueOf(MAX_QUEUE_SIZE)), tags);
+        assertGaugeMatches("strimzi.reconciliations.max.batch.size", is(Double.valueOf(MAX_BATCH_SIZE)), tags);
+        assertCounterMatches("strimzi.reconciliations.locked", greaterThan(0.0), tags);
+        batchingLoop.stop();
+    }
+    
+    private static BatchingLoop createAndStartBatchingLoop() throws InterruptedException {
+        BatchingTopicController controller = mock(BatchingTopicController.class);
+        ItemStore<KafkaTopic> itemStore = mock(ItemStore.class);
+        Runnable stop = mock(Runnable.class);
+        BatchingLoop batchingLoop = new BatchingLoop(
+            MAX_QUEUE_SIZE,
+            controller,
+            MAX_THREADS,
+            MAX_BATCH_SIZE,
+            MAX_BATCH_LINGER_MS,
+            itemStore,
+            stop,
+            metrics,
+            NAMESPACE);
+        batchingLoop.start();
+        while (!batchingLoop.isReady()) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+        return batchingLoop;
+    }
+
+    @Test
+    public void shouldHaveMetricsAfterSomeReconciliations(KafkaCluster cluster) throws ExecutionException, InterruptedException {
+        Admin admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers()));
+        BatchingTopicController controller = new BatchingTopicController(Map.of("key", "VALUE"), admin, client, true, metrics, NAMESPACE);
+
+        KafkaTopic t1 = createResource(client, "t1", "t1");
+        KafkaTopic t2 = createResource(client, "t2", "t1");
+        List<ReconcilableTopic> updateBatch = List.of(
+            new ReconcilableTopic(new Reconciliation("test", RESOURCE_KIND, NAMESPACE, topicName(t1)), t1, topicName(t1)),
+            new ReconcilableTopic(new Reconciliation("test", RESOURCE_KIND, NAMESPACE, topicName(t2)), t2, topicName(t2))
+        );
+        controller.onUpdate(updateBatch);
+        List<ReconcilableTopic> deleteBatch = List.of(
+            new ReconcilableTopic(new Reconciliation("test", RESOURCE_KIND, NAMESPACE, topicName(t1)), t1, topicName(t1))
+        );
+        controller.onDelete(deleteBatch);
+
+        String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
+        assertCounterMatches("strimzi.reconciliations", is(3.0), tags);
+        assertCounterMatches("strimzi.reconciliations.successful", is(2.0), tags);
+        assertCounterMatches("strimzi.reconciliations.failed", is(1.0), tags);
+        assertTimerMatches("strimzi.reconciliations.duration", is(3.0), greaterThan(0.0), tags);
+    }
+
+    private KafkaTopic createResource(KubernetesClient client, String resourceName, String topicName) {
+        var kt = Crds.topicOperation(client).
+            resource(new KafkaTopicBuilder()
+                .withNewMetadata()
+                    .withName(resourceName)
+                    .withNamespace(NAMESPACE)
+                    .addToLabels("key", "VALUE")
+                .endMetadata()
+                .withNewSpec()
+                    .withTopicName(topicName)
+                    .withPartitions(2)
+                    .withReplicas(1)
+                .endSpec().build()).create();
+        return kt;
+    }
+
+    private static void assertCounterMatches(String counterName, Matcher<Double> matcher, String... tags) {
+        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
+        RequiredSearch requiredSearch = registry.get(counterName).tags(tags);
+        assertThat(requiredSearch.counter().count(), matcher);
+    }
+
+    private static void assertGaugeMatches(String counterName, Matcher<Double> matcher, String... tags) {
+        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
+        RequiredSearch requiredSearch = registry.get(counterName).tags(tags);
+        assertThat(requiredSearch.gauge().value(), matcher);
+    }
+
+    private static void assertTimerMatches(String timerName, Matcher<Double> count, Matcher<Double> greaterThan, String... tags) {
+        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
+        RequiredSearch requiredSearch = registry.get(timerName).tags(tags);
+        assertThat(Double.valueOf(requiredSearch.timer().count()), count);
+        assertThat(requiredSearch.timer().totalTime(TimeUnit.MILLISECONDS), greaterThan);
+    }
+}

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.informers.cache.ItemStore;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.strimzi.api.kafka.Crds;
@@ -18,8 +18,7 @@ import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.metrics.MetricsHolder;
-import io.strimzi.operator.common.metrics.OperatorMetricsHolder;
+import io.strimzi.operator.common.metrics.BatchOperatorMetricsHolder;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.hamcrest.Matcher;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.api.kafka.model.KafkaTopic.RESOURCE_KIND;
 import static io.strimzi.operator.topic.v2.BatchingTopicController.topicName;
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -45,14 +46,13 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(KafkaClusterExtension.class)
 public class TopicOperatorMetricsTest {
     private static final String NAMESPACE = "ns";
-    private static final int KT_RESOURCES = 100;
     private static final int MAX_QUEUE_SIZE = 200;
     private static final int MAX_BATCH_SIZE = 10;
     private static final int MAX_THREADS = 2;
     private static final long MAX_BATCH_LINGER_MS = 10_000;
 
     private static KubernetesClient client;
-    private static MetricsHolder metrics;
+    private static BatchOperatorMetricsHolder metrics;
 
     @BeforeAll
     public static void beforeAll() {
@@ -60,7 +60,7 @@ public class TopicOperatorMetricsTest {
         client = new KubernetesClientBuilder().build();
 
         MetricsProvider metricsProvider = new MicrometerMetricsProvider(new SimpleMeterRegistry());
-        metrics = new OperatorMetricsHolder(RESOURCE_KIND, null, metricsProvider);
+        metrics = new BatchOperatorMetricsHolder(RESOURCE_KIND, null, metricsProvider);
     }
 
     @AfterAll
@@ -71,10 +71,11 @@ public class TopicOperatorMetricsTest {
     }
 
     @Test
-    public void shouldHaveMetricsAfterSomeEvents() {
+    public void shouldHaveMetricsAfterSomeEvents() throws InterruptedException {
         BatchingLoop mockQueue = mock(BatchingLoop.class);
         TopicOperatorEventHandler eventHandler = new TopicOperatorEventHandler(mockQueue, true, metrics, NAMESPACE);
-        for (int i = 0; i < KT_RESOURCES; i++) {
+        int numOfTestResources = 100;
+        for (int i = 0; i < numOfTestResources; i++) {
             KafkaTopic kt = new KafkaTopic();
             kt.getMetadata().setNamespace(NAMESPACE);
             kt.getMetadata().setName("t" + i);
@@ -82,23 +83,24 @@ public class TopicOperatorMetricsTest {
             eventHandler.onAdd(kt);
         }
         String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
-        assertGaugeMatches("strimzi.resources", is(Double.valueOf(KT_RESOURCES)), tags);
+        assertMetricMatches("strimzi.resources", tags, "gauge", is(Double.valueOf(numOfTestResources)));
 
-        for (int i = 0; i < KT_RESOURCES; i++) {
+        for (int i = 0; i < numOfTestResources; i++) {
             KafkaTopic kt = new KafkaTopic();
             kt.getMetadata().setNamespace(NAMESPACE);
             kt.getMetadata().setName("t" + i);
             kt.getMetadata().setResourceVersion("1");
             eventHandler.onDelete(kt, false);
         }
-        assertGaugeMatches("strimzi.resources", is(0.0), tags);
+        assertMetricMatches("strimzi.resources", tags, "gauge", is(0.0));
     }
 
     @Test
     public void shouldHaveMetricsAfterSomeUpserts() throws InterruptedException {
         BatchingLoop batchingLoop = createAndStartBatchingLoop();
-        for (int i = 0; i < KT_RESOURCES; i++) {
-            if (i < KT_RESOURCES / 2) {
+        int numOfTestResources = 100;
+        for (int i = 0; i < numOfTestResources; i++) {
+            if (i < numOfTestResources / 2) {
                 batchingLoop.offer(new TopicUpsert(0, NAMESPACE, "t0", "10010" + i));
             } else {
                 batchingLoop.offer(new TopicUpsert(0, NAMESPACE, "t" + i, "100100"));
@@ -106,10 +108,11 @@ public class TopicOperatorMetricsTest {
         }
 
         String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
-        assertGaugeMatches("strimzi.reconciliations.max.queue.size", greaterThan(0.0), tags);
-        assertGaugeMatches("strimzi.reconciliations.max.queue.size", lessThanOrEqualTo(Double.valueOf(MAX_QUEUE_SIZE)), tags);
-        assertGaugeMatches("strimzi.reconciliations.max.batch.size", is(Double.valueOf(MAX_BATCH_SIZE)), tags);
-        assertCounterMatches("strimzi.reconciliations.locked", greaterThan(0.0), tags);
+        assertMetricMatches("strimzi.reconciliations.max.queue.size", tags, "gauge", greaterThan(0.0));
+        assertMetricMatches("strimzi.reconciliations.max.queue.size", tags, "gauge", lessThanOrEqualTo(Double.valueOf(MAX_QUEUE_SIZE)));
+        assertMetricMatches("strimzi.reconciliations.max.batch.size", tags, "gauge", greaterThan(0.0));
+        assertMetricMatches("strimzi.reconciliations.max.batch.size", tags, "gauge", lessThanOrEqualTo(Double.valueOf(MAX_BATCH_SIZE)));
+        assertMetricMatches("strimzi.reconciliations.locked", tags, "counter", greaterThan(0.0));
         batchingLoop.stop();
     }
     
@@ -128,9 +131,6 @@ public class TopicOperatorMetricsTest {
             metrics,
             NAMESPACE);
         batchingLoop.start();
-        while (!batchingLoop.isReady()) {
-            TimeUnit.MILLISECONDS.sleep(10);
-        }
         return batchingLoop;
     }
 
@@ -152,10 +152,10 @@ public class TopicOperatorMetricsTest {
         controller.onDelete(deleteBatch);
 
         String[] tags = new String[]{"kind", RESOURCE_KIND, "namespace", NAMESPACE};
-        assertCounterMatches("strimzi.reconciliations", is(3.0), tags);
-        assertCounterMatches("strimzi.reconciliations.successful", is(2.0), tags);
-        assertCounterMatches("strimzi.reconciliations.failed", is(1.0), tags);
-        assertTimerMatches("strimzi.reconciliations.duration", is(3.0), greaterThan(0.0), tags);
+        assertMetricMatches("strimzi.reconciliations", tags, "counter", is(2.0));
+        assertMetricMatches("strimzi.reconciliations.successful", tags, "counter", is(2.0));
+        assertMetricMatches("strimzi.reconciliations.failed", tags, "counter", is(1.0));
+        assertMetricMatches("strimzi.reconciliations.duration", tags, "timer", greaterThan(0.0));
     }
 
     private KafkaTopic createResource(KubernetesClient client, String resourceName, String topicName) {
@@ -174,22 +174,32 @@ public class TopicOperatorMetricsTest {
         return kt;
     }
 
-    private static void assertCounterMatches(String counterName, Matcher<Double> matcher, String... tags) {
-        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
-        RequiredSearch requiredSearch = registry.get(counterName).tags(tags);
-        assertThat(requiredSearch.counter().count(), matcher);
-    }
-
-    private static void assertGaugeMatches(String counterName, Matcher<Double> matcher, String... tags) {
-        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
-        RequiredSearch requiredSearch = registry.get(counterName).tags(tags);
-        assertThat(requiredSearch.gauge().value(), matcher);
-    }
-
-    private static void assertTimerMatches(String timerName, Matcher<Double> count, Matcher<Double> greaterThan, String... tags) {
-        MeterRegistry registry = metrics.metricsProvider().meterRegistry();
-        RequiredSearch requiredSearch = registry.get(timerName).tags(tags);
-        assertThat(Double.valueOf(requiredSearch.timer().count()), count);
-        assertThat(requiredSearch.timer().totalTime(TimeUnit.MILLISECONDS), greaterThan);
+    private static void assertMetricMatches(String name, String[] tags, String type, Matcher<Double> matcher) throws InterruptedException {
+        // wait some time because events are queued, and processing may be delayed
+        int timeoutSec = 120;
+        RequiredSearch requiredSearch = null;
+        while (requiredSearch == null && timeoutSec-- > 0) {
+            try {
+                requiredSearch = metrics.metricsProvider().meterRegistry().get(name).tags(tags);
+                switch (type) {
+                    case "counter":
+                        assertThat(requiredSearch.counter().count(), matcher);
+                        break;
+                    case "gauge":
+                        assertThat(requiredSearch.gauge().value(), matcher);
+                        break;
+                    case "timer":
+                        assertThat(requiredSearch.timer().totalTime(TimeUnit.MILLISECONDS), matcher);
+                        break;
+                    default:
+                        throw new RuntimeException(format("Unknown metric type %s", type));
+                }
+            } catch (MeterNotFoundException mnfe) {
+                TimeUnit.SECONDS.sleep(1);
+            }
+        }
+        if (requiredSearch == null) {
+            throw new RuntimeException(format("Unable to find metric %s with tags %s", name, Arrays.toString(tags)));
+        }
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
@@ -48,14 +48,14 @@ class TopicOperatorTestUtil {
         return testInfo.getTestMethod().map(m -> m.getName() + "() " + testInfo.getDisplayName().replaceAll("[\r\n]+", " ")).orElse("");
     }
 
-    static void setupKubeCluster() {
+    static void setupKubeCluster(String namespace) {
         try {
             KubeCluster.bootstrap();
         } catch (NoClusterException e) {
             assumeTrue(false, e.getMessage());
         }
         KubeClusterResource.getInstance();
-        cmdKubeClient().createNamespace(BatchingTopicControllerTest.NAMESPACE);
+        cmdKubeClient().createNamespace(namespace);
         LOGGER.info("#### Creating " + "../packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml");
         cmdKubeClient().create(TestUtils.USER_PATH + "/../packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml");
         LOGGER.info("#### Creating " + TestUtils.CRD_TOPIC);
@@ -64,12 +64,12 @@ class TopicOperatorTestUtil {
         cmdKubeClient().create(TestUtils.USER_PATH + "/src/test/resources/TopicOperatorIT-rbac.yaml");
     }
 
-    static void teardownKubeCluster2() {
+    static void teardownKubeCluster2(String namespace) {
         cmdKubeClient()
                 .delete(TestUtils.USER_PATH + "/src/test/resources/TopicOperatorIT-rbac.yaml")
                 .delete(TestUtils.CRD_TOPIC)
                 .delete(TestUtils.USER_PATH + "/../packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml")
-                .deleteNamespace(BatchingTopicControllerTest.NAMESPACE);
+                .deleteNamespace(namespace);
     }
 
     static void cleanupNamespace(KubernetesClient client, TestInfo testInfo, String pop) {


### PR DESCRIPTION
This change adds Prometheus metrics to the Unidirectional Topic Operator (UTO).

In addition to the standard JVM metrics, we provide the following custom metrics:

- `strimzi.resources` (gauge): Number of custom resources the operator sees
- `strimzi.reconciliations` (counter): Number of reconciliations done by the operator for individual resources
- `strimzi.reconciliations.failed` (counter): Number of reconciliations done by the operator for individual resources which failed
- `strimzi.reconciliations.successful` (counter): Number of reconciliations done by the operator for individual resources which were successful
- `strimzi.reconciliations.duration` (timer): The time the reconciliation takes to complete
- `strimzi.reconciliations.paused` (gauge): Number of custom resources the operator sees but does not reconcile due to paused reconciliations
- `strimzi.reconciliations.locked` (counter): Number of reconciliations skipped because another reconciliation for the same resource was still running
- `strimzi.reconciliations.max.queue.size` (gauge): Max size recorded for the shared event queue
- `strimzi.reconciliations.max.batch.size` (gauge): Max size recorded for a single event batch

Should close #8650.

