### PR TITLE
Increase the size of the `/tmp` volumes to 10Mi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.39.0
-
+*  Increase the size of the `/tmp` volumes to 10Mi
 
 ## 0.38.0
 
@@ -9,7 +9,7 @@
 * Sign containers using `cosign`
 * Generate and publish Software Bill of Materials (SBOMs) of Strimzi containers
 * Add support for stopping connectors according to [Strimzi Proposal #54](https://github.com/strimzi/proposals/blob/main/054-stopping-kafka-connect-connectors.md)
-* Allow manual rolling of Kafka Connect and Kafka Mirror Maker 2 pods using the `strimzi.io/manual-rolling-update` annotation (supported only when `StableConnectIdentities` feature gate is enabled) 
+* Allow manual rolling of Kafka Connect and Kafka Mirror Maker 2 pods using the `strimzi.io/manual-rolling-update` annotation (supported only when `StableConnectIdentities` feature gate is enabled)
 * Make sure brokers are empty before scaling them down
 * Update Cruise Control to 2.5.128
 * Add support for pausing reconciliations to the Unidirectional Topic Operator
@@ -209,7 +209,7 @@
 * In previous versions, the `ssl.secure.random.implementation` option in Kafka brokers was always set to `SHA1PRNG`.
   From Strimzi 0.33 on, it is using the default SecureRandom implementation from the Java Runtime.
   If you want to keep using `SHA1PRNG` as your SecureRandom, you can configure it in `.spec.kafka.config` in your `Kafka` custom resource.
-* Support for JmxTrans in Strimzi is deprecated. 
+* Support for JmxTrans in Strimzi is deprecated.
   It is currently planned to be removed in Strimzi 0.35.0.
 * Support for `type: jaeger` tracing based on Jaeger clients and OpenTracing API was deprecated in the Strimzi 0.31 release.
   As the Jaeger clients are retired and the OpenTracing project is archived, we cannot guarantee their support for future versions.
@@ -246,13 +246,13 @@
 * The `ClusterRole` from file `020-ClusterRole-strimzi-cluster-operator-role.yaml` was split into two separate roles:
   * The original `strimzi-cluster-operator-namespaced` `ClusterRole` in the file `020-ClusterRole-strimzi-cluster-operator-role.yaml` contains the rights related to the resources created based on some Strimzi custom resources.
   * The new `strimzi-cluster-operator-watched` `ClusterRole` in the file `023-ClusterRole-strimzi-cluster-operator-role.yaml` contains the rights required to watch and manage the Strimzi custom resources.
-  
+
   When deploying the Strimzi Cluster Operator as cluster-wide, the `strimzi-cluster-operator-watched` `ClusterRole` needs to be always granted at the cluster level.
   But the `strimzi-cluster-operator-namespaced` `ClusterRole` might be granted only for the namespaces where any custom resources are created.
-* The `ControlPlaneListener` feature gate moves to GA. 
+* The `ControlPlaneListener` feature gate moves to GA.
   Direct upgrade from Strimzi 0.22 or earlier is not possible anymore.
   You have to upgrade first to one of the Strimzi versions between 0.22 and 0.32 before upgrading to Strimzi 0.32 or newer.
-  Please follow the docs for more details.  
+  Please follow the docs for more details.
 * The `spec.authorization.acls[*].operation` field in the `KafkaUser` resource has been deprecated in favour of the field
   `spec.authorization.acls[*].operations` which allows to set multiple operations per ACLRule.
 
@@ -268,7 +268,7 @@
 
 * Add support for Kafka 3.2.1
 * Update Kaniko builder to 1.9.0 and Maven builder to 1.14
-* Update Kafka Exporter to 1.6.0 
+* Update Kafka Exporter to 1.6.0
 * Pluggable Pod Security Profiles with built-in support for _restricted_ Kubernetes Security Profile
 * Add support for leader election and running multiple operator replicas (1 active leader replicas and one or more stand-by replicas)
 * Update Strimzi Kafka Bridge to 0.22.0
@@ -297,7 +297,7 @@
   By default, StrimziPodSets are used instead of StatefulSets.
   If needed, `UseStrimziPodSets` can be disabled in the feature gates configuration in the Cluster Operator.
 * Use better encryption and digest algorithms when creating the PKCS12 stores.
-  For existing clusters, the certificates will not be updated during upgrade but only next time the PKCS12 store is created. 
+  For existing clusters, the certificates will not be updated during upgrade but only next time the PKCS12 store is created.
 * Add CPU capacity overrides for Cruise Control capacity config
 * Use CustomResource existing spec and status to fix Quarkus native build's serialization
 * Update JMX Exporter to version 0.17.0
@@ -311,7 +311,7 @@
 * Increase the size of the `/tmp` volumes to 5Mi to allow unpacking of compression libraries
 * Use `/healthz` endpoint for Kafka Exporter health checks
 * Renew user certificates in User Operator only during maintenance windows
-* Ensure Topic Operator using Kafka Streams state store can start up successfully 
+* Ensure Topic Operator using Kafka Streams state store can start up successfully
 * Update Cruise Control to 2.5.89
 * Remove TLS sidecar from Cruise Control pod. Cruise Control is now configured to not using ZooKeeper, so the TLS sidecar is not needed anymore.
 * Allow Cruise Control topic names to be configured
@@ -399,7 +399,7 @@
 * Open Policy Agent authorizer updated to a new version supporting Scala 2.13. See the _Changes, deprecations and removals_ sections for more details. (#5192)
 * Allow a custom password to be set for SCRAM-SHA-512 users by referencing a secret in the `KafkaUser` resource
 * Add support for [EnvVar Configuration Provider for Apache Kafka](https://github.com/strimzi/kafka-env-var-config-provider)
-* Add support for `tls-external` authentication to User Operator to allow management of ACLs and Quotas for TLS users with user certificates generated externally (#5249) 
+* Add support for `tls-external` authentication to User Operator to allow management of ACLs and Quotas for TLS users with user certificates generated externally (#5249)
 * Support for disabling the automatic generation of network policies by the Cluster Operator. Set the Cluster Operator's `STRIMZI_NETWORK_POLICY_GENERATION` environment variable to `false` to disable network policies. (#5258)
 * Update User Operator to use Admin API for managing SCRAM-SHA-512 users
 * Configure fixed size limit for `emptyDir` volumes used for temporary files (#5340)
@@ -432,11 +432,11 @@
 * Support for broker load information added to the rebalance optimization proposal. Information on the load difference, before and after a rebalance is stored in a ConfigMap
 * Add support for selectively changing the verbosity of logging for individual CRs, using markers.
 * Added support for `controller_mutation_rate' quota. Creation/Deletion of topics and creation of partitions can be configured through this.
-* Use newer version of Kafka Exporter with different bugfixes 
+* Use newer version of Kafka Exporter with different bugfixes
 
 ### Changes, deprecations and removals
 
-* The deprecated `KafkaConnectS2I` custom resource will be removed after the 0.24.0 release. 
+* The deprecated `KafkaConnectS2I` custom resource will be removed after the 0.24.0 release.
   Please use the [migration guide](https://strimzi.io/docs/operators/latest/full/using.html#proc-migrating-kafka-connect-s2i-str) to migrate your `KafkaConnectS2I` deployments to [`KafkaConnect` Build](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * The fields `topicsBlacklistPattern` and `groupsBlacklistPattern` in the `KafkaMirrorMaker2` resource are deprecated and will be removed in the future.
   They are replaced by new fields `topicsExcludePattern` and `groupsExcludePattern`.
@@ -445,8 +445,8 @@
 * `bind-utils` removed from containers to improve security posture.
 * Kafka Connect Build now uses hashes to name downloaded artifact files. Previously, it was using the last segment of the download URL.
   If your artifact requires a specific name, you can use the new `type: other` artifact and its `fileName` field.
-* The option `enableECDSA` of Kafka CR `authentication` of type `oauth` has been deprecated and is ignored. 
-  ECDSA token signature support is now always enabled without the need for Strimzi Cluster Operator installing the BouncyCastle JCE crypto provider. 
+* The option `enableECDSA` of Kafka CR `authentication` of type `oauth` has been deprecated and is ignored.
+  ECDSA token signature support is now always enabled without the need for Strimzi Cluster Operator installing the BouncyCastle JCE crypto provider.
   BouncyCastle library is no longer packaged with Strimzi Kafka images.
 
 ## 0.23.0
@@ -454,14 +454,14 @@
 * Add support for Kafka 2.8.0 and 2.6.2, remove support for Kafka 2.5.x
 * Make it possible to configure maximum number of connections and maximum connection creation rate in listener configuration
 * Add support for configuring finalizers for `loadbalancer` type listeners
-* Use dedicated Service Account for Kafka Connect Build on Kubernetes 
+* Use dedicated Service Account for Kafka Connect Build on Kubernetes
 * Remove direct ZooKeeper access for handling user quotas in the User Operator. Add usage of Admin Client API instead.
 * Migrate to CRD v1 (required by Kubernetes 1.22+)
-* Support for configuring custom Authorizer implementation 
+* Support for configuring custom Authorizer implementation
 * Changed Reconciliation interval for Topic Operator from 90 to 120 seconds (to keep it the same as for other operators)
 * Changed Zookeeper session timeout default value to 18 seconds for Topic and User Operators (for improved resiliency)
 * Removed requirement for replicas and partitions KafkaTopic spec making these parameters optional
-* Support to configure a custom filter for parent CR's labels propagation into subresources 
+* Support to configure a custom filter for parent CR's labels propagation into subresources
 * Allow disabling service links (environment variables describing Kubernetes services) in Pod template
 * Update Kaniko executor to 1.6.0
 * Add support for separate control plane listener (disabled by default, available via the `ControlPlaneListener` feature gate)
@@ -499,9 +499,9 @@
 
 ### Changes, deprecations and removals
 
-* In the past, when no Ingress class was specified in the Ingress-type listener in the Kafka custom resource, the 
-  `kubernetes.io/ingress.class` annotation was automatically set to `nginx`. Because of the support for the new 
-  IngressClass resource and the new `ingressClassName` field in the Ingress resource, the default value will not be set 
+* In the past, when no Ingress class was specified in the Ingress-type listener in the Kafka custom resource, the
+  `kubernetes.io/ingress.class` annotation was automatically set to `nginx`. Because of the support for the new
+  IngressClass resource and the new `ingressClassName` field in the Ingress resource, the default value will not be set
   anymore. Please use the `class` field in `.spec.kafka.listeners[].configuration` to specify the class name.
 * The `KafkaConnectS2I` custom resource is deprecated and will be removed in the future. You can use the new [`KafkaConnect` build feature](https://strimzi.io/docs/operators/latest/full/deploying.html#creating-new-image-using-kafka-connect-build-str) instead.
 * Removed support for Helm2 charts as that version is now unsupported. There is no longer the need for separate `helm2` and `helm3` binaries, only `helm` (version 3) is required.
@@ -525,14 +525,14 @@
       configMapKeyRef:
         name: my-config-map
         key: my-key
-  ``` 
+  ```
 * Existing Cruise Control logging configurations must be updated from `Log4j` syntax to `Log4j 2` syntax.
   * For existing inline configurations, replace the `cruisecontrol.root.logger` property with `rootLogger.level`.
   * For existing external configurations, replace the existing configuration with a new configuration file named `log4j2.properties` using `log4j 2` syntax.
 
 ## 0.21.0
 
-* Add support for declarative management of connector plugins in Kafka Connect CR 
+* Add support for declarative management of connector plugins in Kafka Connect CR
 * Add `inter.broker.protocol.version` to the default configuration in example YAMLs
 * Add support for `secretPrefix` property for User Operator to prefix all secret names created from KafkaUser resource.
 * Allow configuring labels and annotations for Cluster CA certificate secrets
@@ -563,12 +563,12 @@
 * Cruise Control metrics integration:
   * Enable metrics JMX exporter configuration in the `cruiseControl` property of the Kafka custom resource
   * New Grafana dashboard for the Cruise Control metrics
-* Configure Cluster Operator logging using ConfigMap instead of environment variable and support dynamic changes  
+* Configure Cluster Operator logging using ConfigMap instead of environment variable and support dynamic changes
 * Switch to use the `AclAuthorizer` class for the `simple` Kafka authorization type. `AclAuthorizer` contains new features such as the ability to control the amount of authorization logs in the broker logs.
 * Support dynamically changeable logging configuration of Kafka Connect and Kafka Connect S2I
 * Support dynamically changeable logging configuration of Kafka brokers
 * Support dynamically changeable logging configuration of Kafka MirrorMaker2
-* Add support for `client.rack` property for Kafka Connect to use `fetch from closest replica` feature. 
+* Add support for `client.rack` property for Kafka Connect to use `fetch from closest replica` feature.
 * Refactored operators Grafana dashboard
   * Fixed bug on maximum reconcile time graph
   * Removed the avarage reconcile time graph
@@ -624,10 +624,10 @@ For example the following old configuration:
 listeners:
   plain:
     # ...
-  tls: 
+  tls:
     # ...
   external:
-    type: loadbalancer 
+    type: loadbalancer
     # ...
 ```
 
@@ -673,7 +673,7 @@ Since the Kafka TLS sidecar has been removed, the related configuration options 
   * KafkaBridge
   * KafkaMirrorMaker
   * KafkaMirrorMaker2
-  * KafkaConnector 
+  * KafkaConnector
 * Remove deprecated `Kafka.spec.topicOperator` classes and deployment logic
 * Use Java 11 as the Java runtime
 * Removed the need to manually create Cruise Control metrics topics if topic auto creation is disabled.
@@ -685,14 +685,14 @@ Since the Kafka TLS sidecar has been removed, the related configuration options 
 * Strimzi Kafka Bridge metrics integration:
   * enable/disable metrics in the KafkaBridge custom resource
   * new Grafana dashboard for the bridge metrics
-* Support dynamically changeable logging in the Entity Operator and Kafka Bridge 
+* Support dynamically changeable logging in the Entity Operator and Kafka Bridge
 * Extended the Grafana example dashboard for Kafka Connect to provide more relevant information
 
 ### Deprecations and removals
 
 #### Deprecation of Helm v2 chart
 
-The Helm v2 support will end soon. 
+The Helm v2 support will end soon.
 Bug fixing should stop on August 13th 2020 and security fixes on November 13th.
 See https://helm.sh/blog/covid-19-extending-helm-v2-bug-fixes/ for more details.
 
@@ -709,7 +709,7 @@ In Strimzi 0.12.0, the `v1alpha1` versions of the following resources have been 
 * `KafkaTopic`
 * `KafkaUser`
 
-In the next release, the `v1alpha1` versions of these resources will be removed. 
+In the next release, the `v1alpha1` versions of these resources will be removed.
 Please follow the guide for upgrading the resources: https://strimzi.io/docs/operators/latest/full/deploying.html#assembly-upgrade-resources-str.
 
 #### Removal deprecated cadvisor metric labels
@@ -736,7 +736,7 @@ Because of the new Cluster Operator dynamic logging configuration via [PR#3328](
 * Make it possible to configure PodManagementPolicy for StatefulSets
 * Update build system to use `yq` version 3 (https://github.com/mikefarah/yq)
 * Add more metrics to Cluster and User Operators
-* New Grafana dashboard for Operator monitoring 
+* New Grafana dashboard for Operator monitoring
 * Allow `ssl.cipher.suites`, `ssl.protocol` and `ssl.enabled.protocols` to be configurable for Kafka and the different components supported by Strimzi
 * Add support for user configurable SecurityContext for each Strimzi container
 * Allow standalone User Operator to modify status on KafkaUser
@@ -768,8 +768,8 @@ Because of the new Cluster Operator dynamic logging configuration via [PR#3328](
 * Expose JMX port on Kafka brokers via an internal service
 * Add support for `externalTrafficPolicy` and `loadBalancerSourceRanges` properties on loadbalancer and nodeport type services
 * Add support for user quotas
-* Add support for Istio protocol selection in service port names  
-Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka services and headless services.  
+* Add support for Istio protocol selection in service port names
+Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka services and headless services.
 (e.g clientstls -> tcp-clientstls)
 * Add service discovery labels and annotations
 * Add possibility to specify custom server certificates to TLS based listeners
@@ -813,8 +813,8 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
 ## 0.12.0
 
 * **Drop support for Kubernetes 1.9 and 1.10 and OpenShift 3.9 and 3.10.**
-**Versions supported since Strimzi 0.12.0 are Kubernetes 1.11 and higher and OpenShift 3.11 and higher.** 
-**This was required because the CRD versioning and CRD subresources support.** 
+**Versions supported since Strimzi 0.12.0 are Kubernetes 1.11 and higher and OpenShift 3.11 and higher.**
+**This was required because the CRD versioning and CRD subresources support.**
 * Added support for Kafka 2.2.0 and 2.1.1, dropped support for Kafka 2.0.0 and 2.0.1
 * Persistent storage improvements
   * Add resizing of persistent volumes
@@ -823,7 +823,7 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
 * Custom Resources improvements
   * New CRD version `v1beta1`. See documentation for more information about upgrading from `v1alpha1` to `v1beta1`.
   * Log at the warn level when a custom resource uses deprecated or unknown properties
-  * Add initial support for the `status` sub-resource in the `Kafka` custom resource 
+  * Add initial support for the `status` sub-resource in the `Kafka` custom resource
 * Add support for [Strimzi Kafka Bridge](https://github.com/strimzi/strimzi-kafka-bridge) for HTTP protocol
 * Reduce the number of container images needed to run Strimzi to just two: `kafka` and `operator`.
 * Add support for unprivileged users to install the operator with Helm
@@ -849,8 +849,8 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
 * Add healthchecks to TLS sidecars
 * Add support for new fields in the Pod template: terminationGracePeriod, securityContext and imagePullSecrets
 * Rename annotations to use the `strimzi.io` domain consistently (The old annotations are deprecated, but still functional):
-    * `cluster.operator.strimzi.io/delete-claim` → `strimzi.io/delete-claim` 
-    * `operator.strimzi.io/manual-rolling-update` → `strimzi.io/manual-rolling-update` 
+    * `cluster.operator.strimzi.io/delete-claim` → `strimzi.io/delete-claim`
+    * `operator.strimzi.io/manual-rolling-update` → `strimzi.io/manual-rolling-update`
     * `operator.strimzi.io/delete-pod-and-pvc` → `strimzi.io/delete-pod-and-pvc`
     * `operator.strimzi.io/generation` → `strimzi.io/generation`
 * Add support for mounting Secrets and Config Maps into Kafka Connect and Kafka Connect S2I
@@ -863,8 +863,8 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
 * Add possibility to label and annotate different resources (#1039)
 * Add support for TransactionalID in KafkaUser resource
 * Update to Kafka 2.0.1
-* Add maintenance time windows support for allowing CA certificates renewal rolling update started only in specific times (#1117)  
-* Add support for upgrading between Kafka versions (#1103). This removes support for `STRIMZI_DEFAULT_KAFKA_IMAGE` environment variable in the Cluster Operator, replacing it with `STRIMZI_KAFKA_IMAGES`.  
+* Add maintenance time windows support for allowing CA certificates renewal rolling update started only in specific times (#1117)
+* Add support for upgrading between Kafka versions (#1103). This removes support for `STRIMZI_DEFAULT_KAFKA_IMAGE` environment variable in the Cluster Operator, replacing it with `STRIMZI_KAFKA_IMAGES`.
 
 
 ## 0.8.2
@@ -890,7 +890,7 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
   * LoadBalancers
   * NodePorts
 * Use less wide RBAC permissions (`ClusterRoleBindings` where converted to `RoleBindings` where possible)
-* Support for SASL authentication using the SCRAM-SHA-512 mechanism added to Kafka Connect and Kafka Connect with S2I support 
+* Support for SASL authentication using the SCRAM-SHA-512 mechanism added to Kafka Connect and Kafka Connect with S2I support
 * Network policies for managing access to Zookeeper ports and Kafka replication ports
 * Use OwnerReference and Kubernetes garbage collection feature to delete resources and to track the ownership
 
@@ -912,7 +912,7 @@ Note: Strimzi is essentially adding a `tcp-` prefix to the port names in Kafka s
 * Kafka 2.0.0
 * Kafka Connect:
   * Added TLS support for connecting to the Kafka cluster
-  * Added TLS client authentication when connecting to the Kafka cluster 
+  * Added TLS client authentication when connecting to the Kafka cluster
 
 ## 0.5.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/PodTemplate.java
@@ -185,9 +185,9 @@ public class PodTemplate implements HasMetadataTemplate, Serializable, UnknownPr
     }
 
     @Pattern(Constants.MEMORY_REGEX)
-    @JsonProperty(defaultValue = "5Mi")
+    @JsonProperty(defaultValue = "10Mi")
     @Description("Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). " +
-            "Default value is `5Mi`.")
+            "Default value is `10Mi`.")
     public String getTmpDirSizeLimit() {
         return tmpDirSizeLimit;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeCluster.java
@@ -300,7 +300,7 @@ public class KafkaBridgeCluster extends AbstractModel implements SupportsLogging
             VolumeUtils.createSecretVolume(volumeList, tls.getTrustedCertificates(), isOpenShift);
         }
         if (rack != null) {
-            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "10Mi", "Memory"));
         }
         AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift);
         return volumeList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1182,7 +1182,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<Volume> volumeList = new ArrayList<>();
 
         if (rack != null || isExposedWithNodePort()) {
-            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "10Mi", "Memory"));
         }
 
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -372,7 +372,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         volumeList.add(VolumeUtils.createConfigMapVolume(LOG_AND_METRICS_CONFIG_VOLUME_NAME, loggingAndMetricsConfigMapName));
 
         if (rack != null) {
-            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
+            volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "10Mi", "Memory"));
         }
 
         if (tls != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -45,7 +45,7 @@ public class VolumeUtils {
      */
     /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_VOLUME_NAME = "strimzi-tmp";
     /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH = "/tmp";
-    /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE = "5Mi";
+    /*test*/ static final String STRIMZI_TMP_DIRECTORY_DEFAULT_SIZE = "10Mi";
 
     private static final Pattern VOLUME_NAME_PATTERN = Pattern.compile("^([a-z0-9]{1}[a-z0-9-]{0,61}[a-z0-9]{1})$");
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -117,7 +117,7 @@ include::../api/io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaLi
 |string
 |port                1.2+<.<a|Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 |integer
-|type                1.2+<.<a|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. 
+|type                1.2+<.<a|Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`.
 
 * `internal` type exposes Kafka internally only within the Kubernetes cluster.
 * `route` type uses OpenShift Routes to expose Kafka.
@@ -248,7 +248,7 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |string
 |type                               1.2+<.<a|Must be `oauth`.
 |string
-|userInfoEndpointUri                1.2+<.<a|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
+|userInfoEndpointUri                1.2+<.<a|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id.
 |string
 |userNameClaim                      1.2+<.<a|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
 |string
@@ -840,7 +840,7 @@ It must have the value `external` for the type `ExternalLogging`.
 |Property          |Description
 |type       1.2+<.<a|Must be `external`.
 |string
-|valueFrom  1.2+<.<a|`ConfigMap` entry where the logging configuration is stored. 
+|valueFrom  1.2+<.<a|`ConfigMap` entry where the logging configuration is stored.
 |xref:type-ExternalConfigurationReference-{context}[`ExternalConfigurationReference`]
 |====
 
@@ -974,7 +974,7 @@ include::../api/io.strimzi.api.kafka.model.template.PodTemplate.adoc[leveloffset
 
 
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostalias-v1-core[HostAlias] array
-|tmpDirSizeLimit                1.2+<.<a|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+|tmpDirSizeLimit                1.2+<.<a|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
 |string
 |enableServiceLinks             1.2+<.<a|Indicates whether information about services should be injected into Pod's environment variables.
 |boolean
@@ -2221,7 +2221,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |Property          |Description
 |url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
 |string
-|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type.
 |string
 |insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
@@ -2240,7 +2240,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |Property          |Description
 |url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
 |string
-|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type.
 |string
 |insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
@@ -2259,7 +2259,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |Property          |Description
 |url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
 |string
-|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type.
 |string
 |insecure   1.2+<.<a|By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
 |boolean
@@ -2303,7 +2303,7 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |Property          |Description
 |url        1.2+<.<a|URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
 |string
-|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type. 
+|sha512sum  1.2+<.<a|SHA512 checksum of the artifact. Optional. If specified, the checksum will be verified while building the new container. If not specified, the downloaded artifact will not be verified. Not applicable to the `maven` artifact type.
 |string
 |fileName   1.2+<.<a|Name under which the artifact will be stored.
 |string
@@ -2424,7 +2424,7 @@ Used in: xref:type-KafkaUser-{context}[`KafkaUser`]
 [options="header"]
 |====
 |Property               |Description
-|authentication  1.2+<.<a|Authentication mechanism enabled for this Kafka user. The supported authentication mechanisms are `scram-sha-512`, `tls`, and `tls-external`. 
+|authentication  1.2+<.<a|Authentication mechanism enabled for this Kafka user. The supported authentication mechanisms are `scram-sha-512`, `tls`, and `tls-external`.
 
 * `scram-sha-512` generates a secret with SASL SCRAM-SHA-512 credentials.
 * `tls` generates a secret with user certificate for mutual TLS authentication.
@@ -3365,7 +3365,7 @@ Used in: xref:type-KafkaRebalance-{context}[`KafkaRebalance`]
 |====
 |Property                                        |Description
 |mode                                     1.2+<.<a|Mode to run the rebalancing. The supported modes are `full`, `add-brokers`, `remove-brokers`.
-If not specified, the `full` mode is used by default. 
+If not specified, the `full` mode is used by default.
 
 * `full` mode runs the rebalancing across all the brokers in the cluster.
 * `add-brokers` mode can be used after scaling up the cluster to move some replicas to the newly added brokers.

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -197,7 +197,7 @@ the documentation for more details.
 | `labels`                                    | Add labels to Operator Pod                                                      | `{}`                         |
 | `nodeSelector`                              | Add a node selector to Operator Pod                                             | `{}`                         |
 | `featureGates`                              | Feature Gates configuration                                                     | `nil`                        |
-| `tmpDirSizeLimit`                           | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `1Mi`                        |
+| `tmpDirSizeLimit`                           | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `10Mi`                        |
 | `labelsExclusionPattern`                    | Override the exclude pattern for exclude some labels                            | `""`                         |
 | `generateNetworkPolicy`                     | Controls whether Strimzi generates network policy resources                     | `true`                       |
 | `connectBuildTimeoutMs`                     | Overrides the default timeout value for building new Kafka Connect              | `300000`                     |

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1282,7 +1282,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -2416,7 +2416,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -3527,7 +3527,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -4559,7 +4559,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5414,7 +5414,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -6030,7 +6030,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -838,7 +838,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1555,7 +1555,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -982,7 +982,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -846,7 +846,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -983,7 +983,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1700,7 +1700,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -622,7 +622,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -27,7 +27,7 @@ fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
-tmpDirSizeLimit: 1Mi
+tmpDirSizeLimit: 10Mi
 
 # Example on how to configure extraEnvs
 # extraEnvs:

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1281,7 +1281,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -2415,7 +2415,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -3526,7 +3526,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -4558,7 +4558,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5413,7 +5413,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -6029,7 +6029,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -837,7 +837,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1554,7 +1554,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -981,7 +981,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -845,7 +845,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -982,7 +982,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1699,7 +1699,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -622,7 +622,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -21,7 +21,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 1Mi
+            sizeLimit: 10Mi
         - name: co-config-volume
           configMap:
             name: strimzi-cluster-operator

--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -19,7 +19,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 5Mi
+            sizeLimit: 10Mi
       containers:
         - name: strimzi-topic-operator
           image: quay.io/strimzi/operator:0.38.0

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -19,7 +19,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 5Mi
+            sizeLimit: 10Mi
       containers:
         - name: strimzi-user-operator
           image: quay.io/strimzi/operator:0.38.0

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -197,7 +197,7 @@ the documentation for more details.
 | `labels`                                    | Add labels to Operator Pod                                                      | `{}`                         |
 | `nodeSelector`                              | Add a node selector to Operator Pod                                             | `{}`                         |
 | `featureGates`                              | Feature Gates configuration                                                     | `nil`                        |
-| `tmpDirSizeLimit`                           | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `1Mi`                        |
+| `tmpDirSizeLimit`                           | Set the `sizeLimit` for the tmp dir volume used by the operator                 | `10Mi`                        |
 | `labelsExclusionPattern`                    | Override the exclude pattern for exclude some labels                            | `""`                         |
 | `generateNetworkPolicy`                     | Controls whether Strimzi generates network policy resources                     | `true`                       |
 | `connectBuildTimeoutMs`                     | Overrides the default timeout value for building new Kafka Connect              | `300000`                     |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1282,7 +1282,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -2416,7 +2416,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -3527,7 +3527,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -4559,7 +4559,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5414,7 +5414,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -6030,7 +6030,7 @@ spec:
                             tmpDirSizeLimit:
                               type: string
                               pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                             enableServiceLinks:
                               type: boolean
                               description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -838,7 +838,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1555,7 +1555,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -982,7 +982,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -846,7 +846,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -983,7 +983,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1700,7 +1700,7 @@ spec:
                         tmpDirSizeLimit:
                           type: string
                           pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                         enableServiceLinks:
                           type: boolean
                           description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -622,7 +622,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -27,7 +27,7 @@ fullReconciliationIntervalMs: 120000
 operationTimeoutMs: 300000
 kubernetesServiceDnsDomain: cluster.local
 featureGates: ""
-tmpDirSizeLimit: 1Mi
+tmpDirSizeLimit: 10Mi
 
 # Example on how to configure extraEnvs
 # extraEnvs:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1281,7 +1281,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -2415,7 +2415,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -3526,7 +3526,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -4558,7 +4558,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -5413,7 +5413,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -6029,7 +6029,7 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -837,7 +837,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1554,7 +1554,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -981,7 +981,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -845,7 +845,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -982,7 +982,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.
@@ -1699,7 +1699,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -622,7 +622,7 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `10Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services should be injected into Pod's environment variables.

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -21,7 +21,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 1Mi
+            sizeLimit: 10Mi
         - name: co-config-volume
           configMap:
             name: strimzi-cluster-operator

--- a/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -19,7 +19,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 5Mi
+            sizeLimit: 10Mi
       containers:
         - name: strimzi-topic-operator
           image: quay.io/strimzi/operator:latest

--- a/packaging/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/packaging/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -19,7 +19,7 @@ spec:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
-            sizeLimit: 5Mi
+            sizeLimit: 10Mi
       containers:
         - name: strimzi-user-operator
           image: quay.io/strimzi/operator:latest


### PR DESCRIPTION
### Type of change


- Enhancement 

### Description

https://github.com/strimzi/strimzi-kafka-operator/issues/9275

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

This resolves #9275 

