### PR TITLE
[ST] Refactor FeatureGateST 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -144,6 +144,10 @@ final public class TestStorage {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(key);
     }
 
+    public ExtensionContext getExtensionContext() {
+        return extensionContext;
+    }
+
     public String getTestName() {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(TestConstants.TEST_NAME_KEY).toString();
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -6,29 +6,18 @@ package io.strimzi.systemtest.kafka;
 
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+
 import io.strimzi.api.kafka.model.Kafka;
-import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
-import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
-import io.strimzi.systemtest.resources.ResourceManager;
-import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,170 +40,6 @@ import java.util.Map;
 @Tag(REGRESSION)
 public class KafkaNodePoolST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaNodePoolST.class);
-
-    /**
-     * @description This test case verifies transfer of Kafka Cluster from and to management by KafkaNodePool, by creating corresponding Kafka and KafkaNodePool custom resources
-     * and manipulating according kafka annotation.
-     *
-     * @steps
-     * 1. - Deploy Kafka with annotated to enable management by KafkaNodePool, and KafkaNodePool targeting given Kafka Cluster.
-     *    - Kafka is deployed, KafkaNodePool custom resource is targeting Kafka Cluster as expected.
-     * 2. - Modify KafkaNodePool by increasing number of Kafka Replicas.
-     *    - Number of Kafka Pods is increased to match specification from KafkaNodePool
-     * 3. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     * 4. - Modify Kafka custom resource annotation strimzi.io/node-pool to disable management by KafkaNodePool.
-     *    - StrimziPodSet is modified, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) are ignored.
-     * 5. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     * 6. - Modify Kafka custom resource annotation strimzi.io/node-pool to enable management by KafkaNodePool.
-     *    - new StrimziPodSet is created, replacing former one, Pods are replaced and specification from KafkaNodePool (i.e., changed replica count) has priority over Kafka specification.
-     * 7. - Produce and consume messages in given Kafka Cluster.
-     *    - Clients can produce and consume messages.
-     *
-     * @usecase
-     * - kafka-node-pool
-     */
-    @ParallelNamespaceTest
-    void testKafkaManagementTransferToAndFromKafkaNodePool(ExtensionContext extensionContext) {
-
-        final TestStorage testStorage = new TestStorage(extensionContext);
-
-        final int originalKafkaReplicaCount = 3;
-        final int nodePoolIncreasedKafkaReplicaCount = 5;
-        final String kafkaNodePoolName = "kafka";
-
-        // setup clients
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withDelayMs(200)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .build();
-
-        Map<String, String> coPod = DeploymentUtils.depSnapshot(clusterOperator.getDeploymentNamespace(), ResourceManager.getCoDeploymentName());
-
-        LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaNodePoolName);
-
-        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), originalKafkaReplicaCount, 1)
-            .editOrNewMetadata()
-                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-            .endMetadata()
-            .build();
-
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
-            .editOrNewMetadata()
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER)
-                .withStorage(kafkaCr.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafkaCr.getSpec().getKafka().getJvmOptions())
-                .withResources(kafkaCr.getSpec().getKafka().getResources())
-            .endSpec()
-            .build();
-
-        resourceManager.createResourceWithWait(extensionContext,
-            kafkaNodePoolCr,
-            kafkaCr);
-
-        LOGGER.info("Creating KafkaTopic: {}/{}", testStorage.getNamespaceName(), testStorage.getTopicName());
-        resourceManager.createResourceWithWait(extensionContext, KafkaTopicTemplates.topic(testStorage).build());
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        // increase number of kafka replicas in KafkaNodePool
-        LOGGER.info("Modifying KafkaNodePool: {}/{} by increasing number of Kafka replicas from '3' to '5'", testStorage.getNamespaceName(), kafkaNodePoolName);
-        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(kafkaNodePoolName, kafkaNodePool -> {
-            kafkaNodePool.getSpec().setReplicas(nodePoolIncreasedKafkaReplicaCount);
-        }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            nodePoolIncreasedKafkaReplicaCount
-        );
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        LOGGER.info("Changing FG env variable to disable Kafka Node Pools");
-        List<EnvVar> coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools");
-
-        Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME);
-        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
-
-        coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
-
-        LOGGER.info("Disable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
-            kafka -> {
-                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "disabled");
-            }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            originalKafkaReplicaCount
-        );
-        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), originalKafkaReplicaCount);
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        LOGGER.info("Changing FG env variable to enable Kafka Node Pools");
-        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("+KafkaNodePools");
-
-        coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME);
-        coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
-        kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
-
-        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
-
-        LOGGER.info("Enable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
-            kafka -> {
-                kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled");
-            }, testStorage.getNamespaceName());
-
-        StrimziPodSetUtils.waitForAllStrimziPodSetAndPodsReady(
-            testStorage.getNamespaceName(),
-            KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), kafkaNodePoolName),
-            KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()),
-            nodePoolIncreasedKafkaReplicaCount
-        );
-        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()), nodePoolIncreasedKafkaReplicaCount);
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-    }
 
     /**
      * @description This test case verifies KafkaNodePools scaling up and down with correct NodePool IDs, with different NodePools.

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
-import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.systemtest.kafka;
 
-
 import io.fabric8.kubernetes.api.model.EnvVar;
-
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.operator.common.Annotations;
@@ -31,7 +29,6 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -195,18 +195,20 @@ public class FeatureGatesST extends AbstractST {
     void testKafkaNodePoolFeatureGate(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
-        final TestStorage testStorage = new TestStorage(extensionContext, CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(extensionContext);
 
         List<EnvVar> coEnvVars = new ArrayList<>();
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
         
         clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withExtraEnvVars(coEnvVars)
+            .withNamespace(Constants.CO_NAMESPACE)
+            .withBindingsNamespaces(Arrays.asList(Constants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
             .createInstallation()
             .runInstallation();
 
         LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getKafkaNodePoolName());
-        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 1)
+        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
@@ -236,7 +238,7 @@ public class FeatureGatesST extends AbstractST {
             .withTopicName(testStorage.getTopicName())
             .withMessageCount(testStorage.getMessageCount())
             .withDelayMs(500)
-            .withNamespaceName(clusterOperator.getDeploymentNamespace())
+            .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
         LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
@@ -280,17 +282,20 @@ public class FeatureGatesST extends AbstractST {
      * - kafka-node-pool
      */
     @IsolatedTest
