### PR TITLE
Fixed comment on setting control plane listener only for ZK-based clusters

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -319,7 +319,7 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println("inter.broker.listener.name=" + REPLICATION_LISTENER_NAME);
         }
 
-        // Control plane listener is on all ZooKeeper based brokers or on KRaft nodes with only the broker role (i.e. not mixed nodes)
+        // Control plane listener is on all ZooKeeper based brokers, it's not supported in KRaft mode
         if (!useKRaft) {
             writer.println("control.plane.listener.name=" + CONTROL_PLANE_LISTENER_NAME);
         }


### PR DESCRIPTION
The `control.plane.listener.name` property has to be empty when in KRaft mode because not supported.
This is a validation happening in the Kafka cluster via `validateControlPlaneListenerEmptyForKRaft` method in all cases: on broker node, on controller node, on mixed (broker+controller) node.
This happens:

https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaConfig.scala#L2318
https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaConfig.scala#L2345
https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaConfig.scala#L2362

So it's not supported at all in KRaft mode.
In the end the operator code is right because checks `!useKRaft` but the comment is misleding.
This trivial PR just change a comment when building such a configuration because it says it's supported in KRaft mode for broker only nodes, which is not true.
