### PR TITLE
Update CHANGELOG with the planned Kubernetes version support changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 0.39.0
 
 
+
+### Changes, deprecations and removals
+
+* Strimzi 0.39.0 (and any of its patch releases) is the last Strimzi version with support for Kubernetes 1.21 and 1.22.
+  From Strimzi 0.40.0 on, we will support only Kubernetes 1.23 and newer.
+
 ## 0.38.0
 
 * Add support for Apache Kafka 3.6.0 and drop support for 3.4.0 and 3.4.1


### PR DESCRIPTION
### Type of change

- Task

### Description

As discussed on the Strimzi Community Call, we plan to drop support for Kube 1.21 and 1.22 in Strimzi 0.40. This PR adds a warning about it to the CHANGELOG for 0.39 as the last version supported on those Kubernetes versions.