### PR TITLE
Deprecate the Deployment option in the Connect and MM2 template

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/AbstractKafkaConnectSpec.java
@@ -163,7 +163,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
     }
 
     @Description("Template for Kafka Connect and Kafka Mirror Maker 2 resources. " +
-            "The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.")
+            "The template allows users to specify how the `Pods`, `Service`, and other services are generated.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public KafkaConnectTemplate getTemplate() {
         return template;

--- a/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/template/KafkaConnectTemplate.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.Constants;
 import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -50,6 +51,8 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable,
 
     @Description("Template for Kafka Connect `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Deprecated
+    @DeprecatedProperty(description = "Kafka Connect and MirrorMaker 2 operands do not use `Deployment` resources anymore. This field will be ignored.")
     public DeploymentTemplate getDeployment() {
         return deployment;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyIngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeer;
@@ -477,51 +476,6 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
             builder = ModelUtils.populateAffinityBuilderWithRackLabelSelector(builder, userAffinity, rack.getTopologyKey());
         }
         return builder.build();
-    }
-
-    /**
-     * Generates the Kafka Connect deployment
-     *
-     * @param replicas              Number of replicas the deployment should have
-     * @param deploymentAnnotations Map with Deployment annotations
-     * @param podAnnotations        Map with Pod annotations
-     * @param isOpenShift           Flag indicating if we are on OpenShift or not
-     * @param imagePullPolicy       Image pull policy
-     * @param imagePullSecrets      List of image pull Secrets
-     * @param customContainerImage  Custom container image produced by Kafka Connect Build. If null, the default
-     *                              image will be used.
-     * @return Generated deployment
-     */
-    public Deployment generateDeployment(int replicas,
-                                         Map<String, String> deploymentAnnotations,
-                                         Map<String, String> podAnnotations,
-                                         boolean isOpenShift,
-                                         ImagePullPolicy imagePullPolicy,
-                                         List<LocalObjectReference> imagePullSecrets,
-                                         String customContainerImage) {
-        return WorkloadUtils.createDeployment(
-                componentName,
-                namespace,
-                labels,
-                ownerReference,
-                templateDeployment,
-                replicas,
-                deploymentAnnotations,
-                WorkloadUtils.deploymentStrategy(TemplateUtils.deploymentStrategy(templateDeployment, ROLLING_UPDATE)),
-                WorkloadUtils.createPodTemplateSpec(
-                        componentName,
-                        labels,
-                        templatePod,
-                        defaultPodLabels(),
-                        podAnnotations,
-                        getMergedAffinity(),
-                        ContainerUtils.listOrNull(createInitContainer(imagePullPolicy)),
-                        List.of(createContainer(imagePullPolicy, customContainerImage)),
-                        getVolumes(isOpenShift),
-                        imagePullSecrets,
-                        securityProvider.kafkaConnectPodSecurityContext(new PodSecurityProviderContextImpl(templatePod))
-                )
-        );
     }
 
     /**

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1763,7 +1763,7 @@ include::../api/io.strimzi.api.kafka.model.KafkaConnectSpec.adoc[leveloffset=+1]
 |xref:type-Rack-{context}[`Rack`]
 |tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
-|template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
+|template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
@@ -2007,7 +2007,7 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 [options="header"]
 |====
 |Property                    |Description
-|deployment           1.2+<.<a|Template for Kafka Connect `Deployment`.
+|deployment           1.2+<.<a|**The `deployment` property has been deprecated.** Kafka Connect and MirrorMaker 2 operands do not use `Deployment` resources anymore. This field will be ignored. Template for Kafka Connect `Deployment`.
 |xref:type-DeploymentTemplate-{context}[`DeploymentTemplate`]
 |podSet               1.2+<.<a|Template for Kafka Connect `StrimziPodSet` resource.
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
@@ -3225,7 +3225,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-Rack-{context}[`Rack`]
 |tracing                1.2+<.<a|The configuration of tracing in Kafka Connect. The type depends on the value of the `tracing.type` property within the given object, which must be one of [jaeger, opentelemetry].
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
-|template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.
+|template               1.2+<.<a|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 |externalConfiguration  1.2+<.<a|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1726,7 +1726,7 @@ spec:
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
                       description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
                 externalConfiguration:
                   type: object
                   properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1871,7 +1871,7 @@ spec:
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
                       description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
                 externalConfiguration:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1725,7 +1725,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1870,7 +1870,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated."
+                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the Deployment template in the Connect and MM2 template section that is not used anymore after `StableConnectIdentities` feature gate graduated. It also removes the unused method to generate the deployment and updates the template docs to not reference Deployment resources anymore.

### Checklist

- [x] Update documentation