### PR TITLE
docs(scaling): adds instructions to skip the partition check on scale-down operations

### DIFF
--- a/documentation/modules/configuring/con-scaling-kafka-clusters.adoc
+++ b/documentation/modules/configuring/con-scaling-kafka-clusters.adoc
@@ -52,3 +52,5 @@ You can use Cruise Control's `add-brokers` and `remove-brokers` modes when scali
 
 * Use the `add-brokers` mode after scaling up a Kafka cluster to move partition replicas from existing brokers to the newly added brokers.
 * Use the `remove-brokers` mode before scaling down a Kafka cluster to move partition replicas off the brokers that are going to be removed.
+
+include::../../modules/configuring/con-skipping-scale-down-checks.adoc[leveloffset=+1]

--- a/documentation/modules/configuring/con-skipping-scale-down-checks.adoc
+++ b/documentation/modules/configuring/con-skipping-scale-down-checks.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// con-scaling-kafka-clusters.adoc
+
+[id='con-skipping-scale-down-checks-{context}']
+= Skipping checks on scale-down operations
+
+[role="_abstract"]
+By default, Strimzi performs a check to ensure that there are no partition replicas on a broker before initiating a scale-down operation on a Kafka cluster. 
+If replicas are found, the scale-down operation is blocked to prevent potential data loss. 
+To fix this, no replicas must be left on the broker before trying to scale it down again.
+
+However, there may be scenarios where you want to bypass this blocking mechanism.
+Disabling the check might be necessary on busy clusters, for example, because new topics keep generating replicas for the broker.
+This situation can indefinitely block the scaling down of clusters, even when brokers are nearly empty. 
+
+You can bypass the blocking mechanism by annotating the `Kafka` resource for the Kafka cluster.
+Annotate the resource by setting the `strimzi.io/skip-broker-scaledown-check` annotation to `true`:
+
+.Adding the annotation to skip checks on scale-down operations  
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl annotate Kafka my-kafka-cluster strimzi.io/skip-broker-scaledown-check="true"
+----
+
+This annotation instructs Strimzi to skip the scale-down check.
+Replace `my-kafka-cluster` with the name of your specific `Kafka` resource.
+
+To restart the check, remove the annotation:
+
+.Removing the annotation to skip checks on scale-down operations  
+[source,shell,subs="+quotes,attributes+"]
+----
+kubectl annotate Kafka my-kafka-cluster strimzi.io/skip-broker-scaledown-check-
+----

--- a/documentation/modules/configuring/con-skipping-scale-down-checks.adoc
+++ b/documentation/modules/configuring/con-skipping-scale-down-checks.adoc
@@ -7,12 +7,14 @@
 
 [role="_abstract"]
 By default, Strimzi performs a check to ensure that there are no partition replicas on a broker before initiating a scale-down operation on a Kafka cluster. 
-If replicas are found, the scale-down operation is blocked to prevent potential data loss. 
-To fix this, no replicas must be left on the broker before trying to scale it down again.
+If replicas are found, cluster operations are blocked to prevent potential data loss. 
+To resume cluster operations, no replicas must be left on the broker before trying to scale it down again.
 
 However, there may be scenarios where you want to bypass this blocking mechanism.
 Disabling the check might be necessary on busy clusters, for example, because new topics keep generating replicas for the broker.
-This situation can indefinitely block the scaling down of clusters, even when brokers are nearly empty. 
+This situation can indefinitely block cluster operations, even when brokers are nearly empty. 
+Overriding the blocking mechanism in this way has an impact:
+the presence of topics on the broker being scaled down will likely cause a reconciliation failure for the Kafka cluster. 
 
 You can bypass the blocking mechanism by annotating the `Kafka` resource for the Kafka cluster.
 Annotate the resource by setting the `strimzi.io/skip-broker-scaledown-check` annotation to `true`:
@@ -26,7 +28,7 @@ kubectl annotate Kafka my-kafka-cluster strimzi.io/skip-broker-scaledown-check="
 This annotation instructs Strimzi to skip the scale-down check.
 Replace `my-kafka-cluster` with the name of your specific `Kafka` resource.
 
-To restart the check, remove the annotation:
+To restore the check for scale-down operations, remove the annotation:
 
 .Removing the annotation to skip checks on scale-down operations  
 [source,shell,subs="+quotes,attributes+"]


### PR DESCRIPTION
**Documentation**

Adds a new set of instructions to describe how to skip the check on residual partitions during a scale-down operation.
The instructions sit under the scaling concepts section that describes scaling in Kafka and node pool resources and the reassigning of partitions through Cruise Control. 

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

