### PR TITLE
[UTO] Fix wrong error message on resource conflicts

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -211,7 +211,7 @@ public class BatchingTopicController {
         var existing = topics.get(tn);
         KubeRef thisRef = new KubeRef(reconcilableTopic.kt());
         if (existing.size() != 1) {
-            var byCreationTime = existing.stream().sorted(Comparator.comparing(KubeRef::creationTime)).toList();
+            var byCreationTime = existing.stream().sorted(Comparator.comparing(KubeRef::creationTimeNs)).toList();
 
             var oldest = byCreationTime.get(0);
             var nextOldest = byCreationTime.size() >= 2 ? byCreationTime.get(1) : null;
@@ -219,7 +219,7 @@ public class BatchingTopicController {
             if (nextOldest == null) {
                 // This is only resource for that topic => it is the unique oldest
                 return Either.ofRight(true);
-            } else if (thisRef.equals(oldest) && nextOldest.creationTime() != oldest.creationTime()) {
+            } else if (thisRef.equals(oldest) && nextOldest.creationTimeNs() != oldest.creationTimeNs()) {
                 // This resource is the unique oldest, so it's OK.
                 // The others will eventually get reconciled and put into ResourceConflict
                 return Either.ofRight(true);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/KubeRef.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/KubeRef.java
@@ -5,17 +5,71 @@
 package io.strimzi.operator.topic.v2;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.operator.common.model.StatusUtils;
 
 import java.util.Objects;
 
 /**
  * Reference to a resource in Kube.
  * Equality is based on {@link #namespace()} and {@link #name()}.
- * {@link #creationTimeNs()} is present to allow disambiguation of multiple KafkaTopics managing the same topic in Kafka.
+ * {@link #creationTime()} is present to allow disambiguation of multiple KafkaTopics with the same topicName.
+ * {@link #processingOrder()} is present to allow disambiguation of multiple KafkaTopics with the same topicName in the same batch.
  */
-record KubeRef(String namespace, String name, long creationTimeNs) {
+public class KubeRef {
+    private String namespace;
+    private String name; 
+    private long creationTime;
+    private long processingOrder;
+
+    KubeRef(String namespace, String name, long creationTime) {
+        this.namespace = namespace;
+        this.name = name;
+        this.creationTime = creationTime;
+    }
+
     KubeRef(KafkaTopic kt) {
-        this(kt.getMetadata().getNamespace(), kt.getMetadata().getName(), System.nanoTime());
+        this(kt.getMetadata().getNamespace(), kt.getMetadata().getName(), 
+            StatusUtils.isoUtcDatetime(kt.getMetadata().getCreationTimestamp()).toEpochMilli());
+    }
+
+    /**
+     * Returns the metadata.namespace.
+     * @return metadata.namespace
+     */
+    public String namespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns the metadata.name.
+     * @return metadata.name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the metadata.creationTime.
+     * @return metadata.creationTime
+     */
+    public long creationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Returns the processing order
+     * @return processing order
+     */
+    public long processingOrder() {
+        return processingOrder;
+    }
+
+    /**
+     * Sets the processing order.
+     * @param processingOrder processing order
+     */
+    public void processingOrder(long processingOrder) {
+        this.processingOrder = processingOrder;
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/KubeRef.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/KubeRef.java
@@ -5,18 +5,17 @@
 package io.strimzi.operator.topic.v2;
 
 import io.strimzi.api.kafka.model.KafkaTopic;
-import io.strimzi.operator.common.model.StatusUtils;
 
 import java.util.Objects;
 
 /**
  * Reference to a resource in Kube.
  * Equality is based on {@link #namespace()} and {@link #name()}.
- * {@link #creationTime()} is present to allow disambiguation of multiple KafkaTopics managing the same topic in Kafka.
+ * {@link #creationTimeNs()} is present to allow disambiguation of multiple KafkaTopics managing the same topic in Kafka.
  */
-record KubeRef(String namespace, String name, long creationTime) {
+record KubeRef(String namespace, String name, long creationTimeNs) {
     KubeRef(KafkaTopic kt) {
-        this(kt.getMetadata().getNamespace(), kt.getMetadata().getName(), StatusUtils.isoUtcDatetime(kt.getMetadata().getCreationTimestamp()).toEpochMilli());
+        this(kt.getMetadata().getNamespace(), kt.getMetadata().getName(), System.nanoTime());
     }
 
     @Override

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -67,7 +67,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -79,6 +82,7 @@ import java.util.stream.Collectors;
 
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 import static io.strimzi.operator.topic.v2.BatchingTopicController.isPaused;
+import static io.strimzi.operator.topic.v2.TopicOperatorTestUtil.findKafkaTopicByName;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -473,6 +477,42 @@ class TopicControllerIT {
         LOGGER.info("Test created KafkaTopic {} with resourceVersion {}",
                 created.getMetadata().getName(), BatchingTopicController.resourceVersion(created));
         return waitUntil(created, condition);
+    }
+
+    private List<KafkaTopic> createTopicsConcurrently(KafkaCluster kc, KafkaTopic... kts) throws InterruptedException, ExecutionException {
+        if (kts == null || kts.length == 0) {
+            throw new IllegalArgumentException("You need pass at least one topic to be created");
+        }
+        String ns = namespace(kts[0].getMetadata().getNamespace());
+        maybeStartOperator(topicOperatorConfig(ns, kc));
+        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        CountDownLatch latch = new CountDownLatch(kts.length);
+        List<KafkaTopic> result = new ArrayList<>();
+        for (KafkaTopic kt : kts) {
+            executor.submit(() -> {
+                try {
+                    var created = Crds.topicOperation(client).resource(kt).create();
+                    LOGGER.info("Test created KafkaTopic {} with creationTimestamp {}",
+                        created.getMetadata().getName(),
+                        created.getMetadata().getCreationTimestamp());
+                    var reconciled = waitUntil(created, readyIsTrueOrFalse());
+                    result.add(reconciled);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                latch.countDown();
+            });
+        }
+        latch.await(1, TimeUnit.MINUTES);
+        try {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            if (!executor.isTerminated()) {
+                executor.shutdownNow();
+            }
+        }
+        return result;
     }
 
     private KafkaTopic pauseTopic(String namespace, String topicName) {
@@ -1833,19 +1873,14 @@ class TopicControllerIT {
 
     @Test
     public void shouldFailIfNumPartitionsDivergedWithConfigChange(@BrokerConfig(name = "auto.create.topics.enable", value = "false")
-                                                  KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException, TimeoutException {
-        // Scenario from https://github.com/strimzi/strimzi-kafka-operator/pull/8627#pullrequestreview-1477513413
-
-        // given
+                                                                  KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException, TimeoutException {
+        // scenario from https://github.com/strimzi/strimzi-kafka-operator/pull/8627#pullrequestreview-1477513413
 
         // create foo
         var topicName = randomTopicName();
         LOGGER.info("Create foo");
         var foo = kafkaTopic(NAMESPACE, "foo", null, null, 1, 1);
         var createdFoo = createTopicAndAssertSuccess(kafkaCluster, foo);
-
-        // TODO remove after fixing https://github.com/strimzi/strimzi-kafka-operator/issues/9270
-        Thread.sleep(1000);
 
         // create conflicting bar
         LOGGER.info("Create conflicting bar");
@@ -1860,30 +1895,75 @@ class TopicControllerIT {
         // increase partitions of foo
         LOGGER.info("Increase partitions of foo");
         var editedFoo = modifyTopicAndAwait(createdFoo, theKt ->
-                        new KafkaTopicBuilder(theKt).editSpec().withPartitions(3).endSpec().build(),
-                readyIsTrue());
+                new KafkaTopicBuilder(theKt).editSpec().withPartitions(3).endSpec().build(),
+            readyIsTrue());
 
         // unmanage foo
         LOGGER.info("Unmanage foo");
         var unmanagedFoo = modifyTopicAndAwait(editedFoo, theKt ->
-                        new KafkaTopicBuilder(theKt).editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
-                readyIsTrue());
+                new KafkaTopicBuilder(theKt).editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
+            readyIsTrue());
 
         // when: delete foo
         LOGGER.info("Delete foo");
         Crds.topicOperation(client).resource(unmanagedFoo).delete();
         LOGGER.info("Test deleted KafkaTopic {} with resourceVersion {}",
-                unmanagedFoo.getMetadata().getName(), BatchingTopicController.resourceVersion(unmanagedFoo));
+            unmanagedFoo.getMetadata().getName(), BatchingTopicController.resourceVersion(unmanagedFoo));
         Resource<KafkaTopic> resource = Crds.topicOperation(client).resource(unmanagedFoo);
         TopicOperatorTestUtil.waitUntilCondition(resource, Objects::isNull);
 
         // then: expect bar's unreadiness to be due to mismatching #partitions
         waitUntil(createdBar, readyIsFalseAndReasonIs(
-                TopicOperatorException.Reason.NOT_SUPPORTED.reason,
-                "Decreasing partitions not supported"));
+            TopicOperatorException.Reason.NOT_SUPPORTED.reason,
+            "Decreasing partitions not supported"));
     }
 
-    private static <T> KafkaFuture<T> failedFuture(Throwable error) throws ExecutionException, InterruptedException {
+    @Test
+    public void shouldDetectConflictingKafkaTopicCreations(
+            @BrokerConfig(name = "auto.create.topics.enable", value = "false")
+            KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException {
+        var foo = kafkaTopic("ns", "foo", null, null, 1, 1);
+        var bar = kafkaTopic("ns", "bar", SELECTOR, null, null, "foo", 1, 1,
+            Map.of(TopicConfig.COMPRESSION_TYPE_CONFIG, "snappy"));
+
+        LOGGER.info("Create conflicting topics: foo and bar");
+        var reconciledTopics = createTopicsConcurrently(kafkaCluster, foo, bar);
+        var reconciledFoo = findKafkaTopicByName(reconciledTopics, "foo");
+        var reconciledBar = findKafkaTopicByName(reconciledTopics, "bar");
+
+        // only one resource with the same topicName should be reconciled
+        var fooFailed = readyIsFalse().test(reconciledFoo);
+        var barFailed = readyIsFalse().test(reconciledBar);
+        assertTrue(fooFailed ^ barFailed);
+
+        if (fooFailed) {
+            assertKafkaTopicConflict(reconciledFoo, reconciledBar);
+        } else {
+            assertKafkaTopicConflict(reconciledBar, reconciledFoo);
+        }
+    }
+
+    private void assertKafkaTopicConflict(KafkaTopic failed, KafkaTopic ready) {
+        // the error message should refer to the ready resource name
+        var condition = assertExactlyOneCondition(failed);
+        assertEquals(TopicOperatorException.Reason.RESOURCE_CONFLICT.reason, condition.getReason());
+        assertEquals(format("Managed by Ref{namespace='ns', name='%s'}", ready.getMetadata().getName()), condition.getMessage());
+
+        // the failed resource should become ready after we unmanage and delete the other
+        LOGGER.info("Unmanage {}", ready.getMetadata().getName());
+        var unmanagedBar = modifyTopicAndAwait(ready, theKt -> new KafkaTopicBuilder(theKt)
+                .editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
+            readyIsTrue());
+
+        LOGGER.info("Delete {}", ready.getMetadata().getName());
+        Crds.topicOperation(client).resource(unmanagedBar).delete();
+        Resource<KafkaTopic> resource = Crds.topicOperation(client).resource(unmanagedBar);
+        TopicOperatorTestUtil.waitUntilCondition(resource, Objects::isNull);
+
+        waitUntil(failed, readyIsTrue());
+    }
+
+    private static <T> KafkaFuture<T> failedFuture(Throwable error) {
         var future = new KafkaFutureImpl<T>();
         future.completeExceptionally(error);
         return future;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.TestInfo;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -123,5 +124,9 @@ class TopicOperatorTestUtil {
                 }
             }
         }
+    }
+
+    static KafkaTopic findKafkaTopicByName(List<KafkaTopic> topics, String name) {
+        return topics.stream().filter(kt -> kt.getMetadata().getName().equals(name)).findFirst().orElse(null);
     }
 }


### PR DESCRIPTION
In case of `ResourceConflict` (two or more `KafkaTopic` resources with the same `topicName`) we build the error message using `creationTime` to determine the the oldest resource, that is supposed to be ready. Due to the poor resolution of the timestamp provided by Kubernetes, we sometimes generate the wrong error message, as shown in the following example.

```sh
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaTopic
metadata:
  creationTimestamp: "2023-10-19T14:46:47Z"
  name: bar
spec:
  topicName: foo
status:
  conditions:
  - lastTransitionTime: "2023-10-19T14:46:47.311487120Z" 
    message: Managed by Ref{namespace='test', name='bar'} 
    reason: ResourceConflict status: "False" type: Ready

apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaTopic
metadata:
  creationTimestamp: "2023-10-19T14:46:47Z"
  name: foo
spec:
  topicName: foo
status:
    conditions: 
    - lastTransitionTime: "2023-10-19T14:46:47.230152899Z"
      status: "True" 
      type: Ready
```

In order to fix this, I simply propose to use `System.nanoTime`, whithout changing the original logic. I also created a new integration test that makes the concurrency issue more evident.

Should fix #9270.
