### PR TITLE
Add support for managing KRaft metadata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The `UnidirectionalTopicOperator` feature gate moves to beta stage and is enabled by default.
   If needed, `UnidirectionalTopicOperator` can be disabled in the feature gates configuration in the Cluster Operator.
 * Improved Kafka Connect metrics and dashboard example files
+* Allow specifying and managing KRaft metadata version
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterSpec.java
@@ -34,7 +34,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "version", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
+    "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
     "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
 public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving, Serializable {
@@ -56,6 +56,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     protected Storage storage;
     private String version;
+    private String metadataVersion;
     private Map<String, Object> config = new HashMap<>(0);
     private String brokerRackInitImage;
     private Rack rack;
@@ -73,7 +74,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     private KafkaClusterTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("The kafka broker version. Defaults to {DefaultKafkaVersion}. " +
+    @Description("The Kafka broker version. Defaults to {DefaultKafkaVersion}. " +
             "Consult the user documentation to understand the process required to upgrade or downgrade the version.")
     public String getVersion() {
         return version;
@@ -81,6 +82,17 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    @Description("The KRaft metadata.version that should be used by this Kafka cluster. " +
+            "This field will be ignored when running in ZooKeeper mode. " +
+            "Defaults to {DefaultKafkaMetadataVersion}.")
+    public String getMetadataVersion() {
+        return metadataVersion;
+    }
+
+    public void setMetadataVersion(String metadataVersion) {
+        this.metadataVersion = metadataVersion;
     }
 
     @Description("Kafka broker config properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")

--- a/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/status/KafkaStatus.java
@@ -22,7 +22,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools", "clusterId", "operatorLastSuccessfulVersion", "kafkaVersion" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools", "clusterId", "operatorLastSuccessfulVersion", "kafkaVersion", "kafkaMetadataVersion" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
@@ -34,6 +34,7 @@ public class KafkaStatus extends Status {
     private String clusterId;
     private String operatorLastSuccessfulVersion;
     private String kafkaVersion;
+    private String kafkaMetadataVersion;
 
     @Description("Addresses of the internal and external listeners")
     public List<ListenerStatus> getListeners() {
@@ -78,5 +79,14 @@ public class KafkaStatus extends Status {
 
     public void setKafkaVersion(String kafkaVersion) {
         this.kafkaVersion = kafkaVersion;
+    }
+
+    @Description("The KRaft metadata.version currently used by the Kafka cluster.")
+    public String getKafkaMetadataVersion() {
+        return kafkaMetadataVersion;
+    }
+
+    public void setKafkaMetadataVersion(String kafkaMetadataVersion) {
+        this.kafkaMetadataVersion = kafkaMetadataVersion;
     }
 }

--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -224,6 +224,11 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
+            <!-- Required for managing KRaft Metadata version -->
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.api.kafka.model.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.operator.common.model.InvalidResourceException;
+import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -46,6 +47,19 @@ public class KRaftUtils {
     /* test */ static void validateEntityOperatorSpec(Set<String> errors, EntityOperatorSpec entityOperator, boolean utoEnabled) {
         if (entityOperator != null && entityOperator.getTopicOperator() != null && !utoEnabled) {
             errors.add("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.");
+        }
+    }
+
+    /**
+     * Validates the metadata version
+     *
+     * @param metadataVersion   Metadata version that should be validated
+     */
+    public static void validateMetadataVersion(String metadataVersion)   {
+        try {
+            MetadataVersion.fromVersionString(metadataVersion);
+        } catch (IllegalArgumentException e)    {
+            throw new InvalidResourceException("Metadata version " + metadataVersion + " is invalid", e);
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -283,7 +283,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         // This also validates that the Kafka version is supported
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
 
-        // Sets the LRaft metadata version and validates it is supported
+        // Sets the KRaft metadata version and validates it is supported
         String metadataVersion = kafkaClusterSpec.getMetadataVersion() != null ? kafkaClusterSpec.getMetadataVersion() : result.kafkaVersion.metadataVersion();
         KRaftUtils.validateMetadataVersion(metadataVersion);
         result.metadataVersion = metadataVersion;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -123,7 +123,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final int CONTROLPLANE_PORT = 9090;
     protected static final String CONTROLPLANE_PORT_NAME = "tcp-ctrlplane"; // port name is up to 15 characters
 
-
     /**
      * Port used by the Route listeners
      */
@@ -199,12 +198,18 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     public static final String BROKER_CLUSTER_ID_FILENAME = "cluster.id";
 
+    /**
+     * Key under which the desired Kafka metadata version is stored in Config Map
+     */
+    public static final String BROKER_METADATA_VERSION_FILENAME = "metadata.version";
+
     // Kafka configuration
     private Rack rack;
     private String initImage;
     private List<GenericKafkaListener> listeners;
     private KafkaAuthorization authorization;
     private KafkaVersion kafkaVersion;
+    private String metadataVersion;
     private boolean useKRaft = false;
     private String clusterId;
     private JmxModel jmx;
@@ -277,6 +282,11 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
         // This also validates that the Kafka version is supported
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
+
+        // Sets the LRaft metadata version and validates it is supported
+        String metadataVersion = kafkaClusterSpec.getMetadataVersion() != null ? kafkaClusterSpec.getMetadataVersion() : result.kafkaVersion.metadataVersion();
+        KRaftUtils.validateMetadataVersion(metadataVersion);
+        result.metadataVersion = metadataVersion;
 
         // Number of broker nodes => used later in various validation methods
         long numberOfBrokers = result.brokerNodes().size();
@@ -1690,8 +1700,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 data.put(BROKER_LISTENERS_FILENAME, node.broker() ? listeners.stream().map(ListenersUtils::envVarIdentifier).collect(Collectors.joining(" ")) : null);
 
                 if (useKRaft) {
-                    // In KRaft, we need to pass the Kafka CLuster ID
+                    // In KRaft, we need to pass the Kafka CLuster ID and the metadata version
                     data.put(BROKER_CLUSTER_ID_FILENAME, clusterId);
+                    data.put(BROKER_METADATA_VERSION_FILENAME, metadataVersion);
                 }
 
                 configMaps.add(ConfigMapUtils.createConfigMap(node.podName(), namespace, pool.labels.withStrimziPodName(node.podName()), pool.ownerReference, data));
@@ -1739,6 +1750,20 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     public void setInterBrokerProtocolVersion(String interBrokerProtocolVersion) {
         configuration.setConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, interBrokerProtocolVersion);
+    }
+
+    /**
+     * @return  Kafka's desired metadata version
+     */
+    public String getMetadataVersion() {
+        return metadataVersion;
+    }
+
+    /**
+     * @return  Indicates whether this is a KRaft cluster or not
+     */
+    public boolean usesKRaft() {
+        return useKRaft;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -406,6 +406,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
     private final String version;
     private final String protocolVersion;
     private final String messageVersion;
+    private final String metadataVersion;
     private final String zookeeperVersion;
     private final boolean isDefault;
     private final boolean isSupported;
@@ -417,6 +418,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      * @param version               Kafka version
      * @param protocolVersion       Inter-broker protocol version
      * @param messageVersion        Log message format version
+     * @param metadataVersion       KRaft Metadata version
      * @param zookeeperVersion      ZooKeeper version
      * @param isDefault             Flag indicating if this Kafka version is default
      * @param isSupported           Flag indicating if this Kafka version is supported by this operator version
@@ -426,6 +428,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
     public KafkaVersion(@JsonProperty("version") String version,
                         @JsonProperty("protocol") String protocolVersion,
                         @JsonProperty("format") String messageVersion,
+                        @JsonProperty("metadata") String metadataVersion,
                         @JsonProperty("zookeeper") String zookeeperVersion,
                         @JsonProperty("default") boolean isDefault,
                         @JsonProperty("supported") boolean isSupported,
@@ -435,6 +438,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
         this.protocolVersion = protocolVersion;
         this.messageVersion = messageVersion;
         this.zookeeperVersion = zookeeperVersion;
+        this.metadataVersion = metadataVersion;
         this.isDefault = isDefault;
         this.isSupported = isSupported;
         this.unsupportedFeatures = unsupportedFeatures;
@@ -447,6 +451,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
                 ", protocolVersion='" + protocolVersion + '\'' +
                 ", messageVersion='" + messageVersion + '\'' +
                 ", zookeeperVersion='" + zookeeperVersion + '\'' +
+                ", metadataVersion='" + metadataVersion + '\'' +
                 ", isDefault=" + isDefault +
                 ", isSupported=" + isSupported +
                 ", unsupportedFeatures='" + unsupportedFeatures  + '\'' +
@@ -472,6 +477,13 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
      */
     public String messageVersion() {
         return messageVersion;
+    }
+
+    /**
+     * @return  KRaft metadata version
+     */
+    public String metadataVersion() {
+        return metadataVersion;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.common.AdminClientProvider;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.VertxUtil;
+import io.strimzi.operator.common.model.StatusUtils;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.FeatureUpdate;
+import org.apache.kafka.clients.admin.UpdateFeaturesOptions;
+import org.apache.kafka.server.common.MetadataVersion;
+
+import java.util.Map;
+
+/**
+ * Utility class for managing KRaft the metadata version. It encapsulates the methods for getting the current metadata
+ * version and updating it.
+ */
+public class KRaftMetadataManager {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KRaftMetadataManager.class.getName());
+    /* test */ static final String METADATA_VERSION_KEY = MetadataVersion.FEATURE_NAME;
+
+    /**
+     * Method for managing the KRaft metadata version. This method will get the current metadata version and if needed,
+     * upgrade or downgrade it. It will also update the currently used metadata version in the Kafka CR status. This
+     * method might fail when it fails to communicate with the Kafka cluster and get the metadata version. But it will
+     * not fail when the update of the metadata version fails in order to not fail the whole reconciliation. Such event
+     * will be only logged into the regular logs as well as added to warnings in stat Kafka status. This method also
+     * never attempts unsafe downgrade. Unsafe downgrade is always expected to be done by the user manually.
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param vertx                     Vert.x instance
+     * @param secretOperator            Secret operator for getting the secrets for connecting to the Kafka cluster
+     * @param adminClientProvider       Kafka Admin client provider
+     * @param desiredMetadataVersion    Desired metadata version
+     * @param status                    Kafka status
+     *
+     * @return  Future that completes when the metadata update is finished (or was not needed) and the status is updated
+     */
+    public static Future<Void> maybeUpdateMetadataVersion(
+            Reconciliation reconciliation,
+            Vertx vertx,
+            SecretOperator secretOperator,
+            AdminClientProvider adminClientProvider,
+            String desiredMetadataVersion,
+            KafkaStatus status
+    ) {
+        return ReconcilerUtils.clientSecrets(reconciliation, secretOperator)
+                .compose(secrets -> {
+                    String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
+                    LOGGER.debugCr(reconciliation, "Creating AdminClient for Kafka cluster in namespace {}", reconciliation.namespace());
+                    Admin kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, secrets.resultAt(0), secrets.resultAt(1), "cluster-operator");
+
+                    Promise<Void> updatePromise = Promise.promise();
+                    maybeUpdateMetadataVersion(reconciliation, vertx, kafkaAdmin, desiredMetadataVersion, status)
+                            .onComplete(res -> {
+                                // Close the Admin client and return the original result
+                                LOGGER.debugCr(reconciliation, "Closing the Kafka Admin API connection");
+                                kafkaAdmin.close();
+                                updatePromise.handle(res);
+                            });
+
+                    return updatePromise.future();
+                });
+    }
+
+    private static Future<Void> maybeUpdateMetadataVersion(
+            Reconciliation reconciliation,
+            Vertx vertx,
+            Admin kafkaAdmin,
+            String desiredMetadataVersion,
+            KafkaStatus status
+    )    {
+        short desiredMetadataLevel = MetadataVersion.fromVersionString(desiredMetadataVersion).featureLevel();
+
+        return currentVersion(reconciliation, vertx, kafkaAdmin)
+                .compose(currentMetadataLevel -> {
+                    if (currentMetadataLevel.equals(desiredMetadataLevel))  {
+                        // No metadata version change as the current and desired versions are equal
+                        // We convert the metadata level to the version for the use in the status instead of using the
+                        // desired version directly in order to get the full version including the subversion
+                        String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString();
+                        LOGGER.debugCr(reconciliation, "Metadata version is already set to desired level {}", metadataVersion);
+                        status.setKafkaMetadataVersion(MetadataVersion.fromFeatureLevel(currentMetadataLevel).toString());
+                        return Future.succeededFuture();
+                    } else {
+                        Promise<Void> promise = Promise.promise();
+
+                        updateVersion(reconciliation, vertx, kafkaAdmin, currentMetadataLevel, desiredMetadataLevel)
+                                .onComplete(res -> {
+                                    if (res.succeeded())    {
+                                        // We convert the metadata level to the version for the use in the status instead of using the
+                                        // desired version directly in order to get the full version including the subversion
+                                        String metadataVersion = MetadataVersion.fromFeatureLevel(desiredMetadataLevel).toString();
+                                        LOGGER.infoCr(reconciliation, "Successfully updated metadata version to {}", metadataVersion);
+                                        status.setKafkaMetadataVersion(metadataVersion);
+                                        promise.complete();
+                                    } else {
+                                        // We failed to update the metadata version, but we do not want to break the
+                                        // reconciliation. We log the error and update the metadata version status.
+                                        currentVersion(reconciliation, vertx, kafkaAdmin)
+                                                .compose(currentMetadataLevelAfterFailure -> {
+                                                    String metadataVersion = MetadataVersion.fromFeatureLevel(currentMetadataLevelAfterFailure).toString();
+                                                    LOGGER.warnCr(reconciliation, "Failed to update metadata version to {} (the current version is {})", desiredMetadataVersion, metadataVersion, res.cause());
+                                                    status.addCondition(StatusUtils.buildWarningCondition("MetadataUpdateFailed", "Failed to update metadata version to " + desiredMetadataVersion));
+                                                    status.setKafkaMetadataVersion(metadataVersion);
+
+                                                    promise.complete();
+                                                    return Future.succeededFuture();
+                                                });
+                                    }
+                                });
+
+                        return promise.future();
+                    }
+                });
+    }
+
+    private static Future<Short> currentVersion(
+            Reconciliation reconciliation,
+            Vertx vertx,
+            Admin kafkaAdmin
+    )  {
+        return VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.describeFeatures().featureMetadata())
+                .compose(featureMetadata -> {
+                    if (featureMetadata.finalizedFeatures().get(METADATA_VERSION_KEY) != null)  {
+                        return Future.succeededFuture(featureMetadata.finalizedFeatures().get(METADATA_VERSION_KEY).maxVersionLevel());
+                    } else {
+                        return Future.failedFuture("Failed to describe " + METADATA_VERSION_KEY + " feature");
+                    }
+                });
+    }
+
+    private static Future<Void> updateVersion(
+            Reconciliation reconciliation,
+            Vertx vertx,
+            Admin kafkaAdmin,
+            short currentMetadataLevel,
+            short desiredMetadataLevel
+    )  {
+        UpdateFeaturesOptions options = new UpdateFeaturesOptions().validateOnly(false);
+        FeatureUpdate.UpgradeType upgradeType = desiredMetadataLevel > currentMetadataLevel ? FeatureUpdate.UpgradeType.UPGRADE : FeatureUpdate.UpgradeType.SAFE_DOWNGRADE;
+        FeatureUpdate featureUpdate = new FeatureUpdate(desiredMetadataLevel, upgradeType);
+
+        LOGGER.debugCr(reconciliation, "Updating metadata version from {} to {}", currentMetadataLevel, desiredMetadataLevel);
+
+        return VertxUtil
+                .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.updateFeatures(Map.of(METADATA_VERSION_KEY, featureUpdate), options).values().get(METADATA_VERSION_KEY))
+                .map((Void) null);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -24,7 +24,7 @@ import org.apache.kafka.server.common.MetadataVersion;
 import java.util.Map;
 
 /**
- * Utility class for managing KRaft the metadata version. It encapsulates the methods for getting the current metadata
+ * Utility class for managing the KRaft metadata version. It encapsulates the methods for getting the current metadata
  * version and updating it.
  */
 public class KRaftMetadataManager {
@@ -32,12 +32,24 @@ public class KRaftMetadataManager {
     /* test */ static final String METADATA_VERSION_KEY = MetadataVersion.FEATURE_NAME;
 
     /**
-     * Method for managing the KRaft metadata version. This method will get the current metadata version and if needed,
-     * upgrade or downgrade it. It will also update the currently used metadata version in the Kafka CR status. This
-     * method might fail when it fails to communicate with the Kafka cluster and get the metadata version. But it will
-     * not fail when the update of the metadata version fails in order to not fail the whole reconciliation. Such event
-     * will be only logged into the regular logs as well as added to warnings in stat Kafka status. This method also
-     * never attempts unsafe downgrade. Unsafe downgrade is always expected to be done by the user manually.
+     * Utility method for managing the KRaft metadata version.
+     *
+     * This method will get the current metadata version and compare it with the desired. If needed, it will try to
+     * upgrade or downgrade the metadata version to match the desired. It will also update the currently used metadata
+     * version in the Kafka CR status.
+     *
+     * In case this method fails while trying to upgrade the metadata version, it will not fail the whole reconciliation.
+     * And instead, it will log the issue at a warning level and add a warning to the .status section of the Kafka
+     * custom resource. The currently set metadata version will be kept in the status section as well. The main reason
+     * for this is that failures to change the metadata version are expected to happen often. Especially
+     * for downgrades, because Kafka support for metadata version downgrades is very limited. And we do not want to stop
+     * the whole reconciliation just because of that.
+     *
+     * Any other failures - such as failure with getting the current metadata version will be reported as errors and
+     * would break the reconciliation as usually.
+     *
+     * This method also never attempts unsafe downgrade. Unsafe downgrade is always expected to be done by the user
+     * manually.
      *
      * @param reconciliation            Reconciliation marker
      * @param vertx                     Vert.x instance

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -150,32 +150,31 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 status.setObservedGeneration(kafkaAssembly.getMetadata().getGeneration());
             }
 
-            if (status.getClusterId() == null
-                    && kafkaAssembly.getStatus() != null
-                    && kafkaAssembly.getStatus().getClusterId() != null)  {
-                // If not set in the status prepared by reconciliation but set in the status previously, we copy the
-                // cluster ID into the new status. This is useful for example when the reconciliation fails for some
-                // reason before setting the cluster ID
-                status.setClusterId(kafkaAssembly.getStatus().getClusterId());
-            }
+            // When some of the fields are not set in the new status (for example because the reconciliation failed),
+            // but the existing resource has them set in its status, we copy them over.
+            if (kafkaAssembly.getStatus() != null)  {
+                if (status.getClusterId() == null
+                        && kafkaAssembly.getStatus().getClusterId() != null)  {
+                    // Copy the Cluster ID if needed
+                    status.setClusterId(kafkaAssembly.getStatus().getClusterId());
+                }
 
-            if (kafkaAssembly.getStatus() != null
-                    && kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion() != null
-            )  {
-                // If not set in the status prepared by reconciliation but set in the status previously, we copy the
-                // operatorLastSuccessfulVersion version into the new status. This is useful for example when the reconciliation fails for some
-                // reason before setting the cluster ID
-                status.setOperatorLastSuccessfulVersion(kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion());
-            }
+                if (kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion() != null)  {
+                    // Copy the last successful operator version if needed
+                    status.setOperatorLastSuccessfulVersion(kafkaAssembly.getStatus().getOperatorLastSuccessfulVersion());
+                }
 
-            if (status.getKafkaVersion() == null
-                    && kafkaAssembly.getStatus() != null
-                    && kafkaAssembly.getStatus().getKafkaVersion() != null
-            )  {
-                // If not set in the status prepared by reconciliation but set in the status previously, we copy the
-                // kafka version into the new status. This is useful for example when the reconciliation fails for some
-                // reason before setting the cluster ID
-                status.setKafkaVersion(kafkaAssembly.getStatus().getKafkaVersion());
+                if (status.getKafkaVersion() == null
+                        && kafkaAssembly.getStatus().getKafkaVersion() != null)  {
+                    // Copy the Kafka version if needed
+                    status.setKafkaVersion(kafkaAssembly.getStatus().getKafkaVersion());
+                }
+
+                if (status.getKafkaMetadataVersion() == null
+                        && kafkaAssembly.getStatus().getKafkaMetadataVersion() != null)  {
+                    // Copy the metadata version if needed
+                    status.setKafkaMetadataVersion(kafkaAssembly.getStatus().getKafkaMetadataVersion());
+                }
             }
 
             if (reconcileResult.succeeded())    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -281,6 +281,7 @@ public class KafkaReconciler {
                 .compose(i -> serviceEndpointsReady())
                 .compose(i -> headlessServiceEndpointsReady())
                 .compose(i -> clusterId(kafkaStatus))
+                .compose(i -> metadataVersion(kafkaStatus))
                 .compose(i -> deletePersistentClaims())
                 .compose(i -> sharedKafkaConfigurationCleanup())
                 // This has to run after all possible rolling updates which might move the pods to different nodes
@@ -925,6 +926,19 @@ public class KafkaReconciler {
                                 return null;
                             });
                 });
+    }
+
+    /**
+     * Manages the KRaft metadata version
+     *
+     * @return  Future which completes when the KRaft metadata version is set to the current version or updated.
+     */
+    protected Future<Void> metadataVersion(KafkaStatus kafkaStatus) {
+        if (kafka.usesKRaft()) {
+            return KRaftMetadataManager.maybeUpdateMetadataVersion(reconciliation, vertx, secretOperator, adminClientProvider, kafka.getMetadataVersion(), kafkaStatus);
+        } else {
+            return Future.succeededFuture();
+        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -140,5 +141,19 @@ public class KRaftUtilsTest {
         KRaftUtils.validateEntityOperatorSpec(errors, eo, false);
 
         assertThat(errors, is(Set.of("Only Unidirectional Topic Operator is supported when the UseKRaft feature gate is enabled.")));
+    }
+
+    @ParallelTest
+    public void testKRaftMetadataVersionValidation()    {
+        // Valid values
+        assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.6"));
+        assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.6-IV2"));
+
+        // Invalid Values
+        InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3.6-IV9"));
+        assertThat(e.getMessage(), containsString("Metadata version 3.6-IV9 is invalid"));
+
+        e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3"));
+        assertThat(e.getMessage(), containsString("Metadata version 3 is invalid"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaVersionTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
@@ -33,7 +34,7 @@ public class KafkaVersionTest {
 
     @ParallelTest
     public void parsingInvalidVersionTest() {
-        KafkaVersion kv = new KafkaVersion("2.8.0", "2.8", "2.8", "3.6.9", false, true, "");
+        KafkaVersion kv = new KafkaVersion("2.8.0", "2.8", "2.8", "2.8", "3.6.9", false, true, "");
         assertThat(KafkaVersion.compareDottedIVVersions("2.7-IV1", kv.protocolVersion()), lessThan(0));
         assertThat(KafkaVersion.compareDottedIVVersions("2.9-IV1", kv.protocolVersion()), greaterThan(0));
 
@@ -53,24 +54,28 @@ public class KafkaVersionTest {
         assertThat(map.get("1.2.0").version(), is("1.2.0"));
         assertThat(map.get("1.2.0").protocolVersion(), is("1.2"));
         assertThat(map.get("1.2.0").messageVersion(), is("1.2"));
+        assertThat(map.get("1.2.0").metadataVersion(), is("1.2-IV2"));
         assertThat(map.get("1.2.0").isSupported(), is(true));
 
         assertThat(map.containsKey("1.1.0"), is(true));
         assertThat(map.get("1.1.0").version(), is("1.1.0"));
         assertThat(map.get("1.1.0").protocolVersion(), is("1.1"));
         assertThat(map.get("1.1.0").messageVersion(), is("1.1"));
+        assertThat(map.get("1.1.0").metadataVersion(), is(nullValue()));
         assertThat(map.get("1.1.0").isSupported(), is(true));
 
         assertThat(map.containsKey("1.1.1"), is(true));
         assertThat(map.get("1.1.1").version(), is("1.1.1"));
         assertThat(map.get("1.1.1").protocolVersion(), is("1.1"));
         assertThat(map.get("1.1.1").messageVersion(), is("1.1"));
+        assertThat(map.get("1.1.1").metadataVersion(), is("1.1"));
         assertThat(map.get("1.1.1").isSupported(), is(true));
 
         assertThat(map.containsKey("1.0.0"), is(true));
         assertThat(map.get("1.0.0").version(), is("1.0.0"));
         assertThat(map.get("1.0.0").protocolVersion(), is("1.0"));
         assertThat(map.get("1.0.0").messageVersion(), is("1.0"));
+        assertThat(map.get("1.0.0").metadataVersion(), is(nullValue()));
         assertThat(map.get("1.0.0").isSupported(), is(false));
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManagerTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.api.kafka.model.status.KafkaStatus;
+import io.strimzi.operator.common.AdminClientProvider;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.operator.resource.SecretOperator;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeFeaturesResult;
+import org.apache.kafka.clients.admin.FeatureMetadata;
+import org.apache.kafka.clients.admin.FeatureUpdate;
+import org.apache.kafka.clients.admin.FinalizedVersionRange;
+import org.apache.kafka.clients.admin.UpdateFeaturesResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.InvalidUpdateVersionException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class KRaftMetadataManagerTest {
+    private static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    private SecretOperator mockSecretOperator() {
+        SecretOperator mockSecretOps = mock(SecretOperator.class);
+        when(mockSecretOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(new Secret()));
+
+        return mockSecretOps;
+    }
+
+    private AdminClientProvider mockAdminClientProvider(Admin adminClient)  {
+        AdminClientProvider mockAdminClientProvider = mock(AdminClientProvider.class);
+        when(mockAdminClientProvider.createAdminClient(anyString(), any(), any(), anyString())).thenReturn(adminClient);
+
+        return mockAdminClientProvider;
+    }
+
+    private void mockDescribeVersion(Admin mockAdminClient)   {
+        FinalizedVersionRange fvr = mock(FinalizedVersionRange.class);
+        when(fvr.maxVersionLevel()).thenReturn((short) 13);
+
+        FeatureMetadata fm = mock(FeatureMetadata.class);
+        when(fm.finalizedFeatures()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, fvr));
+
+        DescribeFeaturesResult dfr = mock(DescribeFeaturesResult.class);
+        when(dfr.featureMetadata()).thenReturn(KafkaFuture.completedFuture(fm));
+
+        when(mockAdminClient.describeFeatures()).thenReturn(dfr);
+    }
+
+    @Test
+    public void testNoMetadataVersionChange(VertxTestContext context)   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock the Admin client provider and Secret ops
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+        SecretOperator mockSecretOps = mockSecretOperator();
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint checkpoint = context.checkpoint();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, mockSecretOps, mockAdminClientProvider, "3.6-IV1", status)
+                .onComplete(context.succeeding(s -> {
+                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
+
+                    verify(mockAdminClient, never()).updateFeatures(any(), any());
+                    verify(mockAdminClient, times(1)).describeFeatures();
+
+                    checkpoint.flag();
+                }));
+    }
+
+    @Test
+    public void testSuccessfulMetadataVersionUpgrade(VertxTestContext context)   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock updating metadata version
+        UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
+        when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, KafkaFuture.completedFuture(null)));
+        @SuppressWarnings(value = "unchecked")
+        ArgumentCaptor<Map<String, FeatureUpdate>> updateCaptor = ArgumentCaptor.forClass(Map.class);
+        when(mockAdminClient.updateFeatures(updateCaptor.capture(), any())).thenReturn(ufr);
+
+        // Mock the Admin client provider and Secret ops
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+        SecretOperator mockSecretOps = mockSecretOperator();
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint checkpoint = context.checkpoint();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, mockSecretOps, mockAdminClientProvider, "3.6", status)
+                .onComplete(context.succeeding(s -> {
+                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV2"));
+
+                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+                    verify(mockAdminClient, times(1)).describeFeatures();
+
+                    assertThat(updateCaptor.getAllValues().size(), is(1));
+                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.UPGRADE));
+                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 14));
+
+                    checkpoint.flag();
+                }));
+    }
+
+    @Test
+    public void testSuccessfulMetadataVersionDowngrade(VertxTestContext context)   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock updating metadata version
+        UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
+        when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, KafkaFuture.completedFuture(null)));
+        @SuppressWarnings(value = "unchecked")
+        ArgumentCaptor<Map<String, FeatureUpdate>> updateCaptor = ArgumentCaptor.forClass(Map.class);
+        when(mockAdminClient.updateFeatures(updateCaptor.capture(), any())).thenReturn(ufr);
+
+        // Mock the Admin client provider and Secret ops
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+        SecretOperator mockSecretOps = mockSecretOperator();
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint checkpoint = context.checkpoint();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, mockSecretOps, mockAdminClientProvider, "3.5", status)
+                .onComplete(context.succeeding(s -> {
+                    assertThat(status.getKafkaMetadataVersion(), is("3.5-IV2"));
+
+                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+                    verify(mockAdminClient, times(1)).describeFeatures();
+
+                    assertThat(updateCaptor.getAllValues().size(), is(1));
+                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).upgradeType(), is(FeatureUpdate.UpgradeType.SAFE_DOWNGRADE));
+                    assertThat(updateCaptor.getValue().get(KRaftMetadataManager.METADATA_VERSION_KEY).maxVersionLevel(), is((short) 11));
+
+                    checkpoint.flag();
+                }));
+    }
+
+    @Test
+    public void testUnsuccessfulMetadataVersionChange(VertxTestContext context)   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeVersion(mockAdminClient);
+
+        // Mock updating metadata version
+        @SuppressWarnings(value = "unchecked")
+        KafkaFuture<Void> kf = mock(KafkaFuture.class);
+        when(kf.whenComplete(any())).thenAnswer(i -> {
+            KafkaFuture.BiConsumer<Void, Throwable> action = i.getArgument(0);
+            action.accept(null, new InvalidUpdateVersionException("Test error ..."));
+            return null;
+        });
+        UpdateFeaturesResult ufr = mock(UpdateFeaturesResult.class);
+        when(ufr.values()).thenReturn(Map.of(KRaftMetadataManager.METADATA_VERSION_KEY, kf));
+        when(mockAdminClient.updateFeatures(any(), any())).thenReturn(ufr);
+
+        // Mock the Admin client provider and Secret ops
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+        SecretOperator mockSecretOps = mockSecretOperator();
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint checkpoint = context.checkpoint();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, mockSecretOps, mockAdminClientProvider, "3.6", status)
+                .onComplete(context.succeeding(s -> {
+                    assertThat(status.getKafkaMetadataVersion(), is("3.6-IV1"));
+                    assertThat(status.getConditions().size(), is(1));
+                    assertThat(status.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(status.getConditions().get(0).getReason(), is("MetadataUpdateFailed"));
+                    assertThat(status.getConditions().get(0).getMessage(), is("Failed to update metadata version to 3.6"));
+
+                    verify(mockAdminClient, times(1)).updateFeatures(any(), any());
+                    verify(mockAdminClient, times(2)).describeFeatures();
+
+                    checkpoint.flag();
+                }));
+    }
+
+    @Test
+    public void testUnexpectedError(VertxTestContext context)   {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        @SuppressWarnings(value = "unchecked")
+        KafkaFuture<FeatureMetadata> kf = mock(KafkaFuture.class);
+        when(kf.whenComplete(any())).thenAnswer(i -> {
+            KafkaFuture.BiConsumer<FeatureMetadata, Throwable> action = i.getArgument(0);
+            action.accept(null, new RuntimeException("Test error ..."));
+            return null;
+        });
+        DescribeFeaturesResult dfr = mock(DescribeFeaturesResult.class);
+        when(dfr.featureMetadata()).thenReturn(kf);
+        when(mockAdminClient.describeFeatures()).thenReturn(dfr);
+
+        // Mock the Admin client provider and Secret ops
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+        SecretOperator mockSecretOps = mockSecretOperator();
+
+        // Dummy KafkaStatus to check the values from
+        KafkaStatus status = new KafkaStatus();
+
+        Checkpoint checkpoint = context.checkpoint();
+        KRaftMetadataManager.maybeUpdateMetadataVersion(Reconciliation.DUMMY_RECONCILIATION, vertx, mockSecretOps, mockAdminClientProvider, "3.5", status)
+                .onComplete(context.failing(s -> {
+                    assertThat(s, instanceOf(RuntimeException.class));
+                    assertThat(s.getMessage(), is("Test error ..."));
+
+                    assertThat(status.getKafkaMetadataVersion(), is(nullValue()));
+
+                    verify(mockAdminClient, never()).updateFeatures(any(), any());
+                    verify(mockAdminClient, times(1)).describeFeatures();
+
+                    checkpoint.flag();
+                }));
+    }
+}
+

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -344,6 +344,7 @@ public class KafkaStatusTest {
                                     .build())
                     .withKafkaVersion("old-kafka")
                     .withOperatorLastSuccessfulVersion("old-operator")
+                    .withKafkaMetadataVersion("old-metadata-version")
                 .endStatus()
                 .build();
 
@@ -382,6 +383,7 @@ public class KafkaStatusTest {
             assertThat(status.getObservedGeneration(), is(2L));
             assertThat(status.getKafkaVersion(), is("old-kafka"));
             assertThat(status.getOperatorLastSuccessfulVersion(), is("old-operator"));
+            assertThat(status.getKafkaMetadataVersion(), is("old-metadata-version"));
 
             async.flag();
         })));

--- a/cluster-operator/src/test/resources/kafka-versions/kafka-versions-valid.yaml
+++ b/cluster-operator/src/test/resources/kafka-versions/kafka-versions-valid.yaml
@@ -36,6 +36,7 @@
 - version: 1.1.1
   format: 1.1
   protocol: 1.1
+  metadata: 1.1
   url: https://download.tld/kafka-1.1.1.tgz
   checksum: DUMMYSHA512CHECKSUM111
   zookeeper: 3.5.7
@@ -45,6 +46,7 @@
 - version: 1.2.0
   format: 1.2
   protocol: 1.2
+  metadata: 1.2-IV2
   url: https://download.tld/kafka-1.2.0.tgz
   checksum: DUMMYSHA512CHECKSUM120
   zookeeper: 3.5.7

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -61,11 +61,12 @@ if [ "$STRIMZI_KRAFT_ENABLED" = "true" ]; then
 
   if [ ! -f "$KRAFT_LOG_DIR/meta.properties" ]; then
     STRIMZI_CLUSTER_ID=$(cat "$KAFKA_HOME/custom-config/cluster.id")
-    echo "Formatting Kraft storage with cluster ID $STRIMZI_CLUSTER_ID"
+    METADATA_VERSION=$(cat "$KAFKA_HOME/custom-config/metadata.version")
+    echo "Formatting Kraft storage with cluster ID $STRIMZI_CLUSTER_ID and metadata version $METADATA_VERSION"
     mkdir -p "$KRAFT_LOG_DIR"
     # Using "=" to assign arguments for the Kafka storage tool to avoid issues if the generated
     # cluster ID starts with a "-". See https://issues.apache.org/jira/browse/KAFKA-15754
-    ./bin/kafka-storage.sh format -t="$STRIMZI_CLUSTER_ID" -c=/tmp/strimzi.properties
+    ./bin/kafka-storage.sh format -t="$STRIMZI_CLUSTER_ID" -r="$METADATA_VERSION" -c=/tmp/strimzi.properties
   else
     echo "Kraft storage is already formatted"
   fi

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -59,7 +59,9 @@ include::../api/io.strimzi.api.kafka.model.KafkaClusterSpec.adoc[leveloffset=+1]
 [options="header"]
 |====
 |Property                    |Description
-|version              1.2+<.<a|The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|version              1.2+<.<a|The Kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.
+|string
+|metadataVersion      1.2+<.<a|The KRaft metadata.version that should be used by this Kafka cluster. This field will be ignored when running in ZooKeeper mode. Defaults to {DefaultKafkaMetadataVersion}.
 |string
 |replicas             1.2+<.<a|The number of pods in the cluster.
 |integer
@@ -1627,6 +1629,8 @@ Used in: xref:type-Kafka-{context}[`Kafka`]
 |operatorLastSuccessfulVersion  1.2+<.<a|The version of the Strimzi Cluster Operator which performed the last successful reconciliation.
 |string
 |kafkaVersion                   1.2+<.<a|The version of Kafka currently deployed in the cluster.
+|string
+|kafkaMetadataVersion           1.2+<.<a|The KRaft metadata.version currently used by the Kafka cluster.
 |string
 |====
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -24,6 +24,7 @@
 
 // Kafka upgrade attributes used in kafka upgrades section
 :DefaultKafkaVersion: 3.6.0
+:DefaultKafkaMetadataVersion: 3.6
 :KafkaVersionLower: 3.5.1
 :KafkaVersionHigher: 3.6.0
 :ExampleImageTagUpgrades: quay.io/strimzi/kafka:{ProductVersion}-kafka-{KafkaVersionHigher}

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -258,6 +258,7 @@
 - version: 3.5.0
   format: 3.5
   protocol: 3.5
+  metadata: 3.5
   url: https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz
   checksum: 7B79BD0844DB683C06C3491955BB183D48A47FA4639D2E241B9F4FF4060C4B70814DAC7D96BEA87DFFCA0C8AE038278C4FABF68D4EA1194228D67D9C3B1D247C
   zookeeper: 3.6.4
@@ -267,6 +268,7 @@
 - version: 3.5.1
   format: 3.5
   protocol: 3.5
+  metadata: 3.5
   url: https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz
   checksum: B6CEB010A5FE1791843CBC53D34D35993E97E03F9518344B4B5BDF7146D0A4E866CD2D4760CAB319D8B3323A5BF53037A78FED88C9384381AEA2CD0366877763
   zookeeper: 3.6.4
@@ -276,6 +278,7 @@
 - version: 3.6.0
   format: 3.6
   protocol: 3.6
+  metadata: 3.6
   url: https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz
   checksum: 98D20F475BCCC11EB3CF05362112C788EEA7BFC88ABDDBA66CFCFB48880D3BB97918A90D44EB7C1720527BEBCA93DD231002B5159876F6EE8B7FCD91CC1B0644
   zookeeper: 3.8.2

--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -28,6 +28,7 @@ metadata:
 spec:
   kafka:
     version: 3.6.0
+    metadataVersion: 3.6-IV2
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
@@ -36,6 +36,7 @@ metadata:
 spec:
   kafka:
     version: 3.6.0
+    metadataVersion: 3.6-IV2
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -46,6 +46,7 @@ metadata:
 spec:
   kafka:
     version: 3.6.0
+    metadataVersion: 3.6-IV2
     # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
     # But it will be ignored when Kafka Node Pools are used
     replicas: 3

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -55,7 +55,10 @@ spec:
                   properties:
                     version:
                       type: string
-                      description: "The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+                      description: "The Kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+                    metadataVersion:
+                      type: string
+                      description: "The KRaft metadata.version that should be used by this Kafka cluster. This field will be ignored when running in ZooKeeper mode. Defaults to {DefaultKafkaMetadataVersion}."
                     replicas:
                       type: integer
                       minimum: 1
@@ -6318,4 +6321,7 @@ spec:
                 kafkaVersion:
                   type: string
                   description: The version of Kafka currently deployed in the cluster.
+                kafkaMetadataVersion:
+                  type: string
+                  description: The KRaft metadata.version currently used by the Kafka cluster.
               description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -54,7 +54,10 @@ spec:
                 properties:
                   version:
                     type: string
-                    description: "The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+                    description: "The Kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version."
+                  metadataVersion:
+                    type: string
+                    description: "The KRaft metadata.version that should be used by this Kafka cluster. This field will be ignored when running in ZooKeeper mode. Defaults to {DefaultKafkaMetadataVersion}."
                   replicas:
                     type: integer
                     minimum: 1
@@ -6317,4 +6320,7 @@ spec:
               kafkaVersion:
                 type: string
                 description: The version of Kafka currently deployed in the cluster.
+              kafkaMetadataVersion:
+                type: string
+                description: The KRaft metadata.version currently used by the Kafka cluster.
             description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the first part of the [SP#61](https://github.com/strimzi/proposals/blob/main/061-kraft-upgrades-and-downgrades.md). It adds support for managing KRaft metadata versions:
* Adds a new field to the Kafka CR to specify the desired metadata version
* Adds the possibility to define the initial metadata version when deploying new clusters
* Adds the possibility to change the metadata versions (to the extent in which it is supported by Kafka itself)

It does not deliver the actual KRaft upgrades yet not any documentation -> that will be done in follow up PR in order to allow for less disruption and faster reviews.

It also adds the initial metadata version to the KRaft example YAMLs. It uses the full format including the subversion. That is important given the significant limitation KRaft currently has when it comes to downgrading the metadata version.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md