### PR TITLE
External IP Configurability for Kafka brokers and External Bootstrap

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBootstrap.java
@@ -38,6 +38,7 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
     private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
+    private List<String> externalIPs;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -109,6 +110,16 @@ public class GenericKafkaListenerConfigurationBootstrap implements Serializable,
 
     public void setLoadBalancerIP(String loadBalancerIP) {
         this.loadBalancerIP = loadBalancerIP;
+    }
+
+    @Description("External IPs to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getExternalIPs() {
+        return externalIPs;
+    }
+
+    public void setExternalIP(List<String> externalIPs) {
+        this.externalIPs = externalIPs;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/listener/arraylistener/GenericKafkaListenerConfigurationBroker.java
@@ -16,6 +16,7 @@ import lombok.EqualsAndHashCode;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -42,6 +43,7 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
     private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
+    private List<String> externalIPs;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -133,6 +135,16 @@ public class GenericKafkaListenerConfigurationBroker implements Serializable, Un
 
     public void setLoadBalancerIP(String loadBalancerIP) {
         this.loadBalancerIP = loadBalancerIP;
+    }
+
+    @Description("External IPs to the resource.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getExternalIPs() {
+        return externalIPs;
+    }
+
+    public void setExternalIPs(List<String> externalIPs) {
+        this.externalIPs = externalIPs;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -626,6 +626,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             }
 
             if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
+                List<String> eip = ListenersUtils.bootstrapExternalIPs(listener);
+                if (eip != null && !eip.isEmpty()) {
+                    service.getSpec().setExternalIPs(eip);
+                }
                 ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                 if (etp != null) {
                     service.getSpec().setExternalTrafficPolicy(etp.toValue());
@@ -704,6 +708,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         }
 
                         if (KafkaListenerType.LOADBALANCER == listener.getType() || KafkaListenerType.NODEPORT == listener.getType()) {
+                            List<String> eip = ListenersUtils.brokerExternalIPs(listener, nodeId);
+                            if (eip != null && !eip.isEmpty()) {
+                                service.getSpec().setExternalIPs(eip);
+                            }
                             ExternalTrafficPolicy etp = ListenersUtils.externalTrafficPolicy(listener);
                             if (etp != null) {
                                 service.getSpec().setExternalTrafficPolicy(etp.toValue());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -699,4 +699,39 @@ public class ListenersUtils {
 
         return String.valueOf(advertisedPort != null ? advertisedPort : port);
     }
+
+    /**
+     * Finds bootstrap service external IPs
+     *
+     * @param listener  Listener for which the external IPs should be found
+     * @return          External IPs or null if not specified
+     */
+    public static List<String> bootstrapExternalIPs(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBootstrap() != null) {
+            return listener.getConfiguration().getBootstrap().getExternalIPs();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Finds broker service external IPs
+     *
+     * @param listener  Listener for which the external IPs should be found
+     * @param pod       Pod ID for which we should get the configuration option
+     * @return          External IPs or null if not specified
+     */
+    public static List<String> brokerExternalIPs(GenericKafkaListener listener, int pod)    {
+        if (listener.getConfiguration() != null
+                && listener.getConfiguration().getBrokers() != null) {
+            return listener.getConfiguration().getBrokers().stream()
+                    .filter(broker -> broker != null && broker.getBroker() != null && broker.getBroker() == pod && broker.getExternalIPs() != null)
+                    .map(GenericKafkaListenerConfigurationBroker::getExternalIPs)
+                    .findAny()
+                    .orElse(null);
+        } else {
+            return null;
+        }
+    }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -411,6 +411,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |annotations       1.2+<.<a|Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
+|externalIPs       1.2+<.<a|External IPs to the resource.
+|string array
 |labels            1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====
@@ -445,6 +447,8 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |annotations     1.2+<.<a|Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.
 |map
+|externalIPs     1.2+<.<a|External IPs to the resource.
+|string array
 |labels          1.2+<.<a|Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.
 |map
 |====

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -310,6 +310,11 @@ spec:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
                                   description: "Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
+                                externalIPs:
+                                  type: array
+                                  items:
+                                    type: string
+                                  description: External IPs to the resource.
                                 labels:
                                   x-kubernetes-preserve-unknown-fields: true
                                   type: object
@@ -342,6 +347,11 @@ spec:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object
                                     description: "Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners."
+                                  externalIPs:
+                                    type: array
+                                    items:
+                                      type: string
+                                    description: External IPs to the resource.
                                   labels:
                                     x-kubernetes-preserve-unknown-fields: true
                                     type: object


### PR DESCRIPTION
### Type of change

Enhancement

### Description

Cluster operator does not provide any configurability of the external IPs associated with the nodeport. In other words, user is not able to provide any external IP. We have tried to perform a kubectl patch with the external IP but the setting is not permanent. After a while, the change will be reverted and external IP is gone. To address this, we updated the CRD template with a new option where user can provide external IP for the broker and IP for each of the nodeports. The cluster operator is also updated to retrieve the user provided values and provision them during the init container step.

#### Sample Configuration
```
  external:
    type: nodeport
    tls: false
    overrides:
      bootstrap:
        advertisedHost: 107.250.139.224
        nodePort: 32100
      brokers:
      - broker: 0
        advertisedHost: 107.250.139.225
        nodePort: 32000
      - broker: 1
        advertisedHost: 107.250.139.226
        nodePort: 32001
      - broker: 2
        advertisedHost: 107.250.139.227
        nodePort: 32002
template:
  externalBootstrapService:
    externalTrafficPolicy: Local
    externalIPs:
      - 107.250.139.224
  perPodService:
    externalTrafficPolicy: Local
    externalIPs:
      - 107.250.139.225
      - 107.250.139.226
      - 107.250.139.227
```
```
$ kubectl get svc
NAME                                  TYPE        CLUSTER-IP       EXTERNAL-IP                       PORT(S)                      AGE
my-cluster-kafka-0                    NodePort    10.103.116.212   107.250.139.225                   9094:32000/TCP               107s
my-cluster-kafka-1                    NodePort    10.104.170.243   107.250.139.226                   9094:32001/TCP               107s
my-cluster-kafka-2                    NodePort    10.110.163.100   107.250.139.227                   9094:32002/TCP               107s
my-cluster-kafka-bootstrap            ClusterIP   10.107.234.220   <none>                            9091/TCP,9093/TCP            107s
my-cluster-kafka-brokers              ClusterIP   None             <none>                            9091/TCP,9093/TCP            107s
my-cluster-kafka-external-bootstrap   NodePort    10.102.65.138    107.250.139.224                   9094:32100/TCP               107s
my-cluster-zookeeper-client           ClusterIP   10.106.192.45    <none>                            2181/TCP                     2m9s
my-cluster-zookeeper-nodes            ClusterIP   None             <none>                            
```

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

