### PR TITLE
[ST] Make possible to run Connect tests with file-sink plugin using pre-built image (and enable running Connect tests on Microshift)

### DIFF
--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -104,7 +104,7 @@ jobs:
         echo "##vso[task.setvariable variable=connectImage]$(echo $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)"
       displayName: "Build KafkaConnect's image with file-sink plugin"
       env:
-        BASE_IMAGE: 'localhost:5000/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION'
+        BASE_IMAGE: '$(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION'
         KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
 
     - task: Maven@3

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -87,16 +87,6 @@ jobs:
       displayName: "Create dir for Kafka binaries cache"
       condition: ne(variables['docker_tag'], 'latest')
 
-    # We need to set DOCKER_REGISTRY to IP and port of service, which is created by minikube registry addon, port is always 80
-    # Default value for PRs is localhost:5000 because we need to push built images into minikube registry and make them available for pods
-    - script: echo "##vso[task.setvariable variable=docker_registry]$(kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'):80"
-      displayName: "Set docker_registry to local registry in minikube"
-      condition: eq(variables['docker_registry'], 'localhost:5000')
-
-    - bash: ".azure/scripts/setup_upgrade.sh"
-      displayName: "Setup environment for upgrade"
-      condition: contains('${{ parameters.profile }}', 'upgrade')
-
     - bash: |
         eval $(minikube docker-env)
         eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh "$KAFKA_VERSION" "$BASE_IMAGE")
@@ -106,6 +96,16 @@ jobs:
       env:
         BASE_IMAGE: '$(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION'
         KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
+
+    # We need to set DOCKER_REGISTRY to IP and port of service, which is created by minikube registry addon, port is always 80
+    # Default value for PRs is localhost:5000 because we need to push built images into minikube registry and make them available for pods
+    - script: echo "##vso[task.setvariable variable=docker_registry]$(kubectl get service registry -n kube-system -o=jsonpath='{.spec.clusterIP}'):80"
+      displayName: "Set docker_registry to local registry in minikube"
+      condition: eq(variables['docker_registry'], 'localhost:5000')
+
+    - bash: ".azure/scripts/setup_upgrade.sh"
+      displayName: "Setup environment for upgrade"
+      condition: contains('${{ parameters.profile }}', 'upgrade')
 
     - task: Maven@3
       inputs:

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -99,7 +99,7 @@ jobs:
 
     - bash: |
         eval $(minikube docker-env)
-        eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh)
+        eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh ${{ parameters.kafkaVersion }}) $(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION
         echo "##vso[task.setvariable variable=connectImage]$(echo $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)"
       displayName: "Build KafkaConnect's image with file-sink plugin"
 

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -99,9 +99,13 @@ jobs:
 
     - bash: |
         eval $(minikube docker-env)
-        eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh ${{ parameters.kafkaVersion }}) $(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION
+        eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh "$KAFKA_VERSION" "$BASE_IMAGE")
+        echo "connect build image: $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN"
         echo "##vso[task.setvariable variable=connectImage]$(echo $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)"
       displayName: "Build KafkaConnect's image with file-sink plugin"
+      env:
+        BASE_IMAGE: 'localhost:5000/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION'
+        KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
 
     - task: Maven@3
       inputs:

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -97,6 +97,12 @@ jobs:
       displayName: "Setup environment for upgrade"
       condition: contains('${{ parameters.profile }}', 'upgrade')
 
+    - bash: |
+        eval $(minikube docker-env)
+        eval $(./systemtest/src/test/resources/connect-build/build-connect-image.sh)
+        echo "##vso[task.setvariable variable=connectImage]$(echo $CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)"
+      displayName: "Build KafkaConnect's image with file-sink plugin"
+
     - task: Maven@3
       inputs:
         mavenPomFile: 'systemtest/pom.xml'
@@ -128,6 +134,7 @@ jobs:
         BUILD_ID: $(Agent.JobName)
         RESOURCE_ALLOCATION_STRATEGY: "NOT_SHARED"
         TEST_LOG_DIR: $(test_log_dir)
