### PR TITLE
Update topic inactivity rule in prometheus-rules.yaml

### DIFF
--- a/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -246,7 +246,7 @@ spec:
         summary: 'Consumer group lag is too big'
         description: 'Consumer group {{ $labels.consumergroup}} lag is too big ({{ $value }}) on topic {{ $labels.topic }}/partition {{ $labels.partition }}'
     - alert: NoMessageForTooLong
-      expr: changes(kafka_topic_partition_current_offset{topic!="__consumer_offsets"}[10m]) == 0
+      expr: changes(kafka_topic_partition_current_offset[10m]) == 0
       for: 10s
       labels:
         severity: warning

--- a/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -246,7 +246,7 @@ spec:
         summary: 'Consumer group lag is too big'
         description: 'Consumer group {{ $labels.consumergroup}} lag is too big ({{ $value }}) on topic {{ $labels.topic }}/partition {{ $labels.partition }}'
     - alert: NoMessageForTooLong
-      expr: changes(kafka_topic_partition_current_offset[10m]) == 0
+      expr: changes(kafka_topic_partition_current_offset{topic!="__consumer_offsets"}[10m]) == 0
       for: 10s
       labels:
         severity: warning

--- a/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -246,7 +246,7 @@ spec:
         summary: 'Consumer group lag is too big'
         description: 'Consumer group {{ $labels.consumergroup}} lag is too big ({{ $value }}) on topic {{ $labels.topic }}/partition {{ $labels.partition }}'
     - alert: NoMessageForTooLong
-      expr: changes(kafka_topic_partition_current_offset{topic!="__consumer_offsets"}[10m]) == 0
+      expr: changes(kafka_topic_partition_current_offset[10m]) == 0
       for: 10s
       labels:
         severity: warning


### PR DESCRIPTION
### Type of change

- Improvement/Cleanup?

### Description

As discussed in #9264, this removes the __consumer_offsets topic from the filter. Users should update this rule accordingly if they want to exclude topics from this alert.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

