### PR TITLE
[ST] Add metrics test for UTO

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -269,4 +269,13 @@ public class KafkaTopicUtils {
             KafkaTopicResource.replaceTopicResourceInSpecificNamespace(kafkaTopic.getMetadata().getName(), kt -> kt.getMetadata().setFinalizers(null), namespaceName)
         );
     }
+
+    public static void waitForTopicStatusMessage(String namespaceName, String topicName, String message) {
+        LOGGER.info("Waiting for KafkaTopic: {}/{} to contain message: {} in its status", namespaceName, topicName, message);
+
+        TestUtils.waitFor(String.join("KafkaTopic: %s/%s status to contain message: %s", namespaceName, topicName, message), Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_TIMEOUT,
+            () -> KafkaTopicResource.kafkaTopicClient().inNamespace(namespaceName).withName(topicName).get()
+                .getStatus().getConditions().stream().anyMatch(condition -> condition.getMessage().contains(message))
+        );
+    }
 }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR "adds" test for KafkaTopic metrics in UTO mode. Originally, I updated `testKafkaTopicDifferentStates` for running it in both modes -> BTO & UTO. But I found it really confusing (a lot of `if`s and other changes). So I decided to duplicate the test, make one running just in BTO mode and second in UTO mode, to make the test more clear.

Once BTO will be removed, we can just simply remove the test without any issue.

It also updates the name of `testKafkaTopicDifferentStates` -> `testKafkaTopicDifferentStatesInBTOMode` -> and creates a new one `testKafkaTopicDifferentStatesInUTOMode`

### Checklist

- [ ] Make sure all tests pass