+    @SuppressWarnings({"checkstyle:MethodLength"})
     void testKafkaManagementTransferToAndFromKafkaNodePool(ExtensionContext extensionContext) {
         assumeFalse(Environment.isKRaftModeEnabled());
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
-        final TestStorage testStorage = new TestStorage(extensionContext, CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(extensionContext);
 
         List<EnvVar> coEnvVars = new ArrayList<>();
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
 
         clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withExtraEnvVars(coEnvVars)
+            .withNamespace(Constants.CO_NAMESPACE)
+            .withBindingsNamespaces(Arrays.asList(Constants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
             .createInstallation()
             .runInstallation();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -5,13 +5,9 @@
 package io.strimzi.systemtest.operators;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
-import io.strimzi.api.kafka.model.StrimziPodSet;
-import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
-import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
@@ -29,10 +25,8 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
-import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
-import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -44,17 +38,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Feature Gates should give us additional options on
@@ -66,7 +58,19 @@ public class FeatureGatesST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(FeatureGatesST.class);
 
     /**
-     * UseKRaft feature gate
+     * @description This test case verifies basic working of Kafka Cluster managed by Cluster Operator with KRaft feature gate enabled.
+     *
+     * @steps
+     *  1. - Deploy Kafka annotated to enable Kraft (and additionally annotated to enable management by KafkaNodePool due to default usage of NodePools), and KafkaNodePool targeting given Kafka Cluster.
+     *     - Kafka is deployed, KafkaNodePool custom resource is targeting Kafka Cluster as expected.
+     *  2. - Produce and consume messages in given Kafka Cluster.
+     *     - Clients can produce and consume messages.
+     *  3. - Trigger manual Rolling Update.
+     *     - Rolling update is triggered and completed shortly after.
+     *
+     * @usecase
+     *  - kafka-node-pool
+     *  - kraft
      */
     @IsolatedTest("Feature Gates test for enabled UseKRaft gate")
     @Tag(INTERNAL_CLIENTS_USED)
@@ -74,54 +78,16 @@ public class FeatureGatesST extends AbstractST {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         final TestStorage testStorage = new TestStorage(extensionContext);
+        final int kafkaReplicas = 3;
 
-        final String clusterName = testStorage.getClusterName();
-        final String producerName = testStorage.getProducerName();
-        final String consumerName = testStorage.getConsumerName();
-        final String topicName = testStorage.getTopicName();
+        setupClusterOperatorWithFeatureGate(extensionContext, "+UseKRaft");
 
-        final LabelSelector zkSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.zookeeperStatefulSetName(clusterName));
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(clusterName, KafkaResources.kafkaStatefulSetName(clusterName));
-
-        int messageCount = 180;
-        List<EnvVar> testEnvVars = new ArrayList<>();
-        int kafkaReplicas = 3;
-
-        testEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft", null));
-
-        this.clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
-            .withNamespace(TestConstants.CO_NAMESPACE)
-            .withBindingsNamespaces(Arrays.asList(TestConstants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
-            .withExtraEnvVars(testEnvVars)
-            .createInstallation()
-            .runInstallation();
-
-        Kafka kafka = KafkaTemplates.kafkaPersistent(clusterName, kafkaReplicas)
+        final Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas)
             .editOrNewMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
-            .editSpec()
-                .editKafka()
-                .withListeners(
-                        new GenericKafkaListenerBuilder()
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
-                                .withPort(9092)
-                                .withTls(false)
-                                .build(),
-                        new GenericKafkaListenerBuilder()
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
-                                .withPort(9093)
-                                .withTls(true)
-                                .withNewKafkaListenerAuthenticationTlsAuth()
-                                .endKafkaListenerAuthenticationTlsAuth()
-                                .build()
-                )
-                .endKafka()
-            .endSpec()
             .build();
         kafka.getSpec().getEntityOperator().setTopicOperator(null); // The builder cannot disable the EO. It has to be done this way.
 
@@ -141,40 +107,11 @@ public class FeatureGatesST extends AbstractST {
             kafka
         );
 
-        resourceManager.createResourceWithWait(extensionContext,
-            KafkaUserTemplates.tlsUser(testStorage).build()
-        );
-
-        LOGGER.info("Trying to send some messages to Kafka in next few minutes");
-
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(producerName)
-            .withConsumerName(consumerName)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withUsername(testStorage.getUsername())
-            .withTopicName(topicName)
-            .withMessageCount(messageCount)
-            .withDelayMs(500)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .build();
-
-        resourceManager.createResourceWithWait(extensionContext, kafkaClients.producerTlsStrimzi(clusterName));
-        resourceManager.createResourceWithWait(extensionContext, kafkaClients.consumerTlsStrimzi(clusterName));
-
         // Check that there is no ZooKeeper
-        Map<String, String> zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), zkSelector);
+        Map<String, String> zkPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getZookeeperSelector());
         assertThat("No ZooKeeper Pods should exist", zkPods.size(), is(0));
 
-        // Roll Kafka
-        LOGGER.info("Forcing rolling update of Kafka via read-only configuration change");
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaSelector);
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, k -> k.getSpec().getKafka().getConfig().put("log.retention.hours", 72), testStorage.getNamespaceName());
-
-        LOGGER.info("Waiting for the next reconciliation to happen");
-        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), kafkaSelector, kafkaReplicas, kafkaPods);
-
-        LOGGER.info("Waiting for clients to finish sending/receiving messages");
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, testStorage.getNamespaceName(), MESSAGE_COUNT);
+        rollKafkaNodePoolWithActiveProducerConsumer(testStorage, kafkaReplicas);
     }
 
     /**
@@ -196,26 +133,19 @@ public class FeatureGatesST extends AbstractST {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         final TestStorage testStorage = new TestStorage(extensionContext);
+        final int kafkaReplicas = 3;
 
-        List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
-        
-        clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
-            .withExtraEnvVars(coEnvVars)
-            .withNamespace(Constants.CO_NAMESPACE)
-            .withBindingsNamespaces(Arrays.asList(Constants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
-            .createInstallation()
-            .runInstallation();
+        setupClusterOperatorWithFeatureGate(extensionContext, "+KafkaNodePools");
 
         LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getKafkaNodePoolName());
-        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
+        final Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas, 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
             .endMetadata()
             .build();
 
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), testStorage.getClusterName(), 3)
+        final KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), testStorage.getClusterName(), 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
@@ -227,34 +157,9 @@ public class FeatureGatesST extends AbstractST {
             .endSpec()
             .build();
 
-        resourceManager.createResourceWithWait(extensionContext, kafkaNodePoolCr);
-        resourceManager.createResourceWithWait(extensionContext, kafkaCr);
+        resourceManager.createResourceWithWait(extensionContext, kafkaNodePoolCr, kafkaCr);
 
-        // setup clients
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withDelayMs(500)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .build();
-
-        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        resourceManager.createResourceWithWait(extensionContext,
-            clients.producerStrimzi(),
-            clients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
-        // snapshot Kafka Pods before triggering manual rolling update.
-        final LabelSelector kafkaSelector = KafkaResource.getLabelSelector(testStorage.getClusterName(), KafkaResources.kafkaStatefulSetName(testStorage.getClusterName()));
-        Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaSelector);
-
-        LOGGER.info("Annotating {} of Kafka Cluster: {}/{} with manual rolling update annotation", StrimziPodSet.RESOURCE_KIND, testStorage.getNamespaceName(), testStorage.getClusterName());
-        StrimziPodSetUtils.annotateStrimziPodSet(testStorage.getNamespaceName(), testStorage.getClusterName() + "-" + testStorage.getKafkaNodePoolName(), Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
-        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), kafkaSelector, 3, kafkaPods);
+        rollKafkaNodePoolWithActiveProducerConsumer(testStorage, kafkaReplicas);
 
     }
 
@@ -282,29 +187,19 @@ public class FeatureGatesST extends AbstractST {
      * - kafka-node-pool
      */
     @IsolatedTest
-    @SuppressWarnings({"checkstyle:MethodLength"})
     void testKafkaManagementTransferToAndFromKafkaNodePool(ExtensionContext extensionContext) {
         assumeFalse(Environment.isKRaftModeEnabled());
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         final TestStorage testStorage = new TestStorage(extensionContext);
-
-        List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
-
-        clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
-            .withExtraEnvVars(coEnvVars)
-            .withNamespace(Constants.CO_NAMESPACE)
-            .withBindingsNamespaces(Arrays.asList(Constants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
-            .createInstallation()
-            .runInstallation();
-
         final int originalKafkaReplicaCount = 3;
         final int nodePoolIncreasedKafkaReplicaCount = 5;
         final String kafkaNodePoolName = "kafka";
 
+        setupClusterOperatorWithFeatureGate(extensionContext, "+KafkaNodePools");
+
         // setup clients
-        KafkaClients clients = new KafkaClientsBuilder()
+        final KafkaClients clients = new KafkaClientsBuilder()
             .withProducerName(testStorage.getProducerName())
             .withConsumerName(testStorage.getConsumerName())
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
@@ -318,14 +213,14 @@ public class FeatureGatesST extends AbstractST {
 
         LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), kafkaNodePoolName);
 
-        Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), originalKafkaReplicaCount, 3)
+        final Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), originalKafkaReplicaCount, 3)
             .editOrNewMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .build();
 
-        KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
+        final KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
@@ -372,14 +267,14 @@ public class FeatureGatesST extends AbstractST {
         ClientUtils.waitForClientsSuccess(testStorage);
 
         LOGGER.info("Changing FG env variable to disable Kafka Node Pools");
-        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        List<EnvVar> coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("-KafkaNodePools");
 
-        Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
+        Deployment coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
         kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
 
-        coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+        coPod = DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
 
         LOGGER.info("Disable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
@@ -404,14 +299,14 @@ public class FeatureGatesST extends AbstractST {
         ClientUtils.waitForClientsSuccess(testStorage);
 
         LOGGER.info("Changing FG env variable to enable Kafka Node Pools");
-        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        coEnvVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         coEnvVars.stream().filter(env -> env.getName().equals(Environment.STRIMZI_FEATURE_GATES_ENV)).findFirst().get().setValue("+KafkaNodePools");
 
-        coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME);
+        coDep = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME);
         coDep.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(coEnvVars);
         kubeClient().getClient().apps().deployments().inNamespace(clusterOperator.getDeploymentNamespace()).resource(coDep).update();
 
-        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), Constants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
+        DeploymentUtils.waitTillDepHasRolled(clusterOperator.getDeploymentNamespace(), TestConstants.STRIMZI_DEPLOYMENT_NAME, 1, coPod);
 
         LOGGER.info("Enable KafkaNodePool in Kafka Cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
@@ -434,5 +329,64 @@ public class FeatureGatesST extends AbstractST {
         );
         ClientUtils.waitForClientsSuccess(testStorage);
 
+    }
+
+    /**
+     * Sets up a Cluster Operator with specified feature gates.
+     *
+     * @param extensionContext  Extension context which provides access to the test environment and its state.
+     * @param extraFeatureGates A String representing additional feature gates (comma separated) to be
+     *                          enabled or disabled for the Cluster Operator.
+     */
+    private void setupClusterOperatorWithFeatureGate(ExtensionContext extensionContext, String extraFeatureGates) {
+        List<EnvVar> coEnvVars = new ArrayList<>();
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, extraFeatureGates, null));
+
+        clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
+            .withExtraEnvVars(coEnvVars)
+            // necessary as each isolated test removes TEST_SUITE_NAMESPACE
+            .withBindingsNamespaces(Arrays.asList(TestConstants.CO_NAMESPACE, Environment.TEST_SUITE_NAMESPACE))
+            .createInstallation()
+            .runInstallation();
+    }
+
+    /**
+     * Performs a rolling update of the Kafka (node pool) while maintaining active Kafka producer and consumer clients.
+     *
+     * @param testStorage      An instance of TestStorage containing test-related configuration
+     * @param kafkaReplicas    The number of Kafka replicas in the Kafka cluster, which is used to verify
+     *                         if the rolling update has been completed across all replicas     .
+     */
+    private void rollKafkaNodePoolWithActiveProducerConsumer(TestStorage testStorage, int kafkaReplicas) {
+        final String producerName = testStorage.getProducerName() + "-rolling";
+        final String consumerName = testStorage.getConsumerName() + "-rolling";
+
+        // setup clients
+        KafkaClients clients = new KafkaClientsBuilder()
+            .withProducerName(producerName)
+            .withConsumerName(consumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withDelayMs(500)
+            .withNamespaceName(testStorage.getNamespaceName())
+            .build();
+
+        LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", producerName, consumerName, testStorage.getNamespaceName());
+        resourceManager.createResourceWithWait(testStorage.getExtensionContext(),
+            clients.producerStrimzi(),
+            clients.consumerStrimzi()
+        );
+
+        // Roll Kafka
+        LOGGER.info("Forcing rolling update of Kafka via read-only configuration change");
+        final Map<String, String> kafkaPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getKafkaSelector());
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), k -> k.getSpec().getKafka().getConfig().put("log.retention.hours", 72), testStorage.getNamespaceName());
+
+        LOGGER.info("Waiting for the next reconciliation to happen");
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaSelector(), kafkaReplicas, kafkaPods);
+
+        LOGGER.info("Waiting for clients to finish sending/receiving messages");
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -160,7 +160,6 @@ public class FeatureGatesST extends AbstractST {
         resourceManager.createResourceWithWait(extensionContext, kafkaNodePoolCr, kafkaCr);
 
         rollKafkaNodePoolWithActiveProducerConsumer(testStorage, kafkaReplicas);
-
     }
 
     /**
@@ -328,7 +327,6 @@ public class FeatureGatesST extends AbstractST {
             clients.consumerStrimzi()
         );
         ClientUtils.waitForClientsSuccess(testStorage);
-
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring


### Description

- **what**: 
  - moving  `testKafkaManagementTransferToAndFromKafkaNodePool` into `FeatureGateST`
  -  some slight changes such as changing test Storage a bit to reflect latest agreement to use `test-storage-namespace` in isolated system tests, to have the same approach in each test case, also increasing number of zookeeper pods, supresing method length check style and explicitly creating namespace.  
  - usage of helper methods to decrease amount of code
  - document



### Checklist


- [x] Write tests
- [x] Make sure all tests pass


