### PR TITLE
[ST] Add UnidirectionalTopicOperator to FG pipelines in Azure

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +21,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +34,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +47,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +60,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +73,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +86,6 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities'
+      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -488,8 +488,10 @@ public abstract class AbstractST implements TestSeparator {
         if (!Environment.isKRaftModeEnabled()) {
             imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "topic-operator");
             assertThat(imgFromPod, containsString(imgFromDeplConf.get(TO_IMAGE)));
-            imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "tls-sidecar");
-            assertThat(imgFromPod, containsString(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE)));
+            if (!Environment.isUnidirectionalTopicOperatorEnabled()) {
+                imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, entityOperatorPodName, "tls-sidecar");
+                assertThat(imgFromPod, containsString(imgFromDeplConf.get(TLS_SIDECAR_EO_IMAGE)));
+            }
         }
 
         LOGGER.info("Docker images verified");

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -89,7 +89,8 @@ public class CruiseControlConfigurationST extends AbstractST {
         LOGGER.info("Verifying that there is no configuration to CruiseControl metric reporter in Kafka ConfigMap");
         assertThrows(WaitException.class, () -> CruiseControlUtils.verifyCruiseControlMetricReporterConfigurationInKafkaConfigMapIsPresent(CruiseControlUtils.getKafkaCruiseControlMetricsReporterConfiguration(namespaceName, clusterName)));
 
-        if (!Environment.isKRaftModeEnabled()) {
+        // https://github.com/strimzi/strimzi-kafka-operator/issues/8864
+        if (!Environment.isKRaftModeEnabled() && !Environment.isUnidirectionalTopicOperatorEnabled()) {
             LOGGER.info("Cruise Control Topics will not be deleted and will stay in the Kafka cluster");
             CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(namespaceName);
         }
@@ -104,7 +105,8 @@ public class CruiseControlConfigurationST extends AbstractST {
         LOGGER.info("Verifying that configuration of CruiseControl metric reporter is present in Kafka ConfigMap");
         CruiseControlUtils.verifyCruiseControlMetricReporterConfigurationInKafkaConfigMapIsPresent(CruiseControlUtils.getKafkaCruiseControlMetricsReporterConfiguration(namespaceName, clusterName));
 
-        if (!Environment.isKRaftModeEnabled()) {
+        // https://github.com/strimzi/strimzi-kafka-operator/issues/8864
+        if (!Environment.isKRaftModeEnabled() && !Environment.isUnidirectionalTopicOperatorEnabled()) {
             LOGGER.info("Verifying that {} Topics are created after CC is instantiated", Constants.CRUISE_CONTROL_NAME);
 
             CruiseControlUtils.verifyThatCruiseControlTopicsArePresent(namespaceName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -172,7 +172,9 @@ class MirrorMaker2ST extends AbstractST {
 
         LOGGER.info("Mirrored successful");
 
-        if (!Environment.isKRaftModeEnabled()) {
+        // TODO: https://github.com/strimzi/strimzi-kafka-operator/issues/8864
+        // currently disabled for UTO, as KafkaTopic CR is not created -> we should check it directly in Kafka
+        if (!Environment.isKRaftModeEnabled() && !Environment.isUnidirectionalTopicOperatorEnabled()) {
             KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).withName(sourceMirroredTopicName).get();
             assertThat(mirroredTopic.getSpec().getPartitions(), is(3));
             assertThat(mirroredTopic.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL), is(kafkaClusterTargetName));
@@ -307,7 +309,9 @@ class MirrorMaker2ST extends AbstractST {
         ClientUtils.waitForConsumerClientSuccess(testStorage);
         LOGGER.info("Messages successfully mirrored");
 
-        if (!Environment.isKRaftModeEnabled()) {
+        // TODO: https://github.com/strimzi/strimzi-kafka-operator/issues/8864
+        // currently disabled for UTO, as KafkaTopic CR is not created -> we should check it directly in Kafka
+        if (!Environment.isKRaftModeEnabled() && !Environment.isUnidirectionalTopicOperatorEnabled()) {
             KafkaTopicUtils.waitForKafkaTopicCreation(testStorage.getNamespaceName(), sourceMirroredTopicName);
             KafkaTopic mirroredTopic = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).withName(sourceMirroredTopicName).get();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -92,7 +92,7 @@ public class TopicST extends AbstractST {
         assertThat("Topic exists in Kafka CR (Kubernetes)", hasTopicInCRK8s(kafkaTopic, topicName));
         assertThat("Topic doesn't exists in Kafka itself", !hasTopicInKafka(topicName, KAFKA_CLUSTER_NAME));
 
-        String errorMessage = Environment.isUnidirectionalTopicOperatorEnabled() ?
+        String errorMessage = Environment.isUnidirectionalTopicOperatorEnabled() && Environment.isKRaftModeEnabled() ?
             "org.apache.kafka.common.errors.InvalidReplicationFactorException: Unable to replicate the partition 5 time(s): The target replication factor of 5 cannot be reached because only 3 broker(s) are registered." :
             "org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 5 larger than available brokers: 3";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -162,7 +162,14 @@ class RollingUpdateST extends AbstractST {
         final TestStorage testStorage = new TestStorage(extensionContext, Environment.TEST_SUITE_NAMESPACE);
 
         resourceManager.createResourceWithWait(extensionContext,
-            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3).build(),
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
+                .editSpec()
+                    .editKafka()
+                        // in case consumer is created after we move one Kafka Pod to pending state, we need just 2 replicas
+                        .addToConfig(singletonMap("offsets.topic.replication.factor", 2))
+                    .endKafka()
+                .endSpec()
+                .build(),
             KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 2, 2, testStorage.getNamespaceName()).build(),
             KafkaUserTemplates.tlsUser(testStorage).build()
         );


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds `UnidirectionalTopicOperator` to FG pipelines in Azure, as it was missing there and it was only present in the KRaft pipelines.

### Checklist

- [ ] Make sure all tests pass
