### PR TITLE
docs(uto): considerations when disabling topic deletion

### DIFF
--- a/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
+++ b/documentation/assemblies/operators/assembly-using-the-topic-operator.adoc
@@ -28,5 +28,7 @@ include::../../modules/operators/con-deleting-managed-topics.adoc[leveloffset=+1
 include::../../modules/operators/proc-changing-topic-operator-mode.adoc[leveloffset=+1]
 //removing finalizers from topics
 include::../../modules/operators/con-removing-topic-finalizers.adoc[leveloffset=+1]
+//disabling topic deletion considerations
+include::../../modules/operators/con-disabling-topic-deletion.adoc[leveloffset=+1]
 //tuning request batches
 include::../../modules/operators/con-tuning-topic-request-batches.adoc[leveloffset=+1]

--- a/documentation/modules/operators/con-disabling-topic-deletion.adoc
+++ b/documentation/modules/operators/con-disabling-topic-deletion.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// assembly-using-the-topic-operator.adoc
+
+[id='con-disabling-topic-deletion-{context}']
+= Considerations when disabling topic deletion
+
+[role="_abstract"]
+When the `delete.topic.enable` configuration in Kafka is set to `false`, topics cannot be deleted. 
+This might be required in certain scenarios, but it introduces a consideration when using the Topic Operator in unidirectional mode.
+
+As topics cannot be deleted, finalizers added to the metadata of a `KafkaTopic` resource to control topic deletion are never removed by the Topic Operator (though they can be xref:con-removing-topic-finalizers-{context}[removed manually]). 
+Similarly, any Custom Resource Definitions (CRDs) or namespaces associated with topics cannot be deleted.
+
+Before configuring `delete.topic.enable=false`, assess these implications to ensure it aligns with your specific requirements.
+
+NOTE: To avoid using finalizers, you can set the `STRIMZI_USE_FINALIZERS` Topic Operator environment variable to `false`. 


### PR DESCRIPTION
**Documentation**

Updates the doc for the unidirectional Topic Operator.
Describes considerations when disabling topic deletion

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

