### PR TITLE
docs(mm2): adds list of resources created for MirrorMaker 2

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-kafka-mirror-maker.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-kafka-mirror-maker.adoc
@@ -20,6 +20,8 @@ Data replication across clusters supports scenarios that require the following:
 
 //Procedure to deploy a MirrorMaker cluster
 include::../../modules/deploying/proc-deploy-kafka-mirror-maker.adoc[leveloffset=+1]
+//Resources created for Kafka MirrorMaker 2
+include::../../modules/configuring/ref-list-of-mirrormaker2-resources.adoc[leveloffset=+1]
 //Resources created for Kafka MirrorMaker
 include::../../modules/configuring/ref-list-of-mirrormaker-resources.adoc[leveloffset=+1]
 

--- a/documentation/modules/configuring/ref-list-of-mirrormaker-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-mirrormaker-resources.adoc
@@ -7,6 +7,11 @@
 
 The following resources are created by the Cluster Operator in the Kubernetes cluster:
 
-<mirrormaker_cluster_name>-mirror-maker:: Deployment which is responsible for creating the Kafka MirrorMaker pods.
-<mirrormaker_cluster_name>-config:: ConfigMap which contains ancillary configuration for the Kafka MirrorMaker, and is mounted as a volume by the Kafka broker pods.
-<mirrormaker_cluster_name>-mirror-maker:: Pod Disruption Budget configured for the Kafka MirrorMaker worker nodes.
+<mirrormaker_cluster_name>-mirror-maker:: Name given to the following MirrorMaker resources:
++
+- Deployment which is responsible for creating the MirrorMaker pods.
+- Service account used by the MirrorMaker nodes.
+- Pod Disruption Budget configured for the MirrorMaker worker nodes.
+
+<mirrormaker_cluster_name>-mirror-maker-config:: ConfigMap which contains ancillary configuration for MirrorMaker, and is mounted as a volume by the MirrorMaker pods.
+

--- a/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// assembly-deploy-kafka-mirror-maker.adoc
+
+[id='ref-list-of-kafka-mirrormaker2-resources-{context}']
+= List of Kafka MirrorMaker 2 cluster resources
+
+The following resources are created by the Cluster Operator in the Kubernetes cluster:
+
+<mirrormaker2_cluster_name>-mirrormaker2:: Name given to the following MirrorMaker 2 resources:
++
+- Deployment which is responsible for creating the MirrorMaker 2 pods.
+- Service account used by the MirrorMaker 2 nodes.
+- Pod Disruption Budget configured for the MirrorMaker2 worker nodes.
+
+<mirrormaker2_cluster_name>-mirrormaker2-config:: ConfigMap which contains ancillary configuration for the MirrorMaker2, and is mounted as a volume by the MirrorMaker 2 pods.


### PR DESCRIPTION
**Documentation**

Adds a list of resources created for MirrorMaker 2.
Updates the resources list for MirrorMaker 1.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

