### PR TITLE
docs(connectors): makes connector examples consistent across doc set

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.connect.build.Build.adoc
@@ -40,9 +40,9 @@ spec:
   #...
   build:
     output:
-      type: docker <1>
-      image: my-registry.io/my-org/my-connect-cluster:latest <2>
-      pushSecret: my-registry-credentials <3>
+      type: docker # <1>
+      image: my-registry.io/my-org/my-connect-cluster:latest # <2>
+      pushSecret: my-registry-credentials # <3>
   #...
 ----
 <1> (Required) Type of output used by Strimzi.
@@ -148,9 +148,9 @@ spec:
     plugins:
       - name: my-plugin
         artifacts:
-          - type: jar <1>
-            url: https://my-domain.tld/my-jar.jar <2>
-            sha512sum: 589...ab4 <3>
+          - type: jar # <1>
+            url: https://my-domain.tld/my-jar.jar # <2>
+            sha512sum: 589...ab4 # <3>
           - type: jar
             url: https://my-domain.tld/my-jar2.jar
   #...
@@ -184,9 +184,9 @@ spec:
     plugins:
       - name: my-plugin
         artifacts:
-          - type: tgz <1>
-            url: https://my-domain.tld/my-connector-archive.tgz <2>
-            sha512sum: 158...jg10 <3>
+          - type: tgz # <1>
+            url: https://my-domain.tld/my-connector-archive.tgz # <2>
+            sha512sum: 158...jg10 # <3>
   #...
 ----
 <1> (Required) Type of artifact.
@@ -221,11 +221,11 @@ spec:
     plugins:
       - name: my-plugin
         artifacts:
-          - type: maven <1>
-            repository: https://mvnrepository.com <2>
-            group: org.apache.camel.kafkaconnector <3>
-            artifact: camel-kafka-connector <4>
-            version: 0.11.0 <5>
+          - type: maven # <1>
+            repository: https://mvnrepository.com # <2>
+            group: <maven_group> # <3>
+            artifact: <maven_artifact> # <4>
+            version:  <maven_version_number> # <5>
   #...
 ----
 <1> (Required) Type of artifact.
@@ -258,10 +258,10 @@ spec:
     plugins:
       - name: my-plugin
         artifacts:
-          - type: other  <1>
-            url: https://my-domain.tld/my-other-file.ext  <2>
-            sha512sum: 589...ab4  <3>
-            fileName: name-the-file.ext  <4>
+          - type: other  # <1>
+            url: https://my-domain.tld/my-other-file.ext  # <2>
+            sha512sum: 589...ab4  # <3>
+            fileName: name-the-file.ext  # <4>
   #...
 ----
 <1> (Required) Type of artifact.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -76,16 +76,16 @@ spec:
       image: my-registry.io/my-org/my-connect-cluster:latest
       pushSecret: my-registry-credentials
     plugins: # <10>
-      - name: debezium-postgres-connector
+      - name: connector-1
         artifacts:
           - type: tgz
-            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.1.3.Final/debezium-connector-postgres-2.1.3.Final-plugin.tar.gz
-            sha512sum: c4ddc97846de561755dc0b021a62aba656098829c70eb3ade3b817ce06d852ca12ae50c0281cc791a5a131cb7fc21fb15f4b8ee76c6cae5dd07f9c11cb7c6e79
-      - name: camel-telegram
+            url: <url_to_download_connector_1_artifact>
+            sha512sum: <SHA-512_checksum_of_connector_1_artifact>
+      - name: connector-2
         artifacts:
-          - type: tgz
-            url: https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-telegram-kafka-connector/0.11.5/camel-telegram-kafka-connector-0.11.5-package.tar.gz
-            sha512sum: d6d9f45e0d1dbfcc9f6d1c7ca2046168c764389c78bc4b867dab32d24f710bb74ccf2a007d7d7a8af2dfca09d9a52ccbc2831fc715c195a3634cca055185bd91
+          - type: jar
+            url: <url_to_download_connector_2_artifact>
+            sha512sum: <SHA-512_checksum_of_connector_2_artifact>
   externalConfiguration: # <11>
     env:
       - name: AWS_ACCESS_KEY_ID

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -37,16 +37,16 @@ spec: # <1>
       image: my-registry.io/my-org/my-connect-cluster:latest
       pushSecret: my-registry-credentials
     plugins: # <3>
-      - name: debezium-postgres-connector
+      - name: connector-1
         artifacts:
           - type: tgz
