### PR TITLE
Update and clean various dependencies - Vert.x, Jetty, Scala

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -241,11 +241,6 @@
             <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -149,6 +149,7 @@ public class ClusterOperator extends AbstractVerticle {
                 .onComplete(start);
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Void> maybeStartStrimziPodSetController() {
         Promise<Void> handler = Promise.promise();
         vertx.executeBlocking(future -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -130,6 +130,7 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
         return vib.build();
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private static Future<VersionInfo> getVersionInfoFromKubernetes(Vertx vertx, KubernetesClient client)   {
         Promise<VersionInfo> promise = Promise.promise();
 
@@ -145,6 +146,7 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
         return promise.future();
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private static Future<Boolean> checkApiAvailability(Vertx vertx, KubernetesClient client, String group, String version)   {
         Promise<Boolean> promise = Promise.promise();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -214,7 +214,7 @@ public class CaReconciler {
      * @param clock     The clock for supplying the reconciler with the time instant of each reconciliation cycle.
      *                  That time is used for checking maintenance windows
      */
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
+    @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "deprecation"}) // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     Future<Void> reconcileCas(Clock clock) {
         Promise<Void> resultPromise = Promise.promise();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -889,6 +889,7 @@ public class KafkaReconciler {
      *
      * @return  Future which completes when the Cluster ID is retrieved and set in the status
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     protected Future<Void> clusterId(KafkaStatus kafkaStatus) {
         return ReconcilerUtils.clientSecrets(reconciliation, secretOperator)
                 .compose(compositeFuture -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -794,6 +794,7 @@ public class KafkaRoller {
      *
      * @return a Future which completes when the Pod has been recreated
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     protected Future<Void> restart(Pod pod, RestartContext restartContext) {
         return  podOperations.restart(reconciliation, pod, operationTimeoutMs)
                              .onComplete(i -> vertx.executeBlocking(ignored -> eventsPublisher.publishRestartEvents(pod, restartContext.restartReasons)));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -208,6 +208,7 @@ public class ZookeeperScaler implements AutoCloseable {
      *
      * @return  Future containing Map with the current Zookeeper configuration
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Map<String, String>> getCurrentConfig(ZooKeeperAdmin zkAdmin)    {
         Promise<Map<String, String>> configPromise = Promise.promise();
 
@@ -232,6 +233,7 @@ public class ZookeeperScaler implements AutoCloseable {
      * @param newServers    New configuration which will be used for the update
      * @return              Future with the updated configuration
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Map<String, String>> updateConfig(ZooKeeperAdmin zkAdmin, Map<String, String> newServers)    {
         Promise<Map<String, String>> configPromise = Promise.promise();
 
@@ -255,6 +257,7 @@ public class ZookeeperScaler implements AutoCloseable {
     /**
      * Closes the Zookeeper connection
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Void> closeConnection(ZooKeeperAdmin zkAdmin) {
         Promise<Void> closePromise = Promise.promise();
 
@@ -280,6 +283,7 @@ public class ZookeeperScaler implements AutoCloseable {
      *
      * @return
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<ZKClientConfig> getClientConfig()  {
         Promise<ZKClientConfig> configPromise = Promise.promise();
 

--- a/config-model-generator/pom.xml
+++ b/config-model-generator/pom.xml
@@ -65,10 +65,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
@@ -52,6 +52,7 @@ public final class VertxUtil {
      *
      * @param <T>   Type of the result
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
         Promise<T> result = Promise.promise();
         vertx.executeBlocking(
@@ -123,6 +124,7 @@ public final class VertxUtil {
         long deadline = System.currentTimeMillis() + timeoutMs;
         Handler<Long> handler = new Handler<>() {
             @Override
+            @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
             public void handle(Long timerId) {
                 vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
                     future -> {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -91,6 +91,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * @param desired The desired state of the resource.
      * @return A future which completes when the resource has been updated.
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T desired) {
         if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
             return Future.failedFuture("Given namespace " + namespace + " incompatible with desired namespace " + desired.getMetadata().getNamespace());

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNonNamespacedResourceOperator.java
@@ -73,6 +73,7 @@ public abstract class AbstractNonNamespacedResourceOperator<C extends Kubernetes
      * @param desired The desired state of the resource.
      * @return A future which completes when the resource was reconciled.
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String name, T desired) {
         if (desired != null && !name.equals(desired.getMetadata().getName())) {
             return Future.failedFuture("Given name " + name + " incompatible with desired name "

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractScalableNamespacedResourceOperator.java
@@ -64,6 +64,7 @@ public abstract class AbstractScalableNamespacedResourceOperator<C extends Kuber
      *         {@code scaleTo} then this value will be the original scale. The value will be null if the resource didn't
      *         exist (hence no scaling occurred).
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Integer> scaleUp(Reconciliation reconciliation, String namespace, String name, int scaleTo, long timeoutMs) {
         Promise<Integer> promise = Promise.promise();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
@@ -104,6 +105,7 @@ public abstract class AbstractScalableNamespacedResourceOperator<C extends Kuber
      *         {@code scaleTo} then this value will be the original scale. The value will be null if the resource
      *         didn't exist (hence no scaling occurred).
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Integer> scaleDown(Reconciliation reconciliation, String namespace, String name, int scaleTo, long timeoutMs) {
         Promise<Integer> promise = Promise.promise();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/CrdOperator.java
@@ -90,6 +90,7 @@ public class CrdOperator<C extends KubernetesClient,
      *
      * @return  Future which completes when the resource is patched
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<T> patchAsync(Reconciliation reconciliation, T resource) {
         Promise<T> blockingPromise = Promise.promise();
 
@@ -117,6 +118,7 @@ public class CrdOperator<C extends KubernetesClient,
      *
      * @return  Future which completes when the status is patched
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<T> updateStatusAsync(Reconciliation reconciliation, T resource) {
         Promise<T> blockingPromise = Promise.promise();
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceSupport.java
@@ -64,6 +64,7 @@ public class ResourceSupport {
             });
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
         Promise<T> result = Promise.promise();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool")
@@ -190,6 +191,7 @@ public class ResourceSupport {
             }
 
             @Override
+            @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
             public void eventReceived(Action action, T resource) {
                 vertx.executeBlocking(
                     f -> {

--- a/pom.xml
+++ b/pom.xml
@@ -132,18 +132,17 @@
         <fasterxml.jackson-databind.version>2.15.2</fasterxml.jackson-databind.version>
         <fasterxml.jackson-dataformat.version>2.15.2</fasterxml.jackson-dataformat.version>
         <fasterxml.jackson-annotations.version>2.15.2</fasterxml.jackson-annotations.version>
-        <vertx.version>4.4.4</vertx.version>
-        <vertx-junit5.version>4.4.4</vertx-junit5.version>
+        <vertx.version>4.4.6</vertx.version>
+        <vertx-junit5.version>4.4.6</vertx-junit5.version>
         <kafka.version>3.6.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
-        <scala-library.version>2.13.9</scala-library.version>
         <zookeeper.version>3.6.4</zookeeper.version>
         <zkclient.version>0.11</zkclient.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <quartz.version>2.3.2</quartz.version>
         <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
         <netty.version>4.1.100.Final</netty.version>
@@ -493,11 +492,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala-library.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -1127,7 +1121,6 @@
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-streams</ignoredUnusedDeclaredDependency>
                                 <!-- Used in Kafka Agent through reflection -->
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-server-common</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>io.sundr:builder-annotations</ignoredUnusedDeclaredDependency>

--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -210,11 +210,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>operator-common</artifactId>
         </dependency>
@@ -272,7 +267,6 @@
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-httpclient-jdk</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.scala-lang:scala-library</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/K8sImpl.java
@@ -61,6 +61,7 @@ public class K8sImpl implements K8s {
      * @return  Future which completes with result of the request. If the request was successful, this returns the Kafka topic
      */
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<KafkaTopic> createResource(KafkaTopic topicResource) {
         Promise<KafkaTopic> handler = Promise.promise();
         vertx.executeBlocking(future -> {
@@ -85,6 +86,7 @@ public class K8sImpl implements K8s {
      * @return  Future which completes with result of the request. If the request was successful, this returns the updated Kafka topic
      */
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<KafkaTopic> updateResource(KafkaTopic topicResource) {
         Promise<KafkaTopic> handler = Promise.promise();
         vertx.executeBlocking(future -> {
@@ -122,6 +124,7 @@ public class K8sImpl implements K8s {
      * @return  Future which completes when the resource is deleted successfully.
      */
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Void> deleteResource(Reconciliation reconciliation, ResourceName resourceName) {
         Promise<Void> handler = Promise.promise();
         vertx.executeBlocking(future -> {
@@ -171,6 +174,7 @@ public class K8sImpl implements K8s {
      * Create the given k8s event
      */
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Void> createEvent(Event event) {
         Promise<Void> handler = Promise.promise();
         vertx.executeBlocking(future -> {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -133,6 +133,7 @@ public class Session extends AbstractVerticle {
      * Stop the operator.
      */
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public void stop(Promise<Void> stop) throws Exception {
         this.stopped = true;
         Long timerId = this.timerId;
@@ -247,6 +248,7 @@ public class Session extends AbstractVerticle {
                 });
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Promise<Void>> createK8sWatcher(TopicOperator topicOperator) {
         return executor.executeBlocking(blockingPromise -> {
             Promise<Void> initReconcilePromise = Promise.promise();
@@ -256,6 +258,7 @@ public class Session extends AbstractVerticle {
         });
     }
 
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<TopicStore> createTopicStoreAsync(Zk zk, Config config) {
         return executor.executeBlocking(storePromise -> {
             Instant startedAt = Instant.now();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -30,6 +30,7 @@ public interface Zk {
      * @param connectionTimeout Timeout for connection
      * @return  Future completes if the Zookeeper instance is created successfully.
      */
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     static Future<Zk> create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
         return vertx.executeBlocking(f -> {
             try {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/ZkImpl.java
@@ -51,6 +51,7 @@ public class ZkImpl implements Zk {
 
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk create(String path, byte[] data, List<ACL> acls, CreateMode createMode, Handler<AsyncResult<Void>> handler) {
         workerExecutor.executeBlocking(
             future -> {
@@ -66,6 +67,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk setData(String path, byte[] data, int version, Handler<AsyncResult<Void>> handler) {
         workerExecutor.executeBlocking(
             future -> {
@@ -81,6 +83,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk disconnect(Handler<AsyncResult<Void>> handler) {
 
         workerExecutor.executeBlocking(
@@ -97,6 +100,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk getData(String path, Handler<AsyncResult<byte[]>> handler) {
         workerExecutor.executeBlocking(
             future -> {
@@ -130,6 +134,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Zk> watchData(String path, Handler<AsyncResult<byte[]>> watcher) {
         Promise<Zk> result = Promise.promise();
         workerExecutor.executeBlocking(
@@ -155,6 +160,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk unwatchData(String path) {
         workerExecutor.executeBlocking(
             future -> {
@@ -173,6 +179,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk delete(String path, int version, Handler<AsyncResult<Void>> handler) {
         workerExecutor.executeBlocking(
             future -> {
@@ -191,6 +198,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk children(String path, Handler<AsyncResult<List<String>>> handler) {
         workerExecutor.executeBlocking(
             future -> {
@@ -205,6 +213,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Zk> watchChildren(String path, Handler<AsyncResult<List<String>>> watcher) {
         Promise<Zk> result = Promise.promise();
         workerExecutor.executeBlocking(
@@ -230,6 +239,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Zk unwatchChildren(String path) {
         workerExecutor.executeBlocking(
             future -> {
@@ -248,6 +258,7 @@ public class ZkImpl implements Zk {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<Boolean> pathExists(String path) {
         Promise<Boolean> promise = Promise.promise();
         workerExecutor.<Boolean>executeBlocking(

--- a/user-operator/pom.xml
+++ b/user-operator/pom.xml
@@ -97,16 +97,6 @@
             <artifactId>strimzi-test-container</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>test</artifactId>
         </dependency>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Jetty and Vert.x dependencies before the 0.38.0 release. The Vert.x deprecations to various `executeBlocking` methods are only suppressed in this PR. They will be addressed as part of #9233 after the 0.38 release to avoid any issues.

It also removes the direct dependency on Scala -> we do not seem to use it anywhere as a direct dependency (it will be still a transitive dependency in places where Kafka core JAR is used.)

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally