### PR TITLE
docs(topic operator): adds instructions for switching topic management modes

### DIFF
--- a/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
@@ -24,3 +24,7 @@ include::../../modules/operators/proc-converting-managed-topics.adoc[leveloffset
 include::../../modules/operators/proc-converting-non-managed-topics.adoc[leveloffset=+1]
 //deleting managed topics
 include::../../modules/operators/con-deleting-managed-topics.adoc[leveloffset=+1]
+//changing the topic operator mode
+include::../../modules/operators/con-changing-topic-operator-mode.adoc[leveloffset=+1]
+//removing finalizers from topics
+include::../../modules/operators/con-removing-topic-finalizers.adoc[leveloffset=+1]

--- a/documentation/modules/operators/con-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/con-changing-topic-operator-mode.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-topic-operator.adoc
+
+[id='con-changing-topic-operator-mode-{context}']
+= (Preview) Switching between Topic Operator modes
+
+[role="_abstract"]
+You can switch between topic management modes when upgrading or downgrading Strimzi, or when using the same version of Strimzi, as long as the mode is supported for that version. 
+
+* To switch from the default bidirectional mode to unidirectional mode, xref:ref-operator-unidirectional-topic-operator-feature-gate-str[enable the `UnidirectionalTopicOperator` feature gate]. 
+* To switch from unidirectional mode to bidirectional mode, check whether finalizers are being used to control topic deletion. If `KafkaTopic` resources are using finalizers, ensure that you do one of the following  before making the switch:
+** xref:con-removing-topic-finalizers-{context}[Remove all finalizers from topics].
+** Disable the finalizers by setting the `STRIMZI_USE_FINALIZERS` environment variable to `false` in the Topic Operator `env` configuration.
+
+The Topic Operator does not use finalizers in bidirectional mode.
+If they are retained after making the switch from unidirectional mode, you won't be able to delete `KafkaTopic` and related resources. 

--- a/documentation/modules/operators/con-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/con-changing-topic-operator-mode.adoc
@@ -12,6 +12,17 @@ You can switch between topic management modes when upgrading or downgrading Stri
 * To switch from unidirectional mode to bidirectional mode, check whether finalizers are being used to control topic deletion. If `KafkaTopic` resources are using finalizers, ensure that you do one of the following  before making the switch:
 ** xref:con-removing-topic-finalizers-{context}[Remove all finalizers from topics].
 ** Disable the finalizers by setting the `STRIMZI_USE_FINALIZERS` environment variable to `false` in the Topic Operator `env` configuration.
++
+.Disabling the topic finalizers
+[source,shell,subs=+quotes]
+----
+# ...
+env:
+  - name: STRIMZI_USE_FINALIZERS
+    value: "false"
+----
++
+Use the same configuration for a Topic Operator running in a Strimzi-managed cluster or as a standalone deployment.  
 
 The Topic Operator does not use finalizers in bidirectional mode.
 If they are retained after making the switch from unidirectional mode, you won't be able to delete `KafkaTopic` and related resources. 

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -57,31 +57,4 @@ When the finalization tasks are successfully executed, the finalizer is removed 
 Finalizers also serve to prevent related resources from being deleted. 
 If the unidirectional Topic Operator is not running, it won't be able to remove its finalizer from the `metadata.finalizers`. 
 And any attempt to directly delete the `KafkaTopic` resources or the namespace will fail or timeout, leaving the namespace in a stuck terminating state.
-
-== Removing finalizers
-
-If the Topic Operator is not running, and you want to bypass the finalization process when deleting topics, you have to remove the finalizers.   
-You can do this manually by editing the resources directly or by using a command.
-
-To remove finalizers on all topics, use the following command:
-
-.Removing finalizers on topics
-[source,shell]
-----
-kubectl get kt -o=json | jq '.items[].metadata.finalizers = null' | kubectl apply -f -
-----
-
-The command uses the `jq` tool to modify the `KafkaTopic` (`kt`) resources by setting the finalizers to `null`.
-You can also use the command for a specific topic:
-
-.Removing a finalizer on a specific topic
-[source,shell]
-----
-kubectl get kt <topic_name> -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -
-----
-
-After running the command, you can go ahead and delete the topics.
-Alternatively, if the topics were already being deleted but were blocked due to outstanding finalizers then their deletion should complete.
-
-WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed. 
-For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related Kafka topic won't be deleted.  
+If this happens, you can bypass the finalization process by xref:con-removing-topic-finalizers-{context}[removing the finalizers on topics]. 

--- a/documentation/modules/operators/con-removing-topic-finalizers.adoc
+++ b/documentation/modules/operators/con-removing-topic-finalizers.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-topic-operator.adoc
+
+[id='con-removing-topic-finalizers-{context}']
+= (Preview) Removing finalizers on topics
+
+[role="_abstract"]
+If the unidirectional Topic Operator is not running, and you want to bypass the finalization process when deleting managed topics, you have to remove the finalizers.   
+You can do this manually by editing the resources directly or by using a command.
+
+To remove finalizers on all topics, use the following command:
+
+.Removing finalizers on topics
+[source,shell]
+----
+kubectl get kt -o=json | jq '.items[].metadata.finalizers = null' | kubectl apply -f -
+----
+
+The command uses the `jq` tool to modify the `KafkaTopic` (`kt`) resources by setting the finalizers to `null`.
+You can also use the command for a specific topic:
+
+.Removing a finalizer on a specific topic
+[source,shell]
+----
+kubectl get kt <topic_name> -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -
+----
+
+After running the command, you can go ahead and delete the topics.
+Alternatively, if the topics were already being deleted but were blocked due to outstanding finalizers then their deletion should complete.
+
+WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed. 
+For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related Kafka topic won't be deleted.  

--- a/documentation/modules/operators/con-removing-topic-finalizers.adoc
+++ b/documentation/modules/operators/con-removing-topic-finalizers.adoc
@@ -29,5 +29,5 @@ kubectl get kt <topic_name> -o=json | jq '.metadata.finalizers = null' | kubectl
 After running the command, you can go ahead and delete the topics.
 Alternatively, if the topics were already being deleted but were blocked due to outstanding finalizers then their deletion should complete.
 
-WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed. 
+WARNING: Be careful when removing finalizers, as any cleanup operations associated with the finalization process are not performed if the Topic Operator is not running. 
 For example, if you remove the finalizer from a `KafkaTopic` resource and subsequently delete the resource, the related Kafka topic won't be deleted.  


### PR DESCRIPTION
**Documentation**

Adds a new **Switching between Topic Operator modes** section that describes how to switch between topic management modes.
Pays particular attention to the switch from UTO to BTO mode and how to handle finalizers before doing so.
**Removing finalizers on topics** becomes a separate section the serves the **Deleting managed topics** and **Switching between Topic Operator modes** sections

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

