### PR TITLE
Update Vert.x to 4.5.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -402,7 +402,7 @@ public abstract class AbstractOperator<
                 callSafely(reconciliation, callable)
                     .onSuccess(handleSafely(reconciliation, handler::complete))
                     .onFailure(handleSafely(reconciliation, handler::fail))
-                    .eventually(ignored -> releaseLockAndTimer(reconciliation, lock, lockName, timerId));
+                    .eventually(() -> releaseLockAndTimer(reconciliation, lock, lockName, timerId));
             } else {
                 LOGGER.debugCr(reconciliation, "Failed to acquire lock {} within {}ms.", lockName, lockTimeoutMs);
                 handler.fail(new UnableToAcquireLockException());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -162,7 +162,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                    AsyncResult<HttpClientRequest> request, Promise<CruiseControlRebalanceResponse> result) {
         if (request.succeeded()) {
             if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-                request.result().setTimeout(idleTimeout * 1000);
+                request.result().idleTimeout(idleTimeout * 1000);
             }
 
             if (userTaskId != null) {
@@ -238,7 +238,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskId) {
 
         if (options == null && userTaskId == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -128,12 +128,14 @@
         <fabric8.openshift-client.version>6.9.2</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>6.9.2</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.15.2</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.15.2</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.15.2</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.15.2</fasterxml.jackson-annotations.version>
-        <vertx.version>4.4.6</vertx.version>
-        <vertx-junit5.version>4.4.6</vertx-junit5.version>
+        <fasterxml.jackson-core.version>2.15.3</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.15.3</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.15.3</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.15.3</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-datatype.version>2.15.3</fasterxml.jackson-datatype.version>
+        <fasterxml.jackson-jaxrs.version>2.15.3</fasterxml.jackson-jaxrs.version>
+        <vertx.version>4.5.0</vertx.version>
+        <vertx-junit5.version>4.5.0</vertx-junit5.version>
         <kafka.version>3.6.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.3</zookeeper.version>
@@ -542,6 +544,26 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-scala_2.13</artifactId>
                 <version>${fasterxml.jackson-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${fasterxml.jackson-datatype.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${fasterxml.jackson-datatype.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${fasterxml.jackson-jaxrs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${fasterxml.jackson-jaxrs.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x to 4.5.0 and addresses few new deprecations in this version. Together with it it also updates Jackson FasterXML to be in-sync with what is used by VErt.x and improves the aligmnet for Jackson dependencies to use the same version for all of them.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally