### PR TITLE
docs(cruise control): adds capacity config order of precedence

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -231,6 +231,16 @@ spec:
         outboundNetwork: 30000KiB/s
 ----
 
+If you are using `cruiseControl.brokerCapacity.cpu` or `cruiseControl.brokerCapacity.overrides.cpu` to change the default capacity limits for goals related to resource distribution, the order of precedence is as follows, with highest priority first:
+
+. `Kafka.spec.cruiseControl.brokerCapacity.overrides.cpu` that define custom CPU capacity limits for individual brokers
+. `Kafka.cruiseControl.brokerCapacity.cpu` that defines custom CPU capacity limits for all brokers in the kafka cluster
+. `Kafka.spec.kafka.resources.requests.cpu` that defines the CPU resources that are reserved for each broker in the Kafka cluster.
+. `Kafka.spec.kafka.resources.limits.cpu` that defines the maximum CPU resources that can be consumed by each broker in the Kafka cluster.
+
+This order of precedence is the sequence in which different configuration values are considered when determining the actual capacity limit for a Kafka broker. 
+If none of the CPU capacity configurations are specified, the default CPU capacity for a Kafka broker is set to 1 CPU core. 
+
 For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapacity schema reference].
 
 [id='property-cruise-control-logging-{context}']

--- a/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.CruiseControlSpec.adoc
@@ -231,7 +231,7 @@ spec:
         outboundNetwork: 30000KiB/s
 ----
 
-If you are using `cruiseControl.brokerCapacity.cpu` or `cruiseControl.brokerCapacity.overrides.cpu` to change the default capacity limits for goals related to resource distribution, the order of precedence is as follows, with highest priority first:
+CPU capacity is determined using configuration values in the following order of precedence, with the highest priority first:
 
 . `Kafka.spec.cruiseControl.brokerCapacity.overrides.cpu` that define custom CPU capacity limits for individual brokers
 . `Kafka.cruiseControl.brokerCapacity.cpu` that defines custom CPU capacity limits for all brokers in the kafka cluster
@@ -239,6 +239,7 @@ If you are using `cruiseControl.brokerCapacity.cpu` or `cruiseControl.brokerCapa
 . `Kafka.spec.kafka.resources.limits.cpu` that defines the maximum CPU resources that can be consumed by each broker in the Kafka cluster.
 
 This order of precedence is the sequence in which different configuration values are considered when determining the actual capacity limit for a Kafka broker. 
+For example, broker-specific overrides take precedence over capacity limits for all brokers.
 If none of the CPU capacity configurations are specified, the default CPU capacity for a Kafka broker is set to 1 CPU core. 
 
 For more information, refer to the xref:type-BrokerCapacity-reference[BrokerCapacity schema reference].


### PR DESCRIPTION
**Documentation**

Updates the Cruise Control documentation to describe the order of precedence in CPU capacity configuration to change the default capacity limits for goals related to resource distribution.

The order of precedence is as follows:

Order | config
-- | --
1 | .spec.cruiseControl.brokerCapacity overrides
2 | .spec.cruiseControl.brokerCapacity
3 | Kafka resource requests
4 | Kafka resource limits

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

