### PR TITLE
Promote UnidirectionalTopicOperator feature gate to beta

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +21,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +34,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +47,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +60,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +73,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +86,6 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator'
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/kraft_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'kraft-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +16,7 @@ jobs:
       display_name: 'kraft-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +27,7 @@ jobs:
       display_name: 'kraft-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +38,7 @@ jobs:
       display_name: 'kraft-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +49,7 @@ jobs:
       display_name: 'kraft-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +60,7 @@ jobs:
       display_name: 'kraft-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +71,7 @@ jobs:
       display_name: 'kraft-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+UseKRaft,+UnidirectionalTopicOperator'
+      strimzi_feature_gates: '+UseKRaft'
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   All Connect and Mirror Maker 2 operands will now use StrimziPodSets.
 * The `KafkaNodePools` feature gate moves to beta stage and is enabled by default.
   If needed, `KafkaNodePools` can be disabled in the feature gates configuration in the Cluster Operator.
+* The `UnidirectionalTopicOperator` feature gate moves to beta stage and is enabled by default.
+  If needed, `UnidirectionalTopicOperator` can be disabled in the feature gates configuration in the Cluster Operator.
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -23,7 +23,7 @@ public class FeatureGates {
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, false);
     private final FeatureGate kafkaNodePools = new FeatureGate(KAFKA_NODE_POOLS, true);
-    private final FeatureGate unidirectionalTopicOperator = new FeatureGate(UNIDIRECTIONAL_TOPIC_OPERATOR, false);
+    private final FeatureGate unidirectionalTopicOperator = new FeatureGate(UNIDIRECTIONAL_TOPIC_OPERATOR, true);
 
     /**
      * Constructs the feature gates configuration.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -45,7 +45,7 @@ public class KRaftUtils {
      */
     /* test */ static void validateEntityOperatorSpec(Set<String> errors, EntityOperatorSpec entityOperator, boolean utoEnabled) {
         if (entityOperator != null && entityOperator.getTopicOperator() != null && !utoEnabled) {
-            errors.add("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.");
+            errors.add("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.");
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -76,7 +76,7 @@ public class KRaftUtilsTest {
 
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateKafkaCrForKRaft(spec, false));
 
-        assertThat(ex.getMessage(), is("Kafka configuration is not valid: [Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.]"));
+        assertThat(ex.getMessage(), is("Kafka configuration is not valid: [Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.]"));
     }
 
     @ParallelTest
@@ -111,7 +111,7 @@ public class KRaftUtilsTest {
 
         KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
 
-        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.")));
+        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.")));
     }
 
     @ParallelTest
@@ -139,6 +139,6 @@ public class KRaftUtilsTest {
 
         KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
 
-        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled. You can enable it using the UnidirectionalTopicOperator feature gate.")));
+        assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.")));
     }
 }

--- a/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-with-cluster-operator.adoc
@@ -10,9 +10,6 @@ This procedure describes how to deploy the Topic Operator using the Cluster Oper
 The Topic Operator can be deployed for use in either bidirectional mode or unidirectional mode.
 To learn more about bidirectional and unidirectional topic management, see xref:ref-operator-topic-{context}[].
 
-NOTE: Unidirectional topic management is available as a preview. 
-Unidirectional topic management is not enabled by default, so you must xref:ref-operator-unidirectional-topic-operator-feature-gate-{context}[enable the `UnidirectionalTopicOperator` feature gate] to be able to use it.
-
 You configure the `entityOperator` property of the `Kafka` resource to include the `topicOperator`.
 By default, the Topic Operator watches for `KafkaTopic` resources in the namespace of the Kafka cluster deployed by the Cluster Operator.
 You can also specify a namespace using `watchedNamespace` in the Topic Operator `spec`.

--- a/documentation/modules/operators/con-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/con-changing-topic-operator-mode.adoc
@@ -3,14 +3,13 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='con-changing-topic-operator-mode-{context}']
-= (Preview) Switching between Topic Operator modes
+= Switching between Topic Operator modes
 
 [role="_abstract"]
 You can switch between topic management modes when upgrading or downgrading Strimzi, or when using the same version of Strimzi, as long as the mode is supported for that version. 
 
-* To switch from the default unidirectional mode to bidirectional mode you have to xref:ref-operator-unidirectional-topic-operator-feature-gate-str[disable the `UnidirectionalTopicOperator` feature gate], and check whether finalizers are being used to control topic deletion. If `KafkaTopic` resources are using finalizers, ensure that you do one of the following  before making the switch:
-** xref:con-removing-topic-finalizers-{context}[Remove all finalizers from topics].
-** Disable the finalizers by setting the `STRIMZI_USE_FINALIZERS` environment variable to `false` in the Topic Operator `env` configuration.
+* To switch from the default unidirectional mode to bidirectional mode you have to:
+** Disable the use of finalizers.
 +
 .Disabling the topic finalizers
 [source,shell,subs=+quotes]
@@ -21,7 +20,9 @@ env:
     value: "false"
 ----
 +
+** xref:ref-operator-unidirectional-topic-operator-feature-gate-str[Disable the `UnidirectionalTopicOperator` feature gate].
+
 Use the same configuration for a Topic Operator running in a Strimzi-managed cluster or as a standalone deployment.  
 
 The Topic Operator does not use finalizers in bidirectional mode.
-If they are retained after making the switch from unidirectional mode, you won't be able to delete `KafkaTopic` and related resources. 
+If they are retained after making the switch from unidirectional mode, you won't be able to delete `KafkaTopic` and related resources.

--- a/documentation/modules/operators/con-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/con-changing-topic-operator-mode.adoc
@@ -8,8 +8,7 @@
 [role="_abstract"]
 You can switch between topic management modes when upgrading or downgrading Strimzi, or when using the same version of Strimzi, as long as the mode is supported for that version. 
 
-* To switch from the default bidirectional mode to unidirectional mode, xref:ref-operator-unidirectional-topic-operator-feature-gate-str[enable the `UnidirectionalTopicOperator` feature gate]. 
-* To switch from unidirectional mode to bidirectional mode, check whether finalizers are being used to control topic deletion. If `KafkaTopic` resources are using finalizers, ensure that you do one of the following  before making the switch:
+* To switch from the default unidirectional mode to bidirectional mode you have to xref:ref-operator-unidirectional-topic-operator-feature-gate-str[disable the `UnidirectionalTopicOperator` feature gate], and check whether finalizers are being used to control topic deletion. If `KafkaTopic` resources are using finalizers, ensure that you do one of the following  before making the switch:
 ** xref:con-removing-topic-finalizers-{context}[Remove all finalizers from topics].
 ** Disable the finalizers by setting the `STRIMZI_USE_FINALIZERS` environment variable to `false` in the Topic Operator `env` configuration.
 +

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -10,9 +10,6 @@ Unidirectional topic management supports the deletion of topics managed through 
 This is determined by the `STRIMZI_USE_FINALIZERS` Topic Operator environment variable.
 By default, this is set to `true`, though it can be set to `false` in the Topic Operator `env` configuration if you do not want the Topic Operator to add finalizers.
 
-NOTE: Unidirectional topic management is available as a preview. 
-Unidirectional topic management is not enabled by default, so you must xref:ref-operator-unidirectional-topic-operator-feature-gate-{context}[enable the `UnidirectionalTopicOperator` feature gate] to be able to use it.
-
 Finalizers ensure orderly and controlled deletion of `KafkaTopic` resources.
 A finalizer for the Topic Operator is added to the metadata of the `KafkaTopic` resource:
 

--- a/documentation/modules/operators/proc-converting-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-managed-topics.adoc
@@ -16,9 +16,6 @@ This allows you to retain the Kafka topic while making changes to the resource's
 
 You can perform this task if you are using unidirectional topic management.
 
-NOTE: Unidirectional topic management is available as a preview. 
-Unidirectional topic management is not enabled by default, so you must xref:ref-operator-unidirectional-topic-operator-feature-gate-{context}[enable the `UnidirectionalTopicOperator` feature gate] to be able to use it.
-
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]

--- a/documentation/modules/operators/proc-converting-non-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-non-managed-topics.adoc
@@ -11,9 +11,6 @@ You do this by creating a matching `KafkaTopic` resource.
 
 You can perform this task if you are using unidirectional topic management.
 
