### PR TITLE
Remove `inter.broker.protocol.version` from KRaft examples

### DIFF
--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -45,7 +45,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.5"
     # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     storage:

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
@@ -53,7 +53,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.5"
     # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     storage:

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -63,7 +63,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.5"
     # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     storage:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Our KRaft example files have `inter.broker.protocol.version` set. This option is deprecated in KRaft and just results in warnings in Kafka logs:

```
2023-10-01 21:03:28,801 WARN inter.broker.protocol.version is deprecated in KRaft mode as of 3.3 and will only be read when first upgrading from a KRaft prior to 3.3. See kafka-storage.sh help for details on setting the metadata version for a new KRaft cluster. (kafka.server.KafkaConfig) [data-plane-kafka-request-handler-7]
```

This PR removes it from the examples.