### PR TITLE
Improvement of Resource Regeneration Due to x-kubernetes-preserve-unknown-fields

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -753,7 +753,21 @@ class CrdGenerator {
         PropertyType propertyType = property.getType();
         Class<?> returnType = propertyType.getType();
         final ObjectNode schema;
-        if (propertyType.getGenericType() instanceof ParameterizedType
+        if (property.getName().equals("limits")
+                || property.getName().equals("requests")) {
+            ObjectNode properties = nf.objectNode();
+            ObjectNode cpuProperty = nf.objectNode();
+            ObjectNode memoryProperty = nf.objectNode();
+            schema = nf.objectNode();
+            schema.put("type", "object");
+            schema.set("properties", properties);
+
+            cpuProperty.put("type", "string");
+            memoryProperty.put("type", "string");
+
+            properties.set("cpu", cpuProperty);
+            properties.set("memory", memoryProperty);
+        } else if (propertyType.getGenericType() instanceof ParameterizedType
                 && ((ParameterizedType) propertyType.getGenericType()).getRawType().equals(Map.class)
                 && ((ParameterizedType) propertyType.getGenericType()).getActualTypeArguments()[0].equals(Integer.class)) {
             System.err.println("It's OK");
@@ -761,7 +775,7 @@ class CrdGenerator {
             schema.put("type", "object");
             schema.putObject("patternProperties").set("-?[0-9]+", buildArraySchema(crApiVersion, property, new PropertyType(null, ((ParameterizedType) propertyType.getGenericType()).getActualTypeArguments()[1]), description));
         } else if (Schema.isJsonScalarType(returnType)
-                || Map.class.equals(returnType)) {            
+                || Map.class.equals(returnType)) {
             schema = addSimpleTypeConstraints(crApiVersion, buildBasicTypeSchema(property, returnType), property);
         } else if (returnType.isArray() || List.class.equals(returnType)) {
             schema = buildArraySchema(crApiVersion, property, property.getType(), description);

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -786,11 +786,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve.
                     metricsConfig:
                       type: object
@@ -1920,11 +1928,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve.
                     metricsConfig:
                       type: object
@@ -2790,11 +2806,19 @@ spec:
                                   name:
                                     type: string
                             limits:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                             requests:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                           description: CPU and memory resources to reserve.
                         topicMetadataMaxAttempts:
                           type: integer
@@ -2941,11 +2965,19 @@ spec:
                                   name:
                                     type: string
                             limits:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                             requests:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                           description: CPU and memory resources to reserve.
                         logging:
                           type: object
@@ -3086,11 +3118,19 @@ spec:
                                   name:
                                     type: string
                             limits:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                             requests:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                           description: CPU and memory resources to reserve.
                       description: TLS sidecar configuration.
                     template:
@@ -3992,11 +4032,19 @@ spec:
                                   name:
                                     type: string
                             limits:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                             requests:
-                              x-kubernetes-preserve-unknown-fields: true
                               type: object
+                              properties:
+                                cpu:
+                                  type: string
+                                memory:
+                                  type: string
                           description: CPU and memory resources to reserve.
                       description: TLS sidecar configuration.
                     resources:
@@ -4010,11 +4058,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve for the Cruise Control container.
                     livenessProbe:
                       type: object
@@ -4974,11 +5030,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve.
                     template:
                       type: object
@@ -5584,11 +5648,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve.
                     logging:
                       type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -233,11 +233,19 @@ spec:
                           name:
                             type: string
                     limits:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                     requests:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                   description: The maximum limits for CPU and memory resources and the requested initial resources.
                 livenessProbe:
                   type: object
@@ -1858,11 +1866,19 @@ spec:
                               name:
                                 type: string
                         limits:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                         requests:
-                          x-kubernetes-preserve-unknown-fields: true
                           type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
                       description: CPU and memory resources to reserve for the build.
                     plugins:
                       type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -437,11 +437,19 @@ spec:
                           name:
                             type: string
                     limits:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                     requests:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                   description: CPU and memory resources to reserve.
                 whitelist:
                   type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -281,11 +281,19 @@ spec:
                           name:
                             type: string
                     limits:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                     requests:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                   description: CPU and memory resources to reserve.
                 jvmOptions:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -378,11 +378,19 @@ spec:
                           name:
                             type: string
                     limits:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                     requests:
-                      x-kubernetes-preserve-unknown-fields: true
                       type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
                   description: The maximum limits for CPU and memory resources and the requested initial resources.
                 livenessProbe:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -157,11 +157,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: CPU and memory resources to reserve.
               jvmOptions:
                 type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -785,11 +785,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve.
                   metricsConfig:
                     type: object
@@ -1919,11 +1927,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve.
                   metricsConfig:
                     type: object
@@ -2789,11 +2805,19 @@ spec:
                                 name:
                                   type: string
                           limits:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                           requests:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                         description: CPU and memory resources to reserve.
                       topicMetadataMaxAttempts:
                         type: integer
@@ -2940,11 +2964,19 @@ spec:
                                 name:
                                   type: string
                           limits:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                           requests:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                         description: CPU and memory resources to reserve.
                       logging:
                         type: object
@@ -3085,11 +3117,19 @@ spec:
                                 name:
                                   type: string
                           limits:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                           requests:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                         description: CPU and memory resources to reserve.
                     description: TLS sidecar configuration.
                   template:
@@ -3991,11 +4031,19 @@ spec:
                                 name:
                                   type: string
                           limits:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                           requests:
-                            x-kubernetes-preserve-unknown-fields: true
                             type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
                         description: CPU and memory resources to reserve.
                     description: TLS sidecar configuration.
                   resources:
@@ -4009,11 +4057,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve for the Cruise Control container.
                   livenessProbe:
                     type: object
@@ -4973,11 +5029,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve.
                   template:
                     type: object
@@ -5583,11 +5647,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve.
                   logging:
                     type: string

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -232,11 +232,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: The maximum limits for CPU and memory resources and the requested initial resources.
               livenessProbe:
                 type: object
@@ -1857,11 +1865,19 @@ spec:
                             name:
                               type: string
                       limits:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                       requests:
-                        x-kubernetes-preserve-unknown-fields: true
                         type: object
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
                     description: CPU and memory resources to reserve for the build.
                   plugins:
                     type: array

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -436,11 +436,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: CPU and memory resources to reserve.
               whitelist:
                 type: string

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -280,11 +280,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: CPU and memory resources to reserve.
               jvmOptions:
                 type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -377,11 +377,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: The maximum limits for CPU and memory resources and the requested initial resources.
               livenessProbe:
                 type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -157,11 +157,19 @@ spec:
                         name:
                           type: string
                   limits:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                   requests:
-                    x-kubernetes-preserve-unknown-fields: true
                     type: object
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
                 description: CPU and memory resources to reserve.
               jvmOptions:
                 type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

- This is an idea to address the resource regeneration issue that occurs when modifying the resources property with the same terraform as described in the issue.
- resolve #9291

### Checklist

- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging


