### PR TITLE
docs(node pools): adds node pools resources to resources list

### DIFF
--- a/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
@@ -60,10 +60,10 @@ kubectl get pods -n <my_cluster_operator_namespace>
 .Output shows three Kafka nodes in the node pool
 [source,shell]
 ----
-NAME                       READY  STATUS   RESTARTS
-my-cluster-pool-a-kafka-0  1/1    Running  0
-my-cluster-pool-a-kafka-1  1/1    Running  0
-my-cluster-pool-a-kafka-2  1/1    Running  0
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
 ----
 
 . To migrate to a new storage class, create a new node pool with the required storage configuration:

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -52,15 +52,15 @@ kubectl get pods -n <my_cluster_operator_namespace>
 .Output shows four Kafka nodes in the target node pool
 [source,shell]
 ----
-NAME                       READY  STATUS   RESTARTS
-my-cluster-pool-a-kafka-0  1/1    Running  0
-my-cluster-pool-a-kafka-1  1/1    Running  0
-my-cluster-pool-a-kafka-4  1/1    Running  0
-my-cluster-pool-a-kafka-5  1/1    Running  0
+NAME                      READY    STATUS  RESTARTS
+my-cluster-pool-a-0  1/1  Running  0
+my-cluster-pool-a-1  1/1  Running  0
+my-cluster-pool-a-4  1/1  Running  0
+my-cluster-pool-a-5  1/1  Running  0
 ----
 +
 Node IDs are appended to the name of the node on creation.
-We add node `my-cluster-pool-a-kafka-5`, which has a node ID of `5`.
+We add node `my-cluster-pool-a-5`, which has a node ID of `5`.
 
 . Reassign the partitions from the old node to the new node.
 +

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -52,11 +52,11 @@ kubectl get pods -n <my_cluster_operator_namespace>
 .Output shows four Kafka nodes in the target node pool
 [source,shell]
 ----
-NAME                      READY    STATUS  RESTARTS
-my-cluster-pool-a-0  1/1  Running  0
-my-cluster-pool-a-1  1/1  Running  0
-my-cluster-pool-a-4  1/1  Running  0
-my-cluster-pool-a-5  1/1  Running  0
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-4  1/1    Running  0
+my-cluster-pool-a-5  1/1    Running  0
 ----
 +
 Node IDs are appended to the name of the node on creation.

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -13,11 +13,11 @@ In this procedure, we start with four nodes for node pool `pool-a`:
 .Kafka nodes in the node pool
 [source,shell,subs="+quotes"]
 ----
-NAME                       READY  STATUS  RESTARTS
-my-cluster-pool-a-0  1/1   Running  0
-my-cluster-pool-a-1  1/1   Running  0
-my-cluster-pool-a-2  1/1   Running  0
-my-cluster-pool-a-3  1/1   Running  0
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
+my-cluster-pool-a-3  1/1    Running  0
 ----
 
 Node IDs are appended to the name of the node on creation.
@@ -53,8 +53,8 @@ kubectl scale kafkanodepool pool-a --replicas=3
 .Output shows three Kafka nodes in the node pool
 [source,shell]
 ----
-NAME                        READY   STATUS    RESTARTS
-my-cluster-pool-b-kafka-0   1/1     Running   0
-my-cluster-pool-b-kafka-1   1/1     Running   0
-my-cluster-pool-b-kafka-2   1/1     Running   0
+NAME                       READY  STATUS   RESTARTS
+my-cluster-pool-b-kafka-0  1/1    Running  0
+my-cluster-pool-b-kafka-1  1/1    Running  0
+my-cluster-pool-b-kafka-2  1/1    Running  0
 ----

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -13,15 +13,15 @@ In this procedure, we start with four nodes for node pool `pool-a`:
 .Kafka nodes in the node pool
 [source,shell,subs="+quotes"]
 ----
-NAME                       READY  STATUS   RESTARTS
-my-cluster-pool-a-kafka-0  1/1    Running  0
-my-cluster-pool-a-kafka-1  1/1    Running  0
-my-cluster-pool-a-kafka-2  1/1    Running  0
-my-cluster-pool-a-kafka-3  1/1    Running  0
+NAME                       READY  STATUS  RESTARTS
+my-cluster-pool-a-0  1/1   Running  0
+my-cluster-pool-a-1  1/1   Running  0
+my-cluster-pool-a-2  1/1   Running  0
+my-cluster-pool-a-3  1/1   Running  0
 ----
 
 Node IDs are appended to the name of the node on creation.
-We remove node `my-cluster-pool-a-kafka-3`, which has a node ID of `3`.
+We remove node `my-cluster-pool-a-3`, which has a node ID of `3`.
 
 NOTE: During this process, the ID of the node that holds the partition replicas changes. Consider any dependencies that reference the node ID.
 

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -13,10 +13,10 @@ In this procedure, we start with three nodes for node pool `pool-a`:
 .Kafka nodes in the node pool
 [source,shell]
 ----
-NAME                      READY    STATUS  RESTARTS
-my-cluster-pool-a-0  1/1  Running  0
-my-cluster-pool-a-1  1/1  Running  0
-my-cluster-pool-a-2  1/1  Running  0
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
 ----
 
 Node IDs are appended to the name of the node on creation.
@@ -55,7 +55,7 @@ kubectl get pods -n <my_cluster_operator_namespace>
 .Output shows four Kafka nodes in the node pool
 [source,shell]
 ----
-NAME                       READY  STATUS   RESTARTS
+NAME                 READY  STATUS   RESTARTS
 my-cluster-pool-a-0  1/1    Running  0
 my-cluster-pool-a-1  1/1    Running  0
 my-cluster-pool-a-2  1/1    Running  0

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -13,14 +13,14 @@ In this procedure, we start with three nodes for node pool `pool-a`:
 .Kafka nodes in the node pool
 [source,shell]
 ----
-NAME                       READY  STATUS   RESTARTS
-my-cluster-pool-a-kafka-0  1/1    Running  0
-my-cluster-pool-a-kafka-1  1/1    Running  0
-my-cluster-pool-a-kafka-2  1/1    Running  0
+NAME                      READY    STATUS  RESTARTS
+my-cluster-pool-a-0  1/1  Running  0
+my-cluster-pool-a-1  1/1  Running  0
+my-cluster-pool-a-2  1/1  Running  0
 ----
 
 Node IDs are appended to the name of the node on creation.
-We add node `my-cluster-pool-a-kafka-3`, which has a node ID of `3`.
+We add node `my-cluster-pool-a-3`, which has a node ID of `3`.
 
 NOTE: During this process, the ID of the node that holds the partition replicas changes. Consider any dependencies that reference the node ID.
 
@@ -56,10 +56,10 @@ kubectl get pods -n <my_cluster_operator_namespace>
 [source,shell]
 ----
 NAME                       READY  STATUS   RESTARTS
-my-cluster-pool-a-kafka-0  1/1    Running  0
-my-cluster-pool-a-kafka-1  1/1    Running  0
-my-cluster-pool-a-kafka-2  1/1    Running  0
-my-cluster-pool-a-kafka-3  1/1    Running  0
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
+my-cluster-pool-a-3  1/1    Running  0
 ---- 
 
 . Reassign the partitions after increasing the number of nodes in the node pool.

--- a/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
+++ b/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
@@ -7,12 +7,12 @@
 
 The following resources are created by the Cluster Operator in the Kubernetes cluster:
 
-_connect-cluster-name_-connect:: Name given to the following Kafka Connect resources:
+<connect_cluster_name>-connect:: Name given to the following Kafka Connect resources:
 +
 - Deployment that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is disabled).
 - StrimziPodSet that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is enabled).
 - Headless service that provides stable DNS names to the Connect pods (when `StableConnectIdentities` feature gate is enabled).
 - Pod Disruption Budget configured for the Kafka Connect worker nodes.
-_connect-cluster-name_-connect-_idx_:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled). 
-_connect-cluster-name_-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
-_connect-cluster-name_-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.
+<connect_cluster_name>-connect-<pod_id>:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled). 
+<connect_cluster_name>-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
+<connect_cluster_name>-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.

--- a/documentation/modules/configuring/ref-list-of-kafka-bridge-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-bridge-resources.adoc
@@ -7,7 +7,7 @@
 
 The following resources are created by the Cluster Operator in the Kubernetes cluster:
 
-_bridge-cluster-name_-bridge:: Deployment which is in charge to create the Kafka Bridge worker node pods.
-_bridge-cluster-name_-bridge-service:: Service which exposes the REST interface of the Kafka Bridge cluster.
-_bridge-cluster-name_-bridge-config:: ConfigMap which contains the Kafka Bridge ancillary configuration and is mounted as a volume by the Kafka broker pods.
-_bridge-cluster-name_-bridge:: Pod Disruption Budget configured for the Kafka Bridge worker nodes.
+<bridge_cluster_name>-bridge:: Deployment which is in charge to create the Kafka Bridge worker node pods.
+<bridge_cluster_name>-bridge-service:: Service which exposes the REST interface of the Kafka Bridge cluster.
+<bridge_cluster_name>-bridge-config:: ConfigMap which contains the Kafka Bridge ancillary configuration and is mounted as a volume by the Kafka broker pods.
+<bridge_cluster_name>-bridge:: Pod Disruption Budget configured for the Kafka Bridge worker nodes.

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -5,105 +5,120 @@
 [id='ref-list-of-kafka-cluster-resources-{context}']
 = List of Kafka cluster resources
 
-The following resources are created by the Cluster Operator in the Kubernetes cluster:
+The following resources are created by the Cluster Operator in the Kubernetes cluster.
 
 .Shared resources
 
-`_cluster-name_-cluster-ca`:: Secret with the Cluster CA private key used to encrypt the cluster communication.
-`_cluster-name_-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
-`_cluster-name_-clients-ca`::  Secret with the Clients CA private key used to sign user certificates
-`_cluster-name_-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka users.
-`_cluster-name_-cluster-operator-certs`:: Secret with Cluster operators keys for communication with Kafka and ZooKeeper.
+`<kafka_cluster_name>-cluster-ca`:: Secret with the Cluster CA private key used to encrypt the cluster communication.
+`<kafka_cluster_name>-cluster-ca-cert`:: Secret with the Cluster CA public key. This key can be used to verify the identity of the Kafka brokers.
+`<kafka_cluster_name>-clients-ca`::  Secret with the Clients CA private key used to sign user certificates
+`<kafka_cluster_name>-clients-ca-cert`:: Secret with the Clients CA public key. This key can be used to verify the identity of the Kafka users.
+`<kafka_cluster_name>-cluster-operator-certs`:: Secret with Cluster operators keys for communication with Kafka and ZooKeeper.
 
 .ZooKeeper nodes
 
-`_cluster-name_-zookeeper`:: Name given to the following ZooKeeper resources:
+`<kafka_cluster_name>-zookeeper`:: Name given to the following ZooKeeper resources:
 +
 - StrimziPodSet for managing the ZooKeeper node pods.
 - Service account used by the ZooKeeper nodes.
 - PodDisruptionBudget configured for the ZooKeeper nodes.
 
-`_cluster-name_-zookeeper-_idx_`:: Pods created by the StrimziPodSet.
-`_cluster-name_-zookeeper-nodes`:: Headless Service needed to have DNS resolve the ZooKeeper pods IP addresses directly.
-`_cluster-name_-zookeeper-client`:: Service used by Kafka brokers to connect to ZooKeeper nodes as clients.
-`_cluster-name_-zookeeper-config`:: ConfigMap that contains the ZooKeeper ancillary configuration, and is mounted as a volume by the ZooKeeper node pods.
-`_cluster-name_-zookeeper-nodes`:: Secret with ZooKeeper node keys.
-`_cluster-name_-network-policy-zookeeper`:: Network policy managing access to the ZooKeeper services.
-`data-_cluster-name_-zookeeper-_idx_`:: Persistent Volume Claim for the volume used for storing data for the ZooKeeper node pod `_idx_`. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
+`<kafka_cluster_name>-zookeeper-<pod_id>`:: Pods created by the StrimziPodSet.
+`<kafka_cluster_name>-zookeeper-nodes`:: Headless Service needed to have DNS resolve the ZooKeeper pods IP addresses directly.
+`<kafka_cluster_name>-zookeeper-client`:: Service used by Kafka brokers to connect to ZooKeeper nodes as clients.
+`<kafka_cluster_name>-zookeeper-config`:: ConfigMap that contains the ZooKeeper ancillary configuration, and is mounted as a volume by the ZooKeeper node pods.
+`<kafka_cluster_name>-zookeeper-nodes`:: Secret with ZooKeeper node keys.
+`<kafka_cluster_name>-network-policy-zookeeper`:: Network policy managing access to the ZooKeeper services.
+`data-<kafka_cluster_name>-zookeeper-<pod_id>`:: Persistent Volume Claim for the volume used for storing data for a specific ZooKeeper node. This resource will be created only if persistent storage is selected for provisioning persistent volumes to store data.
 
 .Kafka brokers
 
-`_cluster-name_-kafka`:: Name given to the following Kafka resources:
+`<kafka_cluster_name>-kafka`:: Name given to the following Kafka resources:
 +
 - StrimziPodSet for managing the Kafka broker pods.
 - Service account used by the Kafka pods.
 - PodDisruptionBudget configured for the Kafka brokers.
 
-`_cluster-name_-kafka-_idx_`:: Name given to the following Kafka resources:
+`<kafka_cluster_name>-kafka-<pod_id>`:: Name given to the following Kafka resources:
 +
 - Pods created by the StrimziPodSet.
 - ConfigMaps with Kafka broker configuration.
 
-`_cluster-name_-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
-`_cluster-name_-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients connecting from within the Kubernetes cluster.
-`_cluster-name_-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled. The old service name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
-`_cluster-name_-kafka-_pod-id_`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The old service name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
-`_cluster-name_-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The old route name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
-`_cluster-name_-kafka-_pod-id_`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The old route name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
-`_cluster-name_-kafka-_listener-name_-bootstrap`:: Bootstrap service for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
-`_cluster-name_-kafka-_listener-name_-_pod-id_`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
-`_cluster-name_-kafka-_listener-name_-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
-`_cluster-name_-kafka-_listener-name_-_pod-id_`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
-`_cluster-name_-kafka-config`:: ConfigMap containing the Kafka ancillary configuration, which is mounted as a volume by the broker pods when the `UseStrimziPodSets` feature gate is disabled.
-`_cluster-name_-kafka-brokers`:: Secret with Kafka broker keys.
-`_cluster-name_-network-policy-kafka`:: Network policy managing access to the Kafka services.
-`strimzi-_namespace-name_-_cluster-name_-kafka-init`:: Cluster role binding used by the Kafka brokers.
-`_cluster-name_-jmx`:: Secret with JMX username and password used to secure the Kafka broker port. This resource is created only when JMX is enabled in Kafka.
-`data-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `_idx_`. This resource is created only if persistent storage is selected for provisioning persistent volumes to store data.
-`data-_id_-_cluster-name_-kafka-_idx_`:: Persistent Volume Claim for the volume `_id_` used for storing data for the Kafka broker pod `_idx_`. This resource is created only if persistent storage is selected for JBOD volumes when provisioning persistent volumes to store data.
+`<kafka_cluster_name>-kafka-brokers`:: Service needed to have DNS resolve the Kafka broker pods IP addresses directly.
+`<kafka_cluster_name>-kafka-bootstrap`:: Service can be used as bootstrap servers for Kafka clients connecting from within the Kubernetes cluster.
+`<kafka_cluster_name>-kafka-external-bootstrap`:: Bootstrap service for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled. The old service name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
+`<kafka_cluster_name>-kafka-<pod_id>`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The old service name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
+`<kafka_cluster_name>-kafka-external-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The old route name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
+`<kafka_cluster_name>-kafka-<pod_id>`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The old route name will be used for backwards compatibility when the listener name is `external` and port is `9094`.
+`<kafka_cluster_name>-kafka-<listener_name>-bootstrap`:: Bootstrap service for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
+`<kafka_cluster_name>-kafka-<listener_name>-<pod_id>`:: Service used to route traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled. The new service name will be used for all other external listeners.
+`<kafka_cluster_name>-kafka-<listener_name>-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
+`<kafka_cluster_name>-kafka-<listener_name>-<pod_id>`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
+`<kafka_cluster_name>-kafka-config`:: ConfigMap containing the Kafka ancillary configuration, which is mounted as a volume by the broker pods when the `UseStrimziPodSets` feature gate is disabled.
+`<kafka_cluster_name>-kafka-brokers`:: Secret with Kafka broker keys.
+`<kafka_cluster_name>-network-policy-kafka`:: Network policy managing access to the Kafka services.
+`strimzi-_namespace-name_-<kafka_cluster_name>-kafka-init`:: Cluster role binding used by the Kafka brokers.
+`<kafka_cluster_name>-jmx`:: Secret with JMX username and password used to secure the Kafka broker port. This resource is created only when JMX is enabled in Kafka.
+`data-<kafka_cluster_name>-kafka-<pod_id>`:: Persistent Volume Claim for the volume used for storing data for a specific Kafka broker. This resource is created only if persistent storage is selected for provisioning persistent volumes to store data.
+`data-<id>-<kafka_cluster_name>-kafka-<pod_id>`:: Persistent Volume Claim for the volume `id` used for storing data for a specific Kafka broker. This resource is created only if persistent storage is selected for JBOD volumes when provisioning persistent volumes to store data.
+
+.(Preview) Kafka node pools
+
+If you are using Kafka node pools, the resources created apply to the nodes managed in the node pools whether they are operating as brokers, controllers, or both.
+The naming convention includes the name of the Kafka cluster and the node pool: `<kafka_cluster_name>-<pool_name>`.
+
+`<kafka_cluster_name>-<pool_name>`:: Name given to the StrimziPodSet for managing the Kafka node pool.
+
+`<kafka_cluster_name>-<pool_name>-<pod_id>`:: Name given to the following Kafka node pool resources:
++
+- Pods created by the StrimziPodSet.
+- ConfigMaps with Kafka node configuration.
+
+`data-<kafka_cluster_name>-<pool_name>-<pod_id>`:: Persistent Volume Claim for the volume used for storing data for a specific node. This resource is created only if persistent storage is selected for provisioning persistent volumes to store data.
+`data-<id>-<kafka_cluster_name>-<pool_name>-<pod_id>`:: Persistent Volume Claim for the volume `id` used for storing data for a specific node. This resource is created only if persistent storage is selected for JBOD volumes when provisioning persistent volumes to store data.
 
 .Entity Operator
 
 These resources are only created if the Entity Operator is deployed using the Cluster Operator.
 
