### PR TITLE
Update Fabric8 to 6.9.1

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
@@ -215,7 +215,7 @@ public class PvcReconcilerTest {
     // Tests volume reconciliation when the PVC has some weird value
     //         => we cannot handle it successfully, but we should fail the reconciliation
     @Test
-    public void testVolumesBoundExpandableStorageClassWithInvalidUnit(VertxTestContext context)  {
+    public void testVolumesBoundExpandableStorageClassWithInvalidSize(VertxTestContext context)  {
         List<PersistentVolumeClaim> pvcs = List.of(
                 createPvc("data-pod-0"),
                 createPvc("data-pod-1"),
@@ -235,7 +235,7 @@ public class PvcReconcilerTest {
                         PersistentVolumeClaim pvcWithStatus = new PersistentVolumeClaimBuilder(currentPvc)
                                 .editSpec()
                                     .withNewResources()
-                                        .withRequests(Map.of("storage", new Quantity("50000000000200inv", null)))
+                                        .withRequests(Map.of("storage", new Quantity("-50000000000200Gi", null)))
                                     .endResources()
                                 .endSpec()
                                 .withNewStatus()
@@ -268,7 +268,7 @@ public class PvcReconcilerTest {
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(false));
                     assertThat(res.cause(), is(instanceOf(IllegalArgumentException.class)));
-                    assertThat(res.cause().getMessage(), is("Invalid memory suffix: inv"));
+                    assertThat(res.cause().getMessage(), is("Invalid memory suffix: -50000000000200Gi"));
                     async.flag();
                 });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.9.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.9.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.9.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.9.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.9.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.9.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.15.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.15.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to a new version 6.9.1.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally