### PR TITLE
Update JMX Exporter to 0.20.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/ignorelist
@@ -1,2 +1,2 @@
-jmx_prometheus_javaagent-0.18.0.jar
+jmx_prometheus_javaagent-0.20.0.jar
 snakeyaml-2.0.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -23,7 +23,7 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.20.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/ignorelist
@@ -1,2 +1,2 @@
-jmx_prometheus_javaagent-0.18.0.jar
+jmx_prometheus_javaagent-0.20.0.jar
 snakeyaml-2.0.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -23,7 +23,7 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>0.18.0</jmx-prometheus-javaagent.version>
+        <jmx-prometheus-javaagent.version>0.20.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the JMX Exporter to version 0.20.0 that is supposed to bring some performance improvements.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally