### PR TITLE
[ST] Fix CodeQL build after refactor of the constants

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -432,7 +432,7 @@ class UserST extends AbstractST {
     void setup(ExtensionContext extensionContext) {
         this.clusterOperator = this.clusterOperator
             .defaultInstallation(extensionContext)
-            .withBindingsNamespaces(List.of(Environment.TEST_SUITE_NAMESPACE, Constants.CO_NAMESPACE))
+            .withBindingsNamespaces(List.of(Environment.TEST_SUITE_NAMESPACE, TestConstants.CO_NAMESPACE))
             .createInstallation()
             .runInstallation();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes CodeQL that reports wrong usage of `Constants` -> where `TestConstants` should be use

### Checklist

- [ ] Make sure build passes

