### PR TITLE
[DOC] Promote `StableConnectIdentities` feature gate to GA

### DIFF
--- a/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
+++ b/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
@@ -9,10 +9,14 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 <connect_cluster_name>-connect:: Name given to the following Kafka Connect resources:
 +
-- Deployment that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is disabled).
-- StrimziPodSet that creates the Kafka Connect worker node pods (when `StableConnectIdentities` feature gate is enabled).
-- Headless service that provides stable DNS names to the Connect pods (when `StableConnectIdentities` feature gate is enabled).
+- StrimziPodSet that creates the Kafka Connect worker node pods.
+- Headless service that provides stable DNS names to the Connect pods.
+- Service account used by the Kafka Connect pods.
 - Pod Disruption Budget configured for the Kafka Connect worker nodes.
-<connect_cluster_name>-connect-<pod_id>:: Pods created by the Kafka Connect StrimziPodSet (when `StableConnectIdentities` feature gate is enabled). 
+- Network Policy managing access to the Kafka Connect REST API.
+<connect_cluster_name>-connect-<pod_id>:: Pods created by the Kafka Connect StrimziPodSet.
 <connect_cluster_name>-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
-<connect_cluster_name>-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka broker pods.
+<connect_cluster_name>-connect-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka Connect pods.
+strimzi-<namespace-name>-<connect_cluster_name>-connect-init:: Cluster role binding used by the Kafka Connect cluster.
+<connect_cluster_name>-connect-build:: Pod used to build a new container image with additional connector plugins (only when Kafka Connect Build feature is used).
+<connect_cluster_name>-connect-dockerfile:: ConfigMap with the Dockerfile generated to build the new container image with additional connector plugins (only when Kafka Connect Build feature is used).

--- a/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
+++ b/documentation/modules/configuring/ref-config-list-of-kafka-connect-resources.adoc
@@ -10,13 +10,13 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 <connect_cluster_name>-connect:: Name given to the following Kafka Connect resources:
 +
 - StrimziPodSet that creates the Kafka Connect worker node pods.
-- Headless service that provides stable DNS names to the Connect pods.
+- Headless service that provides stable DNS names to the Kafka Connect pods.
 - Service account used by the Kafka Connect pods.
-- Pod Disruption Budget configured for the Kafka Connect worker nodes.
-- Network Policy managing access to the Kafka Connect REST API.
+- Pod disruption budget configured for the Kafka Connect worker nodes.
+- Network policy managing access to the Kafka Connect REST API.
 <connect_cluster_name>-connect-<pod_id>:: Pods created by the Kafka Connect StrimziPodSet.
 <connect_cluster_name>-connect-api:: Service which exposes the REST interface for managing the Kafka Connect cluster.
 <connect_cluster_name>-connect-config:: ConfigMap which contains the Kafka Connect ancillary configuration and is mounted as a volume by the Kafka Connect pods.
 strimzi-<namespace-name>-<connect_cluster_name>-connect-init:: Cluster role binding used by the Kafka Connect cluster.
 <connect_cluster_name>-connect-build:: Pod used to build a new container image with additional connector plugins (only when Kafka Connect Build feature is used).
-<connect_cluster_name>-connect-dockerfile:: ConfigMap with the Dockerfile generated to build the new container image with additional connector plugins (only when Kafka Connect Build feature is used).
+<connect_cluster_name>-connect-dockerfile:: ConfigMap with the Dockerfile generated to build the new container image with additional connector plugins (only when the Kafka Connect build feature is used).

--- a/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
@@ -9,8 +9,12 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 
 <mirrormaker2_cluster_name>-mirrormaker2:: Name given to the following MirrorMaker 2 resources:
 +
-- Deployment which is responsible for creating the MirrorMaker 2 pods.
-- Service account used by the MirrorMaker 2 nodes.
-- Pod Disruption Budget configured for the MirrorMaker2 worker nodes.
-
-<mirrormaker2_cluster_name>-mirrormaker2-config:: ConfigMap which contains ancillary configuration for the MirrorMaker2, and is mounted as a volume by the MirrorMaker 2 pods.
+- StrimziPodSet that creates the MirrorMaker 2 worker node pods.
+- Headless service that provides stable DNS names to the MirrorMaker 2 pods.
+- Service account used by the MirrorMaker 2 pods.
+- Pod Disruption Budget configured for the MirrorMaker 2 worker nodes.
+- Network Policy managing access to the MirrorMaker 2 REST API.
+<mirrormaker2_cluster_name>-mirrormaker2-<pod_id>:: Pods created by the MirrorMaker 2 StrimziPodSet.
+<mirrormaker2_cluster_name>-mirrormaker2-api:: Service which exposes the REST interface for managing the MirrorMaker 2 cluster.
+<mirrormaker2_cluster_name>-mirrormaker2-config:: ConfigMap which contains the MirrorMaker 2 ancillary configuration and is mounted as a volume by the MirrorMaker 2 pods.
+strimzi-<namespace-name>-<mirrormaker2_cluster_name>-mirrormaker2-init:: Cluster role binding used by the MirrorMaker 2 cluster.

--- a/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-mirrormaker2-resources.adoc
@@ -12,7 +12,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 - StrimziPodSet that creates the MirrorMaker 2 worker node pods.
 - Headless service that provides stable DNS names to the MirrorMaker 2 pods.
 - Service account used by the MirrorMaker 2 pods.
-- Pod Disruption Budget configured for the MirrorMaker 2 worker nodes.
+- Pod disruption budget configured for the MirrorMaker 2 worker nodes.
 - Network Policy managing access to the MirrorMaker 2 REST API.
 <mirrormaker2_cluster_name>-mirrormaker2-<pod_id>:: Pods created by the MirrorMaker 2 StrimziPodSet.
 <mirrormaker2_cluster_name>-mirrormaker2-api:: Service which exposes the REST interface for managing the MirrorMaker 2 cluster.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -20,9 +20,9 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `ControlPlaneListener` feature gate moved to GA stage in Strimzi 0.32. It is now permanently enabled and cannot be disabled.
 * The `ServiceAccountPatching` feature gate moved to GA stage in Strimzi 0.30. It is now permanently enabled and cannot be disabled.
 * The `UseStrimziPodSets` feature gate moved to GA stage in Strimzi 0.35 and the support for StatefulSets is completely removed. It is now permanently enabled and cannot be disabled.
+* The `StableConnectIdentities` feature gate moved to GA stage in Strimzi 0.39.
+  It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
-* The `StableConnectIdentities` feature gate is in beta stage and is enabled by default.
-  It is expected to move to GA phase and be always enabled from Strimzi 0.39.
 * The `KafkaNodePools` feature gate is in beta stage and is enabled by default.
   It is expected to move to GA phase and be always enabled from Strimzi 0.41.
 * The `UnidirectionalTopicOperator` feature gate is in alpha stage and is disabled by default.
@@ -62,7 +62,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`StableConnectIdentities`
 ¦0.34
 ¦0.37
-¦0.39 (planned)
+¦0.39
 
 ¦`KafkaNodePools`
 ¦0.36
@@ -76,7 +76,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 |===
 
-If a feature gate is enabled, you may need to disable it before upgrading or downgrading from a specific Strimzi version.
+If a feature gate is enabled, you may need to disable it before upgrading or downgrading from a specific Strimzi version (or first upgrade / downgrade to a version of Strimzi where it can be disabled).
 The following table shows which feature gates you need to disable when upgrading or downgrading Strimzi versions.
 
 .Feature gates to disable when upgrading or downgrading Strimzi

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -48,6 +48,17 @@ Support for `StatefulSets` has been removed and Strimzi is now always using `Str
 IMPORTANT: With the `UseStrimziPodSets` feature gate permanently enabled, it is no longer possible to downgrade directly from Strimzi 0.35 and newer to Strimzi 0.27 or earlier.
 You have to first downgrade through one of the Strimzi versions in-between, disable the `UseStrimziPodSets` feature gate, and then downgrade to Strimzi 0.27 or earlier.
 
+[id='ref-operator-stable-connect-identities-feature-gate-{context}']
+== StableConnectIdentities feature gate
+
+The `StableConnectIdentities` feature gate has moved to GA, which means it is now permanently enabled and cannot be disabled.
+The `StrimziPodSet` resources are now always used to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes `Deployment` resources.
+`StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
+This helps to minimize the number of rebalances of connector tasks.
+
+IMPORTANT: With the `StableConnectIdentities` feature gate permanently enabled, it is no longer possible to downgrade directly from Strimzi 0.39 and newer to Strimzi 0.33 or earlier.
+You have to first downgrade through one of the Strimzi versions in-between, disable the `StableConnectIdentities` feature gate, and then downgrade to Strimzi 0.33 or earlier.
+
 [id='ref-operator-use-kraft-feature-gate-{context}']
 == (Preview) UseKRaft feature gate
 
@@ -90,20 +101,6 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 To enable the `UseKRaft` feature gate, specify `+UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft: enabled`.
 If this annotation is set to `disabled` or any other value, or if it is missing, the operator handles the `Kafka` custom resource as if it is using ZooKeeper for cluster management.
-
-[id='ref-operator-stable-connect-identities-feature-gate-{context}']
-== StableConnectIdentities feature gate
-
-The `StableConnectIdentities` feature gate has a default state of _enabled_.
-
-The `StableConnectIdentities` feature gate uses `StrimziPodSet` resources to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes `Deployment` resources.
-`StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
-This helps to minimize the number of rebalances of connector tasks.
-
-.Disabling the `StableConnectIdentities` feature gate
-To disable the `StableConnectIdentities` feature gate, specify `-StableConnectIdentities` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-IMPORTANT: The `StableConnectIdentities` feature gate must be disabled when downgrading to Strimzi 0.33 and earlier versions.
 
 [id='ref-operator-kafka-node-pools-feature-gate-{context}']
 == (Preview) KafkaNodePools feature gate

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -53,7 +53,7 @@ You have to first downgrade through one of the Strimzi versions in-between, disa
 
 The `StableConnectIdentities` feature gate has moved to GA, which means it is now permanently enabled and cannot be disabled.
 The `StrimziPodSet` resources are now always used to manage Kafka Connect and Kafka MirrorMaker 2 pods instead of using Kubernetes `Deployment` resources.
-`StrimziPodSets` give the pods stable names and stable addresses, which do not change during rolling upgrades.
+`StrimziPodSet` resources give the pods stable names and stable addresses, which do not change during rolling upgrades.
 This helps to minimize the number of rebalances of connector tasks.
 
 IMPORTANT: With the `StableConnectIdentities` feature gate permanently enabled, it is no longer possible to downgrade directly from Strimzi 0.39 and newer to Strimzi 0.33 or earlier.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR handles the basic documentation changes related to moving the `StableConnectIdentities` feature gate to GA (the promotion is done in https://github.com/strimzi/strimzi-kafka-operator/pull/9285). It also updates the COnnect and Mirror Makerf 2 resource lists that seemed out-of-date.

### Checklist

- [x] Update documentation