### PR TITLE
[ST] Fix missing namespace in beforeAll UserST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -442,6 +442,8 @@ class UserST extends AbstractST {
             .createInstallation()
             .runInstallation();
 
+        cluster.createNamespace(Environment.TEST_SUITE_NAMESPACE);
+
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
             .editMetadata()
                 .withNamespace(Environment.TEST_SUITE_NAMESPACE)


### PR DESCRIPTION
### Type of change

- Fix
- Refactoring

### Description

This PR fixes issue that might appear when running solo test except the whole suite, where a test-suite-namespace would not be created due to lack of parallel tag after the last refactor.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

