### PR TITLE
Improve RBAC rules for subresources

### DIFF
--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -64,8 +64,6 @@ rules:
     resources:
       # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
       - deployments
-      - deployments/scale
-      - deployments/status
       # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
       - statefulsets
       # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
@@ -76,6 +74,15 @@ rules:
       - watch
       - create
       - delete
+      - patch
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      # The Cluster Operator needs to scale Deployments while migrating Connect and Mirror Maker 2 clusters from Deployments to StrimziPodSets
+      - deployments/scale
+    verbs:
+      - get
       - patch
       - update
   - apiGroups:

--- a/cluster-operator/src/main/resources/cluster-roles/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -20,30 +20,43 @@ rules:
   - apiGroups:
       - "kafka.strimzi.io"
     resources:
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      # The Cluster Operator operates the Strimzi custom resources
       - kafkas
-      - kafkas/status
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage KafkaNodePool resources
       - kafkanodepools
-      - kafkanodepools/status
-      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
       - kafkaconnects
-      - kafkaconnects/status
-      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
       - kafkaconnectors
-      - kafkaconnectors/status
-      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
       - kafkamirrormakers
-      - kafkamirrormakers/status
-      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
       - kafkabridges
-      - kafkabridges/status
-      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
       - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
-      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
       - kafkarebalances
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Cluster Operator needs to manage the status of the Strimzi custom resources
+      - kafkas/status
+      - kafkanodepools/status
+      - kafkaconnects/status
+      - kafkaconnectors/status
+      - kafkamirrormakers/status
+      - kafkabridges/status
+      - kafkamirrormaker2s/status
       - kafkarebalances/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
     verbs:
       - get
       - list
@@ -55,14 +68,9 @@ rules:
   - apiGroups:
       - "core.strimzi.io"
     resources:
-      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-      - strimzipodsets
+      # The Cluster Operator needs to manage the status of the StrimziPodSet custom resource
       - strimzipodsets/status
     verbs:
       - get
-      - list
-      - watch
-      - create
-      - delete
       - patch
       - update

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -10,8 +10,6 @@ rules:
     resources:
       # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
       - kafkatopics
-      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
-      - kafkausers
     verbs:
       - get
       - list

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -8,12 +8,10 @@ rules:
   - apiGroups:
       - "kafka.strimzi.io"
     resources:
-      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
       - kafkatopics
-      - kafkatopics/status
-      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
       - kafkausers
-      - kafkausers/status
     verbs:
       - get
       - list
@@ -22,6 +20,29 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+      - kafkausers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
+      - kafkatopics/status
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+      - kafkausers/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -1038,8 +1038,18 @@ public class EntityOperatorTest {
 
         List<PolicyRule> rules = new ArrayList<>();
         rules.add(new PolicyRuleBuilder()
-                .addToResources("kafkatopics", "kafkatopics/status", "kafkausers", "kafkausers/status")
+                .addToResources("kafkatopics")
                 .addToVerbs("get", "list", "watch", "create", "patch", "update", "delete")
+                .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
+                .build());
+        rules.add(new PolicyRuleBuilder()
+                .addToResources("kafkausers")
+                .addToVerbs("get", "list", "watch", "create", "patch", "update")
+                .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
+                .build());
+        rules.add(new PolicyRuleBuilder()
+                .addToResources("kafkatopics/status", "kafkausers/status")
+                .addToVerbs("get", "patch", "update")
                 .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
                 .build());
         rules.add(new PolicyRuleBuilder()

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -69,8 +69,6 @@ rules:
   resources:
     # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
   - deployments
-  - deployments/scale
-  - deployments/status
     # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
   - statefulsets
     # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
@@ -81,6 +79,15 @@ rules:
   - watch
   - create
   - delete
+  - patch
+  - update
+- apiGroups:
+  - "apps"
+  resources:
+    # The Cluster Operator needs to scale Deployments while migrating Connect and Mirror Maker 2 clusters from Deployments to StrimziPodSets
+  - deployments/scale
+  verbs:
+  - get
   - patch
   - update
 - apiGroups:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -25,30 +25,43 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-  # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+  # The Cluster Operator operates the Strimzi custom resources
   - kafkas
-  - kafkas/status
-    # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage KafkaNodePool resources
   - kafkanodepools
-  - kafkanodepools/status
-  # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
   - kafkaconnects
-  - kafkaconnects/status
-  # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
   - kafkaconnectors
-  - kafkaconnectors/status
-  # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
   - kafkamirrormakers
-  - kafkamirrormakers/status
-  # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
   - kafkabridges
-  - kafkabridges/status
-  # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
   - kafkamirrormaker2s
-  - kafkamirrormaker2s/status
-  # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
   - kafkarebalances
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  # The Cluster Operator needs to manage the status of the Strimzi custom resources
+  - kafkas/status
+  - kafkanodepools/status
+  - kafkaconnects/status
+  - kafkaconnectors/status
+  - kafkamirrormakers/status
+  - kafkabridges/status
+  - kafkamirrormaker2s/status
   - kafkarebalances/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - "core.strimzi.io"
+  resources:
+  # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+  - strimzipodsets
   verbs:
   - get
   - list
@@ -60,15 +73,10 @@ rules:
 - apiGroups:
   - "core.strimzi.io"
   resources:
-  # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-  - strimzipodsets
+  # The Cluster Operator needs to manage the status of the StrimziPodSet custom resource
   - strimzipodsets/status
   verbs:
   - get
-  - list
-  - watch
-  - create
-  - delete
   - patch
   - update
 {{- end -}}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -15,8 +15,6 @@ rules:
   resources:
     # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
   - kafkatopics
-    # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
-  - kafkausers
   verbs:
   - get
   - list

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -13,12 +13,10 @@ rules:
 - apiGroups:
   - "kafka.strimzi.io"
   resources:
-    # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+    # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
   - kafkatopics
-  - kafkatopics/status
-    # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+    # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
   - kafkausers
-  - kafkausers/status
   verbs:
   - get
   - list
@@ -27,6 +25,29 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+    # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+    # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
+  - kafkatopics/status
+    # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+  - kafkausers/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -64,8 +64,6 @@ rules:
     resources:
       # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
       - deployments
-      - deployments/scale
-      - deployments/status
       # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
       - statefulsets
       # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
@@ -76,6 +74,15 @@ rules:
       - watch
       - create
       - delete
+      - patch
+      - update
+  - apiGroups:
+      - "apps"
+    resources:
+      # The Cluster Operator needs to scale Deployments while migrating Connect and Mirror Maker 2 clusters from Deployments to StrimziPodSets
+      - deployments/scale
+    verbs:
+      - get
       - patch
       - update
   - apiGroups:

--- a/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -20,30 +20,43 @@ rules:
   - apiGroups:
       - "kafka.strimzi.io"
     resources:
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+      # The Cluster Operator operates the Strimzi custom resources
       - kafkas
-      - kafkas/status
-      # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage KafkaNodePool resources
       - kafkanodepools
-      - kafkanodepools/status
-      # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
       - kafkaconnects
-      - kafkaconnects/status
-      # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
       - kafkaconnectors
-      - kafkaconnectors/status
-      # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
       - kafkamirrormakers
-      - kafkamirrormakers/status
-      # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
       - kafkabridges
-      - kafkabridges/status
-      # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
       - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
-      # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
       - kafkarebalances
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Cluster Operator needs to manage the status of the Strimzi custom resources
+      - kafkas/status
+      - kafkanodepools/status
+      - kafkaconnects/status
+      - kafkaconnectors/status
+      - kafkamirrormakers/status
+      - kafkabridges/status
+      - kafkamirrormaker2s/status
       - kafkarebalances/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - "core.strimzi.io"
+    resources:
+      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+      - strimzipodsets
     verbs:
       - get
       - list
@@ -55,14 +68,9 @@ rules:
   - apiGroups:
       - "core.strimzi.io"
     resources:
-      # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
-      - strimzipodsets
+      # The Cluster Operator needs to manage the status of the StrimziPodSet custom resource
       - strimzipodsets/status
     verbs:
       - get
-      - list
-      - watch
-      - create
-      - delete
       - patch
       - update

--- a/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -10,8 +10,6 @@ rules:
     resources:
       # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
       - kafkatopics
-      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
-      - kafkausers
     verbs:
       - get
       - list

--- a/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -8,12 +8,10 @@ rules:
   - apiGroups:
       - "kafka.strimzi.io"
     resources:
-      # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+      # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
       - kafkatopics
-      - kafkatopics/status
-      # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
       - kafkausers
-      - kafkausers/status
     verbs:
       - get
       - list
@@ -22,6 +20,29 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+      - kafkausers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - "kafka.strimzi.io"
+    resources:
+      # The Entity Operator contains the Topic Operator which needs to access and manage KafkaTopic resources
+      - kafkatopics/status
+      # The Entity Operator contains the User Operator which needs to access and manage KafkaUser resources
+      - kafkausers/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/packaging/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/packaging/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -13,19 +13,13 @@ rules:
   resources:
   - kafkas
   - kafkanodepools
-  - kafkanodepools/scale
   - kafkaconnects
-  - kafkaconnects/scale
   - kafkamirrormakers
-  - kafkamirrormakers/scale
   - kafkausers
   - kafkatopics
   - kafkabridges
-  - kafkabridges/scale
   - kafkaconnectors
-  - kafkaconnectors/scale
   - kafkamirrormaker2s
-  - kafkamirrormaker2s/scale
   - kafkarebalances
   verbs:
   - get
@@ -33,6 +27,19 @@ rules:
   - watch
   - create
   - delete
+  - patch
+  - update
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkanodepools/scale
+  - kafkaconnects/scale
+  - kafkamirrormakers/scale
+  - kafkabridges/scale
+  - kafkaconnectors/scale
+  - kafkamirrormaker2s/scale
+  verbs:
+  - get
   - patch
   - update
 - apiGroups:

--- a/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -9,7 +9,6 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkatopics
-  - kafkatopics/status
   verbs:
   - get
   - list
@@ -18,6 +17,14 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkatopics/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
+++ b/packaging/install/user-operator/02-Role-strimzi-user-operator.yaml
@@ -9,7 +9,6 @@ rules:
   - "kafka.strimzi.io"
   resources:
   - kafkausers
-  - kafkausers/status
   verbs:
   - get
   - list
@@ -17,7 +16,14 @@ rules:
   - create
   - patch
   - update
-  - delete
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkausers/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, our RBAC roles grant the same verbs for all resources and subresources. But the subresources such as `status` or `scale` do not really support all of the verbs such as `list`, `create` etc. That might result in warnings form various tools such as discussed for example in https://github.com/orgs/strimzi/discussions/9333.

This PR separates the granted verbs for the subresources from the regular resources to avoid these warnings. It also removes some verbs we do not need:
* We do not need to do any updates to Deployment status subresource
* We do not need rights to delete most of our custom resources as the operator does not delete them

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging