### PR TITLE
Fix `kubectl set env` command for KafkaNodePools feature gate

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
@@ -38,7 +38,7 @@ NOTE: If you want to migrate an existing Kafka cluster to use node pools, see th
 +
 [source,shell]
 ----
-kubectl set env install/cluster-operator STRIMZI_FEATURE_GATES="+KafkaNodePools"
+kubectl set env deployment/strimzi-cluster-operator STRIMZI_FEATURE_GATES="+KafkaNodePools"
 ----
 +
 Or by editing the Cluster Operator Deployment and updating the `STRIMZI_FEATURE_GATES` environment variable:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a minor bug in the docs in the example `kubectl set env` command to enable the `KafkaNodePools` feature gate.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally