### PR TITLE
docs(node pools): handling storage with node pools

### DIFF
--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -65,6 +65,8 @@ include::../../modules/configuring/proc-managing-node-pools-ids.adoc[leveloffset
 include::../../modules/configuring/proc-scaling-up-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-scaling-down-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-moving-node-pools.adoc[leveloffset=+2]
+include::../../modules/configuring/proc-managing-storage-node-pools.adoc[leveloffset=+2]
+include::../../modules/configuring/proc-managing-storage-affinity-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-migrating-clusters-node-pools.adoc[leveloffset=+2]
 
 //`Kafka` config for operators

--- a/documentation/assemblies/configuring/assembly-storage.adoc
+++ b/documentation/assemblies/configuring/assembly-storage.adoc
@@ -6,21 +6,22 @@
 = Configuring Kafka and ZooKeeper storage
 
 [role="_abstract"]
-As stateful applications, Kafka and ZooKeeper store data on disk. 
-Strimzi supports three storage types for this data:
+Strimzi provides flexibility in configuring the data storage options of Kafka and ZooKeeper. 
+
+The supported storage types are:
 
 * Ephemeral (Recommended for development only)
 * Persistent
-* JBOD (*Kafka only* not ZooKeeper)
+* JBOD (Kafka only; not available for ZooKeeper)
 
-When configuring a `Kafka` resource, you can specify the type of storage used by the Kafka broker and its corresponding ZooKeeper node. You configure the storage type using the `storage` property in the following resources:
+To configure storage, you specify `storage` properties in the custom resource of the component. 
+The storage type is set using the `storage.type` property.
 
-* `Kafka.spec.kafka`
-* `Kafka.spec.zookeeper`
+You can also use the preview of the node pools feature for advanced storage management of the Kafka cluster.
+You can specify storage configuration unique to each node pool used in the cluster. 
+The same storage properties available to the `Kafka` resource are also available to the `KafkaNodePool` pool resource.
 
-The storage type is configured in the `type` field.
-
-Refer to the schema reference for more information on storage configuration properties:
+The storage-related schema references provide more information on the storage configuration properties:
 
 * link:{BookURLConfiguring}#type-EphemeralStorage-reference[`EphemeralStorage` schema reference^]
 * link:{BookURLConfiguring}#type-PersistentClaimStorage-reference[`PersistentClaimStorage` schema reference^]

--- a/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// assembly-config.adoc
+
+[id='proc-managing-storage-affinity-node-pools-{context}']
+= (Preview) Managing storage affinity using node pools
+
+[role="_abstract"]
+In situations where storage resources, such as local persistent volumes, are constrained to specific worker nodes, or availability zones, configuring storage affinity helps to schedule pods to use the right nodes. 
+
+Node pools allow you to configure affinity independently. 
+In this procedure, we create and manage storage affinity for two availability zones: `zone-1` and `zone-2`.
+
+You can configure node pools for separate availability zones, but use the same storage class. 
+We define an `all-zones` persistent storage class representing the storage resources available in each zone.
+
+We also use the `.spec.template.pod` properties to configure the node affinity and schedule Kafka pods on `zone-1` and `zone-2` worker nodes.
+
+The storage class and affinity is specified in node pools representing the nodes in each availability zone:
+
+* `pool-zone-1`
+* `pool-zone-2`. 
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* If you are not familiar with the concepts of affinity, see the {K8sAffinity}.
+
+.Procedure
+
+. Define the storage class for use with each availability zone:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: all-zones
+provisioner: kubernetes.io/my-storage
+parameters:
+  type: ssd
+volumeBindingMode: WaitForFirstConsumer
+----       
+
+. Create node pools representing the two availability zones, specifying the `all-zones` storage class and the affinity for each zone:
++
+.Node pool configuration for zone-1
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-zone-1
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 500Gi
+        class: all-zones
+  template:
+    pod:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                  - zone-1      
+  # ...
+----
++
+.Node pool configuration for zone-2
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-zone-2
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 4
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 500Gi
+        class: all-zones
+  template:
+    pod:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                  - zone-2      
+  # ...
+----
+
+. Apply the node pool configuration.
+. Check the status of the deployment and wait for the pods in the node pools to be created and have a status of `READY`.
++
+[source,shell]
+----
+kubectl get pods -n <my_cluster_operator_namespace>
+----
++
+.Output shows 3 Kafka nodes in `pool-zone-1` and 4 Kafka nodes in `pool-zone-2`:
+[source,shell]
+----
+NAME                       READY  STATUS   RESTARTS
+my-cluster-pool-zone-1-kafka-0  1/1    Running  0
+my-cluster-pool-zone-1-kafka-1  1/1    Running  0
+my-cluster-pool-zone-1-kafka-2  1/1    Running  0
+my-cluster-pool-zone-2-kafka-3  1/1    Running  0
+my-cluster-pool-zone-2-kafka-4  1/1    Running  0
+my-cluster-pool-zone-2-kafka-5  1/1    Running  0
+my-cluster-pool-zone-2-kafka-6  1/1    Running  0
+---- 

--- a/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// assembly-config.adoc
+
+[id='proc-managing-storage-node-pools-{context}']
+= (Preview) Managing storage using node pools
+
+[role="_abstract"]
+Storage management in Strimzi is usually straightforward, and requires little change when set up, but there might be situations where you need to modify your storage configurations. 
+Node pools simplify this process, because you can set up separate node pools that specify your new storage requirements.
+
+In this procedure we create and manage storage for a node pool called `pool-a` containing three nodes.
+We show how to change the storage class (`volumes.class`) that defines the type of persistent storage it uses.
+You can use the same steps to change the storage size (`volumes.size`). 
+
+NOTE: We strongly recommend using block storage. Strimzi is only tested for use with block storage.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
+* For storage that uses persistent volume claims for dynamic volume allocation, storage classes are defined and available in the Kubernetes cluster that correspond to the storage solutions you need. 
+
+.Procedure
+
+. Create the node pool with its own storage settings.
++
+For example, node pool `pool-a` uses JBOD storage with persistent volumes:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 500Gi
+        class: gp2-ebs
+  # ...
+----
++
+Nodes in `pool-a` are configured to use Amazon EBS (Elastic Block Store) GP2 volumes.
+
+. Apply the node pool configuration for `pool-a`.
+. Check the status of the deployment and wait for the pods in `pool-a` to be created and have a status of `READY`.
++
+[source,shell]
+----
+kubectl get pods -n <my_cluster_operator_namespace>
+----
++
+.Output shows three Kafka nodes in the node pool
+[source,shell]
+----
+NAME                       READY  STATUS   RESTARTS
+my-cluster-pool-a-kafka-0  1/1    Running  0
+my-cluster-pool-a-kafka-1  1/1    Running  0
+my-cluster-pool-a-kafka-2  1/1    Running  0
+----
+
+. To migrate to a new storage class, create a new node pool with the required storage configuration:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  roles:
+    - broker
+  replicas: 3
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 1Ti
+        class: gp3-ebs
+  # ...
+----
++
+Nodes in `pool-b` are configured to use Amazon EBS (Elastic Block Store) GP3 volumes.
+
+. Apply the node pool configuration for `pool-b`.
+. Check the status of the deployment and wait for the pods in `pool-b` to be created and have a status of `READY`.
+. Reassign the partitions from `pool-a` to `pool-b`.
++
+When migrating to a new storage configuration, you can use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
+
+. After the reassignment process is complete, delete the old node pool:
++
+[source, shell]
+----
+kubectl delete kafkanodepool pool-a
+----

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -25,6 +25,7 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
 * (Optional) For scale up and scale down operations, xref:proc-managing-node-pools-ids-{context}[you can specify the range of node IDs to use].
 +
 If you have assigned node IDs for the operation, the ID of the node being added or removed is determined by the sequence of nodes given. 

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -28,6 +28,7 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
 * (Optional) For scale down operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use in the operation].
 +
 If you have assigned a range of node IDs for the operation, the ID of the node being removed is determined by the sequence of nodes given.

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -27,6 +27,7 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
 * (Optional) For scale up operations, xref:proc-managing-node-pools-ids-{context}[you can specify the node IDs to use in the operation].
 +
 If you have assigned a range of node IDs for the operation, the ID of the node being added is determined by the sequence of nodes given. 

--- a/documentation/modules/configuring/ref-storage-ephemeral.adoc
+++ b/documentation/modules/configuring/ref-storage-ephemeral.adoc
@@ -21,6 +21,7 @@ You can set the total amount of storage for the `emptyDir` using the `sizeLimit`
 IMPORTANT: Ephemeral storage is not suitable for single-node ZooKeeper clusters or Kafka topics with a replication factor of 1.
 
 To use ephemeral storage, you set the storage type configuration in the `Kafka` or `ZooKeeper` resource to `ephemeral`.
+If you are using the preview of the node pools feature, you can also specify `ephemeral` in the storage configuration of individual node pools.
 
 .Example ephemeral storage configuration
 [source,yaml,subs="attributes+"]
@@ -31,12 +32,10 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    # ...
     storage:
       type: ephemeral
     # ...
   zookeeper:
-    # ...
     storage:
       type: ephemeral
     # ...

--- a/documentation/modules/configuring/ref-storage-jbod.adoc
+++ b/documentation/modules/configuring/ref-storage-jbod.adoc
@@ -6,33 +6,40 @@
 = JBOD storage
 
 [role="_abstract"]
-You can configure Strimzi to use JBOD, a data storage configuration of multiple disks or volumes. 
-JBOD is one approach to providing increased data storage for Kafka brokers. 
-It can also improve performance.
+JBOD storage allows you to configure your Kafka cluster to use multiple disks or volumes. 
+This approach provides increased data storage capacity for Kafka brokers, and can lead to performance improvements.
+A JBOD configuration is defined by one or more volumes, each of which can be either xref:ref-ephemeral-storage-{context}[ephemeral] or xref:ref-persistent-storage-{context}[persistent]. 
+The rules and constraints for JBOD volume declarations are the same as those for ephemeral and persistent storage. 
+For example, you cannot decrease the size of a persistent storage volume after it has been provisioned, nor can you change the value of `sizeLimit` when the type is `ephemeral`.
 
-NOTE: JBOD storage is supported for *Kafka only* not ZooKeeper.
-
-A JBOD configuration is described by one or more volumes, each of which can be either xref:ref-ephemeral-storage-{context}[ephemeral] or xref:ref-persistent-storage-{context}[persistent]. The rules and constraints for JBOD volume declarations are the same as those for ephemeral and persistent storage. For example, you cannot decrease the size of a persistent storage volume after it has been provisioned, or you cannot change the value of `sizeLimit` when the type is `ephemeral`.
+NOTE: JBOD storage is supported for *Kafka only*, not for ZooKeeper.
 
 To use JBOD storage, you set the storage type configuration in the `Kafka` resource to `jbod`.
+If you are using the preview of the node pools feature, you can also specify `jbod` in the storage configuration of individual node pools.
+
 The `volumes` property allows you to describe the disks that make up your JBOD storage array or configuration. 
 
 .Example JBOD storage configuration
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
-# ...
-storage:
-  type: jbod
-  volumes:
-  - id: 0
-    type: persistent-claim
-    size: 100Gi
-    deleteClaim: false
-  - id: 1
-    type: persistent-claim
-    size: 100Gi
-    deleteClaim: false
-# ...
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+      - id: 1
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  # ...
 ----
 
 The IDs cannot be changed once the JBOD volumes are created.

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -8,28 +8,27 @@
 [role="_abstract"]
 Persistent data storage retains data in the event of system disruption.
 For pods that use persistent data storage, data is persisted across pod failures and restarts.
+Because of its permanent nature, persistent storage is recommended for production environments.
 
-A dynamic provisioning framework enables clusters to be created with persistent storage. 
-Pod configuration uses {K8sPersistentVolumeClaims} (PVCs) to make storage requests on persistent volumes (PVs).
-PVs are storage resources that represent a storage volume.
-PVs are independent of the pods that use them.
+To use persistent storage in Strimzi, you specify `persistent-claim` in the storage configuration of the `Kafka` or `ZooKeeper` resources. 
+If you are using the preview of the node pools feature, you can also specify `persistent-claim` in the storage configuration of individual node pools.
+
+You configure the resource so that pods use {K8sPersistentVolumeClaims} (PVCs) to make storage requests on persistent volumes (PVs).
+PVs represent storage volumes that are created on demand and are independent of the pods that use them.
 The PVC requests the amount of storage required when a pod is being created.
 The underlying storage infrastructure of the PV does not need to be understood. 
 If a PV matches the storage criteria, the PVC is bound to the PV.
 
-Because of its permanent nature, persistent storage is recommended for production.
+You have two options for specifying the storage type:
 
-PVCs can request different types of persistent storage by specifying a {K8SStorageClass}.
-Storage classes define storage profiles and dynamically provision PVs.  
-If a storage class is not specified, the default storage class is used.
-Persistent storage options might include SAN storage types or {K8sLocalPersistentVolumes}.
+`storage.type: persistent-claim`:: If you choose `persistent-claim` as the storage type, a single persistent storage volume is defined. 
 
-To use persistent storage, you set the storage type configuration in the `Kafka` or `ZooKeeper` resource to `persistent-claim`.
+`storage.type: jbod`:: When you select `jbod` as the storage type, you have the flexibility to define an array of persistent storage volumes using unique IDs. 
 
-In the production environment, the following configuration is recommended:
+In a production environment, it is recommended to configure the following:
 
-* For Kafka, configure `type: jbod`  with one or more `type: persistent-claim` volumes
-* For ZooKeeper, configure `type: persistent-claim`
+* For Kafka or node pools, set `storage.type` to `jbod` with one or more persistent volumes.
+* For ZooKeeper, set `storage.type` as `persistent-claim` for a single persistent volume.
 
 Persistent storage also has the following configuration options:
 
@@ -41,8 +40,10 @@ Default is `0`.
 The size of the persistent volume claim, for example, "1000Gi".
 
 `class` (optional)::
-The Kubernetes {K8SStorageClass} to use for dynamic volume provisioning.
-Storage `class` configuration includes parameters that describe the profile of a volume in detail. 
+PVCs can request different types of persistent storage by specifying a {K8SStorageClass}.
+Storage classes define storage profiles and dynamically provision PVs based on that profile.  
+If a storage class is not specified, the storage class marked as default in the Kubernetes cluster is used.
+Persistent storage options might include SAN storage types or {K8sLocalPersistentVolumes}.
 
 `selector` (optional)::
 Configuration to specify a specific PV.
@@ -57,12 +58,14 @@ For other versions of Kubernetes and storage classes that do not support volume 
 Decreasing the size of existing persistent volumes is not possible.
 
 .Example persistent storage configuration for Kafka and ZooKeeper
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
-# ...
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
 spec:
   kafka:
-    # ...
     storage:
       type: jbod
       volumes:
@@ -83,11 +86,8 @@ spec:
     storage:
       type: persistent-claim
       size: 1000Gi
-# ...
+    # ...
 ----
-
-If you do not specify a storage class, the default is used.
-The following example specifies a storage class.
 
 .Example persistent storage configuration with specific storage class
 [source,yaml,subs="attributes+"]
@@ -95,7 +95,7 @@ The following example specifies a storage class.
 # ...
 storage:
   type: persistent-claim
-  size: 1Gi
+  size: 500Gi
   class: my-storage-class
 # ...
 ----
@@ -117,13 +117,13 @@ storage:
 
 == Storage class overrides
 
-Instead of using the default storage class, you can specify a different storage class for one or more Kafka brokers or ZooKeeper nodes.
+Instead of using the default storage class, you can specify a different storage class for one or more Kafka or ZooKeeper nodes.
 This is useful, for example, when storage classes are restricted to different availability zones or data centers.
 You can use the `overrides` field for this purpose.
 
 In this example, the default storage class is named `my-storage-class`:
 
-.Example Strimzi cluster using storage class overrides
+.Example storage configuration with class overrides
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: {KafkaApiVersion}
@@ -175,14 +175,13 @@ As a result of the configured `overrides` property, the volumes use the followin
 
 * The persistent volumes of ZooKeeper node 0 use `my-storage-class-zone-1a`.
 * The persistent volumes of ZooKeeper node 1 use `my-storage-class-zone-1b`.
-* The persistent volumes of ZooKeeepr node 2 use `my-storage-class-zone-1c`.
+* The persistent volumes of ZooKeeper node 2 use `my-storage-class-zone-1c`.
 * The persistent volumes of Kafka broker 0 use `my-storage-class-zone-1a`.
 * The persistent volumes of Kafka broker 1 use `my-storage-class-zone-1b`.
 * The persistent volumes of Kafka broker 2 use `my-storage-class-zone-1c`.
 
-The `overrides` property is currently used only to override storage class configurations. 
+The `overrides` property is currently used only to override the storage `class`. 
 Overrides for other storage configuration properties is not currently supported.
-Other storage configuration properties are currently not supported.
 
 [id='ref-persistent-storage-pvc-{context}']
 == PVC resources for persistent storage

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -30,6 +30,7 @@ my-cluster   3                        3
 m|Strimzi resource      |Long name          |Short name
 
 | Kafka                 | kafka             | k
+| Kafka Node Pool       | kafkanodepool     | knp
 | Kafka Topic           | kafkatopic        | kt
 | Kafka User            | kafkauser         | ku
 | Kafka Connect         | kafkaconnect      | kc


### PR DESCRIPTION
**Documentation**

Adds two new procedures to the content previewing the node pools feature: _Managing storage using node pools_ and _Managing storage affinity using node pools_

Also:
- Updates the Configuring Kafka and ZooKeeper storage section to update the introduction and include mentions of node pools
- Updates the descriptions of ephemeral, JBOD, and persistent storage
- Adds `kafkanodepool` and `knp to list` if long and short names for each Strimzi resource


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

