### PR TITLE
[ST] kafka node pool controllers configuration changes  and configuration propagation

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.ResourceLabels;
 import io.strimzi.test.TestUtils;
 
 import java.time.Duration;
@@ -84,6 +85,14 @@ public interface Constants {
     String ECHO_SINK_JAR_CHECKSUM = "3f30d48079578f9f2d0a097ed9a7088773b135dff3dc8e70d87f8422c073adc1181cb41d823c1d1472b0447a337e4877e535daa34ca8ef21d608f8ee6f5e4a9c";
     String ECHO_SINK_FILE_NAME = "echo-sink-test.jar";
     String ECHO_SINK_JAR_WRONG_CHECKSUM = "f1f167902325062efc8c755647bc1b782b2b067a87a6e507ff7a3f6205803220";
+
+
+    String NODE_BROKER_CONFIG_HASH_ANNOTATION = ResourceLabels.STRIMZI_DOMAIN + "broker-configuration-hash";
+
+    /**
+     * Node pool labels
+     */
+    String NODE_POOL_LABEL = ResourceLabels.STRIMZI_DOMAIN + "pool-name";
 
     /**
      * Scraper pod labels

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -86,13 +86,7 @@ public interface Constants {
     String ECHO_SINK_FILE_NAME = "echo-sink-test.jar";
     String ECHO_SINK_JAR_WRONG_CHECKSUM = "f1f167902325062efc8c755647bc1b782b2b067a87a6e507ff7a3f6205803220";
 
-
     String NODE_BROKER_CONFIG_HASH_ANNOTATION = ResourceLabels.STRIMZI_DOMAIN + "broker-configuration-hash";
-
-    /**
-     * Node pool labels
-     */
-    String NODE_POOL_LABEL = ResourceLabels.STRIMZI_DOMAIN + "pool-name";
 
     /**
      * Scraper pod labels

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -23,7 +23,6 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -81,10 +80,11 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
      * @return a LabelSelector tailored for the specified Kafka cluster and node pool.
      */
     public static LabelSelector getLabelSelector(String clusterName, String kafkaNodePoolName) {
-        Map<String, String> matchLabels = new HashMap<>();
-        matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
-        matchLabels.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
-        matchLabels.put(Constants.NODE_POOL_LABEL, kafkaNodePoolName);
+        Map<String, String> matchLabels = Map.of(
+            Labels.STRIMZI_CLUSTER_LABEL, clusterName,
+            Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
+            Labels.STRIMZI_POOL_NAME_LABEL, kafkaNodePoolName
+        );
 
         return new LabelSelectorBuilder()
             .withMatchLabels(matchLabels)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -21,7 +23,9 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.strimzi.operator.common.Util.hashStub;
@@ -67,6 +71,24 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
     @Override
     public boolean waitForReadiness(KafkaNodePool resource) {
         return resource != null;
+    }
+
+    /**
+     * Constructs a LabelSelector specific enough to match all Pods Managed by given {@code kafkaNodePoolName}.
+     *
+     * @param clusterName       the name of the Kafka cluster for which the label selector is to be created.
+     * @param kafkaNodePoolName the name of the Kafka node pool within the specified cluster.
+     * @return a LabelSelector tailored for the specified Kafka cluster and node pool.
+     */
+    public static LabelSelector getLabelSelector(String clusterName, String kafkaNodePoolName) {
+        Map<String, String> matchLabels = new HashMap<>();
+        matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
+        matchLabels.put(Labels.STRIMZI_KIND_LABEL, "Kafka");
+        matchLabels.put(Constants.NODE_POOL_LABEL, kafkaNodePoolName);
+
+        return new LabelSelectorBuilder()
+            .withMatchLabels(matchLabels)
+            .build();
     }
 
     public static MixedOperation<KafkaNodePool, KafkaNodePoolList, Resource<KafkaNodePool>> kafkaNodePoolClient() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaNodePoolUtils.java
@@ -4,8 +4,10 @@
  */
 package io.strimzi.systemtest.utils.kafkaUtils;
 
+import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
+import io.strimzi.systemtest.resources.crd.StrimziPodSetResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import java.util.List;
 import java.util.Map;
@@ -37,4 +39,21 @@ public class KafkaNodePoolUtils {
         LOGGER.info("Scaling KafkaNodePool: {}/{} to {} replicas", namespaceName, kafkaNodePoolName, scaleToReplicas);
         KafkaNodePoolResource.kafkaNodePoolClient().inNamespace(namespaceName).withName(kafkaNodePoolName).scale(scaleToReplicas);
     }
+
+    public static String getStrimziPodSetName(String clusterName, String nodePoolName) {
+        return clusterName + "-" + nodePoolName;
+    }
+
+    /**
+     * Retrieves a StrimziPodSet associated with a specific KafkaNodePool.
+     *
+     * @param namespaceName      the namespace in which the Kafka cluster and its node pools reside.
+     * @param clusterName  the name of the Kafka cluster.
+     * @param kafkaNodePoolName the name of the Kafka node pool within the specified Kafka cluster.
+     * @return the StrimziPodSet associated with the given Kafka node pool, or null if not found.
+     */
+    public static StrimziPodSet getStrimziPodSetByKafkaNodePool(String namespaceName, String clusterName, String kafkaNodePoolName) {
+        return StrimziPodSetResource.strimziPodSetClient().inNamespace(namespaceName).withName(getStrimziPodSetName(clusterName, kafkaNodePoolName)).get();
+    }
+
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StrimziPodSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StrimziPodSetUtils.java
@@ -21,6 +21,7 @@ import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
@@ -52,6 +53,84 @@ public class StrimziPodSetUtils {
         }
     }
 
+    /**
+     * Waits until the single specified annotation of a Pod changes its value.
+     *
+     * @param namespaceName    the namespace in which the Pod is located.
+     * @param podName          the name of the Pod whose annotation value needs to be checked.
+     * @param strimziPodSetName the name of the SPS whose Pod's annotation is being observed.
+     * @param annotationKey    the key of the annotation whose value needs to be checked.
+     * @param annotationValue  the expected value of the annotation to change from.
+     */
+    public static void waitUntilPodAnnotationChange(String namespaceName, String podName, String strimziPodSetName, String annotationKey, String annotationValue) {
+
+        LOGGER.info("Waiting for Pod: {}/{} to change annotation value: {}-{}", namespaceName, podName, annotationKey, annotationValue);
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+
+        TestUtils.waitFor("Pod to change value of annotation" + annotationKey + " with key " + annotationKey, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
+            DELETION_TIMEOUT, () -> {
+                // parse pod from SPS
+                StrimziPodSet sps = StrimziPodSetResource.strimziPodSetClient().inNamespace(namespaceName).withName(strimziPodSetName).get();
+                var podMap = sps.getSpec().getPods();
+                Pod[] spsPods = objectMapper.convertValue(podMap, Pod[].class);
+                Pod pod = Arrays.stream(spsPods).filter(p -> p.getMetadata().getName().contains(podName)).findAny().get();
+
+                return !annotationValue.equals(pod.getMetadata().getAnnotations().get(annotationKey));
+            });
+        LOGGER.info("Pod: {}/{} changed annotation value: {}-{}", namespaceName, podName, annotationKey, annotationValue);
+    }
+
+    /**
+     * Waits for a specific annotation key-value pair to remain stable (from start to beginning) on a given Pod.
+     *
+     * @param namespaceName   the namespace in which the Pod is located.
+     * @param annotationKey   the key of the annotation to be checked.
+     * @param annotationValue the expected value of the annotation to be checked.
+     * @param strimziPodSetName the name of the SPS whose Pod's annotation is being observed.
+     * @param podName the name of the Pod whose annotation is being observed.
+     */
+    public static void waitForPrevailedPodAnnotationKeyValuePairs(String namespaceName, String annotationKey, String annotationValue, String strimziPodSetName, String podName) {
+        LOGGER.info("Waiting for label: {}-{} to keep its value in namespace: {}", namespaceName, annotationKey, annotationValue);
+        int[] stableCounter = {0};
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        TestUtils.waitFor("Label: " + annotationKey + "to prevail its value: " + annotationValue,
+            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
+
+            () -> {
+                // parse pod from SPS
+                StrimziPodSet sps =  StrimziPodSetResource.strimziPodSetClient().inNamespace(namespaceName).withName(strimziPodSetName).get();
+                var podMap = sps.getSpec().getPods();
+
+                Pod[] spsPods = objectMapper.convertValue(podMap, Pod[].class);
+                Pod pod = Arrays.stream(spsPods).filter(p -> p.getMetadata().getName().contains(podName)).findAny().get();
+
+
+                if (annotationValue.equals(pod.getMetadata().getAnnotations().get(annotationKey))) {
+                    stableCounter[0]++;
+                    if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
+                        LOGGER.info("Pod replicas are stable for {} poll intervals", stableCounter[0]);
+                        return true;
+                    }
+                } else {
+                    LOGGER.info("Annotations does not have expected value");
+                    return false;
+                }
+                LOGGER.info("Annotation be assumed stable in {} polls", Constants.GLOBAL_STABILITY_OFFSET_COUNT - stableCounter[0]);
+                return false;
+            });
+        LOGGER.info("Pod: {}/{} kept annotation: {}-{} ", namespaceName, podName, annotationKey, annotationValue);
+    }
+
+
+    /**
+     * Waits for all of specified labels of a StrimziPodSet (SPS) resource to change.
+     *
+     * @param namespaceName  the namespace in which the SPS is located.
+     * @param resourceName   the name of the SPS resource.
+     * @param labels         a map containing key-value pairs of the labels names amd values.
+     */
     public static void waitForStrimziPodSetLabelsChange(String namespaceName, String resourceName, Map<String, String> labels) {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             boolean isK8sTag = entry.getKey().equals("controller-revision-hash") || entry.getKey().equals("statefulset.kubernetes.io/pod-name");

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StrimziPodSetUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/StrimziPodSetUtils.java
@@ -106,7 +106,6 @@ public class StrimziPodSetUtils {
                 Pod[] spsPods = objectMapper.convertValue(podMap, Pod[].class);
                 Pod pod = Arrays.stream(spsPods).filter(p -> p.getMetadata().getName().contains(podName)).findAny().get();
 
-
                 if (annotationValue.equals(pod.getMetadata().getAnnotations().get(annotationKey))) {
                     stableCounter[0]++;
                     if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
@@ -122,7 +121,6 @@ public class StrimziPodSetUtils {
             });
         LOGGER.info("Pod: {}/{} kept annotation: {}-{} ", namespaceName, podName, annotationKey, annotationValue);
     }
-
 
     /**
      * Waits for all of specified labels of a StrimziPodSet (SPS) resource to change.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -239,61 +239,6 @@ public class PodUtils {
     }
 
     /**
-     * Waits until the single specified annotation of a Pod changes its value.
-     *
-     * @param namespaceName    the namespace in which the Pod is located.
-     * @param podName          the name of the Pod whose annotation value needs to be checked.
-     * @param annotationKey    the key of the annotation whose value needs to be checked.
-     * @param annotationValue  the expected value of the annotation to change from.
-     *
-     * @throws TimeoutException if the annotation value does not change within the {@code DELETION_TIMEOUT} period.
-     */
-    public static void waitUntilPodAnnotationChange(String namespaceName, String podName, String annotationKey, String annotationValue) {
-
-        LOGGER.info("Waiting for Pod: {}/{} to change annotation value: {}-{}", namespaceName, podName, annotationKey, annotationValue);
-        TestUtils.waitFor("Pod to change value of annotation" + annotationKey + " with key " + annotationKey, Constants.POLL_INTERVAL_FOR_RESOURCE_READINESS,
-            DELETION_TIMEOUT, () ->
-                !annotationValue.equals(kubeClient(namespaceName).getPod(namespaceName, podName).getMetadata().getAnnotations().get(annotationKey))
-        );
-        LOGGER.info("Pod: {}/{} changed annotation value: {}-{}", namespaceName, podName, annotationKey, annotationValue);
-    }
-
-    /**
-     * Waits for a specific annotation key-value pair to remain stable (from start to beginning) on a given Pod.
-     *
-     * @param namespaceName   the namespace in which the Pod is located.
-     * @param annotationKey   the key of the annotation to be checked.
-     * @param annotationValue the expected value of the annotation to be checked.
-     * @param observedPodName the name of the Pod whose annotation is being observed.
-     *
-     * @throws TimeoutException if the annotation does not remain stable within the {@code Constants.GLOBAL_STATUS_TIMEOUT} period.
-     */
-    public static void waitForPrevailedPodAnnotationKeyValuePairs(String namespaceName, String annotationKey, String annotationValue, String observedPodName) {
-        LOGGER.info("Waiting for label: {}-{} to keep its value", namespaceName, annotationKey, annotationValue);
-        int[] stableCounter = {0};
-        TestUtils.waitFor("Label: " + annotationKey + "to prevail its value: " + annotationValue,
-            Constants.GLOBAL_POLL_INTERVAL, Constants.GLOBAL_STATUS_TIMEOUT,
-            
-            () -> {
-                Pod pod = kubeClient(namespaceName).getPod(observedPodName);
-
-                if (annotationValue.equals(pod.getMetadata().getAnnotations().get(annotationKey))) {
-                    stableCounter[0]++;
-                    if (stableCounter[0] == Constants.GLOBAL_STABILITY_OFFSET_COUNT) {
-                        LOGGER.info("Pod replicas are stable for {} poll intervals", stableCounter[0]);
-                        return true;
-                    }
-                } else {
-                    LOGGER.info("Annotations does not have expected value");
-                    return false;
-                }
-                LOGGER.info("Annotation be assumed stable in {} polls", Constants.GLOBAL_STABILITY_OFFSET_COUNT - stableCounter[0]);
-                return false;
-            });
-        LOGGER.info("Pod: {}/{} kept annotation: {}-{} ", namespaceName, observedPodName, annotationKey, annotationValue);
-    }
-
-    /**
      * Ensures that at least one pod from listed (by prefix) is in {@code Pending} phase
      * @param namespaceName Namespace name
      * @param podPrefix - all pods that matched the prefix will be verified

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -11,30 +11,21 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import java.util.Arrays;
@@ -46,7 +37,6 @@ import org.junit.jupiter.api.Tag;
 
 import static io.strimzi.systemtest.Constants.REGRESSION;
 import static io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils.waitForPodsReady;
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,172 +51,6 @@ import java.util.Map;
 @Tag(REGRESSION)
 public class KafkaNodePoolST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaNodePoolST.class);
-
-    /**
-     * @description This test case verifies transfer of Kafka Cluster from and to management by KafkaNodePool, by creating corresponding Kafka and KafkaNodePool custom resources
-     * and manipulating according kafka annotation.
-     *
-     * @steps
-     * 1. - Deploy Kafka with annotated to enable management by KafkaNodePool, and KafkaNodePool targeting given Kafka Cluster.
-     *    - Kafka is deployed, KafkaNodePool custom resource is targeting Kafka Cluster as expected.
-     * 2. - Modify KafkaNodePool by increasing number of Kafka Replicas.
-     *    - Number of Kafka Pods is increased to match specification from KafkaNodePool
-     * 3. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     * 4. - Modify Kafka custom resource annotation strimzi.io/node-pool to disable management by KafkaNodePool.
-     *    - StrimziPodSet is modified, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) are ignored.
-     * 5. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     * 6. - Modify Kafka custom resource annotation strimzi.io/node-pool to enable management by KafkaNodePool.
-     *    - new StrimziPodSet is created, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) has priority over Kafka specification.
-     * 7. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     *
-     * @usecase
-     * - kafka-node-pool
-     */
-    @IsolatedTest
-    void testKafkaManagementTransferToAndFromKafkaNodePool(ExtensionContext extensionContext) {
-        assumeFalse(Environment.isKRaftModeEnabled());
-
-        final TestStorage testStorage = new TestStorage(extensionContext);
-
-        final int originalKafkaReplicaCount = 3;
-        final int nodePoolIncreasedKafkaReplicaCount = 5;
-        final String kafkaNodePoolName = "kafka";
-
-        // setup clients
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withDelayMs(200)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .build();
-
-        Map<String, String> coPod = DeploymentUtils.depSnapshot(clusterOperator.getDeploymentNamespace(), ResourceManager.getCoDeploymentName());
-
-        LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaNodePoolName);
-
-        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), originalKafkaReplicaCount, 3)
-            .editOrNewMetadata()
-                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .build();
-
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
-            .editOrNewMetadata()
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER)
-                .withStorage(kafkaCr.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafkaCr.getSpec().getKafka().getJvmOptions())
-                .withResources(kafkaCr.getSpec().getKafka().getResources())
-            .endSpec()
-            .build();
-
-        resourceManager.createResourceWithWait(extensionContext,
-            kafkaNodePoolCr,
-            kafkaCr);
-
-        LOGGER.info("Creating KafkaTopic: {}/{}", testStorage.getNamespaceName(), testStorage.getTopicName());
-        resourceManager.createResourceWithWait(extensionContext, KafkaTopicTemplates.topic(testStorage).build());
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        // increase number of kafka replicas in KafkaNodePool
-        LOGGER.info("Modifying KafkaNodePool: {}/{} by increasing number of Kafka replicas from '3' to '5'", testStorage.getNamespaceName(), kafkaNodePoolName);
-        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, kafkaNodePool -> {
-            kafkaNodePool.getSpec().setReplicas(nodePoolIncreasedKafkaReplicaCount);
-        }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            nodePoolIncreasedKafkaReplicaCount
-        );
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        LOGGER.info("Changing FG env variable to disable Kafka Node Pools");
-        List<EnvVar> coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools");
-
-        Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
-        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
-
-        coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
-
-        LOGGER.info("Disable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
-            kafka -> {
-                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "disabled");
-            }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            originalKafkaReplicaCount
-        );
-        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), originalKafkaReplicaCount);
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        LOGGER.info("Changing FG env variable to enable Kafka Node Pools");
-        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("+KafkaNodePools");
-
-        coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
-        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
-
-        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
-
-        LOGGER.info("Enable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
-            kafka -> {
-                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled");
-            }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            nodePoolIncreasedKafkaReplicaCount
-        );
-        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), nodePoolIncreasedKafkaReplicaCount);
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-    }
 
     /**
      * @description This test case verifies KafkaNodePools scaling up and down with correct NodePool IDs, with different NodePools.
@@ -256,6 +80,7 @@ public class KafkaNodePoolST extends AbstractST {
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[5]"))
             .endMetadata()
             .editOrNewSpec()
+            .withRoles(ProcessRoles.CONTROLLER, ProcessRoles.BROKER)
                 .withStorage(kafka.getSpec().getKafka().getStorage())
                 .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
                 .withResources(kafka.getSpec().getKafka().getResources())
@@ -268,6 +93,7 @@ public class KafkaNodePoolST extends AbstractST {
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[6]"))
             .endMetadata()
             .editOrNewSpec()
+                .withRoles(ProcessRoles.CONTROLLER, ProcessRoles.BROKER)
                 .withStorage(kafka.getSpec().getKafka().getStorage())
                 .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
                 .withResources(kafka.getSpec().getKafka().getResources())
@@ -323,7 +149,7 @@ public class KafkaNodePoolST extends AbstractST {
     @ParallelNamespaceTest
     void testKNPConfigurationPropagationAndModification(ExtensionContext extensionContext) {
         // unless kraft is enabled there is no point testing controllers as only allowed role without KRaft is 'Broker'
-        assumeTrue(Environment.isKRaftModeEnabled());
+//        assumeTrue(Environment.isKRaftModeEnabled());
 
         final TestStorage testStorage = new TestStorage(extensionContext);
         final String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";   // node pool (to be) with all roles,
@@ -345,6 +171,10 @@ public class KafkaNodePoolST extends AbstractST {
 
         LOGGER.info("Deploy Kafka: {}/{} with explicit JVM and resource.limit specification", testStorage.getNamespaceName(), testStorage.getClusterName());
         Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 2, 1)
+            .editOrNewMetadata()
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
             .editSpec()
                 .editKafka()
                     .withResources(new ResourceRequirementsBuilder()
@@ -465,13 +295,10 @@ public class KafkaNodePoolST extends AbstractST {
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+        assumeTrue(Environment.isKRaftModeEnabled());
 
         List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
-
-        if (Environment.isKRaftModeEnabled()) {
-            coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft,+KafkaNodePools", null));
-        }
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft,+KafkaNodePools,+UnidirectionalTopicOperator", null));
 
         this.clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withExtraEnvVars(coEnvVars)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -5,7 +5,12 @@
 package io.strimzi.systemtest.kafka;
 
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -26,6 +31,7 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
@@ -38,9 +44,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils.waitForPodsReady;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -308,12 +317,162 @@ public class KafkaNodePoolST extends AbstractST {
             KafkaNodePoolUtils.getCurrentKafkaNodePoolIds(testStorage.getNamespaceName(), nodePoolNameB).equals(Arrays.asList(0, 2, 3, 4, 6, 7)));
     }
 
+    @ParallelNamespaceTest
+    void testKNPConfigurationPropagationAndModification(ExtensionContext extensionContext) {
+
+        // unless kraft is enabled there is no point testing controllers as only allowed role without KRaft is 'Broker'
+        assumeTrue(Environment.isKRaftModeEnabled());
+
+        final TestStorage testStorage = new TestStorage(extensionContext);
+        final String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";   // node pool (to be) with all roles,
+        final String nodePoolNameB = testStorage.getKafkaNodePoolName() + "-b";   // node pool (to be) with broker role
+        final String nodePoolNameC = testStorage.getKafkaNodePoolName() + "-c";   // node pool (to be) with controller role
+
+        final LabelSelector nodePoolALabelSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameA);
+        final LabelSelector nodePoolBLabelSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameB);
+        final LabelSelector nodePoolCLabelSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameC);
+
+        // config for jvm and resource limit present in Kafka CR
+        final String kafkaJvmXmxConfig = "1024m";
+        final String kafkaLimitMemoryQuantityConfig = "1024Mi";
+        final String kafkaLimitMemoryQuantityConfigModified = "1100Mi";
+
+        // overriding configurations in some of kafkaNodePools CRs
+        final String knpBJvmXmxConfig = "2048m";
+        final String knpBAndCLimitMemoryQuantityConfig = "2048Mi";
+
+        LOGGER.info("Deploy Kafka: {}/{} with explicit JVM and resource.limit specification", testStorage.getNamespaceName(), testStorage.getClusterName());
+        Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 2, 1)
+            .editSpec()
+                .editKafka()
+                    .withResources(new ResourceRequirementsBuilder()
+                        .addToLimits("memory", new Quantity(kafkaLimitMemoryQuantityConfig))
+                    .build())
+                    .withNewJvmOptions()
+                        .withXmx(kafkaJvmXmxConfig)
+                    .endJvmOptions()
+                .endKafka()
+            .endSpec()
+            .build();
+
+        // KNP with all roles and without any other optional config. overriding config. provided in Kafka
+        KafkaNodePool poolA =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), nodePoolNameA, testStorage.getClusterName(), 2)
+            .editOrNewSpec()
+                .withRoles(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)
+                .withStorage(kafka.getSpec().getKafka().getStorage())   // storage is mandatory spec, otherwise it not important part of the test
+            .endSpec()
+            .build();
+
+        // KNP with broker role with its own config for jvm and resource.limit overriding provided config in Kafka
+        KafkaNodePool poolB =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), nodePoolNameB, testStorage.getClusterName(), 1)
+            .editOrNewSpec()
+                .withRoles(ProcessRoles.BROKER)
+                .withStorage(kafka.getSpec().getKafka().getStorage()) // mandatory
+                .withNewJvmOptions()
+                    .withXmx(knpBJvmXmxConfig) // overriding jvm configuration
+                .endJvmOptions()
+                .withResources(new ResourceRequirementsBuilder()
+                    .addToLimits("memory", new Quantity(knpBAndCLimitMemoryQuantityConfig)) // overriding resource.limit
+                .build())
+            .endSpec()
+            .build();
+
+        // KNP with broker role with its own config for jvm and resource.limit overriding provided config in Kafka
+        KafkaNodePool poolC =  KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRole(testStorage.getNamespaceName(), nodePoolNameC, testStorage.getClusterName(), 1)
+            .editOrNewSpec()
+                .withRoles(ProcessRoles.CONTROLLER)
+                .withStorage(kafka.getSpec().getKafka().getStorage()) // mandatory
+                .withResources(new ResourceRequirementsBuilder()
+                    .addToLimits("memory", new Quantity(knpBAndCLimitMemoryQuantityConfig)) // overriding resource.limit
+                .build())
+            .endSpec()
+            .build();
+
+        LOGGER.info("Verify correct config. propagation from Kafka to Kafka Node Pool Pods");
+
+        resourceManager.createResourceWithWait(extensionContext, poolA, poolB, poolC, kafka);
+        waitForPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), 4, true);
+
+        // assert jvm and limits config (written in kafka) is propagated into KNP A Pods
+        verifyResourcesConfigurationPropagatedToKnpPods(testStorage, nodePoolNameA, kafkaJvmXmxConfig, kafkaLimitMemoryQuantityConfig);
+
+        // assert jvm and limits config (written in kafka) is overwritten by respective config present in KNP B Pods
+        verifyResourcesConfigurationPropagatedToKnpPods(testStorage, nodePoolNameB, knpBJvmXmxConfig, knpBAndCLimitMemoryQuantityConfig);
+
+        // assert jvm config (written in kafka) is propagated into KNP C Pods while limit configuration not, as it is present in KNP C.
+        verifyResourcesConfigurationPropagatedToKnpPods(testStorage, nodePoolNameC, kafkaJvmXmxConfig, knpBAndCLimitMemoryQuantityConfig);
+
+        LOGGER.info("Verify correct config. propagation when modifying kafka CR");
+
+        final Map<String, String> nodePoolAPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), nodePoolALabelSelector);
+        final Map<String, String> nodePoolBPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), nodePoolBLabelSelector);
+
+        // modify resource.limit in kafka CR
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
+            k.getSpec().getKafka().getResources().getLimits().replace("memory", new Quantity(kafkaLimitMemoryQuantityConfigModified));
+        }, testStorage.getNamespaceName());
+
+        // (as KNP A is the only one that inherit it from Kafka it is the only one which needs to be updated by this change
+        RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), nodePoolBLabelSelector, nodePoolBPodsSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), nodePoolALabelSelector, 2, nodePoolAPodsSnapshot);
+        //waitForPodsReady(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), scaledUpBrokerReplicaCount, false);
+
+        // assert that new changed configuration is present in pods under Kafka Node Pool A
+        verifyResourcesConfigurationPropagatedToKnpPods(testStorage, nodePoolNameA, kafkaJvmXmxConfig, kafkaLimitMemoryQuantityConfigModified);
+
+        LOGGER.info("Modifying configuration relevant or irrelevant based on role of given KafkaNodePools");
+
+        // replacing config which is not relevant to control (also it is part of dynamic config, therefore should not trigger Rolling Update)
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
+            k.getSpec().getKafka().getConfig().put("compression.type", "gzip");
+        }, testStorage.getNamespaceName());
+
+        final Pod podFromKnpC = PodUtils.getPodsByPrefixInNameWithDynamicWait(testStorage.getNamespaceName(), testStorage.getClusterName() + "-" + nodePoolNameC).get(0);
+        final String podCName = podFromKnpC.getMetadata().getName();
+        final String knpCConfigHashAnnotationValue = podFromKnpC.getMetadata().getAnnotations().get(Constants.NODE_BROKER_CONFIG_HASH_ANNOTATION);
+        final String knpCStrimziPodSetName = KafkaNodePoolUtils.getStrimziPodSetName(testStorage.getClusterName(), nodePoolNameC);
+        StrimziPodSetUtils.waitForPrevailedPodAnnotationKeyValuePairs(testStorage.getNamespaceName(), Constants.NODE_BROKER_CONFIG_HASH_ANNOTATION, knpCConfigHashAnnotationValue, knpCStrimziPodSetName, podCName);
+
+        // replacing config relevant only to controllers
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> {
+            k.getSpec().getKafka().getConfig().put("max.connections", "456");
+        }, testStorage.getNamespaceName());
+
+        StrimziPodSetUtils.waitUntilPodAnnotationChange(testStorage.getNamespaceName(), podCName, knpCStrimziPodSetName, Constants.NODE_BROKER_CONFIG_HASH_ANNOTATION, knpCConfigHashAnnotationValue);
+    }
+
+    /**
+     * Verifies that the specified configurations are correctly propagated to the Kafka Node Pool (KNP) pods.
+     *
+     * <p>This method checks the memory limit and JVM heap options of the first pod belonging to the given node pool.
+     *
+     * @param testStorage        the storage object containing test-related information.
+     * @param nodePoolName       the name of the KNP to verify.
+     * @param expectedJvmXmxLimit the expected JVM '-Xmx' heap size limit.
+     * @param expectedMemoryLimit the expected memory limit ('resource.limits.memory') for the pod.
+     *
+     * @throws AssertionError if configurations obtained from Pods do not match the expected values.
+     */
+    public static void verifyResourcesConfigurationPropagatedToKnpPods(TestStorage testStorage, String nodePoolName, String expectedJvmXmxLimit, String expectedMemoryLimit) {
+        Pod nodePoolPod = PodUtils.getPodsByPrefixInNameWithDynamicWait(testStorage.getNamespaceName(), testStorage.getClusterName() + "-" + nodePoolName).get(0);
+        Container container = nodePoolPod.getSpec().getContainers().stream().findFirst().get();
+        Quantity  obtainedMemory = container.getResources().getLimits().get("memory");
+        EnvVar obtainedJvmHeapEnvVariable = container.getEnv().stream().filter(e -> e.getName().equals("KAFKA_HEAP_OPTS")).findAny().get();
+
+        assertThat(obtainedMemory, is(new Quantity(expectedMemoryLimit)));
+        assertThat("NodePool: does not contain expected JVM configuration", obtainedJvmHeapEnvVariable.getValue().contains(expectedJvmXmxLimit));
+    }
+
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         List<EnvVar> coEnvVars = new ArrayList<>();
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
+
+        if (Environment.isKRaftModeEnabled()) {
+            coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft,+KafkaNodePools", null));
+        }
 
         this.clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withExtraEnvVars(coEnvVars)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.operators;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.StrimziPodSet;
