### PR TITLE
Add support for Kafka 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.39.0
 
+* Add support for Apache Kafka 3.5.2
 * The `StableConnectIdentities` feature gate moves to GA stage and is now permanently enabled without the possibility to disable it.
   All Connect and Mirror Maker 2 operands will now use StrimziPodSets.
 * The `KafkaNodePools` feature gate moves to beta stage and is enabled by default.

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -8,6 +8,7 @@
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.5.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.5.1
+* {DockerOrg}/kafka:{DockerTag}-kafka-3.5.2
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.0
 
 a|

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -8,5 +8,6 @@
 |Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
 | 3.5.0 | 3.5 | 3.5 | 3.6.4
 | 3.5.1 | 3.5 | 3.5 | 3.6.4
+| 3.5.2 | 3.5 | 3.5 | 3.6.4
 | 3.6.0 | 3.6 | 3.6 | 3.8.2
 |=================

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -273,6 +273,15 @@
   third-party-libs: 3.5.x
   supported: true
   default: false
+- version: 3.5.2
+  format: 3.5
+  protocol: 3.5
+  url: https://home.apache.org/~showuon/kafka-3.5.2-rc1/kafka_2.13-3.5.2.tgz
+  checksum: 229CCC5E3E6B3B9845F59F6E829D70711C5A5A2293F32B6BCABC37350666F874BC7D8F08130F712A1B32915205C10F2847F04908C20D5F7FDB4B62D058C9DEFE
+  zookeeper: 3.6.4
+  third-party-libs: 3.5.x
+  supported: true
+  default: false
 - version: 3.6.0
   format: 3.6
   protocol: 3.6

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -15,20 +15,24 @@
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.0")) }}
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -57,21 +57,25 @@ spec:
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,13 @@
         <module>systemtest</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>apache-staging</id>
+            <url>https://repository.apache.org/content/groups/staging/</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <!-- Runtime and compile time dependencies-->

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -183,7 +183,8 @@ public class Environment {
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.6.0";
     public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.6.0";
-    public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
+    //public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
+    public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repository.apache.org/content/groups/staging/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.38.0";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds support for Apache Kafka 3.5.2 that brings various bug fixes. 

_This is currently a draft Pr used for testing based on the RC1._

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md