### PR TITLE
Move `KafkaNodePools` feature gate to beta

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +21,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +34,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +47,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +60,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +73,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +86,6 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-StableConnectIdentities,+UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'kraft-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'kraft-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'kraft-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'kraft-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'kraft-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'kraft-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'kraft-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.39.0
 
-* The `KafkaNodePools` feature gate moves to beta stage and will be enabled by default.
+* The `KafkaNodePools` feature gate moves to beta stage and is enabled by default.
   If needed, `KafkaNodePools` can be disabled in the feature gates configuration in the Cluster Operator.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.39.0
 
+* The `KafkaNodePools` feature gate moves to beta stage and will be enabled by default.
+  If needed, `KafkaNodePools` can be disabled in the feature gates configuration in the Cluster Operator.
 
 
 ### Changes, deprecations and removals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * The `KafkaNodePools` feature gate moves to beta stage and is enabled by default.
   If needed, `KafkaNodePools` can be disabled in the feature gates configuration in the Cluster Operator.
 
-
 ### Changes, deprecations and removals
 
 * Strimzi 0.39.0 (and any of its patch releases) is the last Strimzi version with support for Kubernetes 1.21 and 1.22.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -24,7 +24,7 @@ public class FeatureGates {
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, false);
     private final FeatureGate stableConnectIdentities = new FeatureGate(STABLE_CONNECT_IDENTITIES, true);