-NOTE: Unidirectional topic management is available as a preview. 
-Unidirectional topic management is not enabled by default, so you must xref:ref-operator-unidirectional-topic-operator-feature-gate-{context}[enable the `UnidirectionalTopicOperator` feature gate] to be able to use it.
-
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -25,8 +25,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseKRaft` feature gate is available for development only and does not currently have a planned release for moving to the beta phase.
 * The `KafkaNodePools` feature gate is in beta stage and is enabled by default.
   It is expected to move to GA phase and be always enabled from Strimzi 0.41.
-* The `UnidirectionalTopicOperator` feature gate is in alpha stage and is disabled by default.
-  It is expected to move to beta phase and be enabled by default from Strimzi 0.39.
+* The `UnidirectionalTopicOperator` feature gate is in beta stage and is enabled by default.
+  It is expected to move to GA phase and be always enabled from Strimzi 0.41.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -71,8 +71,8 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 ¦`UnidirectionalTopicOperator`
 ¦0.36
-¦0.39 (planned)
-¦ -
+¦0.39
+¦0.41 (planned)
 
 |===
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -92,7 +92,6 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 * Upgrades and downgrades of Apache Kafka versions or the Strimzi operator are not supported.
   Users might need to delete the cluster, upgrade the operator and deploy a new Kafka cluster.
 * Only the _Unidirectional_ Topic Operator is supported in KRaft mode.
-  You can enable it using the `UnidirectionalTopicOperator` feature gate.
   The _Bidirectional_ Topic Operator is not supported and when the `UnidirectionalTopicOperator` feature gate is not enabled, the `spec.entityOperator.topicOperator` property *must be removed* from the `Kafka` custom resource.
 * JBOD storage is not supported. 
   The `type: jbod` storage can be used, but the JBOD array can contain only one disk.
@@ -135,7 +134,7 @@ If your cluster already uses `KafkaNodePool` custom resources, and you wish to d
 [id='ref-operator-unidirectional-topic-operator-feature-gate-{context}']
 == (Preview) UnidirectionalTopicOperator feature gate
 
-The `UnidirectionalTopicOperator` feature gate has a default state of _disabled_.
+The `UnidirectionalTopicOperator` feature gate has a default state of _enabled_.
 
 The `UnidirectionalTopicOperator` feature gate introduces a unidirectional topic management mode for creating Kafka topics using the `KafkaTopic` resource.
 Unidirectional mode is compatible with using KRaft for cluster management.
@@ -143,7 +142,10 @@ With unidirectional mode, you create Kafka topics using the `KafkaTopic` resourc
 Any configuration changes to a topic outside the `KafkaTopic` resource are reverted.
 For more information on topic management, see xref:ref-operator-topic-str[].
 
-.Enabling the UnidirectionalTopicOperator feature gate
+.Disabling the `UnidirectionalTopicOperator` feature gate
 
-To enable the `UnidirectionalTopicOperator` feature gate, specify `+UnidirectionalTopicOperator` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-For the `KafkaTopic` custom resource to use this feature, the `strimzi.io/managed` annotation is set to `true` by default. 
+To disable the `UnidirectionalTopicOperator` feature gate, specify `-UnidirectionalTopicOperator` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+.Downgrading from UnidirectionalTopicOperator
+
+If you want to downgrade to the previous Topic Operator implementation, you can simply disable the feature gate and then remove all the `KafkaTopic` finalizers.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -145,7 +145,3 @@ For more information on topic management, see xref:ref-operator-topic-str[].
 .Disabling the `UnidirectionalTopicOperator` feature gate
 
 To disable the `UnidirectionalTopicOperator` feature gate, specify `-UnidirectionalTopicOperator` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-.Downgrading from UnidirectionalTopicOperator
-
-If you want to downgrade to the previous Topic Operator implementation, you can simply disable the feature gate and then remove all the `KafkaTopic` finalizers.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -132,7 +132,7 @@ The `Kafka` custom resource using the node pools must also have the annotation `
 If your cluster already uses `KafkaNodePool` custom resources, and you wish to downgrade to an older version of Strimzi that does not support them or with the `KafkaNodePools` feature gate disabled, you must first migrate from `KafkaNodePool` custom resources to managing Kafka nodes using only `Kafka` custom resources.
 
 [id='ref-operator-unidirectional-topic-operator-feature-gate-{context}']
-== (Preview) UnidirectionalTopicOperator feature gate
+== UnidirectionalTopicOperator feature gate
 
 The `UnidirectionalTopicOperator` feature gate has a default state of _enabled_.
 

--- a/documentation/modules/operators/ref-operator-topic.adoc
+++ b/documentation/modules/operators/ref-operator-topic.adoc
@@ -12,9 +12,6 @@ Bidirectional mode:: Bidirectional mode requires ZooKeeper for cluster managemen
 
 (Preview) Unidirectional mode:: Unidirectional mode does not require ZooKeeper for cluster management. It is compatible with using Strimzi in KRaft mode.
 
-NOTE: Unidirectional topic management is available as a preview. 
-Unidirectional topic management is not enabled by default, so you must xref:ref-operator-unidirectional-topic-operator-feature-gate-{context}[enable the `UnidirectionalTopicOperator` feature gate] to be able to use it.
-
 == Bidirectional topic management
 
 In bidirectional mode, the Topic Operator operates as follows: 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Constants.java
@@ -201,7 +201,7 @@ public interface Constants {
      */
     String USE_KRAFT_MODE = "+UseKRaft";
     String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
-    String UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
+    String DONT_USE_UNIDIRECTIONAL_TOPIC_OPERATOR = "-UnidirectionalTopicOperator";
 
     /**
      * Default value which allows execution of tests with any tags

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -273,7 +273,7 @@ public class Environment {
     }
 
     public static boolean isUnidirectionalTopicOperatorEnabled() {
-        return STRIMZI_FEATURE_GATES.contains(Constants.UNIDIRECTIONAL_TOPIC_OPERATOR);
+        return !STRIMZI_FEATURE_GATES.contains(Constants.DONT_USE_UNIDIRECTIONAL_TOPIC_OPERATOR);
     }
 
     /**

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -46,7 +46,7 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
-  featureGatesBefore: "-KafkaNodePools,+UnidirectionalTopicOperator"
+  featureGatesBefore: "-KafkaNodePools"
   featureGatesAfter: "-StableConnectIdentities,-UnidirectionalTopicOperator"
 - fromVersion: HEAD
   toVersion: 0.38.0

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -63,4 +63,4 @@
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: "-StableConnectIdentities,-UnidirectionalTopicOperator"
-  featureGatesAfter: "+UnidirectionalTopicOperator"
+  featureGatesAfter: ""


### PR DESCRIPTION
This PR promotes the UnidirectionalTopicOperator feature gate to beta and thus enables it by default. It also updates related documentation, Azure pipelines, unit and system tests. Please double check the pipeline changes, as I don't have a way to test them.
