### PR TITLE
[ST] Correct namespace for the Connect build in OTel ST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -284,7 +284,7 @@ public class OpenTelemetryST extends AbstractST {
                 .endTemplate()
             .endSpec();
 
-        resourceManager.createResourceWithWait(extensionContext, KafkaConnectTemplates.addFileSinkPluginOrImage(Environment.TEST_SUITE_NAMESPACE, connectBuilder).build());
+        resourceManager.createResourceWithWait(extensionContext, KafkaConnectTemplates.addFileSinkPluginOrImage(testStorage.getNamespaceName(), connectBuilder).build());
 
         resourceManager.createResourceWithWait(extensionContext, KafkaConnectorTemplates.kafkaConnector(testStorage.getClusterName())
             .editSpec()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `Environment.TEST_SUITE_NAMESPACE` shouldn't be used inside the Connect build, as it can point to completely different namespace than we are actually deploying things to -> that could cause issues on OpenShift, as we don't have permissions to write to that namespace.

### Checklist

- [x] Make sure all tests pass