-`_cluster-name_-entity-operator`:: Name given to the following Entity Operator resources:
+`<kafka_cluster_name>-entity-operator`:: Name given to the following Entity Operator resources:
 +
 - Deployment with Topic and User Operators.
 - Service account used by the Entity Operator.
 - Network policy managing access to the Entity Operator metrics.
 
-`_cluster-name_-entity-operator-_random-string_`:: Pod created by the Entity Operator deployment.
-`_cluster-name_-entity-topic-operator-config`:: ConfigMap with ancillary configuration for Topic Operators.
-`_cluster-name_-entity-user-operator-config`:: ConfigMap with ancillary configuration for User Operators.
-`_cluster-name_-entity-topic-operator-certs`:: Secret with Topic Operator keys for communication with Kafka and ZooKeeper.
-`_cluster-name_-entity-user-operator-certs`:: Secret with User Operator keys for communication with Kafka and ZooKeeper.
-`strimzi-_cluster-name_-entity-topic-operator`:: Role binding used by the Entity Topic Operator.
-`strimzi-_cluster-name_-entity-user-operator`:: Role binding used by the Entity User Operator.
+`<kafka_cluster_name>-entity-operator-<random_string>`:: Pod created by the Entity Operator deployment.
+`<kafka_cluster_name>-entity-topic-operator-config`:: ConfigMap with ancillary configuration for Topic Operators.
+`<kafka_cluster_name>-entity-user-operator-config`:: ConfigMap with ancillary configuration for User Operators.
+`<kafka_cluster_name>-entity-topic-operator-certs`:: Secret with Topic Operator keys for communication with Kafka and ZooKeeper.
+`<kafka_cluster_name>-entity-user-operator-certs`:: Secret with User Operator keys for communication with Kafka and ZooKeeper.
+`strimzi-<kafka_cluster_name>-entity-topic-operator`:: Role binding used by the Entity Topic Operator.
+`strimzi-<kafka_cluster_name>-entity-user-operator`:: Role binding used by the Entity User Operator.
 
 .Kafka Exporter
 
 These resources are only created if the Kafka Exporter is deployed using the Cluster Operator.
 
