### PR TITLE
docs(mm2): additional information on configuring mm2 authorization

### DIFF
--- a/documentation/modules/configuring/con-config-mm2-multiple-instances.adoc
+++ b/documentation/modules/configuring/con-config-mm2-multiple-instances.adoc
@@ -19,7 +19,7 @@ spec:
   connectCluster: "my-cluster-target"
   clusters:
   - alias: "my-cluster-target"
-    config::
+    config:
       group.id: my-connect-cluster # <1>
       offset.storage.topic: my-connect-cluster-offsets # <2>
       config.storage.topic: my-connect-cluster-configs # <3>

--- a/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
+++ b/documentation/modules/configuring/proc-config-kafka-connect-user-authorization.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 When using authorization in Kafka, a Kafka Connect user requires read/write access to the cluster group and internal topics of Kafka Connect. 
-This procedure outlines how access is granted using `simple` authorization.
+This procedure outlines how access is granted using `simple` authorization and ACLs.
 
 Properties for the Kafka Connect cluster group ID and internal topics are configured by Strimzi by default. 
 Alternatively, you can define them explicitly in the `spec` of the `KafkaConnect` resource. 
@@ -25,7 +25,7 @@ For more information on configuring a `KafkaUser` resource to use simple authori
 
 . Edit the `authorization` property in the `KafkaUser` resource to provide access rights to the user.
 +
-Access rights are configured for the Kafka Connect topics and cluster group using `literal` name values:
+Access rights are configured for the Kafka Connect topics and cluster group using `literal` name values.
 The following table shows the default names configured for the topics and cluster group ID. 
 +
 .Names for the access rights configuration 
@@ -48,7 +48,7 @@ The following table shows the default names configured for the topics and cluste
 |===
 +
 In this example configuration, the default names are used to specify access rights.
-If you are using different names for a Kafka Connect instance, use those.
+If you are using different names for a Kafka Connect instance, use those names in the ACLs configuration.
 +
 .Example configuration for simple authorization
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
@@ -26,14 +26,20 @@ Before starting this procedure, take a look at the xref:config-examples-{context
 They include examples for securing a deployment of MirrorMaker 2 using mTLS or SCRAM-SHA-512 authentication.
 The examples specify internal listeners for connecting within a Kubernetes cluster.
 
-The examples provide the configuration for full authorization, including all the ACLs needed by MirrorMaker 2 to allow operations on the source and target Kafka clusters.
+The examples also provide the configuration for full authorization, including the ACLs that allow user operations on the source and target Kafka clusters.
+
+When configuring user access to source and target Kafka clusters, ACLs must grant access rights to internal MirrorMaker 2 connectors and read/write access to the cluster group and internal topics used by the underlying Kafka Connect framework in the target cluster. 
+If you've renamed the cluster group or internal topics, such as when xref:con-config-kafka-connect-multiple-instances-{context}[configuring MirrorMaker 2 for multiple instances], use those names in the ACLs configuration.
+
+Simple authorization uses ACL rules managed by the Kafka `AclAuthorizer` and `StandardAuthorizer` plugins to ensure appropriate access levels.
+For more information on configuring a `KafkaUser` resource to use simple authorization, see the link:{BookURLConfiguring}#type-AclRule-reference[`AclRule` schema reference^].
 
 .Prerequisites
 
 * Strimzi is running
 * Separate namespaces for source and target clusters
 
-The procedure assumes that the source and target Kafka clusters are installed to separate namespaces
+The procedure assumes that the source and target Kafka clusters are installed to separate namespaces.
 If you want to use the Topic Operator, you'll need to do this.
 The Topic Operator only watches a single cluster in a specified namespace.
 
@@ -157,8 +163,6 @@ The certificates are created in the secret `_<cluster_name>_-cluster-ca-cert`.
 For example, if you used `tls` authentication and the `simple` authorization type in the `Kafka` configuration for the source Kafka cluster, use the same in the `KafkaUser` configuration.
 
 .. Configure the ACLs needed by MirrorMaker 2 to allow operations on the source and target Kafka clusters.
-+
-The ACLs are used by the internal MirrorMaker connectors, and by the underlying Kafka Connect framework.
 --
 +
 .Example source user configuration for mTLS authentication
@@ -223,12 +227,13 @@ spec:
   authorization:
     type: simple
     acls:
-      # Underlying Kafka Connect internal topics to store configuration, offsets, or status
+      # cluster group
       - resource:
           type: group
           name: mirrormaker2-cluster
         operations:
           - Read
+      # access to config.storage.topic    
       - resource:
           type: topic
           name: mirrormaker2-cluster-configs
@@ -238,6 +243,7 @@ spec:
           - DescribeConfigs
           - Read
           - Write
+      # access to status.storage.topic    
       - resource:
           type: topic
           name: mirrormaker2-cluster-status
@@ -247,6 +253,7 @@ spec:
           - DescribeConfigs
           - Read
           - Write
+      # access to offset.storage.topic    
       - resource:
           type: topic
           name: mirrormaker2-cluster-offsets


### PR DESCRIPTION
**Documentation**

Securing MirrorMaker 2 config update.
Clarifies the requirement for configuring ACLs to access the internal topics and groups used by the underlying Kafka Connect framework.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

