### PR TITLE
Remove (some of the) deprecated `executeBlocking` calls

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -149,10 +149,8 @@ public class ClusterOperator extends AbstractVerticle {
                 .onComplete(start);
     }
 
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<Void> maybeStartStrimziPodSetController() {
-        Promise<Void> handler = Promise.promise();
-        vertx.executeBlocking(future -> {
+        return vertx.executeBlocking(() -> {
             try {
                 strimziPodSetController = new StrimziPodSetController(
                         namespace,
@@ -166,13 +164,12 @@ public class ClusterOperator extends AbstractVerticle {
                         config.getPodSetControllerWorkQueueSize()
                 );
                 strimziPodSetController.start();
-                future.complete();
+                return null;
             } catch (Throwable e) {
                 LOGGER.error("StrimziPodSetController start failed");
-                future.fail(e);
+                throw e;
             }
-        }, handler);
-        return handler.future();
+        });
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/PlatformFeaturesAvailability.java
@@ -130,27 +130,19 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
         return vib.build();
     }
 
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private static Future<VersionInfo> getVersionInfoFromKubernetes(Vertx vertx, KubernetesClient client)   {
-        Promise<VersionInfo> promise = Promise.promise();
-
-        vertx.executeBlocking(request -> {
+        return vertx.executeBlocking(() -> {
             try {
-                request.complete(client.getKubernetesVersion());
+                return client.getKubernetesVersion();
             } catch (Exception e) {
                 LOGGER.error("Detection of Kubernetes version failed.", e);
-                request.fail(e);
+                throw e;
             }
-        }, promise);
-
-        return promise.future();
+        });
     }
 
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private static Future<Boolean> checkApiAvailability(Vertx vertx, KubernetesClient client, String group, String version)   {
-        Promise<Boolean> promise = Promise.promise();
-
-        vertx.executeBlocking(request -> {
+        return vertx.executeBlocking(() -> {
             try {
                 APIGroup apiGroup = client.getApiGroup(group);
                 boolean supported;
@@ -162,14 +154,12 @@ public class PlatformFeaturesAvailability implements PlatformFeatures {
                 }
 
                 LOGGER.warn("API Group {} is {}supported", group, supported ? "" : "not ");
-                request.complete(supported);
+                return supported;
             } catch (Exception e) {
                 LOGGER.error("Detection of API availability failed.", e);
-                request.fail(e);
+                throw e;
             }
-        }, promise);
-
-        return promise.future();
+        });
     }
 
     private PlatformFeaturesAvailability() {}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -81,7 +81,6 @@ import io.strimzi.operator.common.operator.resource.ServiceOperator;
 import io.strimzi.operator.common.operator.resource.StorageClassOperator;
 import io.strimzi.operator.common.operator.resource.StrimziPodSetOperator;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.KafkaException;
@@ -889,14 +888,12 @@ public class KafkaReconciler {
      *
      * @return  Future which completes when the Cluster ID is retrieved and set in the status
      */
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     protected Future<Void> clusterId(KafkaStatus kafkaStatus) {
         return ReconcilerUtils.clientSecrets(reconciliation, secretOperator)
                 .compose(compositeFuture -> {
                     LOGGER.debugCr(reconciliation, "Attempt to get clusterId");
-                    Promise<Void> resultPromise = Promise.promise();
-                    vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                            future -> {
+                    return vertx.createSharedWorkerExecutor("kubernetes-ops-pool")
+                            .executeBlocking(() -> {
                                 Admin kafkaAdmin = null;
 
                                 try {
@@ -916,11 +913,8 @@ public class KafkaReconciler {
                                     }
                                 }
 
-                                future.complete();
-                            },
-                            true,
-                            resultPromise);
-                    return resultPromise.future();
+                                return null;
+                            });
                 });
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -794,10 +794,12 @@ public class KafkaRoller {
      *
      * @return a Future which completes when the Pod has been recreated
      */
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     protected Future<Void> restart(Pod pod, RestartContext restartContext) {
-        return  podOperations.restart(reconciliation, pod, operationTimeoutMs)
-                             .onComplete(i -> vertx.executeBlocking(ignored -> eventsPublisher.publishRestartEvents(pod, restartContext.restartReasons)));
+        return podOperations.restart(reconciliation, pod, operationTimeoutMs)
+                             .onComplete(i -> vertx.executeBlocking(() -> {
+                                 eventsPublisher.publishRestartEvents(pod, restartContext.restartReasons);
+                                 return null;
+                             }));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -146,13 +146,16 @@ public class CaReconcilerTest {
         StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
         PodOperator podOps = supplier.podOperations;
 
-        when(secretOps.list(eq(NAMESPACE), any())).thenAnswer(invocation -> {
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenAnswer(invocation -> {
             Map<String, String> requiredLabels = ((Labels) invocation.getArgument(1)).toMap();
-            return secrets.stream().filter(s -> {
+
+            List<Secret> listedSecrets = secrets.stream().filter(s -> {
                 Map<String, String> labels = s.getMetadata().getLabels();
                 labels.keySet().retainAll(requiredLabels.keySet());
                 return labels.equals(requiredLabels);
             }).collect(Collectors.toList());
+
+            return Future.succeededFuture(listedSecrets);
         });
         ArgumentCaptor<Secret> c = ArgumentCaptor.forClass(Secret.class);
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
@@ -1267,6 +1270,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
@@ -1352,6 +1356,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
@@ -1431,6 +1436,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         when(podOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
@@ -1466,7 +1472,6 @@ public class CaReconcilerTest {
 
     @Test
     public void testClusterCAKeyNotTrusted(Vertx vertx, VertxTestContext context) {
-
         Kafka kafka = new KafkaBuilder()
                 .withNewMetadata()
                     .withName(NAME)
@@ -1507,6 +1512,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");
@@ -1590,6 +1596,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
+        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -199,6 +199,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(List.of()));
@@ -311,6 +312,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(KAFKA_CLUSTER.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -445,6 +447,7 @@ public class KafkaAssemblyOperatorPodSetTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -564,6 +567,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -703,6 +707,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -613,10 +613,7 @@ public class KafkaAssemblyOperatorTest {
         );
 
         Map<String, Secret> secretsMap = secrets.stream().collect(Collectors.toMap(s -> s.getMetadata().getName(), s -> s));
-
-        when(mockSecretOps.list(anyString(), any())).thenAnswer(i ->
-                new ArrayList<>(secretsMap.values())
-        );
+        when(mockSecretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(new ArrayList(secretsMap.values())));
         when(mockSecretOps.getAsync(anyString(), any())).thenAnswer(i ->
                 Future.succeededFuture(secretsMap.get(i.<String>getArgument(1)))
         );
@@ -1073,9 +1070,7 @@ public class KafkaAssemblyOperatorTest {
         }
 
         // Mock Secret gets
-        when(mockSecretOps.list(anyString(), any())).thenReturn(
-                emptyList()
-        );
+        when(mockSecretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
         when(mockSecretOps.getAsync(clusterNamespace, KafkaResources.kafkaJmxSecretName(clusterName))).thenReturn(
                 Future.succeededFuture(originalKafkaCluster.jmx().jmxSecret(null))
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -255,6 +255,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(List.of()));
@@ -395,6 +396,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(KAFKA_CLUSTER.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -534,6 +536,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -661,6 +664,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -831,6 +835,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -1005,6 +1010,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(KAFKA_CLUSTER.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -1174,6 +1180,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(secretOps.getAsync(any(), any())).thenReturn(Future.succeededFuture(new Secret()));
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         when(mockCmOps.listAsync(any(), eq(oldKafkaCluster.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaCluster.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), ADVERTISED_HOSTNAMES, ADVERTISED_PORTS)));
@@ -1359,6 +1366,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
 
         SecretOperator secretOps = supplier.secretOperations;
         when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
 
         PodOperator mockPodOps = supplier.podOperations;
         when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(Collections.emptyList()));

--- a/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/VertxUtil.java
@@ -52,19 +52,8 @@ public final class VertxUtil {
      *
      * @param <T>   Type of the result
      */
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public static <T> Future<T> async(Vertx vertx, Supplier<T> supplier) {
-        Promise<T> result = Promise.promise();
-        vertx.executeBlocking(
-            future -> {
-                try {
-                    future.complete(supplier.get());
-                } catch (Throwable t) {
-                    future.fail(t);
-                }
-            }, result
-        );
-        return result.future();
+        return vertx.executeBlocking(() -> supplier.get());
     }
 
     /**
@@ -124,44 +113,45 @@ public final class VertxUtil {
         long deadline = System.currentTimeMillis() + timeoutMs;
         Handler<Long> handler = new Handler<>() {
             @Override
-            @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
             public void handle(Long timerId) {
-                vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                    future -> {
-                        try {
-                            if (completed.getAsBoolean())   {
-                                future.complete();
+                vertx.createSharedWorkerExecutor("kubernetes-ops-pool")
+                        .executeBlocking(() -> {
+                            boolean result;
+
+                            try {
+                                result = completed.getAsBoolean();
+                            } catch (Throwable e) {
+                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                                throw e;
+                            }
+
+                            if (result) {
+                                return null;
                             } else {
                                 LOGGER.traceCr(reconciliation, "{} is not {}", logContext, logState);
-                                future.fail("Not " + logState + " yet");
+                                throw new RuntimeException("Not " + logState + " yet");
                             }
-                        } catch (Throwable e) {
-                            LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
-                            future.fail(e);
-                        }
-                    },
-                    true,
-                    res -> {
-                        if (res.succeeded()) {
-                            LOGGER.debugCr(reconciliation, "{} is {}", logContext, logState);
-                            promise.complete();
-                        } else {
-                            if (failOnError.test(res.cause())) {
-                                promise.fail(res.cause());
+                        })
+                        .onComplete(res -> {
+                            if (res.succeeded()) {
+                                LOGGER.debugCr(reconciliation, "{} is {}", logContext, logState);
+                                promise.complete();
                             } else {
-                                long timeLeft = deadline - System.currentTimeMillis();
-                                if (timeLeft <= 0) {
-                                    String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
-                                    LOGGER.errorCr(reconciliation, exceptionMessage);
-                                    promise.fail(new TimeoutException(exceptionMessage));
+                                if (failOnError.test(res.cause())) {
+                                    promise.fail(res.cause());
                                 } else {
-                                    // Schedule ourselves to run again
-                                    vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
+                                    long timeLeft = deadline - System.currentTimeMillis();
+                                    if (timeLeft <= 0) {
+                                        String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
+                                        LOGGER.errorCr(reconciliation, exceptionMessage);
+                                        promise.fail(new TimeoutException(exceptionMessage));
+                                    } else {
+                                        // Schedule ourselves to run again
+                                        vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
+                                    }
                                 }
                             }
-                        }
-                    }
-                );
+                        });
             }
         };
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/AbstractNamespacedResourceOperator.java
@@ -22,7 +22,6 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.VertxUtil;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 import java.util.ArrayList;
@@ -91,7 +90,6 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * @param desired The desired state of the resource.
      * @return A future which completes when the resource has been updated.
      */
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     public Future<ReconcileResult<T>> reconcile(Reconciliation reconciliation, String namespace, String name, T desired) {
         if (desired != null && !namespace.equals(desired.getMetadata().getNamespace())) {
             return Future.failedFuture("Given namespace " + namespace + " incompatible with desired namespace " + desired.getMetadata().getNamespace());
@@ -99,34 +97,27 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
             return Future.failedFuture("Given name " + name + " incompatible with desired name " + desired.getMetadata().getName());
         }
 
-        Promise<ReconcileResult<T>> promise = Promise.promise();
-        vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-            future -> {
-                T current = operation().inNamespace(namespace).withName(name).get();
-                if (desired != null) {
-                    if (current == null) {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, creating it", resourceKind, namespace, name);
-                        internalCreate(reconciliation, namespace, name, desired).onComplete(future);
+        return getAsync(namespace, name)
+                .compose(current -> {
+                    if (desired != null) {
+                        if (current == null) {
+                            LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, creating it", resourceKind, namespace, name);
+                            return internalCreate(reconciliation, namespace, name, desired);
+                        } else {
+                            LOGGER.debugCr(reconciliation, "{} {}/{} already exists, updating it", resourceKind, namespace, name);
+                            return internalUpdate(reconciliation, namespace, name, current, desired);
+                        }
                     } else {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} already exists, updating it", resourceKind, namespace, name);
-                        internalUpdate(reconciliation, namespace, name, current, desired).onComplete(future);
+                        if (current != null) {
+                            // Deletion is desired
+                            LOGGER.debugCr(reconciliation, "{} {}/{} exist, deleting it", resourceKind, namespace, name);
+                            return internalDelete(reconciliation, namespace, name);
+                        } else {
+                            LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, noop", resourceKind, namespace, name);
+                            return Future.succeededFuture(ReconcileResult.noop(null));
+                        }
                     }
-                } else {
-                    if (current != null) {
-                        // Deletion is desired
-                        LOGGER.debugCr(reconciliation, "{} {}/{} exist, deleting it", resourceKind, namespace, name);
-                        internalDelete(reconciliation, namespace, name).onComplete(future);
-                    } else {
-                        LOGGER.debugCr(reconciliation, "{} {}/{} does not exist, noop", resourceKind, namespace, name);
-                        future.complete(ReconcileResult.noop(null));
-                    }
-                }
-
-            },
-            false,
-            promise
-        );
-        return promise.future();
+                });
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/BuildConfigOperator.java
@@ -71,13 +71,6 @@ public class BuildConfigOperator extends AbstractNamespacedResourceOperator<Open
      * @return              The Build which was created
      */
     public Future<Build> startBuild(String namespace, String name, BuildRequest buildRequest)   {
-        return resourceSupport.executeBlocking(
-            blockingFuture -> {
-                try {
-                    blockingFuture.complete(operation().inNamespace(namespace).withName(name).instantiate(buildRequest));
-                } catch (Throwable t) {
-                    blockingFuture.fail(t);
-                }
-            });
+        return resourceSupport.executeBlocking(() -> operation().inNamespace(namespace).withName(name).instantiate(buildRequest));
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Session.java
@@ -258,17 +258,16 @@ public class Session extends AbstractVerticle {
         });
     }
 
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     private Future<TopicStore> createTopicStoreAsync(Zk zk, Config config) {
-        return executor.executeBlocking(storePromise -> {
+        return executor.executeBlocking(() -> {
             Instant startedAt = Instant.now();
             try {
                 TopicStore topicStore = topicStoreCreator.apply(zk, config);
                 LOGGER.info("Topic store created, took {} ms", Duration.between(startedAt, Instant.now()).toMillis());
-                storePromise.complete(topicStore);
+                return topicStore;
             } catch (Exception e) {
                 LOGGER.error("Failed to create topic store.", e);
-                storePromise.fail(e);
+                throw e;
             }
         });
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/zk/Zk.java
@@ -30,15 +30,8 @@ public interface Zk {
      * @param connectionTimeout Timeout for connection
      * @return  Future completes if the Zookeeper instance is created successfully.
      */
-    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9233
     static Future<Zk> create(Vertx vertx, String zkConnectionString, int sessionTimeout, int connectionTimeout) {
-        return vertx.executeBlocking(f -> {
-            try {
-                f.complete(createSync(vertx, zkConnectionString, sessionTimeout, connectionTimeout));
-            } catch (Throwable t) {
-                f.fail(t);
-            }
-        });
+        return vertx.executeBlocking(() -> createSync(vertx, zkConnectionString, sessionTimeout, connectionTimeout));
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR contributes to #9233 and refactors some of the `executeBlocking` calls. In the easy cases, it is just a simple replacement of the deprecated Vert.x methods using handlers with methods using callable. But in some cases, it was a bit more complicated - for example when we used async futures inside the `executeBlocking` block. In those places, a more significant refactoring was needed, to for example execute only a smaller part as blocking etc.

This PR addresses all occurrences in cluster operator and operator common and only some in the topic operator. The TO containes some of the more complicated calls and fixing those should be done in a separate PR by TO SMEs.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging