### PR TITLE
[ST] Connect build script - replace the placeholder even if the Kafka version is not set to latest

### DIFF
--- a/systemtest/src/test/resources/connect-build/build-connect-image.sh
+++ b/systemtest/src/test/resources/connect-build/build-connect-image.sh
@@ -22,8 +22,10 @@ function buildDockerImage() {
 # in case that Kafka version wasn't supplied or we specify "latest" as a version, we will take the default version from kafka-versions.yaml
 if [ -z "${KAFKA_VERSION}" ] || [ "${KAFKA_VERSION}" == "latest" ]; then
   getLatestKafkaVersionFromYAML
-  BASE_IMAGE=$(echo $BASE_IMAGE | sed "s/KAFKA_VERSION/${KAFKA_VERSION}/g")
 fi
+
+# replace the place holder with the correct version
+BASE_IMAGE=$(echo $BASE_IMAGE | sed "s/KAFKA_VERSION/${KAFKA_VERSION}/g")
 
 buildDockerImage
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a bug in the `build-connect-image.sh`, that replaced the placeholder in the base image only if the Kafka version was set to latest.

### Checklist

- [ ] Make sure all tests pass