+        CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN: $(connectImage)
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -154,6 +154,12 @@ public class Environment {
     public static final String IP_FAMILY_ENV = "IP_FAMILY";
 
     /**
+     * Connect image with file sink plugin
+     */
+    public static final String CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV = "CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN";
+    public static final String CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN = getOrDefault(CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV, "");
+
+    /**
      * Defaults
      */
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupported.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.systemtest.annotations;
 
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupported.java
@@ -1,0 +1,16 @@
+package io.strimzi.systemtest.annotations;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MicroShiftNotSupportedCondition.class)
+public @interface MicroShiftNotSupported {
+
+    String value() default "MicroShift cluster is not supported for this test case";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupportedCondition.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.systemtest.annotations;
 
 import io.strimzi.test.k8s.KubeClusterResource;

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MicroShiftNotSupportedCondition.java
@@ -1,0 +1,23 @@
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class MicroShiftNotSupportedCondition implements ExecutionCondition {
+
+    private static final Logger LOGGER = LogManager.getLogger(MicroShiftNotSupportedCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (!KubeClusterResource.getInstance().isMicroShift()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("MicroShift is not supported by this test case and you are using it. Skipping the test.");
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -107,7 +107,7 @@ public class KafkaConnectTemplates {
      */
     @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     public static KafkaConnectBuilder kafkaConnectWithFilePlugin(String name, String namespaceName, String clusterName, int replicas, String pathToConnectConfig) {
-        if (!KubeClusterResource.getInstance().isMicroShift()) {
+        if (!KubeClusterResource.getInstance().isMicroShift() && Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN.isEmpty()) {
             final Plugin fileSinkPlugin = new PluginBuilder()
                 .withName("file-plugin")
                 .withArtifacts(

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -127,7 +127,12 @@ public class KafkaConnectTemplates {
                     .endBuild()
                 .endSpec();
         } else {
-            LOGGER.warn("Using MicroShift cluster - you should have created your own Connect image with file-sink plugin and pass the image into {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
+            if (KubeClusterResource.getInstance().isMicroShift()) {
+                LOGGER.warn("Using MicroShift cluster - you should have created your own Connect image with file-sink plugin and pass the image into {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
+            }
+
+            LOGGER.info("Using {} image from {} env variable", Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN, Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV);
+
             return kafkaConnect(name, namespaceName, clusterName, replicas, pathToConnectConfig)
                 .editOrNewSpec()
                     .withImage(Environment.CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN)

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -27,6 +27,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.KindNotSupported;
+import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -76,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(REGRESSION)
 @Tag(CONNECT_COMPONENTS)
 @Tag(CONNECT)
+@MicroShiftNotSupported
 class ConnectBuilderST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ConnectBuilderST.class);

--- a/systemtest/src/test/resources/connect-build/Dockerfile
+++ b/systemtest/src/test/resources/connect-build/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=quay.io/strimzi/kafka:latest-kafka
+ARG KAFKA_VERSION
+
+FROM ${BASE_IMAGE}-${KAFKA_VERSION}
+
+USER root:root
+RUN mkdir -p /opt/kafka/plugins/file-sink
+
+ADD --chmod=444 https://repo1.maven.org/maven2/org/apache/kafka/connect-file/${KAFKA_VERSION}/connect-file-${KAFKA_VERSION}.jar /opt/kafka/plugins/file-sink/
+
+USER 1001

--- a/systemtest/src/test/resources/connect-build/Dockerfile
+++ b/systemtest/src/test/resources/connect-build/Dockerfile
@@ -1,7 +1,7 @@
-ARG BASE_IMAGE=quay.io/strimzi/kafka:latest-kafka
 ARG KAFKA_VERSION
+ARG BASE_IMAGE=quay.io/strimzi/kafka:latest-kafka-${KAFKA_VERSION}
 
-FROM ${BASE_IMAGE}-${KAFKA_VERSION}
+FROM ${BASE_IMAGE}
 
 USER root:root
 RUN mkdir -p /opt/kafka/plugins/file-sink

--- a/systemtest/src/test/resources/connect-build/Dockerfile
+++ b/systemtest/src/test/resources/connect-build/Dockerfile
@@ -3,6 +3,9 @@ ARG BASE_IMAGE=quay.io/strimzi/kafka:latest-kafka-${KAFKA_VERSION}
 
 FROM ${BASE_IMAGE}
 
+# to make KAFKA_VERSION arg available again after FROM, we need to specify it once more (different build stage)
+ARG KAFKA_VERSION
+
 USER root:root
 RUN mkdir -p /opt/kafka/plugins/file-sink
 

--- a/systemtest/src/test/resources/connect-build/Dockerfile
+++ b/systemtest/src/test/resources/connect-build/Dockerfile
@@ -9,6 +9,6 @@ ARG KAFKA_VERSION
 USER root:root
 RUN mkdir -p /opt/kafka/plugins/file-sink
 
-ADD --chmod=444 https://repo1.maven.org/maven2/org/apache/kafka/connect-file/${KAFKA_VERSION}/connect-file-${KAFKA_VERSION}.jar /opt/kafka/plugins/file-sink/
+RUN cp /opt/kafka/libs/connect-file-${KAFKA_VERSION}.jar /opt/kafka/plugins/file-sink
 
 USER 1001

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -21,9 +21,10 @@ function buildDockerImage() {
   fi
 }
 
-if [ -z "${KAFKA_VERSION}" ]; then
-  echo "[WARN] Kafka version was not supplied, going to get latest version from kafka-versions.yaml"
+if [ -z "${KAFKA_VERSION}" ] || [ "${KAFKA_VERSION}" == "latest" ]; then
+  echo "[WARN] Kafka version was not supplied or 'latest' was specified, going to get latest version from kafka-versions.yaml"
   getLatestKafkaVersionFromYAML
+  BASE_IMAGE=$(echo $BASE_IMAGE | sed "s/KAFKA_VERSION/${KAFKA_VERSION}/g")
 fi
 
 echo $(dirname "$0")

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-RANDOM=$(shuf -i 60000-99999 -n 1)
-
 KAFKA_VERSION=$1
 BASE_IMAGE=$2
-CONNECT_IMAGE=${3:-"strimzi/connect:$RANDOM"}
+CONNECT_IMAGE=${3:-"strimzi/connect-file-sink:latest"}
 
 function getLatestKafkaVersionFromYAML() {
   local strimziRoot=$(git rev-parse --show-toplevel)

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -4,7 +4,7 @@ RANDOM=$(shuf -i 60000-99999 -n 1)
 
 KAFKA_VERSION=$1
 BASE_IMAGE=$2
-CONNECT_IMAGE=${3:-"quay.io/strimzi/connect:$RANDOM"}
+CONNECT_IMAGE=${3:-"strimzi/connect:$RANDOM"}
 
 function getLatestKafkaVersionFromYAML() {
   local strimziRoot=$(git rev-parse --show-toplevel)

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -21,13 +21,12 @@ function buildDockerImage() {
   fi
 }
 
+# in case that Kafka version wasn't supplied or we specify "latest" as a version, we will take the default version from kafka-versions.yaml
 if [ -z "${KAFKA_VERSION}" ] || [ "${KAFKA_VERSION}" == "latest" ]; then
-  echo "[WARN] Kafka version was not supplied or 'latest' was specified, going to get latest version from kafka-versions.yaml"
   getLatestKafkaVersionFromYAML
   BASE_IMAGE=$(echo $BASE_IMAGE | sed "s/KAFKA_VERSION/${KAFKA_VERSION}/g")
 fi
 
-echo $(dirname "$0")
 buildDockerImage
 
-echo export CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN=$CONNECT_IMAGE
+echo "export CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN=$CONNECT_IMAGE"

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+RANDOM=$(shuf -i 60000-99999 -n 1)
+
+KAFKA_VERSION=$1
+BASE_IMAGE=$2
+CONNECT_IMAGE=${3:-"strimzi/connect:$RANDOM"}
+
+function getLatestKafkaVersionFromYAML() {
+  local strimziRoot=$(git rev-parse --show-toplevel)
+  KAFKA_VERSION=$(cat $strimziRoot/kafka-versions.yaml | yq eval '.[] | select(.default) | .version' -)
+}
+
+function buildDockerImage() {
+  local dockerFileDir=$(dirname "$0")
+
+  if [ -z "${BASE_IMAGE}" ]; then
+    docker build $dockerFileDir --build-arg KAFKA_VERSION=$KAFKA_VERSION -t $CONNECT_IMAGE
+  else
+    docker build $dockerFileDir --build-arg KAFKA_VERSION=$KAFKA_VERSION BASE_IMAGE=$BASE_IMAGE -t $CONNECT_IMAGE
+  fi
+}
+
+if [ -z "${KAFKA_VERSION}" ]; then
+  echo "[WARN] Kafka version was not supplied, going to get latest version from kafka-versions.yaml"
+  getLatestKafkaVersionFromYAML
+fi
+
+echo $(dirname "$0")
+buildDockerImage
+
+echo export CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN=$CONNECT_IMAGE

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -17,7 +17,7 @@ function buildDockerImage() {
   if [ -z "${BASE_IMAGE}" ]; then
     docker build $dockerFileDir --build-arg KAFKA_VERSION=$KAFKA_VERSION -t $CONNECT_IMAGE
   else
-    docker build $dockerFileDir --build-arg KAFKA_VERSION=$KAFKA_VERSION BASE_IMAGE=$BASE_IMAGE -t $CONNECT_IMAGE
+    docker build $dockerFileDir --build-arg KAFKA_VERSION=$KAFKA_VERSION --build-arg BASE_IMAGE=$BASE_IMAGE -t $CONNECT_IMAGE
   fi
 }
 

--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -4,7 +4,7 @@ RANDOM=$(shuf -i 60000-99999 -n 1)
 
 KAFKA_VERSION=$1
 BASE_IMAGE=$2
-CONNECT_IMAGE=${3:-"strimzi/connect:$RANDOM"}
+CONNECT_IMAGE=${3:-"quay.io/strimzi/connect:$RANDOM"}
 
 function getLatestKafkaVersionFromYAML() {
   local strimziRoot=$(git rev-parse --show-toplevel)

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -7,6 +7,7 @@ package io.strimzi.test.k8s;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.strimzi.test.k8s.cluster.Kind;
 import io.strimzi.test.k8s.cluster.KubeCluster;
+import io.strimzi.test.k8s.cluster.Microshift;
 import io.strimzi.test.k8s.cluster.OpenShift;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import io.strimzi.test.logs.CollectorElement;
@@ -369,6 +370,10 @@ public class KubeClusterResource {
 
     public boolean isKind() {
         return kubeClusterResource.cluster() instanceof Kind;
+    }
+
+    public boolean isMicroShift() {
+        return kubeClusterResource.cluster() instanceof Microshift;
     }
 
     /** Returns list of currently deployed resources */


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

Until now, in testcases where we are using Connect with file-sink plugin, we used Connect Build feature for building the image with missing file-sink plugin. Because we are using this plugin in several testcases, it can extend the test duration.
Also, we were not able to execute these testcases on MicroShift. It is due to missing "build" feature on this environment (which have to be used for building the Connect image with the mentioned plugin). 

This PR adds possibility to deploy Connect with pre-built image containing the file-sink plugin.
It also adds Dockerfile and script for building the image itself.

This new possibility will help us:

- unblock testing of Connect on MicroShift
- speed up our pipelines the Connect image will be built before the test step and then the tests will be just executed with the particular Connect image (it takes around 1minute to build the image using build feature, so in case we have ~30 testcases for Connect with file-sink plugin, it can make significant difference).

### Checklist

- [ ] Make sure all tests pass
