### PR TITLE
Improve the description of the `connectCluster` field in MM2

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -43,8 +43,8 @@ public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
     }
 
     @Description("The cluster alias used for Kafka Connect. " +
-            "The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. " +
-            "This Kafka cluster is used by the underlying Kafka Connect for its internal topics.")
+            "The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. " +
+            "The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.")
     @JsonProperty(required = true)
     public String getConnectCluster() {
         return connectCluster;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaMirrorMaker2Spec.java
@@ -42,7 +42,9 @@ public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
         this.clusters = clusters;
     }
 
-    @Description("The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.")
+    @Description("The cluster alias used for Kafka Connect. " +
+            "The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. " +
+            "This Kafka cluster is used by the underlying Kafka Connect for its internal topics.")
     @JsonProperty(required = true)
     public String getConnectCluster() {
         return connectCluster;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3193,7 +3193,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |integer
 |image                  1.2+<.<a|The docker image for the pods.
 |string
-|connectCluster         1.2+<.<a|The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
+|connectCluster         1.2+<.<a|The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.
 |string
 |clusters               1.2+<.<a|Kafka clusters for mirroring.
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3193,7 +3193,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |integer
 |image                  1.2+<.<a|The docker image for the pods.
 |string
-|connectCluster         1.2+<.<a|The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+|connectCluster         1.2+<.<a|The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
 |string
 |clusters               1.2+<.<a|Kafka clusters for mirroring.
 |xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`] array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -57,7 +57,7 @@ spec:
                   description: The docker image for the pods.
                 connectCluster:
                   type: string
-                  description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+                  description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
                 clusters:
                   type: array
                   items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -57,7 +57,7 @@ spec:
                   description: The docker image for the pods.
                 connectCluster:
                   type: string
-                  description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
+                  description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.
                 clusters:
                   type: array
                   items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -56,7 +56,7 @@ spec:
                 description: The docker image for the pods.
               connectCluster:
                 type: string
-                description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+                description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
               clusters:
                 type: array
                 items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -56,7 +56,7 @@ spec:
                 description: The docker image for the pods.
               connectCluster:
                 type: string
-                description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as used in the list at `spec.clusters`. This Kafka cluster is used by the underlying Kafka Connect for its internal topics.
+                description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.
               clusters:
                 type: array
                 items:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This Pr tries to improve the description of the `connectCluster` field in the `KafkaMirrorMaker2` resource and make it more clear it currently has to be the target cluster. This was raised in #9198.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging