### PR TITLE
Update ZooKeeper to 3.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <kafka.version>3.6.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <scala-library.version>2.13.9</scala-library.version>
-        <zookeeper.version>3.6.4</zookeeper.version>
+        <zookeeper.version>3.8.3</zookeeper.version>
         <zkclient.version>0.11</zkclient.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
@@ -459,23 +459,23 @@
                 <exclusions>
                     <exclusion>
                         <groupId>io.netty</groupId>
-                        <artifactId>netty</artifactId>
+                        <artifactId>netty-handler</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>jline</groupId>
-                        <artifactId>jline</artifactId>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport-native-epoll</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.github.spotbugs</groupId>
-                        <artifactId>spotbugs-annotations</artifactId>
+                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR replaces #9237 and updates ZooKeeper to 3.8.3 to avoid CVE-2023-44981. Unlike the original PR from DependaBot, it syncs the minor ZooKeeper version to Kafka 3.6. It also updates the exclusions.

Strimzi is not really affected by CVE-2023-44981 as we do not use SASL Authentication (we use mTLS). Given the past issues with ZooKeeper 3.6.4 (but those were on the server side!), I wonder if we want clear security scanners in operator images in Strimzi 0.38 or prefer more time to catch any possible issues and want to merge it only in 0.39. WDYT @ppatierno?

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally