### PR TITLE
[DOC] Fix misleading example in the Node Pool migration docs

### DIFF
--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -84,16 +84,9 @@ metadata:
     strimzi.io/node-pools: enabled
 spec:
   kafka:
-    version: {DefaultKafkaVersion}
-    replicas: 3
-  # ...
-  storage:
-      type: jbod
-      volumes:
-      - id: 0
-        type: persistent-claim
-        size: 100Gi
-        deleteClaim: false
+    # ...
+  zookeeper:
+    # ...
 ----
 
 . Apply the `Kafka` resource:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The `Kafka` CR example in the Node Pool migration docs is misleading and invalid:
* It has misaligned storage configuration
* It does not seem to make much sense to detail the things such as version, replicas or storage that are irrelevant to node pools. They just distract from the annotation that is the only important part here. 

### Checklist

- [x] Update documentation