### PR TITLE
Remove offset.lag.max from MirrorMaker examples

### DIFF
--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -27,6 +27,7 @@ spec:
         offset-syncs.topic.replication.factor: -1
         sync.topic.acls.enabled: "false"
         refresh.topics.interval.seconds: 600
+        offset.lag.max: 100
     checkpointConnector:
       tasksMax: 1
       config:

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-sync-groups.yaml
@@ -32,7 +32,6 @@ spec:
       config:
         checkpoints.topic.replication.factor: -1
         sync.group.offsets.enabled: "true"
-        offset.lag.max: 100
         emit.checkpoints.interval.seconds: 60
         sync.group.offsets.interval.seconds: 60
         refresh.groups.interval.seconds: 600

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -262,6 +262,7 @@ spec:
           offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
           refresh.topics.interval.seconds: 600
+          offset.lag.max: 100
       checkpointConnector:
         tasksMax: 1
         config:

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -268,7 +268,6 @@ spec:
           # -1 means it will use the default replication factor configured in the broker
           checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
-          offset.lag.max: 100
           emit.checkpoints.interval.seconds: 60
           sync.group.offsets.interval.seconds: 60
           refresh.groups.interval.seconds: 600

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -253,6 +253,7 @@ spec:
           offset-syncs.topic.replication.factor: -1
           sync.topic.acls.enabled: "false"
           refresh.topics.interval.seconds: 600
+          offset.lag.max: 100
       checkpointConnector:
         tasksMax: 1
         config:

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -259,7 +259,6 @@ spec:
           # -1 means it will use the default replication factor configured in the broker
           checkpoints.topic.replication.factor: -1
           sync.group.offsets.enabled: "true"
-          offset.lag.max: 100
           emit.checkpoints.interval.seconds: 60
           sync.group.offsets.interval.seconds: 60
           refresh.groups.interval.seconds: 600


### PR DESCRIPTION


### Type of change

- Documentation/examples

### Description

`offset.lag.max` is a configuration from the source connector so we shouldn't see it on checkpoint connector. Also 100 is the default value so we don't need to see it explicitly.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

