### PR TITLE
Improve the `KafkaMirrorMaker2` examples to list some useful options

### DIFF
--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-custom-replication-policy.yaml
@@ -27,11 +27,14 @@ spec:
         offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+        refresh.topics.interval.seconds: 600
     checkpointConnector:
       tasksMax: 1
       config:
         # -1 means it will use the default replication factor configured in the broker
         checkpoints.topic.replication.factor: -1
         replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+        sync.group.offsets.enabled: "false"
+        refresh.groups.interval.seconds: 600
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -26,10 +26,15 @@ spec:
         replication.factor: -1
         offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
+        refresh.topics.interval.seconds: 600
     checkpointConnector:
       tasksMax: 1
       config:
         checkpoints.topic.replication.factor: -1
         sync.group.offsets.enabled: "true"
+        offset.lag.max: 100
+        emit.checkpoints.interval.seconds: 60
+        sync.group.offsets.interval.seconds: 60
+        refresh.groups.interval.seconds: 600
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -34,9 +34,12 @@ spec:
         replication.factor: -1
         offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
+        refresh.topics.interval.seconds: 600
     checkpointConnector:
       tasksMax: 1
       config:
         checkpoints.topic.replication.factor: -1
+        sync.group.offsets.enabled: "false"
+        refresh.groups.interval.seconds: 600
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2.yaml
@@ -26,10 +26,13 @@ spec:
         replication.factor: -1
         offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
+        refresh.topics.interval.seconds: 600
     checkpointConnector:
       tasksMax: 1
       config:
         # -1 means it will use the default replication factor configured in the broker
         checkpoints.topic.replication.factor: -1
+        sync.group.offsets.enabled: "false"
+        refresh.groups.interval.seconds: 600
     topicsPattern: ".*"
     groupsPattern: ".*"

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -261,11 +261,16 @@ spec:
           replication.factor: -1
           offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
+          refresh.topics.interval.seconds: 600
       checkpointConnector:
         tasksMax: 1
         config:
           # -1 means it will use the default replication factor configured in the broker
           checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
+          offset.lag.max: 100
+          emit.checkpoints.interval.seconds: 60
+          sync.group.offsets.interval.seconds: 60
+          refresh.groups.interval.seconds: 600
       topicsPattern: ".*"
       groupsPattern: ".*"

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -252,11 +252,16 @@ spec:
           replication.factor: -1
           offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
+          refresh.topics.interval.seconds: 600
       checkpointConnector:
         tasksMax: 1
         config:
           # -1 means it will use the default replication factor configured in the broker
           checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
+          offset.lag.max: 100
+          emit.checkpoints.interval.seconds: 60
+          sync.group.offsets.interval.seconds: 60
+          refresh.groups.interval.seconds: 600
       topicsPattern: ".*"
       groupsPattern: ".*"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Mirror Maker 2 seems to have all kinds of options that cause confusion when users (and I) try it. This PR adds them to our example. It uses the default values, so does not change the default behavior. But will make them more obvious to the users when using the examples and might cause less surprises and questions.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally