### PR TITLE
docs(clients): updates the tuning content for producers and consumers

### DIFF
--- a/documentation/assemblies/security/assembly-securing-access.adoc
+++ b/documentation/assemblies/security/assembly-securing-access.adoc
@@ -7,15 +7,26 @@
 
 [role="_abstract"]
 Secure your Kafka cluster by managing the access a client has to Kafka brokers.
-Specify configuration options to secure Kafka brokers and clients
-
 A secure connection between Kafka brokers and clients can encompass the following:
 
 * Encryption for data exchange
 * Authentication to prove identity
 * Authorization to allow or decline actions executed by users
 
-The authentication and authorization mechanisms specified for a client must match those specified for the Kafka brokers.
+In Strimzi, securing a connection involves configuring listeners and user accounts:
+
+Listener configuration:: Use the `Kafka` resource to configure listeners for client connections to Kafka brokers.
+Listeners define how clients authenticate, such as using TLS, SCRAM-SHA-512, OAuth 2.0, or custom authentication methods.
+To enhance security, configure TLS encryption to secure communication between Kafka brokers and clients.
+You can further secure TLS-based communication by specifying the supported TLS versions and cipher suites in the Kafka broker configuration.
+For an added layer of protection, you can also specify authorization methods in the listener configuration, such as simple, OAuth 2.0, OPA, or custom authorization.
+
+User Accounts:: Set up user accounts and credentials with `KafkaUser` resources in Strimzi. 
+Users represent your clients and determine how they should authenticate and authorize with the Kafka cluster. 
+The authentication and authorization mechanisms specified in the user configuration must match the Kafka configuration. 
+Additionally, define Access Control Lists (ACLs) to control user access to specific topics and actions for more fine-grained authorization.
+You can also add configuration to limit the TLS versions and cipher suites your client uses.
+
 Strimzi operators automate the configuration process and create the certificates required for authentication.
 The Cluster Operator automatically sets up TLS certificates for data encryption and authentication within your cluster.
 

--- a/documentation/assemblies/security/assembly-securing-access.adoc
+++ b/documentation/assemblies/security/assembly-securing-access.adoc
@@ -16,16 +16,22 @@ A secure connection between Kafka brokers and clients can encompass the followin
 In Strimzi, securing a connection involves configuring listeners and user accounts:
 
 Listener configuration:: Use the `Kafka` resource to configure listeners for client connections to Kafka brokers.
-Listeners define how clients authenticate, such as using TLS, SCRAM-SHA-512, OAuth 2.0, or custom authentication methods.
+Listeners define how clients authenticate, such as using mTLS, SCRAM-SHA-512, OAuth 2.0, or custom authentication methods.
 To enhance security, configure TLS encryption to secure communication between Kafka brokers and clients.
 You can further secure TLS-based communication by specifying the supported TLS versions and cipher suites in the Kafka broker configuration.
-For an added layer of protection, you can also specify authorization methods in the listener configuration, such as simple, OAuth 2.0, OPA, or custom authorization.
++
+For an added layer of protection, use the `Kafka` resource to specify authorization methods for the Kafka cluster, such as simple, OAuth 2.0, OPA, or custom authorization.
 
-User Accounts:: Set up user accounts and credentials with `KafkaUser` resources in Strimzi. 
+User accounts:: Set up user accounts and credentials with `KafkaUser` resources in Strimzi. 
 Users represent your clients and determine how they should authenticate and authorize with the Kafka cluster. 
 The authentication and authorization mechanisms specified in the user configuration must match the Kafka configuration. 
 Additionally, define Access Control Lists (ACLs) to control user access to specific topics and actions for more fine-grained authorization.
-You can also add configuration to limit the TLS versions and cipher suites your client uses.
+To further enhance security, specify user quotas to limit client access to Kafka brokers based on byte rates or CPU utilization.
++
+You can also add producer or consumer configuration to your clients if you wish to limit the TLS versions and cipher suites they use.
+The configuration on the clients must only use protocols and cipher suites that are enabled on the broker.
+
+NOTE: If you are using an OAuth 2.0 to manage client access, user authentication and authorization credentials are managed through the authorization server.
 
 Strimzi operators automate the configuration process and create the certificates required for authentication.
 The Cluster Operator automatically sets up TLS certificates for data encryption and authentication within your cluster.

--- a/documentation/modules/managing/con-consumer-config-properties.adoc
+++ b/documentation/modules/managing/con-consumer-config-properties.adoc
@@ -69,6 +69,7 @@ but it does mean that there are consumers on standby should one stop functioning
 If you can meet throughput goals with fewer consumers, you save on resources.
 
 Consumers within the same consumer group send offset commits and heartbeats to the same broker.
+The consumer sends heartbeats to the Kafka broker to indicate its activity within the consumer group.
 So the greater the number of consumers in the group, the higher the request load on the broker.
 
 [source,env]
@@ -231,16 +232,20 @@ isolation.level=read_committed <1>
 
 == Recovering from failure to avoid data loss
 
-Kafka provides a rebalance protocol which helps with failure detection and recovery within a consumer group.  
-Two useful properties that aid in this recovery process are `session.timeout.ms` and `heartbeat.interval.ms`.
+In the event of failures within a consumer group, Kafka provides a rebalance protocol designed for effective detection and recovery.
+To minimize the potential impact of these failures, one key strategy is to adjust the `max.poll.records` property to balance efficient processing with system stability. 
+This property determines the maximum number of records a consumer can fetch in a single poll.
+Fine-tuning `max.poll.records` helps to maintain a controlled consumption rate, preventing the consumer from overwhelming itself or the Kafka broker.
 
-The `session.timeout.ms` property specifies the maximum amount of time a consumer in a group can go without sending a heartbeat to the Kafka broker. 
-This heartbeat is an indicator that the consumer is active in the group. 
-If a consumer fails to send a heartbeat within the specified session timeout, Kafka considers it as a failure, and the consumer is marked as inactive. 
+Additionally, Kafka offers advanced configuration properties like `session.timeout.ms` and `heartbeat.interval.ms`. 
+These settings are typically reserved for more specialized use cases and may not require adjustment in standard scenarios.
+
+The `session.timeout.ms` property specifies the maximum amount of time a consumer can go without sending a heartbeat to the Kafka broker to indicate it is active within the consumer group. 
+If a consumer fails to send a heartbeat within the session timeout, it is considered inactive.
 A consumer marked as inactive triggers a rebalancing of the partitions for the topic. 
-Setting this value too low can result in false-positive outcomes, while setting it too high can lead to delayed recovery from failures.
+Setting the `session.timeout.ms` property value too low can result in false-positive outcomes, while setting it too high can lead to delayed recovery from failures.
 
-The `heartbeat.interval.ms` property determines how frequently a consumer sends heartbeats to the Kafka broker. 
+The `heartbeat.interval.ms` property determines how frequently a consumer sends heartbeats to the Kafka broker.    
 A shorter interval between consecutive heartbeats allows for quicker detection of consumer failures. 
 The heartbeat interval must be lower, usually by a third, than the session timeout. 
 Decreasing the heartbeat interval reduces the chance of accidental rebalancing, but more frequent heartbeats increases the overhead on broker resources.

--- a/documentation/modules/managing/con-consumer-config-properties.adoc
+++ b/documentation/modules/managing/con-consumer-config-properties.adoc
@@ -97,8 +97,8 @@ The *range* assignment strategy assigns a range of partitions to each consumer, 
 Alternatively, opt for a *round robin* assignment strategy for equal partition distribution among consumers, which is ideal for high-throughput scenarios requiring parallel processing.
 
 For more stable partition assignments, consider the *sticky* and *cooperative sticky* strategies. 
-Sticky strategies maintain assigned partitions during rebalances, when possible. 
-If a consumer was previously assigned certain partitions, the sticky strategies aim to reassign those same partitions back to the same consumer after a rebalance.
+Sticky strategies aim to maintain assigned partitions during rebalances, when possible. 
+If a consumer was previously assigned certain partitions, the sticky strategies prioritize retaining those same partitions with the same consumer after a rebalance, while only revoking and reassigning the partitions that are actually moved to another consumer.
 Leaving partition assignments in place reduces the overhead on partition movements.
 The cooperative sticky strategy also supports cooperative rebalances, enabling uninterrupted consumption from partitions that are not reassigned.
 

--- a/documentation/modules/managing/con-consumer-config-properties.adoc
+++ b/documentation/modules/managing/con-consumer-config-properties.adoc
@@ -231,7 +231,8 @@ isolation.level=read_committed <1>
 
 == Recovering from failure to avoid data loss
 
-Kafka provides mechanisms to detect and recover from failures within consumer groups. Two useful properties that aid in this recovery process are `session.timeout.ms` and `heartbeat.interval.ms`.
+Kafka provides a rebalance protocol which helps with failure detection and recovery within a consumer group.  
+Two useful properties that aid in this recovery process are `session.timeout.ms` and `heartbeat.interval.ms`.
 
 The `session.timeout.ms` property specifies the maximum amount of time a consumer in a group can go without sending a heartbeat to the Kafka broker. 
 This heartbeat is an indicator that the consumer is active in the group. 

--- a/documentation/modules/managing/con-consumer-config-properties.adoc
+++ b/documentation/modules/managing/con-consumer-config-properties.adoc
@@ -6,10 +6,17 @@
 = Kafka consumer configuration tuning
 
 [role="_abstract"]
-Use a basic consumer configuration with optional properties that are tailored to specific use cases.
-
+Use configuration properties to optimize the performance of Kafka consumers.
+You can use standard Kafka consumer configuration options.
 When tuning your consumers your primary concern will be ensuring that they cope efficiently with the amount of data ingested.
 As with the producer tuning, be prepared to make incremental changes until the consumers operate as expected.
+
+When tuning a consumer, consider the following aspects carefully, as they significantly impact its performance and behavior:
+
+Scaling:: Consumer groups enable parallel processing of messages by distributing the load across multiple consumers. Properly configuring consumer groups can enhance scalability and throughput.
+Message ordering:: A consumer observes messages in a single partition in the same order that they were committed to the broker, which means that Kafka only provides ordering guarantees for messages in a single partition. If absolute ordering within a topic is important, use a single-partition topic. While a single-partition topic allows only one consumer instance, you can leverage a pool of worker threads to create a multi-threaded consumer for more efficient processing. When processing messages for specific entities (like users), you can use the ID (like user ID) as the message key and direct all messages to a single partition. This way, you can maintain message ordering for events specific to individual entities. If a new entity is created, you can create a new topic and migrate its data.
+Offset reset policy:: Setting the appropriate offset policy ensures that the consumer consumes messages from the desired starting point and handles message processing accordingly. The default Kafka reset value is `latest`, which starts at the end of the partition, and consequently means some messages might be missed, depending on the consumer's behavior and the state of the partition. Setting `auto.offset.reset` to `earliest` ensures that when connecting with a `new group.id`, all messages are retrieved from the beginning of the log.
+Securing access:: Implement security measures for authentication, encryption, and authorization by setting up user accounts to xref:assembly-securing-access-{context}[manage secure access to Kafka].
 
 == Basic consumer configuration
 
@@ -64,6 +71,21 @@ group.id=my-group-id <1>
 # ...
 ----
 <1> Add a consumer to a consumer group using a group id.
+
+== Choosing the right partition assignment strategy
+
+Select an appropriate partition assignment strategy, which determines how Kafka topic partitions are distributed among consumer instances in a group.
+
+Specify the strategy using the `partition.assignment.strategy` consumer configuration property. 
+The *range* assignment strategy assigns a range of partitions to each consumer, and is useful when you want to process related data together.
+
+Alternatively, opt for a *round robin* assignment strategy for equal partition distribution among consumers, which is ideal for high-throughput scenarios requiring parallel processing.
+
+For more stable partition assignments, consider the *sticky* and *cooperative sticky* strategies. 
+Sticky strategies maintain assigned partitions during rebalances, when possible. 
+The cooperative sticky strategy also supports cooperative rebalances, enabling uninterrupted consumption from partitions that are not reassigned.
+
+If none of the available strategies suit your data, you can create a custom strategy tailored to your specific requirements.
 
 == Message ordering guarantees
 
@@ -193,17 +215,17 @@ isolation.level=read_committed <1>
 
 == Recovering from failure to avoid data loss
 
-Use the `session.timeout.ms` and `heartbeat.interval.ms` properties to configure the time taken to check and recover from consumer failure within a consumer group.
+Kafka provides mechanisms to detect and recover from failures within consumer groups. Two useful properties that aid in this recovery process are `session.timeout.ms` and `heartbeat.interval.ms`.
 
-The `session.timeout.ms` property specifies the maximum amount of time in milliseconds a consumer within a consumer group can be out of contact with a broker before being considered inactive and a _rebalancing_ is triggered between the active consumers in the group.
-When the group rebalances, the partitions are reassigned to the members of the group.
+The `session.timeout.ms` property specifies the maximum amount of time a consumer in a group can go without sending a heartbeat to the Kafka broker. 
+This heartbeat is an indicator that the consumer is active in the group. 
+If a consumer fails to send a heartbeat within the specified session timeout, Kafka considers it as a failure, and the consumer is marked as inactive. 
+A consumer marked as inactive triggers a rebalancing of the partitions for the topic. 
+Setting this value too low can result in false-positive outcomes, while setting it too high can lead to delayed recovery from failures.
 
-The `heartbeat.interval.ms` property specifies the interval in milliseconds between _heartbeat_ checks to the consumer group coordinator to indicate that the consumer is active and connected.
-The heartbeat interval must be lower, usually by a third, than the session timeout interval.
-
-If you set the `session.timeout.ms` property lower, failing consumers are detected earlier, and rebalancing can take place quicker.
-However, take care not to set the timeout so low that the broker fails to receive a heartbeat in time and triggers an unnecessary rebalance.
-
+The `heartbeat.interval.ms` property determines how frequently a consumer sends heartbeats to the Kafka broker. 
+A shorter interval between consecutive heartbeats allows for quicker detection of consumer failures. 
+The heartbeat interval must be lower, usually by a third, than the session timeout. 
 Decreasing the heartbeat interval reduces the chance of accidental rebalancing, but more frequent heartbeats increases the overhead on broker resources.
 
 == Managing offset policy
@@ -239,26 +261,24 @@ In this case, you can lower `max.partition.fetch.bytes` or increase `session.tim
 
 == Minimizing the impact of rebalances
 
-The rebalancing of a partition between active consumers in a group is the time it takes for:
+The rebalancing of a partition between active consumers in a group is the time it takes for the following to take place:
 
 * Consumers to commit their offsets
 * The new consumer group to be formed
 * The group leader to assign partitions to group members
 * The consumers in the group to receive their assignments and start fetching
 
-Clearly, the process increases the downtime of a service, particularly when it happens repeatedly during a rolling restart of a consumer group cluster.
+The rebalancing process can increase the downtime of a service, particularly if it happens repeatedly during a rolling restart of a consumer group cluster.
 
-In this situation, you can use the concept of _static membership_ to reduce the number of rebalances.
-Rebalancing assigns topic partitions evenly among consumer group members.
+In this situation, you can introduce _static membership_ by assigning a unique identifier (`group.instance.id`) to each consumer instance within the group.
 Static membership uses persistence so that a consumer instance is recognized during a restart after a session timeout.
-
-The consumer group coordinator can identify a new consumer instance using a unique id that is specified using the `group.instance.id` property.
-During a restart, the consumer is assigned a new member id, but as a static member it continues with the same instance id,
-and the same assignment of topic partitions is made.
-
-If the consumer application does not make a call to poll at least every `max.poll.interval.ms` milliseconds, the consumer is considered to be failed, causing a rebalance.
-If the application cannot process all the records returned from poll in time, you can avoid a rebalance by using the `max.poll.interval.ms` property to specify the interval in milliseconds between polls for new messages from a consumer.
-Or you can use the `max.poll.records` property to set a maximum limit on the number of records returned from the consumer buffer, allowing your application to process fewer records within the `max.poll.interval.ms` limit.
+Consequently, the consumer maintains its assignment of topic partitions, reducing unnecessary rebalancing when it rejoins the group after a failure or restart.
+ 
+Additionally, adjusting the `max.poll.interval.ms` configuration can prevent rebalances caused by prolonged processing tasks, allowing you to specify the maximum interval between polls for new messages.
+Use the `max.poll.records` property to cap the number of records returned from the consumer buffer during each poll. 
+Reducing the number of records allows the consumer to process fewer messages more efficiently.  
+In cases where lengthy message processing is unavoidable, consider offloading such tasks to a pool of worker threads. 
+This parallel processing approach prevents delays and potential rebalances caused by overwhelming the consumer with a large volume of records.
 
 [source,shell,subs="+quotes"]
 ----

--- a/documentation/modules/managing/con-consumer-config-properties.adoc
+++ b/documentation/modules/managing/con-consumer-config-properties.adoc
@@ -7,15 +7,22 @@
 
 [role="_abstract"]
 Use configuration properties to optimize the performance of Kafka consumers.
-You can use standard Kafka consumer configuration options.
 When tuning your consumers your primary concern will be ensuring that they cope efficiently with the amount of data ingested.
 As with the producer tuning, be prepared to make incremental changes until the consumers operate as expected.
 
 When tuning a consumer, consider the following aspects carefully, as they significantly impact its performance and behavior:
 
-Scaling:: Consumer groups enable parallel processing of messages by distributing the load across multiple consumers. Properly configuring consumer groups can enhance scalability and throughput.
-Message ordering:: A consumer observes messages in a single partition in the same order that they were committed to the broker, which means that Kafka only provides ordering guarantees for messages in a single partition. If absolute ordering within a topic is important, use a single-partition topic. While a single-partition topic allows only one consumer instance, you can leverage a pool of worker threads to create a multi-threaded consumer for more efficient processing. When processing messages for specific entities (like users), you can use the ID (like user ID) as the message key and direct all messages to a single partition. This way, you can maintain message ordering for events specific to individual entities. If a new entity is created, you can create a new topic and migrate its data.
-Offset reset policy:: Setting the appropriate offset policy ensures that the consumer consumes messages from the desired starting point and handles message processing accordingly. The default Kafka reset value is `latest`, which starts at the end of the partition, and consequently means some messages might be missed, depending on the consumer's behavior and the state of the partition. Setting `auto.offset.reset` to `earliest` ensures that when connecting with a `new group.id`, all messages are retrieved from the beginning of the log.
+Scaling:: Consumer groups enable parallel processing of messages by distributing the load across multiple consumers, enhancing scalability and throughput. 
+The number of topic partitions determines the maximum level of parallelism that you can achieve, as one partition can only be assigned to one consumer in a consumer group. 
+Message ordering:: 
+If absolute ordering within a topic is important, use a single-partition topic. 
+A consumer observes messages in a single partition in the same order that they were committed to the broker, which means that Kafka only provides ordering guarantees for messages in a single partition. 
+It is also possible to maintain message ordering for events specific to individual entities, such as users.
+If a new entity is created, you can create a new topic dedicated to that entity.
+You can use a unique ID, like a user ID, as the message key and route all messages with the same key to a single partition within the topic. 
+Offset reset policy:: Setting the appropriate offset policy ensures that the consumer consumes messages from the desired starting point and handles message processing accordingly. 
+The default Kafka reset value is `latest`, which starts at the end of the partition, and consequently means some messages might be missed, depending on the consumer's behavior and the state of the partition. 
+Setting `auto.offset.reset` to `earliest` ensures that when connecting with a new `group.id`, all messages are retrieved from the beginning of the log.
 Securing access:: Implement security measures for authentication, encryption, and authorization by setting up user accounts to xref:assembly-securing-access-{context}[manage secure access to Kafka].
 
 == Basic consumer configuration
@@ -76,13 +83,22 @@ group.id=my-group-id <1>
 
 Select an appropriate partition assignment strategy, which determines how Kafka topic partitions are distributed among consumer instances in a group.
 
-Specify the strategy using the `partition.assignment.strategy` consumer configuration property. 
+Partition strategies are supported by the following classes:
+
+* `org.apache.kafka.clients.consumer.RangeAssignor`
+* `org.apache.kafka.clients.consumer.RoundRobinAssignor`
+* `org.apache.kafka.clients.consumer.StickyAssignor`
+* `org.apache.kafka.clients.consumer.CooperativeStickyAssignor`
+
+Specify a class using the `partition.assignment.strategy` consumer configuration property. 
 The *range* assignment strategy assigns a range of partitions to each consumer, and is useful when you want to process related data together.
 
 Alternatively, opt for a *round robin* assignment strategy for equal partition distribution among consumers, which is ideal for high-throughput scenarios requiring parallel processing.
 
 For more stable partition assignments, consider the *sticky* and *cooperative sticky* strategies. 
 Sticky strategies maintain assigned partitions during rebalances, when possible. 
+If a consumer was previously assigned certain partitions, the sticky strategies aim to reassign those same partitions back to the same consumer after a rebalance.
+Leaving partition assignments in place reduces the overhead on partition movements.
 The cooperative sticky strategy also supports cooperative rebalances, enabling uninterrupted consumption from partitions that are not reassigned.
 
 If none of the available strategies suit your data, you can create a custom strategy tailored to your specific requirements.

--- a/documentation/modules/managing/con-producer-config-properties.adoc
+++ b/documentation/modules/managing/con-producer-config-properties.adoc
@@ -53,18 +53,23 @@ Compression is useful for improving throughput and reducing the load on storage,
 == Data durability
 
 Message delivery acknowledgments minimize the likelihood that messages are lost.
-Acknowledgments are enabled by default with the `acks` property set at `acks=all`.
+By default, acknowledgments are enabled with the acks property set to `acks=all`. 
+To control the maximum time the producer waits for acknowledgments from the broker and handle potential delays in sending messages, you can use the `delivery.timeout.ms` property.
 
 .Acknowledging message delivery
 [source,env]
 ----
 # ...
 acks=all <1>
+delivery.timeout.ms=120000 <2>
 # ...
 ----
 
 <1> `acks=all` forces a leader replica to replicate messages to a certain number of followers before
 acknowledging that the message request was successfully received. 
+<2> The maximum time in milliseconds to wait for a complete send request. 
+You can set the value to `MAX_LONG` to delegate to Kafka an indefinite number of retries.
+The default is `120000` or 2 minutes.
 
 The `acks=all` setting offers the strongest guarantee of delivery, but it will increase the latency between the producer sending a message and receiving acknowledgment.
 If you don't require such strong guarantees, a setting of `acks=0` or `acks=1` provides either no delivery guarantees or only acknowledgment that the leader replica has written the record to its log.
@@ -251,24 +256,20 @@ batch.size=16384 <2>
 buffer.memory=33554432 <3>
 # ...
 ----
-<1> The `linger` property adds a delay in milliseconds so that larger batches of messages are accumulated and sent in a request. The default is `0`.
+<1> The `linger.ms` property adds a delay in milliseconds so that larger batches of messages are accumulated and sent in a request. The default is `0`.
 <2> If a maximum `batch.size` in bytes is used, a request is sent when the maximum is reached, or messages have been queued for longer than `linger.ms` (whichever comes sooner).
 Adding the delay allows batches to accumulate messages up to the batch size.
 <3> The buffer size must be at least as big as the batch size, and be able to accommodate buffering, compression, and in-flight requests.
 
 .Increasing throughput
 
-You can improve throughput of your message requests by using the `delivery.timeout.ms` property to adjust the maximum time to wait before a message is delivered and completes a send request.
-You can also direct messages to a specified partition by writing a custom partitioner to replace the default.
+You can improve throughput of your message requests by directing messages to a specified partition using a custom partitioner to replace the default.
 
 [source,env]
 ----
 # ...
-delivery.timeout.ms=120000 <1>
-partitioner.class=my-custom-partitioner <2>
+partitioner.class=my-custom-partitioner <1>
 
 # ...
 ----
-<1> The maximum time in milliseconds to wait for a complete send request. You can set the value to `MAX_LONG` to delegate to Kafka an indefinite number of retries.
-The default is `120000` or 2 minutes.
-<2> Specify the class name of the custom partitioner.
+<1> Specify the class name of your custom partitioner.

--- a/documentation/modules/managing/con-producer-config-properties.adoc
+++ b/documentation/modules/managing/con-producer-config-properties.adoc
@@ -13,7 +13,8 @@ You will need to experiment and tune your producer configuration to get the bala
 
 When configuring a producer, consider the following aspects carefully, as they significantly impact its performance and behavior:
 
-Compression:: Implementing message compression can reduce network bandwidth usage, conserving resources and improving throughput.
+Compression:: 
+By compressing messages before they are sent over the network, you can conserve network bandwidth and reduce disk storage requirements, but with the additional cost of increased CPU utilization due to the compression and decompression processes.
 Batching:: Adjusting the batch size and time intervals when the producer sends messages can affect throughput and latency. 
 Partitioning:: Partitioning strategies in the Kafka cluster can support producers through parallelism and load balancing, whereby producers can write to multiple partitions concurrently and each partition receives an equal share of messages. Other strategies might include topic replication for fault tolerance.
 Securing access:: Implement security measures for authentication, encryption, and authorization by setting up user accounts to xref:assembly-securing-access-{context}[manage secure access to Kafka].

--- a/documentation/modules/managing/con-producer-config-properties.adoc
+++ b/documentation/modules/managing/con-producer-config-properties.adoc
@@ -6,10 +6,17 @@
 = Kafka producer configuration tuning
 
 [role="_abstract"]
-Use a basic producer configuration with optional properties that are tailored to specific use cases.
-
+Use configuration properties to optimize the performance of Kafka producers.
+You can use standard Kafka producer configuration options.
 Adjusting your configuration to maximize throughput might increase latency or vice versa.
 You will need to experiment and tune your producer configuration to get the balance you need.
+
+When configuring a producer, consider the following aspects carefully, as they significantly impact its performance and behavior:
+
+Compression:: Implementing message compression can reduce network bandwidth usage, conserving resources and improving throughput.
+Batching:: Adjusting the batch size and time intervals when the producer sends messages can affect throughput and latency. 
+Partitioning:: Partitioning strategies in the Kafka cluster can support producers through parallelism and load balancing, whereby producers can write to multiple partitions concurrently and each partition receives an equal share of messages. Other strategies might include topic replication for fault tolerance.
+Securing access:: Implement security measures for authentication, encryption, and authorization by setting up user accounts to xref:assembly-securing-access-{context}[manage secure access to Kafka].
 
 == Basic producer configuration
 
@@ -214,7 +221,7 @@ such as worse batching, start to counteract the effect on throughput.
 
 .Lowering latency
 
-When your application calls `KafkaProducer.send()` the messages are:
+When your application calls `KafkaProducer.send()`, messages are handled as follows:
 
 * Processed by any interceptors
 * Serialized
@@ -223,7 +230,7 @@ When your application calls `KafkaProducer.send()` the messages are:
 * Added to a batch of messages in a per-partition queue
 
 At which point the `send()` method returns.
-So the time `send()` is blocked is determined by:
+So the time `send()` is blocked is determined by the following:
 
 * The time spent in the interceptors, serializers and partitioner
 * The compression algorithm used
@@ -236,7 +243,8 @@ Batches will remain in the queue until one of the following occurs:
 * The sender is about to send message batches for other partitions to the same broker, and it is possible to add this batch too
 * The producer is being flushed or closed
 
-Look at the configuration for batching and buffering to mitigate the impact of `send()` blocking on latency.
+Consider the configuration for batching and buffering to mitigate the impact of `send()` blocking on latency.
+Use the `linger.ms` and `batch.size` configuration properties to batch more messages into a single produce request for higher throughput. 
 
 [source,env]
 ----
@@ -249,12 +257,11 @@ buffer.memory=33554432 <3>
 <1> The `linger` property adds a delay in milliseconds so that larger batches of messages are accumulated and sent in a request. The default is `0'.`
 <2> If a maximum `batch.size` in bytes is used, a request is sent when the maximum is reached, or messages have been queued for longer than `linger.ms` (whichever comes sooner).
 Adding the delay allows batches to accumulate messages up to the batch size.
-<3> The buffer size must be at least as big as the batch size, and be able to accommodate buffering, compression and in-flight requests.
+<3> The buffer size must be at least as big as the batch size, and be able to accommodate buffering, compression, and in-flight requests.
 
 .Increasing throughput
 
-Improve throughput of your message requests by adjusting the maximum time to wait before a message is delivered and completes a send request.
-
+You can improve throughput of your message requests by using the `delivery.timeout.ms` property to adjust the maximum time to wait before a message is delivered and completes a send request.
 You can also direct messages to a specified partition by writing a custom partitioner to replace the default.
 
 [source,env]

--- a/documentation/modules/managing/con-producer-config-properties.adoc
+++ b/documentation/modules/managing/con-producer-config-properties.adoc
@@ -222,30 +222,26 @@ such as worse batching, start to counteract the effect on throughput.
 
 .Lowering latency
 
-When your application calls `KafkaProducer.send()`, messages are handled as follows:
+When your application calls the `KafkaProducer.send()` method, messages undergo a series of operations before being sent:
 
-* Processed by any interceptors
-* Serialized
-* Assigned to a partition
-* Compressed
-* Added to a batch of messages in a per-partition queue
+* Interception: Messages are processed by any configured interceptors.
+* Serialization: Messages are serialized into the appropriate format.
+* Partition assignment: Each message is assigned to a specific partition.
+* Compression: Messages are compressed to conserve network bandwidth.
+* Batching: Compressed messages are added to a batch in a partition-specific queue.
 
-At which point the `send()` method returns.
-So the time `send()` is blocked is determined by the following:
-
-* The time spent in the interceptors, serializers and partitioner
-* The compression algorithm used
-* The time spent waiting for a buffer to use for compression
+During these operations, the `send()` method is momentarily blocked. 
+It also remains blocked if the `buffer.memory` is full or if metadata is unavailable.
 
 Batches will remain in the queue until one of the following occurs:
 
-* The batch is full (according to `batch.size`)
-* The delay introduced by `linger.ms` has passed
-* The sender is about to send message batches for other partitions to the same broker, and it is possible to add this batch too
-* The producer is being flushed or closed
+* The batch is full (according to `batch.size`).
+* The delay introduced by `linger.ms` has passed.
+* The sender is ready to dispatch batches for other partitions to the same broker and can include this batch.
+* The producer is being flushed or closed.
 
-Consider the configuration for batching and buffering to mitigate the impact of `send()` blocking on latency.
-Use the `linger.ms` and `batch.size` configuration properties to batch more messages into a single produce request for higher throughput. 
+To minimize the impact of `send()` blocking on latency, optimize batching and buffering configurations. 
+Use the `linger.ms` and `batch.size` properties to batch more messages into a single produce request for higher throughput.
 
 [source,env]
 ----
