### PR TITLE
Add proper indentation to a few jmxPrometheusExporter labels blocks in examples.

### DIFF
--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -82,15 +82,15 @@ data:
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-        clientId: "$3"
-        topic: "$4"
-        partition: "$5"
+       clientId: "$3"
+       topic: "$4"
+       partition: "$5"
     - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-        clientId: "$3"
-        broker: "$4:$5"
+       clientId: "$3"
+       broker: "$4:$5"
     - pattern: kafka.server<type=(.+), cipher=(.+), protocol=(.+), listener=(.+), networkProcessor=(.+)><>connections
       name: kafka_server_$1_connections_tls_info
       type: GAUGE
@@ -111,14 +111,14 @@ data:
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-        listener: "$2"
-        networkProcessor: "$3"
+       listener: "$2"
+       networkProcessor: "$3"
     - pattern: kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+)
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-        listener: "$2"
-        networkProcessor: "$3"
+       listener: "$2"
+       networkProcessor: "$3"
     # Some percent metrics use MeanRate attribute
     # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
     - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -82,15 +82,15 @@ data:
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-       clientId: "$3"
-       topic: "$4"
-       partition: "$5"
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
     - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-       clientId: "$3"
-       broker: "$4:$5"
+        clientId: "$3"
+        broker: "$4:$5"
     - pattern: kafka.server<type=(.+), cipher=(.+), protocol=(.+), listener=(.+), networkProcessor=(.+)><>connections
       name: kafka_server_$1_connections_tls_info
       type: GAUGE
@@ -111,14 +111,14 @@ data:
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-       listener: "$2"
-       networkProcessor: "$3"
+        listener: "$2"
+        networkProcessor: "$3"
     - pattern: kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+)
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-       listener: "$2"
-       networkProcessor: "$3"
+        listener: "$2"
+        networkProcessor: "$3"
     # Some percent metrics use MeanRate attribute
     # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
     - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -82,15 +82,15 @@ data:
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-       clientId: "$3"
-       topic: "$4"
-       partition: "$5"
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
     - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
       name: kafka_server_$1_$2
       type: GAUGE
       labels:
-       clientId: "$3"
-       broker: "$4:$5"
+        clientId: "$3"
+        broker: "$4:$5"
     - pattern: kafka.server<type=(.+), cipher=(.+), protocol=(.+), listener=(.+), networkProcessor=(.+)><>connections
       name: kafka_server_$1_connections_tls_info
       type: GAUGE
@@ -111,14 +111,14 @@ data:
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-       listener: "$2"
-       networkProcessor: "$3"
+        listener: "$2"
+        networkProcessor: "$3"
     - pattern: kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+)
       name: kafka_server_$1_$4
       type: GAUGE
       labels:
-       listener: "$2"
-       networkProcessor: "$3"
+        listener: "$2"
+        networkProcessor: "$3"
     # Some percent metrics use MeanRate attribute
     # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
     - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

Add proper indentation to a few jmxPrometheusExporter labels blocks.

When copying and pasting the configs one of my brokers crashed because it could not parse the config. (I think my IDE removed the one-space indentation.)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

