### PR TITLE
Reduce number of situations when KRaft controller-only nodes need rolling updates

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1505,7 +1505,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service
@@ -1693,7 +1693,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service
@@ -2095,7 +2095,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service
@@ -2185,7 +2185,7 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service
@@ -3020,7 +3020,7 @@ public class KafkaClusterTest {
         assertThat(kc.isExposedWithIngress(), is(true));
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service
@@ -3225,7 +3225,7 @@ public class KafkaClusterTest {
         assertThat(kc.isExposedWithClusterIP(), is(true));
 
         // Check port
-        List<ContainerPort> ports = kc.getContainerPortList();
+        List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
         assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
 
         // Check external bootstrap service


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

In KRaft clusters with dedicated controller nodes, we want to reduce the number of rolling updates of the controller nodes as much as possible. One of the ways to achieve that is to reduce the number of configs pass to them to the minimum needed.

This PR implements some changes to reduce the rolling updates:
* Controller-only certificates should not have SANs for external listeners as any external clients don't connect to them.
* Controller-only init containers do not need to pull the node address for node port listeners.
* Controller-only nodes do not need the list of user-defined listeners (we still pass an empty file in the configuration ConfigMap to avoid complexity in the script generating the Kafka node configuration).
* Controller-only nodes do not need to have open ports for all the various user-defined listeners or for the replication listener. They need only the control plane listener. This helps to avoid rolling updates for changed listener configurations by our users.

These changes should help to reduce the amount of rolls. They should not impact Zoo-based clusters or mixed broker or controller nodes (or broker-only nodes).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally