### PR TITLE
Add support for pausing KafkaTopic reconciliations with UTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Allow manual rolling of Kafka Connect and Kafka Mirror Maker 2 pods using the `strimzi.io/manual-rolling-update` annotation (supported only when `StableConnectIdentities` feature gate is enabled) 
 * Make sure brokers are empty before scaling them down
 * Update Cruise Control to 2.5.128
+* Add support for pausing `KafkaTopic` reconciliations with the UnidirectionalTopicOperator
 
 ### Changes, deprecations and removals
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.KafkaTopicBuilder;
 import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.api.kafka.model.status.ConditionBuilder;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.StatusUtils;
@@ -62,7 +63,6 @@ public class BatchingTopicController {
 
     static final String FINALIZER = "strimzi.io/topic-operator";
     static final String MANAGED = "strimzi.io/managed";
-    static final String PAUSED = "strimzi.io/pause-reconciliation";
     static final String AUTO_CREATE_TOPICS_ENABLE = "auto.create.topics.enable";
     private final boolean useFinalizer;
 
@@ -114,10 +114,7 @@ public class BatchingTopicController {
     }
 
     /* test */ static boolean isPaused(KafkaTopic kt) {
-        return kt.getMetadata() != null
-            && kt.getMetadata().getAnnotations() != null
-            && kt.getMetadata().getAnnotations().get(PAUSED) != null
-            && "true".equals(kt.getMetadata().getAnnotations().get(PAUSED));
+        return Annotations.isReconciliationPausedWithAnnotation(kt);
     }
 
     private static boolean isForDeletion(KafkaTopic kt) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -1001,6 +1001,8 @@ public class BatchingTopicController {
                 || oldStatus.getTopicName() == null
                 || oldReadyCondition == null
                 || isDifferentCondition(oldReadyCondition, condition)) {
+            // the observedGeneration is initialized to 0 when creating a paused user (oldStatus null, paused true)
+            // this will result in metadata.generation: 1 > status.observedGeneration: 0 (not reconciled)
             long observedGeneration = oldStatus != null
                 ? !isPaused(kt) ? kt.getMetadata().getGeneration() : oldStatus.getObservedGeneration()
                 : !isPaused(kt) ? kt.getMetadata().getGeneration() : 0L;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -403,7 +403,7 @@ public class BatchingTopicController {
             if (!matchesSelector(selector, kt.getMetadata().getLabels())) {
                 forgetTopic(reconcilableTopic);
                 LOGGER.debugCr(reconcilableTopic.reconciliation(), "Ignoring KafkaTopic with labels {} not selected by selector {}",
-                        kt.getMetadata().getLabels(), selector);
+                    kt.getMetadata().getLabels(), selector);
                 return false;
             }
             return true;
@@ -994,13 +994,13 @@ public class BatchingTopicController {
                               KafkaTopic kt,
                               Condition condition) {
         var oldStatus = kt.getStatus();
-        Condition oldReadyCondition = oldStatus == null || oldStatus.getConditions() == null ? null : oldStatus.getConditions().stream().findFirst().orElse(null);
+        Condition oldReadyCondition = oldStatus == null || oldStatus.getConditions() == null ?
+            null : oldStatus.getConditions().stream().findFirst().orElse(null);
         if (oldStatus == null
-                || oldStatus.getObservedGeneration() != kt.getMetadata().getGeneration()
+                || (!isPaused(kt) && oldStatus.getObservedGeneration() != kt.getMetadata().getGeneration())
                 || oldStatus.getTopicName() == null
                 || oldReadyCondition == null
-                || isDifferentCondition(oldReadyCondition, condition)
-                || isPaused(kt)) {
+                || isDifferentCondition(oldReadyCondition, condition)) {
             long observedGeneration = oldStatus != null
                 ? !isPaused(kt) ? kt.getMetadata().getGeneration() : oldStatus.getObservedGeneration()
                 : !isPaused(kt) ? kt.getMetadata().getGeneration() : 0L;
@@ -1031,7 +1031,7 @@ public class BatchingTopicController {
 
     private static boolean isDifferentCondition(Condition oldReadyCondition,
                                                 Condition condition) {
-        return !Objects.equals(oldReadyCondition.getType(), "Ready")
+        return !Objects.equals(oldReadyCondition.getType(), condition.getType())
                 || !Objects.equals(oldReadyCondition.getStatus(), condition.getStatus())
                 || !Objects.equals(oldReadyCondition.getReason(), condition.getReason())
                 || !Objects.equals(oldReadyCondition.getMessage(), condition.getMessage());


### PR DESCRIPTION
This change adds support for pausing `KafkaTopic` reconciliations with the Unidirectional Topic Operator (UTO). After the `strimzi.io/pause-reconciliation` annotation is set to "true" on a `KafkaTopic`, no configuration change will be reconciled. All valid changes will be reconciled as soon as the annotation is set to "false" or removed. Note that `KafkaTopic` deletions are always reconciled, even when the resource is paused.

Should close #9113.