### PR TITLE
[DOC] Clarify that TLS hostname verification can be disabled only in client based operands

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -55,7 +55,7 @@ The combination is encapsulated in the `TLS_AES_256_GCM_SHA384` cipher suite spe
 
 The `ssl.enabled.protocols` property specifies the available TLS versions that can be used for secure communication between the cluster and its clients. 
 The `ssl.protocol` property sets the default TLS version for all connections, and it must be chosen from the enabled protocols.
-Use the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification (configurable only in components based on Kafka clients - Kafka Connect, MirrorMaker 1/2, and Bridge).
+Use the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification (configurable only in components based on Kafka clients - Kafka Connect, MirrorMaker 1/2, and Kafka Bridge).
 
 .Example SSL configuration
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -55,7 +55,7 @@ The combination is encapsulated in the `TLS_AES_256_GCM_SHA384` cipher suite spe
 
 The `ssl.enabled.protocols` property specifies the available TLS versions that can be used for secure communication between the cluster and its clients. 
 The `ssl.protocol` property sets the default TLS version for all connections, and it must be chosen from the enabled protocols.
-Use the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification. 
+Use the `ssl.endpoint.identification.algorithm` property to enable or disable hostname verification (configurable only in components based on Kafka clients - Kafka Connect, MirrorMaker 1/2, and Bridge).
 
 .Example SSL configuration
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The docs suggest that `ssl.endpoint.identification.algorithm` can be configured by users. But it only applies to client-based operands and not to Kafka brokers. This PR tries to clarify it in the docs.

This should resolve #9181 

### Checklist

- [x] Update documentation