-            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.1.3.Final/debezium-connector-postgres-2.1.3.Final-plugin.tar.gz
-            sha512sum: c4ddc97846de561755dc0b021a62aba656098829c70eb3ade3b817ce06d852ca12ae50c0281cc791a5a131cb7fc21fb15f4b8ee76c6cae5dd07f9c11cb7c6e79
-      - name: camel-telegram
+            url: <url_to_download_connector_1_artifact>
+            sha512sum: <SHA-512_checksum_of_connector_1_artifact>
+      - name: connector-2
         artifacts:
-          - type: tgz
-            url: https://repo.maven.apache.org/maven2/org/apache/camel/kafkaconnector/camel-telegram-kafka-connector/0.11.5/camel-telegram-kafka-connector-0.11.5-package.tar.gz
-            sha512sum: d6d9f45e0d1dbfcc9f6d1c7ca2046168c764389c78bc4b867dab32d24f710bb74ccf2a007d7d7a8af2dfca09d9a52ccbc2831fc715c195a3634cca055185bd91
+          - type: jar
+            url: <url_to_download_connector_2_artifact>
+            sha512sum: <SHA-512_checksum_of_connector_2_artifact>
   #...
 ----
 <1> link:{BookURLConfiguring}#type-KafkaConnectSpec-reference[The specification for the Kafka Connect cluster^].

--- a/documentation/modules/operators/proc-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/proc-changing-topic-operator-mode.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-using-the-topic-operator.adoc
 
-[id='con-changing-topic-operator-mode-{context}']
+[id='proc-changing-topic-operator-mode-{context}']
 = Switching between Topic Operator modes
 
 [role="_abstract"]
@@ -18,7 +18,8 @@ The Cluster Operator deploys the Entity Operator with the Topic Operator in unid
 +
 [source,shell,subs=+quotes]
 ----
-kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-store-topic) && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
+kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-store-topic) \
+&& kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
 ---- 
 +
 This command deletes the internal topics, which have names starting `strimzi-store-topic` and `strimzi-topic-operator`.

--- a/documentation/modules/operators/proc-changing-topic-operator-mode.adoc
+++ b/documentation/modules/operators/proc-changing-topic-operator-mode.adoc
@@ -19,7 +19,7 @@ The Cluster Operator deploys the Entity Operator with the Topic Operator in unid
 [source,shell,subs=+quotes]
 ----
 kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-store-topic) \
-&& kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
+  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
 ---- 
 +
 This command deletes the internal topics, which have names starting `strimzi-store-topic` and `strimzi-topic-operator`.
@@ -31,7 +31,7 @@ This command deletes the internal topics, which have names starting `strimzi-sto
 [source,shell,subs=+quotes]
 ----
 kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) strimzi.io/managed="false" \
-&& kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep transaction-state) strimzi.io/managed="false"
+  && kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep transaction-state) strimzi.io/managed="false"
 ----
 +
 By annotating the `KafkaTopic` resources with `strimzi.io/managed="false"`, you indicate that the Topic Operator should no longer manage those topics. 
@@ -42,7 +42,7 @@ In this case, we are adding the annotation to resources for managing the interna
 [source,shell,subs=+quotes]
 ----
 kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) \
-&& kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep transaction-state)
+  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep transaction-state)
 ---- 
 
 .Switching from unidirectional to bidirectional topic management mode

--- a/documentation/modules/upgrading/con-upgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-upgrade-paths.adoc
@@ -24,6 +24,7 @@ Multi-version upgrades are possible even if the supported Kafka versions differ 
 However, if you attempt to upgrade to a new Strimzi version that does not support the current Kafka version, xref:con-upgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
 In this case, you must upgrade the Kafka version as part of the Strimzi upgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the new Strimzi version.
 
+ifdef::Section[]
 [NOTE]
 ====
 You can review supported Kafka versions in the link:https://strimzi.io/downloads/[Supported versions^] table.
@@ -31,6 +32,7 @@ You can review supported Kafka versions in the link:https://strimzi.io/downloads
 * The *Operators* column lists all released Strimzi versions (the Strimzi version is often called the "Operator version").
 * The *Kafka versions* column lists the supported Kafka versions for each Strimzi version.
 ====
+endif::Section[]
 
 [id='con-upgrade-paths-earlier-versions-{context}']
 == Upgrading from a Strimzi version earlier than 0.22


### PR DESCRIPTION
Documentation

From review of 0.38 doc, updates to the connector config examples to make  conssitent across doc set.
Plus couple of small revisions to doc

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

