### PR TITLE
Fix publishing of the SBOM archive in release pipelines

### DIFF
--- a/.azure/templates/jobs/build/push_containers.yaml
+++ b/.azure/templates/jobs/build/push_containers.yaml
@@ -94,7 +94,7 @@ jobs:
       - bash: tar -z -C ./sbom/ -cvpf sbom.tar.gz ./
         displayName: "Tar the SBOM files"
       - publish: $(System.DefaultWorkingDirectory)/sbom.tar.gz
-        artifact: SBOMs
+        artifact: SBOMs-${{ parameters.dockerTag }}
         displayName: "Publish the SBOM files"
       # push the SBOMs to container registry only for releases
       - ${{ each arch in parameters.architectures }}:


### PR DESCRIPTION
### Type of change

- Bug

### Description

There is a minor bug in the SBOM support in the release pipeline that is fixed by this PR ... in the release pipeline, the SBOM archive might be published twice as a Azure artifact - once in the suffixed run and once in the normal run. This fails when the artifact has the same name. This PR updates the name of the artifact to contain the tag and thus makes the name unique.