### PR TITLE
Update Kaniko and Maven Builder

### DIFF
--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.15.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.16.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.16
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 


### PR DESCRIPTION
### Type of change

- Task

### Description

As we are getting closer to the 0.38.0 release, this PR updates the Kaniko builder and the Maven builder images.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally