### PR TITLE
docs(uto): updates UTO docs to promote unidirectional mode as primary/default

### DIFF
--- a/documentation/modules/configuring/con-configuring-topic-operator.adoc
+++ b/documentation/modules/configuring/con-configuring-topic-operator.adoc
@@ -8,8 +8,7 @@
 [role="_abstract"]
 Use `topicOperator` properties in `Kafka.spec.entityOperator` to configure the Topic Operator.
 
-NOTE: If you are using the preview of unidirectional topic management, the following properties are not used and will be ignored: 
-`Kafka.spec.entityOperator.topicOperator.zookeeperSessionTimeoutSeconds` and `Kafka.spec.entityOperator.topicOperator.topicMetadataMaxAttempts`.
+NOTE: If you are using unidirectional topic management, which is enabled by default, the following properties are not used and are ignored: `Kafka.spec.entityOperator.topicOperator.zookeeperSessionTimeoutSeconds` and `Kafka.spec.entityOperator.topicOperator.topicMetadataMaxAttempts`.
 For more information on unidirectional topic management, refer to xref:ref-operator-topic-{context}[].
 
 The following properties are supported:
@@ -33,7 +32,7 @@ Consider increasing this value when topic creation might take more time due to t
 Default `6`.
 
 `image`::
-The `image` property can be used to configure the container image which will be used.
+The `image` property can be used to configure the container image which is used.
 To learn more, refer to the information provided on link:{BookURLConfiguring}#con-common-configuration-images-reference[configuring the `image` property`^].
 
 `resources`::

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -6,10 +6,11 @@
 = Deploying the standalone Topic Operator
 
 [role="_abstract"]
-This procedure shows how to deploy the Topic Operator as a standalone component for topic management.
+This procedure shows how to deploy the Topic Operator in unidirectional mode as a standalone component for topic management.
 You can use a standalone Topic Operator with a Kafka cluster that is not managed by the Cluster Operator.
-
-A standalone deployment can operate with any Kafka cluster.
+Unidirectional topic management maintains topics solely through `KafkaTopic` resources.
+For more information on unidirectional topic management, see xref:ref-operator-topic-{context}[].
+Alternate configuration is also shown for deploying the Topic Operator in bidirectional mode.
 
 Standalone deployment files are provided with Strimzi.
 Use the `05-Deployment-strimzi-topic-operator.yaml` deployment file to deploy the Topic Operator.
@@ -60,36 +61,32 @@ spec:
               value: my-kafka-bootstrap-address:9092
             - name: STRIMZI_RESOURCE_LABELS # <3>
               value: "strimzi.io/cluster=my-cluster"
-            - name: STRIMZI_ZOOKEEPER_CONNECT # <4>
-              value: my-cluster-zookeeper-client:2181
-            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS # <5>
-              value: "18000"
-            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS # <6>
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS # <4>
               value: "120000"
-            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS # <7>
-              value: "6"
-            - name: STRIMZI_LOG_LEVEL # <8>
+            - name: STRIMZI_LOG_LEVEL # <5>
               value: INFO
-            - name: STRIMZI_TLS_ENABLED # <9>
+            - name: STRIMZI_TLS_ENABLED # <6>
               value: "false"
-            - name: STRIMZI_JAVA_OPTS # <10>
+            - name: STRIMZI_JAVA_OPTS # <7>
               value: "-Xmx=512M -Xms=256M"
-            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES # <11>
+            - name: STRIMZI_JAVA_SYSTEM_PROPERTIES # <8>
               value: "-Djavax.net.debug=verbose -DpropertyName=value"
-            - name: STRIMZI_PUBLIC_CA # <12>
+            - name: STRIMZI_PUBLIC_CA # <9>
               value: "false"
-            - name: STRIMZI_TLS_AUTH_ENABLED # <13>
+            - name: STRIMZI_TLS_AUTH_ENABLED # <10>
               value: "false"
-            - name: STRIMZI_SASL_ENABLED # <14>
+            - name: STRIMZI_SASL_ENABLED # <11>
               value: "false"
-            - name: STRIMZI_SASL_USERNAME # <15>
+            - name: STRIMZI_SASL_USERNAME # <12>
               value: "admin"
-            - name: STRIMZI_SASL_PASSWORD # <16>
+            - name: STRIMZI_SASL_PASSWORD # <13>
               value: "password"
-            - name: STRIMZI_SASL_MECHANISM # <17>
+            - name: STRIMZI_SASL_MECHANISM # <14>
               value: "scram-sha-512"
-            - name: STRIMZI_SECURITY_PROTOCOL # <18>
+            - name: STRIMZI_SECURITY_PROTOCOL # <15>
               value: "SSL"
+            - name: STRIMZI_USE_FINALIZERS
+              value: "false" # <16>
 ----
 <1> The Kubernetes namespace for the Topic Operator to watch for `KafkaTopic` resources. Specify the namespace of the Kafka cluster.
 <2> The host and port pair of the bootstrap broker address to discover and connect to all brokers in the Kafka cluster.
@@ -99,37 +96,30 @@ This does not have to be the name of the Kafka cluster.
 It can be the label assigned to the `KafkaTopic` resource.
 If you deploy more than one Topic Operator, the labels must be unique for each.
 That is, the operators cannot manage the same resources.
-<4> (ZooKeeper) The host and port pair of the address to connect to the ZooKeeper cluster.
-This must be the same ZooKeeper cluster that your Kafka cluster is using.
-<5> (ZooKeeper) The ZooKeeper session timeout, in milliseconds.
-The default is `18000` (18 seconds).
-<6> The interval between periodic reconciliations, in milliseconds.
+<4> The interval between periodic reconciliations, in milliseconds.
 The default is `120000` (2 minutes).
-<7> The number of attempts at getting topic metadata from Kafka.
-The time between each attempt is defined as an exponential backoff.
-Consider increasing this value when topic creation takes more time due to the number of partitions or replicas.
-The default is `6` attempts.
-<8> The level for printing logging messages.
+<5> The level for printing logging messages.
 You can set the level to `ERROR`, `WARNING`, `INFO`, `DEBUG`, or `TRACE`.
-<9> Enables TLS support for encrypted communication with the Kafka brokers.
-<10> (Optional) The Java options used by the JVM running the Topic Operator.
-<11> (Optional) The debugging (`-D`) options set for the Topic Operator.
-<12> (Optional) Skips the generation of trust store certificates if TLS is enabled through `STRIMZI_TLS_ENABLED`. If this environment variable is enabled, the brokers must use a public trusted certificate authority for their TLS certificates.
+<6> Enables TLS support for encrypted communication with the Kafka brokers.
+<7> (Optional) The Java options used by the JVM running the Topic Operator.
+<8> (Optional) The debugging (`-D`) options set for the Topic Operator.
+<9> (Optional) Skips the generation of trust store certificates if TLS is enabled through `STRIMZI_TLS_ENABLED`. If this environment variable is enabled, the brokers must use a public trusted certificate authority for their TLS certificates.
 The default is `false`.
-<13> (Optional) Generates key store certificates for mTLS authentication. Setting this to `false` disables client authentication with mTLS to the Kafka brokers.
+<10> (Optional) Generates key store certificates for mTLS authentication. Setting this to `false` disables client authentication with mTLS to the Kafka brokers.
 The default is `true`.
-<14> (Optional) Enables SASL support for client authentication when connecting to Kafka brokers.
+<11> (Optional) Enables SASL support for client authentication when connecting to Kafka brokers.
 The default is `false`.
-<15> (Optional) The SASL username for client authentication.
+<12> (Optional) The SASL username for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
-<16> (Optional) The SASL password for client authentication.
+<13> (Optional) The SASL password for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
-<17> (Optional) The SASL mechanism for client authentication.
+<14> (Optional) The SASL mechanism for client authentication.
 Mandatory only if SASL is enabled through `STRIMZI_SASL_ENABLED`.
 You can set the value to `plain`, `scram-sha-256`, or `scram-sha-512`.
-<18> (Optional) The security protocol used for communication with Kafka brokers.
+<15> (Optional) The security protocol used for communication with Kafka brokers.
 The default value is "PLAINTEXT".
 You can set the value to `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.
+<16> Set `STRIMZI_USE_FINALIZERS` to `false` if you do not want to use finalizers to control xref:con-deleting-managed-topics-{context}[topic deletion].
 
 . If you want to connect to Kafka brokers that are using certificates from a public certificate authority, set `STRIMZI_PUBLIC_CA` to `true`. Set this property to `true`, for example, if you are using Amazon AWS MSK service.
 . If you enabled mTLS with the `STRIMZI_TLS_ENABLED` environment variable, specify the keystore and truststore used to authenticate connection to the Kafka cluster.
@@ -154,10 +144,7 @@ env:
 <3> The keystore contains the private key for mTLS authentication.
 <4> The password for accessing the keystore.
 
-. Deploy the Topic Operator.
-+
-[source,shell,subs=+quotes]
-kubectl create -f install/topic-operator
+. Apply the changes to the `Deployment` configuration to deploy the Topic Operator.
 
 . Check the status of the deployment:
 +
@@ -176,32 +163,28 @@ strimzi-topic-operator  1/1    1           1
 `READY` shows the number of replicas that are ready/expected.
 The deployment is successful when the `AVAILABLE` output shows `1`.
 
-== (Preview) Deploying the standalone Topic Operator for unidirectional topic management
+== Deploying the standalone Topic Operator for bidirectional topic management
 
-Unidirectional topic management maintains topics solely through `KafkaTopic` resources.
-For more information on unidirectional topic management, see xref:ref-operator-topic-{context}[].
-
-If you want to try the preview of unidirectional topic management, follow these steps to deploy the standalone Topic Operator.
-
-.Procedure
+Bidirectional topic management requires ZooKeeper for cluster management, and maintains topics through `KafkaTopic` resources and within the Kafka cluster. 
+If you want to switch to using the Topic Operator in this mode, follow these steps to deploy the standalone Topic Operator.
 
 . Undeploy the current standalone Topic Operator.
 +
 Retain the `KafkaTopic` resources, which are picked up by the Topic Operator when it is deployed again.
 
-. Edit the `Deployment` configuration for the standalone Topic Operator to remove any ZooKeeper-related environment variables:
+. Edit the `Deployment` configuration for the standalone Topic Operator to include ZooKeeper-related environment variables:
 +
 * `STRIMZI_ZOOKEEPER_CONNECT`
 * `STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS`
 * `TC_ZK_CONNECTION_TIMEOUT_MS`
 * `STRIMZI_USE_ZOOKEEPER_TOPIC_STORE`
 +
-It is the presence or absence of the ZooKeeper variables that defines whether the unidirectional Topic Operator is used.
+It is the presence or absence of the ZooKeeper variables that defines whether the bidirectional Topic Operator is used.
 Unidirectional topic management does not use ZooKeeper.
 If ZooKeeper environment variables are not present, the unidirectional Topic Operator is used.
 Otherwise, the bidirectional Topic Operator is used. 
 +
-Other unused environment variables that can be removed if present:
+Other environment variables that are not used in unidirectional mode can be added if required:
 +
 * `STRIMZI_REASSIGN_THROTTLE`
 * `STRIMZI_REASSIGN_VERIFY_INTERVAL_MS`
@@ -211,21 +194,8 @@ Other unused environment variables that can be removed if present:
 * `STRIMZI_STORE_NAME`
 * `STRIMZI_APPLICATION_ID`
 * `STRIMZI_STALE_RESULT_TIMEOUT_MS`
-
-. (Optional) Set the `STRIMZI_USE_FINALIZERS` environment variable to `false`:
 +
-.Additional configuration for unidirectional topic management
-[source,shell,subs=+quotes]
-----
-# ...
-env:
-  - name: STRIMZI_USE_FINALIZERS
-    value: "false"
-----
-+
-Set this environment variable to `false` if you do not want to use finalizers to control xref:con-deleting-managed-topics-{context}[topic deletion].
-+
-.Example standalone Topic Operator deployment configuration for unidirectional topic management
+.Example standalone Topic Operator deployment configuration for bidirectional topic management
 [source,shell,subs=+quotes]
 ----
 apiVersion: apps/v1
@@ -252,6 +222,12 @@ spec:
               value: my-kafka-bootstrap-address:9092
             - name: STRIMZI_RESOURCE_LABELS
               value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_ZOOKEEPER_CONNECT # <1>
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS # <2>
+              value: "18000"
+            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS # <3>
+              value: "6"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
             - name: STRIMZI_LOG_LEVEL
@@ -276,8 +252,14 @@ spec:
               value: "scram-sha-512"
             - name: STRIMZI_SECURITY_PROTOCOL
               value: "SSL"
-            - name: STRIMZI_USE_FINALIZERS
-              value: "true"  
 ----
+<1> (ZooKeeper) The host and port pair of the address to connect to the ZooKeeper cluster.
+This must be the same ZooKeeper cluster that your Kafka cluster is using.
+<2> (ZooKeeper) The ZooKeeper session timeout, in milliseconds.
+The default is `18000` (18 seconds).
+<3> The number of attempts at getting topic metadata from Kafka.
+The time between each attempt is defined as an exponential backoff.
+Consider increasing this value when topic creation takes more time due to the number of partitions or replicas.
+The default is `6` attempts.
 
-. Deploy the standalone Topic Operator in the standard way.
+. Apply the changes to the `Deployment` configuration to deploy the Topic Operator.

--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -168,6 +168,8 @@ The deployment is successful when the `AVAILABLE` output shows `1`.
 Bidirectional topic management requires ZooKeeper for cluster management, and maintains topics through `KafkaTopic` resources and within the Kafka cluster. 
 If you want to switch to using the Topic Operator in this mode, follow these steps to deploy the standalone Topic Operator.
 
+NOTE: As the feature gate enabling the Topic Operator to run in unidirectional mode progresses to General Availability, bidirectional mode will be phased out. This transition is aimed at enhancing the user experience, particularly in supporting Kafka in KRaft mode. 
+
 . Undeploy the current standalone Topic Operator.
 +
 Retain the `KafkaTopic` resources, which are picked up by the Topic Operator when it is deployed again.

--- a/documentation/modules/operators/con-application-topic-handling.adoc
+++ b/documentation/modules/operators/con-application-topic-handling.adoc
@@ -8,8 +8,8 @@
 [role="_abstract"]
 How the Topic Operator handles changes to topics depends on the xref:ref-operator-topic-{context}[mode of topic management].
 
-* For bidirectional topic management, configuration changes are synchronized between the Kafka topic and the `KafkaTopic` resource in both directions. Incompatible changes prioritize the Kafka configuration, and the `KafkaTopic` resource is adjusted accordingly.
-* For unidirectional topic management (currently in preview), configuration changes only go in one direction: from the `KafkaTopic` resource to the Kafka topic. Any changes to a Kafka topic managed outside the `KafkaTopic` resource are reverted. 
+* For unidirectional topic management, configuration changes only go in one direction: from the `KafkaTopic` resource to the Kafka topic. Any changes to a Kafka topic managed outside the `KafkaTopic` resource are reverted.
+* For bidirectional topic management, configuration changes are synchronized between the Kafka topic and the `KafkaTopic` resource in both directions. Incompatible changes prioritize the Kafka configuration, and the `KafkaTopic` resource is adjusted accordingly. 
 
 == Topic store for bidirectional topic management
 
@@ -75,7 +75,7 @@ When an application is deployed along with its `KafkaTopic` resources, it is pos
 
 For bidirectional topic management, the Topic Operator synchronizes the changes between the topics and `KafkaTopic` resources.
 
-If you are trying the unidirectional topic management preview, this can mean that the topics created for an application deployment are initially created with default topic configuration.
+If you are using unidirectional topic management, this can mean that the topics created for an application deployment are initially created with default topic configuration.
 If the Topic Operator attempts to reconfigure the topics based on `KafkaTopic` resource specifications included with the application deployment, the operation might fail because the required change to the configuration is not allowed.
 For example, if the change means lowering the number of topic partitions.
 For this reason, it is recommended to disable `auto.create.topics.enable` in the Kafka cluster configuration when using unidirectional topic management.

--- a/documentation/modules/operators/con-deleting-managed-topics.adoc
+++ b/documentation/modules/operators/con-deleting-managed-topics.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='con-deleting-managed-topics-{context}']
-= (Preview) Deleting managed topics
+= Deleting managed topics
 
 [role="_abstract"]
 Unidirectional topic management supports the deletion of topics managed through the `KafkaTopic` resource with or without Kubernetes finalizers.

--- a/documentation/modules/operators/con-operator-topic-names.adoc
+++ b/documentation/modules/operators/con-operator-topic-names.adoc
@@ -58,7 +58,7 @@ The status of the newer resources is updated to indicate a conflict, and their `
 
 If a Kafka client application, such as Kafka Streams, automatically creates topics with invalid Kubernetes resource names, the Topic Operator generates a valid `metadata.name` when used in bidirectional mode. 
 It replaces invalid characters and appends a hash to the name. 
-However, this behavior does not apply in (preview) unidirectional mode.
+However, this behavior does not apply in unidirectional mode.
 
 .Example of replacing an invalid topic name
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/operators/con-removing-topic-finalizers.adoc
+++ b/documentation/modules/operators/con-removing-topic-finalizers.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='con-removing-topic-finalizers-{context}']
-= (Preview) Removing finalizers on topics
+= Removing finalizers on topics
 
 [role="_abstract"]
 If the unidirectional Topic Operator is not running, and you want to bypass the finalization process when deleting managed topics, you have to remove the finalizers.   

--- a/documentation/modules/operators/con-tuning-topic-request-batches.adoc
+++ b/documentation/modules/operators/con-tuning-topic-request-batches.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='con-tuning-topic-request-batches-{context}']
-= (Preview) Tuning request batches for topic operations
+= Tuning request batches for topic operations
 
 In unidirectional mode, the Topic Operator uses the request batching capabilities of the Kafka Admin API for operations on topic resources. 
 You can fine-tune the batching mechanism using the following operator configuration properties:

--- a/documentation/modules/operators/proc-configuring-kafka-topic.adoc
+++ b/documentation/modules/operators/proc-configuring-kafka-topic.adoc
@@ -20,7 +20,7 @@ To be able to delete topics, `delete.topic.enable` must be set to `true` (defaul
 
 This procedure shows how to create a topic with 10 partitions and 2 replicas.
 
-NOTE: The procedure is the same for the bidirectional and (preview) unidirectional modes of topic management. 
+NOTE: The procedure is the same for the unidirectional and bidirectional modes of topic management. 
 
 .Before you begin
 

--- a/documentation/modules/operators/proc-converting-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-managed-topics.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='proc-converting-managed-topics-{context}']
-= (Preview) Managing KafkaTopic resources without impacting Kafka topics
+= Managing KafkaTopic resources without impacting Kafka topics
 
 [role="_abstract"]
 This procedure describes how to convert Kafka topics that are currently managed through the `KafkaTopic` resource into non-managed topics.

