### PR TITLE
[ST] - Add support for multi-node kind cluster, update surefire and failsafe plugin version

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -100,9 +100,36 @@ function updateDockerDaemonConfiguration() {
     systemctl restart docker
 }
 
+: '
+@brief: Increases the inotify user watches and user instances limits on a Linux system.
+@param: None.
+@global: None.
+@note: Inotify is a Linux subsystem used for file system event notifications. This function
+       helps adjust the limits for applications or services that monitor a large number
+       of files or directories.
+       This is specifically needed for multi-node control plane cluster
+       https://github.com/kubernetes-sigs/kind/issues/2744#issuecomment-1127808069
+'
+function adjust_inotify_limits {
+    # Increase the inotify user watches limit
+    echo "Setting fs.inotify.max_user_watches to 655360..."
+    echo fs.inotify.max_user_watches=655360 | sudo tee -a /etc/sysctl.conf
+
+    # Increase the inotify user instances limit
+    echo "Setting fs.inotify.max_user_instances to 1280..."
+    echo fs.inotify.max_user_instances=1280 | sudo tee -a /etc/sysctl.conf
+
+    # Reload the system configuration settings
+    echo "Reloading sysctl settings..."
+    sudo sysctl -p
+
+    echo "Inotify limits adjusted successfully."
+}
+
 setup_kube_directory
 install_kubectl
 install_kubernetes_provisioner
+adjust_inotify_limits
 
 reg_name='kind-registry'
 reg_port='5001'
@@ -185,6 +212,13 @@ elif [[ "$IP_FAMILY" = "ipv6" ]]; then
     cat <<EOF | kind create cluster --config=-
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+    - role: control-plane
+    - role: control-plane
+    - role: worker
+    - role: worker
+    - role: worker
     name: kind-cluster
     containerdConfigPatches:
     - |-

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -126,6 +126,8 @@ if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
     - role: control-plane
+    - role: control-plane
+    - role: control-plane
     - role: worker
     - role: worker
     - role: worker

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -124,6 +124,11 @@ if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     cat <<EOF | kind create cluster --config=-
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+    - role: worker
+    - role: worker
+    - role: worker
     name: kind-cluster
     containerdConfigPatches:
     - |-

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 
         <!-- Maven plugin versions -->
         <maven.compiler.version>3.10.1</maven.compiler.version>
-        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <maven.surefire.version>3.1.2</maven.surefire.version>
         <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
         <maven.assembly.version>3.4.2</maven.assembly.version>
         <maven.shade.version>3.4.1</maven.shade.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <!-- Maven plugin versions -->
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.surefire.version>3.1.2</maven.surefire.version>
-        <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
+        <maven.failsafe.version>3.1.2</maven.failsafe.version>
         <maven.assembly.version>3.4.2</maven.assembly.version>
         <maven.shade.version>3.4.1</maven.shade.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -177,9 +177,9 @@ finish:
   summary: Run acceptance strimzi test suite
   provision:
     hardware:
-      memory: ">= 16 GiB"
+      memory: ">= 24 GiB"
       cpu:
-        processors: ">= 4"
+        processors: ">= 8"
   discover+:
     test:
       - acceptance


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR introduces the capability to run on testing farm multi-node clusters using kind. Plus it updates a surefire and failsafe version.

### Checklist

- [x] Make sure all tests pass


