### PR TITLE
[DOC] Improve topic replication factor change procedure

### DIFF
--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -13,103 +13,123 @@ and using a reassignment file to describe how the topic replicas should be chang
 
 This procedure describes a secure process that uses TLS.
 You'll need a Kafka cluster that uses TLS encryption and mTLS authentication.
-A topic called `my-topic` has only 1 replica and we want to increase it to 3 replicas.
 
 .Prerequisites
 
 * You have a running Kafka cluster based on a `Kafka` resource configured with internal TLS encryption and mTLS authentication.
+* You are running an interactive pod container that is connected to the running Kafka broker.
+* You have generated a reassignment JSON file named `reassignment.json`.
 * You are connected as a `KafkaUser` configured with ACL rules that specify permission to manage the Kafka cluster and its topics.
-* You have generated a reassignment JSON file named reassignment.json.
 
 See xref:proc-generating-reassignment-json-files-{context}[Generating reassignment JSON files].
 
+In this procedure, a topic called `my-topic` has 4 replicas and we want to reduce it to 3.
+A JSON file named `topics.json` specifies the topic, and was used to generate the `reassignment.json` file.
+
+.Example JSON file specifies `my-topic`
+[source,json]
+----
+{
+  "version": 1,
+  "topics": [
+    { "topic": "my-topic"}
+  ]
+}
+----
+
 .Procedure
 
-. Create some configuration files that will be used to run the `kafka-reassign-partitions.sh` tool
+. If you haven't done so, xref:proc-generating-reassignment-json-files-{context}[run an interactive pod container to generate a reassignment JSON file] named `reassignment.json`.
++
+.Example reassignment JSON file showing the current and proposed replica assignment
 [source,shell,subs=+quotes]
 ----
-$ mkdir -p /tmp/config
-
-# client truststore and keystore
-$ kubectl get secret my-cluster-cluster-ca-cert -o jsonpath="{.data['ca\.p12']}" | base64 -d >/tmp/config/truststore.p12
-$ kubectl get secret my-user -o jsonpath="{.data['user\.p12']}" | base64 -d >/tmp/config/keystore.p12
-
-# client authentication configuration
-$ echo -e "security.protocol = SSL
-ssl.truststore.type = PKCS12
-ssl.truststore.location = /tmp/config/truststore.p12
-ssl.truststore.password = $(kubectl get secret my-cluster-cluster-ca-cert -o jsonpath="{.data['ca\.password']}" | base64 -d)
-ssl.keystore.type = PKCS12
-ssl.keystore.location = /tmp/config/keystore.p12
-ssl.keystore.password = $(kubectl get secret my-user -o jsonpath="{.data['user\.password']}" | base64 -d)" >/tmp/config/client.properties
-
-# reassignment JSON file describing desired state
-$ echo -e '{
-  "version": 1,
-  "partitions": [
-    {"topic": "my-topic", "partition": 0, "replicas": [0, 2, 1]},
-    {"topic": "my-topic", "partition": 1, "replicas": [2, 1, 0]},
-    {"topic": "my-topic", "partition": 2, "replicas": [1, 0, 2]}
-  ]
-}' >/tmp/config/reassignment.json
-----
-
-. Run a new interactive pod container, copy all configuration files and connect to an interactive shell
-[source,shell,subs=+quotes]
-----
-$ kubectl run reassignment --image="quay.io/strimzi/kafka:latest-kafka-3.6.0" -- /bin/bash -c "trap : TERM INT; sleep infinity & wait"
-$ kubectl cp /tmp/config reassignment:/tmp/config
-$ kubectl exec reassignment -itq -- bash
-----
-
-. From the shell, run the `kafka-reassign-partitions.sh` to start the reassignment with a throttle limit of 5 MB/s (increase if needed)
-[source,shell,subs=+quotes]
-----
-[kafka@reassignment kafka]$ bin/kafka-reassign-partitions.sh \
-  --bootstrap-server my-cluster-kafka-bootstrap:9093 \
-  --command-config /tmp/config/client.properties \
-  --reassignment-json-file /tmp/config/reassignment.json \
-  --execute --throttle 5000000
 Current partition replica assignment
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[3,4,2,0],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[0,2,3,1],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[1,3,0,4],"log_dirs":["any","any","any","any"]}]}
 
-{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[2],"log_dirs":["any"]},{"topic":"my-topic","partition":1,"replicas":[1],"log_dirs":["any"]},{"topic":"my-topic","partition":2,"replicas":[0],"log_dirs":["any"]}]}
-
-Save this to use as the --reassignment-json-file option during rollback
-Warning: You must run --verify periodically, until the reassignment completes, to ensure the throttle is removed.
-The inter-broker throttle limit was set to 5000000 B/s
-Successfully started partition reassignments for my-topic-0,my-topic-1,my-topic-2
+Proposed partition reassignment configuration
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3,4],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4,0],"log_dirs":["any","any","any","any"]}]}
 ----
++
+Save a copy of this file locally in case you need to revert the changes later on.
 
-. It is important to also call `--verify` to check if the operation is completed, and to disable throttling
+. Edit the `reassignment.json` to remove a replica from each partition.
++
+For example use `jq` to remove the last replica in the list for each partition of the topic:
++
+.Removing the last topic replica for each partition
 [source,shell,subs=+quotes]
 ----
-[kafka@reassignment kafka]$ bin/kafka-reassign-partitions.sh \
-  --bootstrap-server my-cluster-kafka-bootstrap:9093 \
-  --command-config /tmp/config/client.properties \
-  --reassignment-json-file /tmp/config/reassignment.json \
+jq '.partitions[].replicas |= del(.[-1])' reassignment.json > reassignment.json
+----
++
+.Example reassignment file showing the updated replicas
+[source,shell,subs=+quotes]
+----
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4],"log_dirs":["any","any","any","any"]}]}
+----
+
+. Copy the `reassignment.json` file to the interactive pod container.
++
+[source,shell,subs=+quotes]
+----
+kubectl cp reassignment.json _<interactive_pod_name>_:/tmp/reassignment.json
+----
++
+Replace _<interactive_pod_name>_ with the name of the pod.
+
+. Start a shell process in the interactive pod container.
++
+[source,shell,subs=+quotes]
+kubectl exec -n _<namespace>_ -ti _<interactive_pod_name>_ /bin/bash
++
+Replace _<namespace>_ with the Kubernetes namespace where the pod is running.
+
+. Make the topic replica change using the `kafka-reassign-partitions.sh` script from the interactive pod container.
++
+[source,shell,subs=+quotes]
+----
+bin/kafka-reassign-partitions.sh --bootstrap-server
+ _<cluster_name>_-kafka-bootstrap:9093 \
+ --command-config /tmp/config.properties \
+ --reassignment-json-file /tmp/reassignment.json \
+ --execute
+----
++
+NOTE: Removing replicas from a broker does not require any inter-broker data movement, so there is no need to throttle replication.
+If you are adding replicas, then you may want to change the throttle rate.
+
+. Verify that the change to the topic replicas has completed using the `kafka-reassign-partitions.sh` command line tool from any of the broker pods.
+This is the same command as the previous step, but with the `--verify` option instead of the `--execute` option.
++
+[source,shell,subs=+quotes]
+----
+bin/kafka-reassign-partitions.sh --bootstrap-server
+  _<cluster_name>_-kafka-bootstrap:9093 \
+  --command-config /tmp/config.properties \
+  --reassignment-json-file /tmp/reassignment.json \
   --verify
-Status of partition reassignment:
-Reassignment of partition my-topic-0 is completed.
-Reassignment of partition my-topic-1 is completed.
-Reassignment of partition my-topic-2 is completed.
-
-Clearing broker-level throttles on brokers 0,1,2
-Clearing topic-level throttles on topic my-topic
 ----
++
+The reassignment has finished when the `--verify` command reports that each of the partitions being moved has completed successfully.
+This final `--verify` will also have the effect of removing any reassignment throttles.
 
-. Once the reassignment is completed, delete the interactive pod, and wait for `KafkaTopic` reconciliation failure
+. Run the `bin/kafka-topics.sh` command with the `--describe` option to see the results of the change to the topics.
++
 [source,shell,subs=+quotes]
 ----
-[kafka@reassignment kafka]$ exit
-exit
-
-$ kubectl delete po reassignment
-pod "reassignment" deleted
-
-$ kubectl get kt -w
-NAME       CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
-my-topic   my-cluster   3            1                    True
-my-topic   my-cluster   3            1                    False
+bin/kafka-topics.sh --bootstrap-server
+  _<cluster_name>_-kafka-bootstrap:9093 \
+  --command-config /tmp/config.properties \
+  --describe
+----
++
+.Results of reducing the number of replicas for a topic
+[source,shell]
+----
+my-topic  Partition: 0  Leader: 0  Replicas: 0,1,2 Isr: 0,1,2
+my-topic  Partition: 1  Leader: 2  Replicas: 1,2,3 Isr: 1,2,3
+my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
 ----
 
 . Finally, patch the `KafkaTopic` custom resource to match the new replication factor, and let the operator do the rest
@@ -122,6 +142,6 @@ kafkatopic.kafka.strimzi.io/my-topic patched
 
 $ kubectl get kt -w
 NAME       CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
-my-topic   my-cluster   3            1                    False
+my-topic   my-cluster   3            4                    False
 my-topic   my-cluster   3            3                    True
 ----

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -13,121 +13,115 @@ and using a reassignment file to describe how the topic replicas should be chang
 
 This procedure describes a secure process that uses TLS.
 You'll need a Kafka cluster that uses TLS encryption and mTLS authentication.
+A topic called `my-topic` has only 1 replica and we want to increase it to 3 replicas.
 
 .Prerequisites
 
 * You have a running Kafka cluster based on a `Kafka` resource configured with internal TLS encryption and mTLS authentication.
-* You are running an interactive pod container that is connected to the running Kafka broker.
-* You have generated a reassignment JSON file named `reassignment.json`.
 * You are connected as a `KafkaUser` configured with ACL rules that specify permission to manage the Kafka cluster and its topics.
+* You have generated a reassignment JSON file named reassignment.json.
 
 See xref:proc-generating-reassignment-json-files-{context}[Generating reassignment JSON files].
 
-In this procedure, a topic called `my-topic` has 4 replicas and we want to reduce it to 3. 
-A JSON file named `topics.json` specifies the topic, and was used to generate the `reassignment.json` file.
-
-.Example JSON file specifies `my-topic` 
-[source,json]
-----
-{
-  "version": 1,
-  "topics": [
-    { "topic": "my-topic"}
-  ]
-}
-----
-
 .Procedure
 
-. If you haven't done so, xref:proc-generating-reassignment-json-files-{context}[run an interactive pod container to generate a reassignment JSON file] named `reassignment.json`.
-+
-.Example reassignment JSON file showing the current and proposed replica assignment
+. Create some configuration files that will be used to run the `kafka-reassign-partitions.sh` tool
 [source,shell,subs=+quotes]
 ----
+$ mkdir -p /tmp/config
+
+# client truststore and keystore
+$ kubectl get secret my-cluster-cluster-ca-cert -o jsonpath="{.data['ca\.p12']}" | base64 -d >/tmp/config/truststore.p12
+$ kubectl get secret my-user -o jsonpath="{.data['user\.p12']}" | base64 -d >/tmp/config/keystore.p12
+
+# client authentication configuration
+$ echo -e "security.protocol = SSL
+ssl.truststore.type = PKCS12
+ssl.truststore.location = /tmp/config/truststore.p12
+ssl.truststore.password = $(kubectl get secret my-cluster-cluster-ca-cert -o jsonpath="{.data['ca\.password']}" | base64 -d)
+ssl.keystore.type = PKCS12
+ssl.keystore.location = /tmp/config/keystore.p12
+ssl.keystore.password = $(kubectl get secret my-user -o jsonpath="{.data['user\.password']}" | base64 -d)" >/tmp/config/client.properties
+
+# reassignment JSON file describing desired state
+$ echo -e '{
+  "version": 1,
+  "partitions": [
+    {"topic": "my-topic", "partition": 0, "replicas": [0, 2, 1]},
+    {"topic": "my-topic", "partition": 1, "replicas": [2, 1, 0]},
+    {"topic": "my-topic", "partition": 2, "replicas": [1, 0, 2]}
+  ]
+}' >/tmp/config/reassignment.json
+----
+
+. Run a new interactive pod container, copy all configuration files and connect to an interactive shell
+[source,shell,subs=+quotes]
+----
+$ kubectl run reassignment --image="quay.io/strimzi/kafka:latest-kafka-3.6.0" -- /bin/bash -c "trap : TERM INT; sleep infinity & wait"
+$ kubectl cp /tmp/config reassignment:/tmp/config
+$ kubectl exec reassignment -itq -- bash
+----
+
+. From the shell, run the `kafka-reassign-partitions.sh` to start the reassignment with a throttle limit of 5 MB/s (increase if needed)
+[source,shell,subs=+quotes]
+----
+[kafka@reassignment kafka]$ bin/kafka-reassign-partitions.sh \
+  --bootstrap-server my-cluster-kafka-bootstrap:9093 \
+  --command-config /tmp/config/client.properties \
+  --reassignment-json-file /tmp/config/reassignment.json \
+  --execute --throttle 5000000
 Current partition replica assignment
-{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[3,4,2,0],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[0,2,3,1],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[1,3,0,4],"log_dirs":["any","any","any","any"]}]}
 
-Proposed partition reassignment configuration
-{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3,4],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4,0],"log_dirs":["any","any","any","any"]}]}
-----
-+
-Save a copy of this file locally in case you need to revert the changes later on.
+{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[2],"log_dirs":["any"]},{"topic":"my-topic","partition":1,"replicas":[1],"log_dirs":["any"]},{"topic":"my-topic","partition":2,"replicas":[0],"log_dirs":["any"]}]}
 
-. Edit the `reassignment.json` to remove a replica from each partition.
-+
-For example use `jq` to remove the last replica in the list for each partition of the topic:
-+
-.Removing the last topic replica for each partition
-[source,shell,subs=+quotes]
-----
-jq '.partitions[].replicas |= del(.[-1])' reassignment.json > reassignment.json
-----
-+
-.Example reassignment file showing the updated replicas
-[source,shell,subs=+quotes]
-----
-{"version":1,"partitions":[{"topic":"my-topic","partition":0,"replicas":[0,1,2],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":1,"replicas":[1,2,3],"log_dirs":["any","any","any","any"]},{"topic":"my-topic","partition":2,"replicas":[2,3,4],"log_dirs":["any","any","any","any"]}]}
+Save this to use as the --reassignment-json-file option during rollback
+Warning: You must run --verify periodically, until the reassignment completes, to ensure the throttle is removed.
+The inter-broker throttle limit was set to 5000000 B/s
+Successfully started partition reassignments for my-topic-0,my-topic-1,my-topic-2
 ----
 
-. Copy the `reassignment.json` file to the interactive pod container.
-+
+. It is important to also call `--verify` to check if the operation is completed, and to disable throttling
 [source,shell,subs=+quotes]
 ----
-kubectl cp reassignment.json _<interactive_pod_name>_:/tmp/reassignment.json
-----
-+
-Replace _<interactive_pod_name>_ with the name of the pod.
-
-. Start a shell process in the interactive pod container.
-+
-[source,shell,subs=+quotes]
-kubectl exec -n _<namespace>_ -ti _<interactive_pod_name>_ /bin/bash
-+
-Replace _<namespace>_ with the Kubernetes namespace where the pod is running.
-
-. Make the topic replica change using the `kafka-reassign-partitions.sh` script from the interactive pod container.
-+
-[source,shell,subs=+quotes]
-----
-bin/kafka-reassign-partitions.sh --bootstrap-server
- _<cluster_name>_-kafka-bootstrap:9093 \
- --command-config /tmp/config.properties \
- --reassignment-json-file /tmp/reassignment.json \
- --execute
-----
-+
-NOTE: Removing replicas from a broker does not require any inter-broker data movement, so there is no need to throttle replication.
-If you are adding replicas, then you may want to change the throttle rate. 
-
-. Verify that the change to the topic replicas has completed using the `kafka-reassign-partitions.sh` command line tool from any of the broker pods.
-This is the same command as the previous step, but with the `--verify` option instead of the `--execute` option.
-+
-[source,shell,subs=+quotes]
-----
-bin/kafka-reassign-partitions.sh --bootstrap-server
-  _<cluster_name>_-kafka-bootstrap:9093 \
-  --command-config /tmp/config.properties \
-  --reassignment-json-file /tmp/reassignment.json \
+[kafka@reassignment kafka]$ bin/kafka-reassign-partitions.sh \
+  --bootstrap-server my-cluster-kafka-bootstrap:9093 \
+  --command-config /tmp/config/client.properties \
+  --reassignment-json-file /tmp/config/reassignment.json \
   --verify
-----
-+
-The reassignment has finished when the `--verify` command reports that each of the partitions being moved has completed successfully.
-This final `--verify` will also have the effect of removing any reassignment throttles.
+Status of partition reassignment:
+Reassignment of partition my-topic-0 is completed.
+Reassignment of partition my-topic-1 is completed.
+Reassignment of partition my-topic-2 is completed.
 
-. Run the `bin/kafka-topics.sh` command with the `--describe` option to see the results of the change to the topics.
-+
+Clearing broker-level throttles on brokers 0,1,2
+Clearing topic-level throttles on topic my-topic
+----
+
+. Once the reassignment is completed, delete the interactive pod, and wait for `KafkaTopic` reconciliation failure
 [source,shell,subs=+quotes]
 ----
-bin/kafka-topics.sh --bootstrap-server
-  _<cluster_name>_-kafka-bootstrap:9093 \
-  --command-config /tmp/config.properties \
-  --describe
+[kafka@reassignment kafka]$ exit
+exit
+
+$ kubectl delete po reassignment
+pod "reassignment" deleted
+
+$ kubectl get kt -w
+NAME       CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
+my-topic   my-cluster   3            1                    True
+my-topic   my-cluster   3            1                    False
 ----
-+
-.Results of reducing the number of replicas for a topic
-[source,shell]
+
+. Finally, patch the `KafkaTopic` custom resource to match the new replication factor, and let the operator do the rest
+[source,shell,subs=+quotes]
 ----
-my-topic  Partition: 0  Leader: 0  Replicas: 0,1,2 Isr: 0,1,2
-my-topic  Partition: 1  Leader: 2  Replicas: 1,2,3 Isr: 1,2,3
-my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
+$ kubectl patch kt my-topic --type merge -p '
+  spec:
+    replicas: 3'
+kafkatopic.kafka.strimzi.io/my-topic patched
+
+$ kubectl get kt -w
+NAME       CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
+my-topic   my-cluster   3            1                    False
+my-topic   my-cluster   3            3                    True
 ----

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -132,7 +132,8 @@ my-topic  Partition: 1  Leader: 2  Replicas: 1,2,3 Isr: 1,2,3
 my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
 ----
 
-. Finally, edit the `KafkaTopic` custom resource, change `.spec.replicas` to 3, and wait the reconciliation.
+. Finally, edit the `KafkaTopic` custom resource to change `.spec.replicas` to 3, and then wait the reconciliation.
++
 [source,shell,subs=+quotes]
 ----
 apiVersion: kafka.strimzi.io/v1beta2

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -135,13 +135,7 @@ my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
 . Finally, patch the `KafkaTopic` custom resource to match the new replication factor, and let the operator do the rest
 [source,shell,subs=+quotes]
 ----
-$ kubectl patch kt my-topic --type merge -p '
+kubectl patch kt my-topic --type merge -p '
   spec:
     replicas: 3'
-kafkatopic.kafka.strimzi.io/my-topic patched
-
-$ kubectl get kt -w
-NAME       CLUSTER      PARTITIONS   REPLICATION FACTOR   READY
-my-topic   my-cluster   3            4                    False
-my-topic   my-cluster   3            3                    True
 ----

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -132,10 +132,16 @@ my-topic  Partition: 1  Leader: 2  Replicas: 1,2,3 Isr: 1,2,3
 my-topic  Partition: 2  Leader: 3  Replicas: 2,3,4 Isr: 2,3,4
 ----
 
-. Finally, patch the `KafkaTopic` custom resource to match the new replication factor, and let the operator do the rest
+. Finally, edit the `KafkaTopic` custom resource, change `.spec.replicas` to 3, and wait the reconciliation.
 [source,shell,subs=+quotes]
 ----
-kubectl patch kt my-topic --type merge -p '
-  spec:
-    replicas: 3'
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: my-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 3
+  replicas: 3
 ----

--- a/documentation/modules/configuring/proc-changing-topic-replicas.adoc
+++ b/documentation/modules/configuring/proc-changing-topic-replicas.adoc
@@ -23,10 +23,10 @@ You'll need a Kafka cluster that uses TLS encryption and mTLS authentication.
 
 See xref:proc-generating-reassignment-json-files-{context}[Generating reassignment JSON files].
 
-In this procedure, a topic called `my-topic` has 4 replicas and we want to reduce it to 3.
+In this procedure, a topic called `my-topic` has 4 replicas and we want to reduce it to 3. 
 A JSON file named `topics.json` specifies the topic, and was used to generate the `reassignment.json` file.
 
-.Example JSON file specifies `my-topic`
+.Example JSON file specifies `my-topic` 
 [source,json]
 ----
 {
@@ -97,7 +97,7 @@ bin/kafka-reassign-partitions.sh --bootstrap-server
 ----
 +
 NOTE: Removing replicas from a broker does not require any inter-broker data movement, so there is no need to throttle replication.
-If you are adding replicas, then you may want to change the throttle rate.
+If you are adding replicas, then you may want to change the throttle rate. 
 
 . Verify that the change to the topic replicas has completed using the `kafka-reassign-partitions.sh` command line tool from any of the broker pods.
 This is the same command as the previous step, but with the `--verify` option instead of the `--execute` option.


### PR DESCRIPTION
This is still based on the original secure cluster setup (mTLS), as it is common in production. The UTO is not able to reconcile a replication factor change done in Kafka, so I also show how to fix the reconciliation error.