### PR TITLE
Fixed KRaft storage formating with UUID starting with dash

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -63,6 +63,8 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     STRIMZI_CLUSTER_ID=$(cat "$KAFKA_HOME/custom-config/cluster.id")
     echo "Formatting Kraft storage with cluster ID $STRIMZI_CLUSTER_ID"
     mkdir -p "$KRAFT_LOG_DIR"
+    # Using "=" to assign arguments for the Kafka storage tool to avoid issues if the generated
+    # cluster ID starts with a "-". See https://issues.apache.org/jira/browse/KAFKA-15754
     ./bin/kafka-storage.sh format -t="$STRIMZI_CLUSTER_ID" -c=/tmp/strimzi.properties
   else
     echo "Kraft storage is already formatted"

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -63,7 +63,7 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
     STRIMZI_CLUSTER_ID=$(cat "$KAFKA_HOME/custom-config/cluster.id")
     echo "Formatting Kraft storage with cluster ID $STRIMZI_CLUSTER_ID"
     mkdir -p "$KRAFT_LOG_DIR"
-    ./bin/kafka-storage.sh format -t "$STRIMZI_CLUSTER_ID" -c /tmp/strimzi.properties
+    ./bin/kafka-storage.sh format -t="$STRIMZI_CLUSTER_ID" -c=/tmp/strimzi.properties
   else
     echo "Kraft storage is already formatted"
   fi


### PR DESCRIPTION
While using KRaft and creating a new KRaft based cluster I came in the following error on Kafka pods while formatting the storage ...

```shell
usage: kafka-storage format [-h] --config CONFIG --cluster-id CLUSTER_ID [--ignore-formatted] [--release-version RELEASE_VERSION]
kafka-storage: error: argument --cluster-id/-t: expected one argument
```

Which keeps the cluster to fail and not starting at all.
The issue was related to an autogenerated UUID starting with dash like this `-rmdB0m4T4--Y4thlNXk4Q`.
Because of the Kafka storage tool works by using argparse4j (for parsing argument), it's safer to assign parameters using the `=` sign on the command line, otherwise such an UUID is taken as a new argument and not a corresponding value.

