### PR TITLE
Fixing logging issue around KafkaRebalanceAssemblyOperator

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -437,11 +437,10 @@ public class KafkaRebalanceAssemblyOperator
                                                 kafkaRebalance.getMetadata().getName(), desiredStatusAndMap.getLoadMap())
                                                 .compose(i -> updateStatus(reconciliation, currentKafkaRebalance, desiredStatusAndMap.getStatus(), null))
                                                 .compose(updatedKafkaRebalance -> {
-                                                    String message;
                                                     if (currentKafkaRebalance.getStatus() != null
                                                             && updatedKafkaRebalance.getStatus() != null
                                                             && !rebalanceStateConditionType(currentKafkaRebalance.getStatus()).equals(rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
-                                                        message = "KafkaRebalance state is now updated to [{}]";
+                                                        String message = "KafkaRebalance state is now updated to [{}]";
 
                                                         if (rawRebalanceAnnotation(updatedKafkaRebalance) != null) {
                                                             message = message + " with annotation {}={} applied on the KafkaRebalance resource";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -437,18 +437,18 @@ public class KafkaRebalanceAssemblyOperator
                                                 kafkaRebalance.getMetadata().getName(), desiredStatusAndMap.getLoadMap())
                                                 .compose(i -> updateStatus(reconciliation, currentKafkaRebalance, desiredStatusAndMap.getStatus(), null))
                                                 .compose(updatedKafkaRebalance -> {
-                                                    String message = "";
+                                                    String message;
                                                     if (currentKafkaRebalance.getStatus() != null
                                                             && updatedKafkaRebalance.getStatus() != null
                                                             && !rebalanceStateConditionType(currentKafkaRebalance.getStatus()).equals(rebalanceStateConditionType(updatedKafkaRebalance.getStatus()))) {
                                                         message = "KafkaRebalance state is now updated to [{}]";
-                                                    }
-                                                    if (rawRebalanceAnnotation(updatedKafkaRebalance) != null) {
-                                                        LOGGER.infoCr(reconciliation, message + " with annotation {}={} applied on the KafkaRebalance resource",
-                                                                rebalanceStateConditionType(updatedKafkaRebalance.getStatus()),
+
+                                                        if (rawRebalanceAnnotation(updatedKafkaRebalance) != null) {
+                                                            message = message + " with annotation {}={} applied on the KafkaRebalance resource";
+                                                        }
+                                                        LOGGER.infoCr(reconciliation, message, rebalanceStateConditionType(updatedKafkaRebalance.getStatus()),
                                                                 ANNO_STRIMZI_IO_REBALANCE,
-                                                                rawRebalanceAnnotation(updatedKafkaRebalance)
-                                                        );
+                                                                rawRebalanceAnnotation(updatedKafkaRebalance));
                                                     }
                                                     if (hasRebalanceAnnotation(updatedKafkaRebalance)) {
                                                         if (currentState != KafkaRebalanceState.ReconciliationPaused && rebalanceAnnotation != KafkaRebalanceAnnotation.none && !currentState.isValidateAnnotation(rebalanceAnnotation)) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Task

### Description

Currently what happen is that if  there is no state change and annotation is applied on resource, then we get the logs as
```
2023-07-10 08:20:49 INFO  KafkaRebalanceAssemblyOperator:475 - Reconciliation #39(kafkarebalance-watch) KafkaRebalance(myproject/my-rebalance):  with annotation PendingProposal=strimzi.io/rebalance applied on the KafkaRebalance resource
```
which is incorrect. I have updated the code to fix this problem

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

