### PR TITLE
Replace usages of the Strimzi's EnvVar configuration provider by Kafka's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@
 * Add support for pausing reconciliations to the Unidirectional Topic Operator
 * Allow running ZooKeeper and KRaft based Apache Kafka clusters in parallel when the `+UseKRaft` feature gate is enabled
 * Add support for metrics to the Unidirectional Topic Operator
+* The `io.strimzi.kafka.EnvVarConfigProvider` configuration provider is now deprecated. Users should migrate to Kafka's implementation, `org.apache.kafka.common.config.provider.EnvVarConfigProvider`, which is a drop-in replacement. 
+  For example:
+  ```yaml
+  config:
+    # ...
+    config.providers: env
+    config.providers.env.class: io.strimzi.kafka.EnvVarConfigProvider
+    # ...
+  ```
+  becomes
+  ```yaml
+  config:
+    # ...
+    config.providers: env
+    config.providers.env.class: org.apache.kafka.common.config.provider.EnvVarConfigProvider
+    # ...
+  ```
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add support for pausing reconciliations to the Unidirectional Topic Operator
 * Allow running ZooKeeper and KRaft based Apache Kafka clusters in parallel when the `+UseKRaft` feature gate is enabled
 * Add support for metrics to the Unidirectional Topic Operator
-* The `io.strimzi.kafka.EnvVarConfigProvider` configuration provider is now deprecated. Users should migrate to Kafka's implementation, `org.apache.kafka.common.config.provider.EnvVarConfigProvider`, which is a drop-in replacement. 
+* The `io.strimzi.kafka.EnvVarConfigProvider` configuration provider is now deprecated and will be removed in Strimzi 0.42. Users should migrate to Kafka's implementation, `org.apache.kafka.common.config.provider.EnvVarConfigProvider`, which is a drop-in replacement.
   For example:
   ```yaml
   config:

--- a/documentation/modules/configuring/con-external-config.adoc
+++ b/documentation/modules/configuring/con-external-config.adoc
@@ -22,7 +22,7 @@ spec:
   config:
     # ...
     config.providers: env
-    config.providers.env.class: io.strimzi.kafka.EnvVarConfigProvider
+    config.providers.env.class: org.apache.kafka.common.config.provider.EnvVarConfigProvider
   # ...
 ----
 

--- a/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
@@ -57,7 +57,7 @@ spec:
   config:
     # ...
     config.providers: env # <1>
-    config.providers.env.class: io.strimzi.kafka.EnvVarConfigProvider # <2>
+    config.providers.env.class: org.apache.kafka.common.config.provider.EnvVarConfigProvider # <2>
   # ...
   externalConfiguration:
     env:

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -85,7 +85,7 @@ public class ConfigProviderST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .addToConfig("config.providers", "configmaps,env")
                 .addToConfig("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider")
-                .addToConfig("config.providers.env.class", "io.strimzi.kafka.EnvVarConfigProvider")
+                .addToConfig("config.providers.env.class", "org.apache.kafka.common.config.provider.EnvVarConfigProvider")
                 .editOrNewExternalConfiguration()
                     .addNewEnv()
                 .withName("FILE_SINK_FILE")


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This implements [proposal 58](https://github.com/strimzi/proposals/blob/main/058-deprecate-and-remove-envvar-config-provider.md).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