-    private final FeatureGate kafkaNodePools = new FeatureGate(KAFKA_NODE_POOLS, false);
+    private final FeatureGate kafkaNodePools = new FeatureGate(KAFKA_NODE_POOLS, true);
     private final FeatureGate unidirectionalTopicOperator = new FeatureGate(UNIDIRECTIONAL_TOPIC_OPERATOR, false);
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -65,7 +65,7 @@ public class ClusterOperatorTest {
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
-        env.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,-StableConnectIdentities");
+        env.put(ClusterOperatorConfig.FEATURE_GATES.key(), "-KafkaNodePools,-StableConnectIdentities");
 
         if (podSetsOnly) {
             env.put(ClusterOperatorConfig.POD_SET_RECONCILIATION_ONLY.key(), "true");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
@@ -21,16 +21,8 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testIndividualFeatureGates() {
         for (FeatureGates.FeatureGate gate : FeatureGates.NONE.allFeatureGates()) {
-            FeatureGates enabled;
-            FeatureGates disabled;
-
-            if ("UseKRaft".equals(gate.getName()))  {
-                enabled = new FeatureGates("+" + gate.getName() + ",+KafkaNodePools");
-                disabled = new FeatureGates("-" + gate.getName() + ",+KafkaNodePools");
-            } else {
-                enabled = new FeatureGates("+" + gate.getName());
-                disabled = new FeatureGates("-" + gate.getName());
-            }
+            FeatureGates enabled = new FeatureGates("+" + gate.getName());
+            FeatureGates disabled = new FeatureGates("-" + gate.getName());
 
             assertThat(enabled.allFeatureGates().stream().filter(g -> gate.getName().equals(g.getName())).findFirst().orElseThrow().isEnabled(), is(true));
             assertThat(disabled.allFeatureGates().stream().filter(g -> gate.getName().equals(g.getName())).findFirst().orElseThrow().isEnabled(), is(false));
@@ -60,14 +52,14 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testFeatureGatesParsing() {
-        assertThat(new FeatureGates("+UseKRaft,+KafkaNodePools").useKRaftEnabled(), is(true));
+        assertThat(new FeatureGates("+UseKRaft").useKRaftEnabled(), is(true));
         assertThat(new FeatureGates("-StableConnectIdentities").stableConnectIdentitiesEnabled(), is(false));
         assertThat(new FeatureGates("+KafkaNodePools").kafkaNodePoolsEnabled(), is(true));
         assertThat(new FeatureGates("-UseKRaft,-StableConnectIdentities").useKRaftEnabled(), is(false));
         assertThat(new FeatureGates("-UseKRaft,-StableConnectIdentities").stableConnectIdentitiesEnabled(), is(false));
         assertThat(new FeatureGates("-UseKRaft,-StableConnectIdentities,-KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
         assertThat(new FeatureGates("  +UseKRaft    ,    +KafkaNodePools").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("  +UseKRaft    ,    +KafkaNodePools").kafkaNodePoolsEnabled(), is(true));
+        assertThat(new FeatureGates("  -UseKRaft    ,    -KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
         assertThat(new FeatureGates("+StableConnectIdentities,-UseKRaft").useKRaftEnabled(), is(false));
         assertThat(new FeatureGates("+StableConnectIdentities,-UseKRaft").stableConnectIdentitiesEnabled(), is(true));
     }
@@ -114,15 +106,13 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testKraftAndKafkaNOdePoolsNotFulfilled() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft"));
-        assertThat(e.getMessage(), containsString("The UseKRaft feature gate can be enabled only together with the KafkaNodePools feature gate."));
-
-        e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft,-KafkaNodePools"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft,-KafkaNodePools"));
         assertThat(e.getMessage(), containsString("The UseKRaft feature gate can be enabled only together with the KafkaNodePools feature gate."));
     }
 
     @ParallelTest
     public void testKraftAndKafkaNodePoolsFulfilled() {
         assertThat(new FeatureGates("+UseKRaft,+KafkaNodePools").useKRaftEnabled(), is(true));
+        assertThat(new FeatureGates("+UseKRaft").useKRaftEnabled(), is(true));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
@@ -172,7 +172,7 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
 
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
                 .with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "10000")
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,+UseKRaft")
+                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+UseKRaft")
                 .build();
         operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(),
                 new PasswordGenerator(10, "a", "a"), supplier, config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
@@ -177,7 +177,6 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
 
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
                 .with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "10000")
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools")
                 .build();
         operator = new KafkaAssemblyOperator(vertx, pfa, new MockCertManager(),
                 new PasswordGenerator(10, "a", "a"), supplier, config);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -107,9 +107,7 @@ import static org.mockito.Mockito.when;
 public class KafkaAssemblyOperatorWithPoolsTest {
     private static final KafkaVersion.Lookup VERSIONS = KafkaVersionTestUtils.getKafkaVersionLookup();
     private static final SharedEnvironmentProvider SHARED_ENV_PROVIDER = new MockSharedEnvironmentProvider();
-    private static final ClusterOperatorConfig CONFIG = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
-            .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools")
-            .build();
+    private static final ClusterOperatorConfig CONFIG = ResourceUtils.dummyClusterOperatorConfig();
     private static final KubernetesVersion KUBERNETES_VERSION = KubernetesVersion.MINIMAL_SUPPORTED_VERSION;
     private static final MockCertManager CERT_MANAGER = new MockCertManager();
     private static final PasswordGenerator PASSWORD_GENERATOR = new PasswordGenerator(10, "a", "a");
@@ -1335,7 +1333,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(kafka));
 
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,+UseKRaft")
+                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+UseKRaft")
                 .build();
 
         KafkaAssemblyOperator kao = new KafkaAssemblyOperator(
@@ -1391,7 +1389,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         when(mockKafkaNodePoolOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(null));
 
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+KafkaNodePools,+UseKRaft")
+                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+UseKRaft")
                 .build();
 
         KafkaAssemblyOperator kao = new KafkaAssemblyOperator(

--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -63,19 +63,7 @@ By applying this resource, you switch Kafka to using node pools.
 +
 There is no change or rolling update and resources are identical to how they were before.
 
-. Update the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration to include `+KafkaNodePools`.
-+
-[source,yaml]
-----
-env:
-  - name: STRIMZI_FEATURE_GATES
-    value: +KafkaNodePools
-----
-+
-After restarting, the Cluster Operator logs a warning indicating that the Kafka node pool has been added but is not yet integrated with the Cluster Operator.
-This is an expected part of the process.
-
-. Enable the `KafkaNodePools` feature gate in the `Kafka` resource using the `strimzi.io/node-pools: enabled` annotation.
+. Enable the `KafkaNodePools` in the `Kafka` resource using the `strimzi.io/node-pools: enabled` annotation.
 +
 .Example configuration for a node pool in a cluster using ZooKeeper
 [source,yaml,subs="+attributes"]

--- a/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
@@ -34,11 +34,11 @@ NOTE: If you want to migrate an existing Kafka cluster to use node pools, see th
 
 .Procedure
 
-. Enable the `KafkaNodePools` feature gate from the command line:
+. If you want to use KRaft, enable the `UseKRaft` feature gate from the command line:
 +
 [source,shell]
 ----
-kubectl set env deployment/strimzi-cluster-operator STRIMZI_FEATURE_GATES="+KafkaNodePools"
+kubectl set env deployment/strimzi-cluster-operator STRIMZI_FEATURE_GATES="+UseKRaft"
 ----
 +
 Or by editing the Cluster Operator Deployment and updating the `STRIMZI_FEATURE_GATES` environment variable:
@@ -47,12 +47,10 @@ Or by editing the Cluster Operator Deployment and updating the `STRIMZI_FEATURE_
 ----
 env
   - name: STRIMZI_FEATURE_GATES
-    value: +KafkaNodePools
+    value: +UseKRaft
 ----
 +
 This updates the Cluster Operator.
-+
-If using KRaft mode, enable the `UseKRaft` feature gate as well.
 
 . Create a node pool.
 +

--- a/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-node-pools.adoc
@@ -41,7 +41,7 @@ NOTE: If you want to migrate an existing Kafka cluster to use node pools, see th
 kubectl set env deployment/strimzi-cluster-operator STRIMZI_FEATURE_GATES="+UseKRaft"
 ----
 +
-Or by editing the Cluster Operator Deployment and updating the `STRIMZI_FEATURE_GATES` environment variable:
+Or by editing the Cluster Operator `Deployment` and updating the `STRIMZI_FEATURE_GATES` environment variable:
 +
 [source,yaml]
 ----

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -23,8 +23,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 * The `StableConnectIdentities` feature gate is in beta stage and is enabled by default.
   It is expected to move to GA phase and be always enabled from Strimzi 0.39.
-* The `KafkaNodePools` feature gate is in alpha stage and is disabled by default.
-  It is expected to move to beta phase and be enabled by default from Strimzi 0.39.
+* The `KafkaNodePools` feature gate is in beta stage and is enabled by default.
+  It is expected to move to GA phase and be always enabled from Strimzi 0.41.
 * The `UnidirectionalTopicOperator` feature gate is in alpha stage and is disabled by default.
   It is expected to move to beta phase and be enabled by default from Strimzi 0.39.
 
@@ -66,8 +66,8 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 ¦`KafkaNodePools`
 ¦0.36
-¦0.39 (planned)
-¦ -
+¦0.39
+¦0.41 (planned)
 
 ¦`UnidirectionalTopicOperator`
 ¦0.36

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -87,7 +87,7 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
   The `type: jbod` storage can be used, but the JBOD array can contain only one disk.
 
 .Enabling the UseKRaft feature gate
-To enable the `UseKRaft` feature gate, specify `+UseKRaft,+KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
 If such annotation is set to `disabled`, missing or any other value, the operator will handle the `Kafka` custom resource as using ZooKeeper mode.
 
@@ -108,7 +108,7 @@ IMPORTANT: The `StableConnectIdentities` feature gate must be disabled when down
 [id='ref-operator-kafka-node-pools-feature-gate-{context}']
 == (Preview) KafkaNodePools feature gate
 
-The `KafkaNodePools` feature gate has a default state of _disabled_.
+The `KafkaNodePools` feature gate has a default state of _enabled_.
 
 The `KafkaNodePools` feature gate introduces a new `KafkaNodePool` custom resource that enables the configuration of different _pools_ of Apache Kafka nodes.
 
@@ -126,10 +126,14 @@ The label must be set to the name of the `Kafka` custom resource.
 
 Examples of the `KafkaNodePool` resources can be found in the xref:config-examples-{context}[example configuration files] provided by Strimzi.
 
-.Enabling the KafkaNodePools feature gate
+.Disabling the KafkaNodePools feature gate
 
-To enable the `KafkaNodePools` feature gate, specify `+KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+To disable the `KafkaNodePools` feature gate, specify `-KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 The `Kafka` custom resource using the node pools must also have the annotation `strimzi.io/node-pools: enabled`.
+
+.Downgrading from KafkaNodePools
+
+If your cluster already uses the `KafkaNodePool` custom resources and want to downgrade to older version of Strimzi that does not support KafkaNodePools or has the `KafkaNodePool` feature gate disabled, you should first migrate from using the `KafkaNodePool` custom resources to use the `Kafka` custom resource only.
 
 [id='ref-operator-unidirectional-topic-operator-feature-gate-{context}']
 == (Preview) UnidirectionalTopicOperator feature gate

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -89,7 +89,7 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 .Enabling the UseKRaft feature gate
 To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
-If such annotation is set to `disabled`, missing or any other value, the operator will handle the `Kafka` custom resource as using ZooKeeper mode.
+If this annotation is set to `disabled` or any other value, or if it is missing, the operator handles the `Kafka` custom resource as if it is using ZooKeeper for cluster management.
 
 [id='ref-operator-stable-connect-identities-feature-gate-{context}']
 == StableConnectIdentities feature gate
@@ -133,7 +133,7 @@ The `Kafka` custom resource using the node pools must also have the annotation `
 
 .Downgrading from KafkaNodePools
 
-If your cluster already uses the `KafkaNodePool` custom resources and want to downgrade to older version of Strimzi that does not support KafkaNodePools or has the `KafkaNodePool` feature gate disabled, you should first migrate from using the `KafkaNodePool` custom resources to use the `Kafka` custom resource only.
+If your cluster already uses `KafkaNodePool` custom resources, and you wish to downgrade to an older version of Strimzi that does not support them or with the `KafkaNodePools` feature gate disabled, you must first migrate from `KafkaNodePool` custom resources to managing Kafka nodes using only `Kafka` custom resources.
 
 [id='ref-operator-unidirectional-topic-operator-feature-gate-{context}']
 == (Preview) UnidirectionalTopicOperator feature gate

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -192,7 +192,7 @@ public interface Constants {
      */
     String USE_KRAFT_MODE = "+UseKRaft";
     String DONT_USE_STABLE_CONNECT_IDENTITIES = "-StableConnectIdentities";
-    String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
+    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
     String UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -277,7 +277,7 @@ public class Environment {
     }
 
     public static boolean isKafkaNodePoolsEnabled() {
-        return STRIMZI_FEATURE_GATES.contains(Constants.USE_KAFKA_NODE_POOLS);
+        return !STRIMZI_FEATURE_GATES.contains(Constants.DONT_USE_KAFKA_NODE_POOLS);
     }
 
     public static boolean isUnidirectionalTopicOperatorEnabled() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -97,7 +97,7 @@ public class FeatureGatesST extends AbstractST {
         List<EnvVar> testEnvVars = new ArrayList<>();
         int kafkaReplicas = 3;
 
-        testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft,+KafkaNodePools", null));
+        testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft", null));
 
         this.clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withNamespace(Constants.CO_NAMESPACE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -208,7 +208,7 @@ public class FeatureGatesST extends AbstractST {
         final String disabledFgProducerName = "disabled-fg-producer";
 
         List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "-StableConnectIdentities", null));
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "-KafkaNodePools,-StableConnectIdentities", null));
 
         LOGGER.info("Deploying CO without Stable Connect Identities");
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -283,7 +283,7 @@ public class FeatureGatesST extends AbstractST {
 
         LOGGER.info("Changing FG env variable to enable Stable Connect Identities");
         coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("+StableConnectIdentities");
+        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools,+StableConnectIdentities");
 
         Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
@@ -310,7 +310,7 @@ public class FeatureGatesST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), enabledFgConnectorPodName, Constants.DEFAULT_SINK_FILE_PATH, continuousMessage);
 
         LOGGER.info("Changing FG env variable to disable again Stable Connect Identities");
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-StableConnectIdentities");
+        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools,-StableConnectIdentities");
 
         coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -46,7 +46,7 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
-  featureGatesBefore: "+StableConnectIdentities,+UnidirectionalTopicOperator"
+  featureGatesBefore: "-KafkaNodePools,+StableConnectIdentities,+UnidirectionalTopicOperator"
   featureGatesAfter: "-StableConnectIdentities,-UnidirectionalTopicOperator"
 - fromVersion: HEAD
   toVersion: 0.37.0
@@ -69,3 +69,4 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
+  featureGatesBefore: "-KafkaNodePools"


### PR DESCRIPTION
### Type of change

- Task

### Description

The `KafkaNodePools` feature gate should be moved to `beta` phase and be enabled by default in Strimzi 0.39. This PR updates the feature gate and the related tests and docs to change the default state of the feature gate.

It does basic update to the docs and system tests as well, but might be followed by a separate PRs with more detailed docs and ST changes.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md