### PR TITLE
docs(node pools): warning on migrating clusters to use node pools

### DIFF
--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -48,7 +48,9 @@ spec:
         deleteClaim: false
 ----
 +
-WARNING: To migrate a cluster while preserving the names of its nodes and resources, the node pool name must be `kafka` and the `strimzi.io/cluster` label must use the name of the `Kafka` resource. Otherwise, nodes and resources are created with new names, including the persistent volume storage used by the nodes. Consequently, your previous data may not be available as expected.        
+WARNING: To migrate a cluster while preserving its data along with the names of its nodes and resources, the node pool name must be `kafka`, and the `strimzi.io/cluster` label must use the name of the Kafka resource. 
+Otherwise, nodes and resources are created with new names, including the persistent volume storage used by the nodes. 
+Consequently, your previous data may not be available.       
 
 . Apply the `KafkaNodePool` resource:
 +

--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -47,6 +47,8 @@ spec:
         size: 100Gi
         deleteClaim: false
 ----
++
+WARNING: To migrate a cluster while preserving the names of its nodes and resources, the node pool name must be `kafka` and the `strimzi.io/cluster` label must use the name of the `Kafka` resource. Otherwise, nodes and resources are created with new names, including the persistent volume storage used by the nodes. Consequently, your previous data may not be available as expected.        
 
 . Apply the `KafkaNodePool` resource:
 +


### PR DESCRIPTION
**Documentation**

Adds a warning about migrating a cluster to use node pools.
The warning makes it clear that the node pool name must be `kafka` and the `strimzi.io/cluster` label must use the name of the `Kafka` resource

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

