### PR TITLE
Support Strimzi Operator Deployment to K8s env + IPv6

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/060-Deployment-strimzi-cluster-operator.yaml
@@ -70,6 +70,14 @@ spec:
             - name: {{ .Values.logVolume }}
               mountPath: /opt/strimzi/custom-config/
           env:
+            {{- if .Values.kubernetesMaster }}
+            - name: KUBERNETES_MASTER
+              value: {{ .Values.kubernetesMaster }}
+            {{- end }}
+            {{- if .Values.kubernetesDisableHostVerification }}
+            - name: KUBERNETES_DISABLE_HOSTNAME_VERIFICATION
+              value: {{ .Values.kubernetesDisableHostVerification | quote }}
+            {{- end }}
             - name: STRIMZI_NAMESPACE
               {{- if .Values.watchAnyNamespace }}
               value: "*"


### PR DESCRIPTION
### Type of change

Enhancement

### Description

While deploying cluster operator to K8s env configured with IPv6, we were stumped by the following errors.
```
2021-01-28 18:23:18 INFO  Main:60 - ClusterOperator 0.19.0 is starting 
2021-01-28 18:23:21 ERROR PlatformFeaturesAvailability:124 - Detection of Kubernetes version failed.
io.fabric8.kubernetes.client.KubernetesClientException: An error has occurred.
       at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:64) ~[io.fabric8.kubernetes-client-4.6.4.ja
r:?]
       at io.fabric8.kubernetes.client.KubernetesClientException.launderThrowable(KubernetesClientException.java:53) ~[io.fabric8.kubernetes-client-4.6.4.ja

Caused by: javax.net.ssl.SSLPeerUnverifiedException: Hostname fc11::1 not verified: 
   certificate: sha256/Vt4FXjXwAY2l7cffNShXdFLUQVnTw12pSsnv4WLdTdY=
   DN: CN=kube-apiserver
   subjectAltNames: [127.0.0.1, fc11:0:0:0:0:0:0:1, x270n01-vm01-ip6-oam, x270n01-vm01-ip6, x270n02-vm01-ip6-oam, x270n02-vm01-ip6, x270n03-vm01-ip6-oam, x2
70n03-vm01-ip6, localhost, kubernetes, kubernetes.default, kubernetes.default.svc, kubernetes.default.svc.cluster.local]
       at okhttp3.internal.connection.RealConnection.connectTls(RealConnection.java:334) ~[com.squareup.okhttp3.okhttp-3.12.6
```
Similar issue was reported by others in https://github.com/strimzi/strimzi-kafka-operator/issues/4002; suggesting that "The workaround I used and verified is setting the KUBERNETES_MASTER to the actual Kubernetes master on the got through the kubectl cluster-info command."

We added the following environment variables in Helm chart and issue is resolved.

```
env:
  - name: KUBERNETES_MASTER
    value: https://[fc00:129:40:80::83]:6443
  - name: KUBERNETES_DISABLE_HOSTNAME_VERIFICATION
    value: "true"
```
The strimzi operator was able to deploy successfully after that.
```
$ k get pod -n odf
NAME                                        READY   STATUS    RESTARTS   AGE
strimzi-cluster-operator-7cb9d78f6f-pscmf   1/1     Running   0          126m
```

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

