### PR TITLE
[ST] - Dual-stack support for Kind on TF

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -107,7 +107,7 @@ install_kubernetes_provisioner
 reg_name='kind-registry'
 reg_port='5001'
 
-if [ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]; then
+if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     hostname=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
 
     # update insecure registries
@@ -157,7 +157,7 @@ EOF
     [host."http://${reg_name}:5000"]
 EOF
     done
-elif [ "$IP_FAMILY" = "ipv6" ]; then
+elif [[ "$IP_FAMILY" = "ipv6" ]]; then
     # for ipv6 configuration
     ula_fixed_ipv6="fd01:2345:6789"
     registry_dns="myregistry.local"

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -107,7 +107,7 @@ install_kubernetes_provisioner
 reg_name='kind-registry'
 reg_port='5001'
 
-if [ "$IP_FAMILY" = "ipv4" ]; then
+if [ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]; then
     hostname=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
 
     # update insecure registries

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -182,6 +182,7 @@ public class Environment {
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";
     public static final String IP_FAMILY_VERSION_6 = "ipv6";
+    public static final String IP_FAMILY_DUAL_STACK = "dual";
 
     /**
      * Set values
@@ -306,6 +307,10 @@ public class Environment {
         return IP_FAMILY.contains(IP_FAMILY_VERSION_6);
     }
 
+    public static boolean isDualStackIpFamily() {
+        return IP_FAMILY.contains(IP_FAMILY_DUAL_STACK);
+    }
+
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);
     }
@@ -317,7 +322,7 @@ public class Environment {
             // we will need a hostname of machine
             String hostname = "";
             try {
-                if (Environment.isIpv4Family()) {
+                if (Environment.isIpv4Family() || Environment.isDualStackIpFamily()) {
                     hostname = InetAddress.getLocalHost().getHostAddress() + ":5001";
                 } else if (Environment.isIpv6Family()) {
                     hostname = "myregistry.local:5001";

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -113,7 +113,7 @@ prepare:
       fi
       #
       HOST=""
-      if [[ ${IP_FAMILY} == "ipv4" ]]; then
+      if [[ ${IP_FAMILY} == "ipv4" || ${IP_FAMILY} == "dual" ]]; then
         HOST=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
       elif [[ ${IP_FAMILY} == "ipv6" ]]; then
         HOST="myregistry.local"

--- a/systemtest/tmt/tests/strimzi/test.sh
+++ b/systemtest/tmt/tests/strimzi/test.sh
@@ -4,7 +4,7 @@
 cd ../../../../
 
 #run tests
-if [[ ${IP_FAMILY} == "ipv4" ]]; then
+if [[ ${IP_FAMILY} == "ipv4" || ${IP_FAMILY} == "dual" ]]; then
     DOCKER_REGISTRY=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
 elif [[ ${IP_FAMILY} == "ipv6" ]]; then
     DOCKER_REGISTRY="myregistry.local"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR introduces dual-stack (IPv4/IPv6) support to our Kind cluster, allowing seamless networking transitions and operations in both IP environments. 

### Checklist

- [x] Make sure all tests pass