--- a/documentation/modules/operators/proc-converting-non-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-non-managed-topics.adoc
@@ -3,7 +3,7 @@
 // assembly-using-the-topic-operator.adoc
 
 [id='proc-converting-non-managed-topics-{context}']
-= (Preview) Enabling topic management for existing Kafka topics
+= Enabling topic management for existing Kafka topics
 
 [role="_abstract"]
 This procedure describes how to enable topic management for topics that are not currently managed through the `KafkaTopic` resource.

--- a/documentation/modules/operators/ref-operator-topic.adoc
+++ b/documentation/modules/operators/ref-operator-topic.adoc
@@ -8,21 +8,10 @@
 [role="_abstract"]
 The `KafkaTopic` resource is responsible for managing a single topic within a Kafka cluster. The Topic Operator provides two modes for managing `KafkaTopic` resources and Kafka topics:
 
+Unidirectional mode (default):: Unidirectional mode does not require ZooKeeper for cluster management. It is compatible with using Strimzi in KRaft mode.
 Bidirectional mode:: Bidirectional mode requires ZooKeeper for cluster management. It is not compatible with using Strimzi in KRaft mode.
 
-(Preview) Unidirectional mode:: Unidirectional mode does not require ZooKeeper for cluster management. It is compatible with using Strimzi in KRaft mode.
-
-== Bidirectional topic management
-
-In bidirectional mode, the Topic Operator operates as follows: 
-
-* When a `KafkaTopic` is created, deleted, or changed, the Topic Operator performs the corresponding operation on the Kafka topic.
-* Similarly, when a topic is created, deleted, or changed within the Kafka cluster, the Topic Operator performs the corresponding operation on the `KafkaTopic` resource.
-
-TIP: Try to stick to one method of managing topics, either through the `KafkaTopic` resources or directly in Kafka.
-Avoid routinely switching between both methods for a given topic.
-
-== (Preview) Unidirectional topic management
+== Unidirectional topic management
 
 In unidirectional mode, the Topic Operator operates as follows: 
 
@@ -34,3 +23,13 @@ If a `KafkaTopic` does exist for a Kafka topic, any configuration changes made o
 
 The Topic Operator can detect cases where where multiple `KafkaTopic` resources are attempting to manage a Kafka topic using the same `.spec.topicName`. 
 Only the oldest resource is reconciled, while the other resources fail with a resource conflict error.
+
+== Bidirectional topic management
+
+In bidirectional mode, the Topic Operator operates as follows: 
+
+* When a `KafkaTopic` is created, deleted, or changed, the Topic Operator performs the corresponding operation on the Kafka topic.
+* Similarly, when a topic is created, deleted, or changed within the Kafka cluster, the Topic Operator performs the corresponding operation on the `KafkaTopic` resource.
+
+TIP: Try to stick to one method of managing topics, either through the `KafkaTopic` resources or directly in Kafka.
+Avoid routinely switching between both methods for a given topic.

--- a/documentation/modules/operators/ref-operator-topic.adoc
+++ b/documentation/modules/operators/ref-operator-topic.adoc
@@ -11,6 +11,8 @@ The `KafkaTopic` resource is responsible for managing a single topic within a Ka
 Unidirectional mode (default):: Unidirectional mode does not require ZooKeeper for cluster management. It is compatible with using Strimzi in KRaft mode.
 Bidirectional mode:: Bidirectional mode requires ZooKeeper for cluster management. It is not compatible with using Strimzi in KRaft mode.
 
+NOTE: As the feature gate enabling the Topic Operator to run in unidirectional mode progresses to General Availability, bidirectional mode will be phased out. This transition is aimed at enhancing the user experience, particularly in supporting Kafka in KRaft mode. 
+
 == Unidirectional topic management
 
 In unidirectional mode, the Topic Operator operates as follows: 

--- a/documentation/modules/overview/con-overview-components-topic-operator.adoc
+++ b/documentation/modules/overview/con-overview-components-topic-operator.adoc
@@ -21,13 +21,13 @@ You can declare a `KafkaTopic` as part of your application's deployment and the 
 
 The Topic Operator operates in the following modes: 
 
+Unidirectional mode:: Unidirectional mode means that the Topic Operator solely manages topics through the `KafkaTopic` resource. This mode does not require ZooKeeper and is compatible with using Strimzi in KRaft mode.
+
 Bidirectional mode:: Bidirectional mode means that the Topic Operator can reconcile changes to a `KafkaTopic` resource to and from a Kafka cluster.
 This means that you can update topics either through the `KafkaTopic` resource or directly in Kafka, and the Topic Operator will ensure that both sources are updated to reflect the changes. This mode requires ZooKeeper for cluster management. 
 +
 The Topic Operator maintains information about each topic in a _topic store_, which is continually synchronized with updates from Kubernetes `KafkaTopic` custom resources or Kafka topics.
 Updates from operations applied to a local in-memory topic store are persisted to a backup topic store on disk.
-
-Unidirectional mode (preview):: Unidirectional mode means that the Topic Operator solely manages topics through the `KafkaTopic` resource. This mode does not require ZooKeeper and is compatible with using Strimzi in KRaft mode.
 
 
 


### PR DESCRIPTION
**Documentation**

Updates the docs to promote the Unidirectional Topic Operator (UTO) from preview.
Switches the order for  the **Deploying the standalone Topic Operator** procedure.
That is, shows install of the UTO as the standard install, and installation of the Bidirectional Topic Operator (BTO) as the alternative.

Continues from work in https://github.com/strimzi/strimzi-kafka-operator/pull/9316

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

