### PR TITLE
[ST] Refactor namespace creation in UserST setup

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -40,6 +40,7 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
 import java.io.IOException;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -439,10 +440,9 @@ class UserST extends AbstractST {
     void setup(ExtensionContext extensionContext) {
         this.clusterOperator = this.clusterOperator
             .defaultInstallation(extensionContext)
+            .withBindingsNamespaces(List.of(Environment.TEST_SUITE_NAMESPACE, Constants.CO_NAMESPACE))
             .createInstallation()
             .runInstallation();
-
-        cluster.createNamespace(Environment.TEST_SUITE_NAMESPACE);
 
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(userClusterName, 1, 1)
             .editMetadata()


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR should be a better solution for namespace creation in UserST setup. As of now there might be an issue with RBACs. Adding binding namespace to operator installation helps to resolve this issue by providing necessary namespace for the kafka to be deployed to and not delete operator namespace with the usage of resourceManager.createNamespace() method if the Environment.TEST_SUITE_NAMESPACE is co-namespace (in case of rbac:namespace scope).

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

