### PR TITLE
Move `EnvVarConfigProvider` deprecation to the right section in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 * Add support for pausing reconciliations to the Unidirectional Topic Operator
 * Allow running ZooKeeper and KRaft based Apache Kafka clusters in parallel when the `+UseKRaft` feature gate is enabled
 * Add support for metrics to the Unidirectional Topic Operator
+
+### Changes, deprecations and removals
+
+* The `Kafka.KafkaStatus.ListenerStatus.type` property has been deprecated for a long time, and now we do not use it anymore.
+  The current plan is to completely remove this property in the next schema version.
+  If needed, you can use the `Kafka.KafkaStatus.ListenerStatus.name` property, which has the same value.
+* Added `strimzi.io/kraft` annotation to be applied on `Kafka` custom resource, together with the `+UseKRaft` feature gate enabled, to declare a ZooKeeper or KRaft based cluster.
+  * if `enabled` the `Kafka` resource defines a KRaft-based cluster.
+  * if `disabled`, missing or any other value, the operator handle the `Kafka` resource as a ZooKeeper-based cluster.
 * The `io.strimzi.kafka.EnvVarConfigProvider` configuration provider is now deprecated and will be removed in Strimzi 0.42. Users should migrate to Kafka's implementation, `org.apache.kafka.common.config.provider.EnvVarConfigProvider`, which is a drop-in replacement.
   For example:
   ```yaml
@@ -29,15 +38,6 @@
     config.providers.env.class: org.apache.kafka.common.config.provider.EnvVarConfigProvider
     # ...
   ```
-
-### Changes, deprecations and removals
-
-* The `Kafka.KafkaStatus.ListenerStatus.type` property has been deprecated for a long time, and now we do not use it anymore.
-  The current plan is to completely remove this property in the next schema version.
-  If needed, you can use the `Kafka.KafkaStatus.ListenerStatus.name` property, which has the same value.
-* Added `strimzi.io/kraft` annotation to be applied on `Kafka` custom resource, together with the `+UseKRaft` feature gate enabled, to declare a ZooKeeper or KRaft based cluster.
-  * if `enabled` the `Kafka` resource defines a KRaft-based cluster.
-  * if `disabled`, missing or any other value, the operator handle the `Kafka` resource as a ZooKeeper-based cluster.
 
 ## 0.37.0
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The information about the `EnvVarConfigProvider` deprecation is in a wrong section f the CHANGELOG.md. This PR moves into the section with deprecations, changes and removals.

### Checklist

- [x] Update CHANGELOG.md