### PR TITLE
[ST] Fix of date time format for externaly generated certs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/security/OpenSsl.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/OpenSsl.java
@@ -12,7 +12,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/OpenSsl.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/OpenSsl.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -184,7 +185,7 @@ public class OpenSsl {
         String endDate = dates.split("\n")[1].replace("notAfter=", "");
 
         ZoneId gmtZone = ZoneId.of("GMT");
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd HH:mm:ss yyyy z");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d[d] HH:mm:ss yyyy z");
         ZonedDateTime notBefore = ZonedDateTime.of(LocalDateTime.parse(startDate, formatter), gmtZone);
         ZonedDateTime notAfter = ZonedDateTime.of(LocalDateTime.parse(endDate, formatter), gmtZone);
 


### PR DESCRIPTION
### Type of change

- Fix
- Refactoring

### Description

This PR is quick and small fix of date formatter used in UserST while testing external tls auth for users. During this test an additional info of NotBefore and NotAfter of generated certificate is being verified. As the date had format of "MMM dd HH:mm:ss yyyy z" when a single digit day number was being parsed, parsing failed. After adding the optional flag to the second day digit, parsing should now be able to parse dates like "Nov 06 13:12:06 GMT" as well as "Nov 6 03:02:06 GMT".

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