-`_cluster-name_-kafka-exporter`:: Name given to the following Kafka Exporter resources:
+`<kafka_cluster_name>-kafka-exporter`:: Name given to the following Kafka Exporter resources:
 +
 - Deployment with Kafka Exporter.
 - Service used to collect consumer lag metrics.
 - Service account used by the Kafka Exporter.
 - Network policy managing access to the Kafka Exporter metrics.
 
-`_cluster-name_-kafka-exporter-_random-string_`:: Pod created by the Kafka Exporter deployment.
+`<kafka_cluster_name>-kafka-exporter-<random_string>`:: Pod created by the Kafka Exporter deployment.
 
 .Cruise Control
 
 These resources are only created if Cruise Control was deployed using the Cluster Operator.
 
-`_cluster-name_-cruise-control`:: Name given to the following Cruise Control resources:
+`<kafka_cluster_name>-cruise-control`:: Name given to the following Cruise Control resources:
 +
 - Deployment with Cruise Control.
 - Service used to communicate with Cruise Control.
 - Service account used by the Cruise Control.
 
-`_cluster-name_-cruise-control-_random-string_`:: Pod created by the Cruise Control deployment.
-`_cluster-name_-cruise-control-config`:: ConfigMap that contains the Cruise Control ancillary configuration, and is mounted as a volume by the Cruise Control pods.
-`_cluster-name_-cruise-control-certs`:: Secret with Cruise Control keys for communication with Kafka and ZooKeeper.
-`_cluster-name_-network-policy-cruise-control`:: Network policy managing access to the Cruise Control service.
+`<kafka_cluster_name>-cruise-control-<random_string>`:: Pod created by the Cruise Control deployment.
+`<kafka_cluster_name>-cruise-control-config`:: ConfigMap that contains the Cruise Control ancillary configuration, and is mounted as a volume by the Cruise Control pods.
+`<kafka_cluster_name>-cruise-control-certs`:: Secret with Cruise Control keys for communication with Kafka and ZooKeeper.
+`<kafka_cluster_name>-network-policy-cruise-control`:: Network policy managing access to the Cruise Control service.

--- a/documentation/modules/configuring/ref-list-of-mirrormaker-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-mirrormaker-resources.adoc
@@ -7,6 +7,6 @@
 
 The following resources are created by the Cluster Operator in the Kubernetes cluster:
 
-_<mirror-maker-name>_-mirror-maker:: Deployment which is responsible for creating the Kafka MirrorMaker pods.
-_<mirror-maker-name>_-config:: ConfigMap which contains ancillary configuration for the Kafka MirrorMaker, and is mounted as a volume by the Kafka broker pods.
-_<mirror-maker-name>_-mirror-maker:: Pod Disruption Budget configured for the Kafka MirrorMaker worker nodes.
+<mirrormaker_cluster_name>-mirror-maker:: Deployment which is responsible for creating the Kafka MirrorMaker pods.
+<mirrormaker_cluster_name>-config:: ConfigMap which contains ancillary configuration for the Kafka MirrorMaker, and is mounted as a volume by the Kafka broker pods.
+<mirrormaker_cluster_name>-mirror-maker:: Pod Disruption Budget configured for the Kafka MirrorMaker worker nodes.

--- a/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
@@ -81,11 +81,11 @@ kubectl get pods -n _<my_cluster_operator_namespace>_
 .Output shows the node pool names and readiness
 [source,shell,subs="+quotes"]
 ----
-NAME                        READY   STATUS    RESTARTS
-my-cluster-entity-operator  3/3     Running   0
-my-cluster-pool-a-kafka-0   1/1     Running   0
-my-cluster-pool-a-kafka-1   1/1     Running   0
-my-cluster-pool-a-kafka-4   1/1     Running   0
+NAME                        READY  STATUS   RESTARTS
+my-cluster-entity-operator  3/3    Running  0
+my-cluster-pool-a-0         1/1    Running  0
+my-cluster-pool-a-1         1/1    Running  0
+my-cluster-pool-a-4         1/1    Running  0
 ----
 +
 * `my-cluster` is the name of the Kafka cluster.


### PR DESCRIPTION
**Documentation**

- Adds a description and naming conventions used for node pool resources
- Makes the naming conventions consistent for the resources lists of all components
- Makes the pool names consistent in the node pool procedures 


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