@@ -21,15 +22,18 @@ import io.strimzi.systemtest.Constants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.annotations.IsolatedTest;
@@ -47,6 +51,7 @@ import java.util.Map;
 import static io.strimzi.systemtest.Constants.CO_NAMESPACE;
 import static io.strimzi.systemtest.Constants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.Constants.REGRESSION;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -251,6 +256,181 @@ public class FeatureGatesST extends AbstractST {
         LOGGER.info("Annotating {} of Kafka Cluster: {}/{} with manual rolling update annotation", StrimziPodSet.RESOURCE_KIND, testStorage.getNamespaceName(), testStorage.getClusterName());
         StrimziPodSetUtils.annotateStrimziPodSet(testStorage.getNamespaceName(), testStorage.getClusterName() + "-" + testStorage.getKafkaNodePoolName(), Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
         RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), kafkaSelector, 3, kafkaPods);
+
+    }
+
+    /**
+     * @description This test case verifies transfer of Kafka Cluster from and to management by KafkaNodePool, by creating corresponding Kafka and KafkaNodePool custom resources
+     * and manipulating according kafka annotation.
+     *
+     * @steps
+     * 1. - Deploy Kafka with annotated to enable management by KafkaNodePool, and KafkaNodePool targeting given Kafka Cluster.
+     *    - Kafka is deployed, KafkaNodePool custom resource is targeting Kafka Cluster as expected.
+     * 2. - Modify KafkaNodePool by increasing number of Kafka Replicas.
+     *    - Number of Kafka Pods is increased to match specification from KafkaNodePool
+     * 3. - Produce and consume messages in given Kafka Cluster.
+     *    - Clients can produce and consume messages.
+     * 4. - Modify Kafka custom resource annotation strimzi.io/node-pool to disable management by KafkaNodePool.
+     *    - StrimziPodSet is modified, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) are ignored.
+     * 5. - Produce and consume messages in given Kafka Cluster.
+     *    - Clients can produce and consume messages.
+     * 6. - Modify Kafka custom resource annotation strimzi.io/node-pool to enable management by KafkaNodePool.
+     *    - new StrimziPodSet is created, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) has priority over Kafka specification.
+     * 7. - Produce and consume messages in given Kafka Cluster.
+     *    - Clients can produce and consume messages.
+     *
+     * @usecase
+     * - kafka-node-pool
+     */
+    @IsolatedTest
+    void testKafkaManagementTransferToAndFromKafkaNodePool(ExtensionContext extensionContext) {
+        assumeFalse(Environment.isKRaftModeEnabled());
+        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+
+        final TestStorage testStorage = new TestStorage(extensionContext, CO_NAMESPACE);
+
+        List<EnvVar> coEnvVars = new ArrayList<>();
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
+
+        clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
+            .withExtraEnvVars(coEnvVars)
+            .createInstallation()
+            .runInstallation();
+
+        final int originalKafkaReplicaCount = 3;
+        final int nodePoolIncreasedKafkaReplicaCount = 5;
+        final String kafkaNodePoolName = "kafka";
+
+        // setup clients
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withDelayMs(200)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .build();
+
+        Map<String, String> coPod = DeploymentUtils.depSnapshot(clusterOperator.getDeploymentNamespace(), ResourceManager.getCoDeploymentName());
+
+        LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaNodePoolName);
+
+        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), originalKafkaReplicaCount, 3)
+            .editOrNewMetadata()
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .build();
+
+        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
+            .editOrNewMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .editOrNewSpec()
+                .addToRoles(ProcessRoles.BROKER)
+                .withStorage(kafkaCr.getSpec().getKafka().getStorage())
+                .withJvmOptions(kafkaCr.getSpec().getKafka().getJvmOptions())
+                .withResources(kafkaCr.getSpec().getKafka().getResources())
+            .endSpec()
+            .build();
+
+        resourceManager.createResourceWithWait(extensionContext,
+            kafkaNodePoolCr,
+            kafkaCr);
+
+        LOGGER.info("Creating KafkaTopic: {}/{}", testStorage.getNamespaceName(), testStorage.getTopicName());
+        resourceManager.createResourceWithWait(extensionContext, KafkaTopicTemplates.topic(testStorage).build());
+
+        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
+        resourceManager.createResourceWithWait(extensionContext,
+            clients.producerStrimzi(),
+            clients.consumerStrimzi()
+        );
+        ClientUtils.waitForClientsSuccess(testStorage);
+
+        // increase number of kafka replicas in KafkaNodePool
+        LOGGER.info("Modifying KafkaNodePool: {}/{} by increasing number of Kafka replicas from '3' to '5'", testStorage.getNamespaceName(), kafkaNodePoolName);
+        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, kafkaNodePool -> {
+            kafkaNodePool.getSpec().setReplicas(nodePoolIncreasedKafkaReplicaCount);
+        }, testStorage.getNamespaceName());
+
+        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
+            testStorage.getNamespaceName(),
+            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
+            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
+            nodePoolIncreasedKafkaReplicaCount
+        );
+
+        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
+        resourceManager.createResourceWithWait(extensionContext,
+            clients.producerStrimzi(),
+            clients.consumerStrimzi()
+        );
+        ClientUtils.waitForClientsSuccess(testStorage);
+
+        LOGGER.info("Changing FG env variable to disable Kafka Node Pools");
+        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools");
+
+        Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
+        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
+
+        coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+
+        LOGGER.info("Disable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> {
+                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "disabled");
+            }, testStorage.getNamespaceName());
+
+        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
+            testStorage.getNamespaceName(),
+            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
+            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
+            originalKafkaReplicaCount
+        );
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), originalKafkaReplicaCount);
+
+        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
+        resourceManager.createResourceWithWait(extensionContext,
+            clients.producerStrimzi(),
+            clients.consumerStrimzi()
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage);
+
+        LOGGER.info("Changing FG env variable to enable Kafka Node Pools");
+        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("+KafkaNodePools");
+
+        coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
+        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
+        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
+
+        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+
+        LOGGER.info("Enable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> {
+                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled");
+            }, testStorage.getNamespaceName());
+
+        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
+            testStorage.getNamespaceName(),
+            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
+            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
+            nodePoolIncreasedKafkaReplicaCount
+        );
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), nodePoolIncreasedKafkaReplicaCount);
+
+        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
+        resourceManager.createResourceWithWait(extensionContext,
+            clients.producerStrimzi(),
+            clients.consumerStrimzi()
+        );
+        ClientUtils.waitForClientsSuccess(testStorage);
 
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description
Implementation of new test to verify proper propagation of configuration when creating resource or modifying specification.

in PodSetUtils and StrimziPodSetUtils there are two new methods for waiting for changes/ stability in Pods annotations, we ho with implementation in StrimziPodSetUtils as data In Pods as such are not reflecting reality in case of Controller role when doing modifications. 

the test itself was discused on triage regarding Kafka Node Pools.  

### Checklist


- [x] Write tests
- [x] Make sure all tests pass


