### PR TITLE
[ST] Add UTO to upgrade/downgrade

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -262,4 +262,11 @@ public class KafkaTopicUtils {
             }
         }
     }
+
+    public static void setFinalizersInAllTopicsToNull(String namespaceName) {
+        LOGGER.info("Setting finalizers in all KafkaTopics in Namespace: {} to null", namespaceName);
+        KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).list().getItems().forEach(kafkaTopic ->
+            KafkaTopicResource.replaceTopicResourceInSpecificNamespace(kafkaTopic.getMetadata().getName(), kt -> kt.getMetadata().setFinalizers(null), namespaceName)
+        );
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
@@ -5,16 +5,13 @@
 package io.strimzi.systemtest.utils.kubeUtils.objects;
 
 import io.fabric8.kubernetes.api.model.Namespace;
-import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceOperation;
-import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class NamespaceUtils {
@@ -50,7 +47,7 @@ public class NamespaceUtils {
                 return true;
             } else if (namespace.getStatus() != null && namespace.getStatus().getConditions() != null) {
                 if (namespace.getStatus().getConditions().stream().anyMatch(condition -> condition.getReason().contains("SomeFinalizersRemain"))) {
-                    LOGGER.info("There are KafkaTopics with finalizers remaining in Namespace: {}, going to set those finalizers to null", namespaceName);
+                    LOGGER.debug("There are KafkaTopics with finalizers remaining in Namespace: {}, going to set those finalizers to null", namespaceName);
                     KafkaTopicUtils.setFinalizersInAllTopicsToNull(namespaceName);
                 }
             }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/NamespaceUtils.java
@@ -4,12 +4,17 @@
  */
 package io.strimzi.systemtest.utils.kubeUtils.objects;
 
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.resources.ResourceOperation;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 public class NamespaceUtils {
@@ -25,5 +30,31 @@ public class NamespaceUtils {
         TestUtils.waitFor("Namespace: " + name, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS, DELETION_TIMEOUT,
             () -> kubeClient().getNamespace(name) == null);
         LOGGER.info("Namespace: {} was deleted", name);
+    }
+
+    /**
+     * Method for Namespace deletion with wait
+     * In case that Namespace is stuck in `Terminating` state (due to finalizers in KafkaTopics), this method
+     * removes these topics, to unblock the Namespace deletion
+     * @param namespaceName name of the Namespace that should be deleted
+     */
+    public static void deleteNamespaceWithWait(String namespaceName) {
+        LOGGER.info("Deleting Namespace: {}", namespaceName);
+
+        kubeClient().deleteNamespace(namespaceName);
+
+        TestUtils.waitFor("Namespace: " + namespaceName + "to be deleted", Constants.POLL_INTERVAL_FOR_RESOURCE_DELETION, DELETION_TIMEOUT, () -> {
+            Namespace namespace = kubeClient().getNamespace(namespaceName);
+
+            if (namespace == null) {
+                return true;
+            } else if (namespace.getStatus() != null && namespace.getStatus().getConditions() != null) {
+                if (namespace.getStatus().getConditions().stream().anyMatch(condition -> condition.getReason().contains("SomeFinalizersRemain"))) {
+                    LOGGER.info("There are KafkaTopics with finalizers remaining in Namespace: {}, going to set those finalizers to null", namespaceName);
+                    KafkaTopicUtils.setFinalizersInAllTopicsToNull(namespaceName);
+                }
+            }
+            return false;
+        });
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -35,8 +35,12 @@ import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
-import io.strimzi.systemtest.utils.kafkaUtils.*;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -245,7 +249,6 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     protected void deleteInstalledYamls(File root, String namespace) {
-
         if (kafkaUserYaml != null) {
             LOGGER.info("Deleting KafkaUser configuration files");
             cmdKubeClient().delete(kafkaUserYaml);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -35,10 +35,7 @@ import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
-import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.*;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -248,12 +245,14 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     protected void deleteInstalledYamls(File root, String namespace) {
+
         if (kafkaUserYaml != null) {
             LOGGER.info("Deleting KafkaUser configuration files");
             cmdKubeClient().delete(kafkaUserYaml);
         }
         if (kafkaTopicYaml != null) {
             LOGGER.info("Deleting KafkaTopic configuration files");
+            KafkaTopicUtils.setFinalizersInAllTopicsToNull(namespace);
             cmdKubeClient().delete(kafkaTopicYaml);
         }
         if (kafkaYaml != null) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziDowngradeST.java
@@ -8,6 +8,7 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.List;
 
+import static io.strimzi.systemtest.Constants.CO_NAMESPACE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.UPGRADE;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -91,6 +93,6 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
     @AfterEach
     void afterEach() {
         deleteInstalledYamls(coDir, Constants.CO_NAMESPACE);
-        cluster.deleteNamespaces();
+        NamespaceUtils.deleteNamespaceWithWait(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/StrimziUpgradeST.java
@@ -16,6 +16,7 @@ import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,8 +31,9 @@ import io.strimzi.systemtest.upgrade.VersionModificationDataLoader.ModificationT
 import java.io.IOException;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Constants.UPGRADE;
+import static io.strimzi.systemtest.Constants.CO_NAMESPACE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.Constants.UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -188,13 +190,11 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     }
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) {
-        deleteInstalledYamls(coDir, Constants.CO_NAMESPACE);
-
         // delete all topics created in test
         cmdKubeClient(Constants.CO_NAMESPACE).deleteAllByResource(KafkaTopic.RESOURCE_KIND);
         KafkaTopicUtils.waitForTopicWithPrefixDeletion(Constants.CO_NAMESPACE, topicName);
 
         ResourceManager.getInstance().deleteResources(extensionContext);
-        cluster.deleteNamespaces();
+        NamespaceUtils.deleteNamespaceWithWait(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -46,8 +46,8 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
-  featureGatesBefore: "+StableConnectIdentities"
-  featureGatesAfter: "-StableConnectIdentities"
+  featureGatesBefore: "+StableConnectIdentities,+UnidirectionalTopicOperator"
+  featureGatesAfter: "-StableConnectIdentities,-UnidirectionalTopicOperator"
 - fromVersion: HEAD
   toVersion: 0.37.0
   fromExamples: HEAD

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -62,5 +62,5 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
-  featureGatesBefore: "-StableConnectIdentities"
-  featureGatesAfter: "+StableConnectIdentities"
+  featureGatesBefore: "-StableConnectIdentities,-UnidirectionalTopicOperator"
+  featureGatesAfter: "+StableConnectIdentities,+UnidirectionalTopicOperator"


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds UTO to upgrade/downgrade tests and adds methods for handling KafkaTopic's finalizers into the suite.

In case that we delete UTO and after that we are deleting KafkaTopic(s) - this happens for both upgrade & downgrade tests, because there is no cleanup for all the KafkaTopics created in the test, only for the one that is created from the example YAML - the deletion of the KafkaTopics is stuck (because BTO doesn't delete these), or when the Namespace is being deleted, it is stuck in Terminating state (as there are resources with finalizers that are not cleaned up).

This is resolved with `KafkaTopicUtils.setFinalizersInAllTopicsToNull()`, which sets for all KafkaTopics the finalizers to `null` before they are deleted. This method is then used in `NamespaceUtils.deleteNamespaceWithWait()`, where the finalizers are set to `null` in case that the Namespace is stuck and one of the condition in the status is `SomeFinalizersRemain`.

### Checklist

- [ ] Make sure all tests pass