@@ -255,7 +251,7 @@ batch.size=16384 <2>
 buffer.memory=33554432 <3>
 # ...
 ----
-<1> The `linger` property adds a delay in milliseconds so that larger batches of messages are accumulated and sent in a request. The default is `0'.`
+<1> The `linger` property adds a delay in milliseconds so that larger batches of messages are accumulated and sent in a request. The default is `0`.
 <2> If a maximum `batch.size` in bytes is used, a request is sent when the maximum is reached, or messages have been queued for longer than `linger.ms` (whichever comes sooner).
 Adding the delay allows batches to accumulate messages up to the batch size.
 <3> The buffer size must be at least as big as the batch size, and be able to accommodate buffering, compression, and in-flight requests.

--- a/documentation/modules/security/con-securing-kafka-authentication.adoc
+++ b/documentation/modules/security/con-securing-kafka-authentication.adoc
@@ -23,6 +23,7 @@ Supported authentication options:
 . SCRAM-SHA-512 authentication
 . xref:assembly-oauth-authentication_str[OAuth 2.0 token-based authentication]
 . link:{BookURLConfiguring}#type-KafkaListenerAuthenticationCustom-reference[Custom authentication^]
+. link:{BookURLConfiguring}#con-common-configuration-ssl-reference[TLS versions and cipher suites^]
 
 The authentication option you choose depends on how you wish to authenticate client access to Kafka brokers.
 


### PR DESCRIPTION
**Documentation**

Some doc updates related to producer and consumer configuration (based on the feedback for the blog posts on developing producer and consumer applications)

- adds an overview of the configuration options for securing access to Kafka
- adds the key configuration considerations for producer and consumer performance
- updates to the producer and consumer tuning content

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

