### PR TITLE
Refactor `KafkaVersionChange` class and how it is used in `KafkaRecocniler` and `KafkaCluster`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -265,12 +265,15 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      * @param kafka                         Kafka custom resource
      * @param pools                         Set of node pools used by this cluster
      * @param versions                      Supported Kafka versions
+     * @param versionChange                 KafkaVersionChange instance describing how the Kafka versions (and the
+     *                                      various protocol and metadata versions) to be used in this reconciliation
      * @param useKRaft                      Flag indicating if KRaft is enabled
      * @param clusterId                     Kafka cluster Id (or null if it is not known yet)
      * @param sharedEnvironmentProvider     Shared environment provider
+     *
      * @return Kafka cluster instance
      */
-    public static KafkaCluster fromCrd(Reconciliation reconciliation, Kafka kafka, List<KafkaPool> pools, KafkaVersion.Lookup versions, boolean useKRaft, String clusterId, SharedEnvironmentProvider sharedEnvironmentProvider) {
+    public static KafkaCluster fromCrd(Reconciliation reconciliation, Kafka kafka, List<KafkaPool> pools, KafkaVersion.Lookup versions, KafkaVersionChange versionChange, boolean useKRaft, String clusterId, SharedEnvironmentProvider sharedEnvironmentProvider) {
         KafkaSpec kafkaSpec = kafka.getSpec();
         KafkaClusterSpec kafkaClusterSpec = kafkaSpec.getKafka();
 
@@ -282,6 +285,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
         // This also validates that the Kafka version is supported
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
+
+        // Validates and sets the metadata version used in KRaft
+        if (useKRaft && versionChange.metadataVersion() != null) {
+            KRaftUtils.validateMetadataVersion(versionChange.metadataVersion());
+            result.metadataVersion = versionChange.metadataVersion();
+        }
 
         // Number of broker nodes => used later in various validation methods
         long numberOfBrokers = result.brokerNodes().size();
@@ -318,6 +327,18 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         KafkaConfiguration configuration = new KafkaConfiguration(reconciliation, kafkaClusterSpec.getConfig().entrySet());
         validateConfiguration(reconciliation, kafka, result.kafkaVersion, configuration);
         result.configuration = configuration;
+
+        // We set the user-configured inter.broker.protocol.version if needed (when not set by the user)
+        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
+        if (!useKRaft && versionChange.interBrokerProtocolVersion() != null) {
+            result.configuration.setConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, versionChange.interBrokerProtocolVersion());
+        }
+
+        // We set the user-configured log.message.format.version if needed (when not set by the user)
+        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
+        if (!useKRaft && versionChange.logMessageFormatVersion() != null) {
+            result.configuration.setConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, versionChange.logMessageFormatVersion());
+        }
 
         result.ccMetricsReporter = CruiseControlMetricsReporter.fromCrd(kafka, configuration, numberOfBrokers);
 
@@ -1723,15 +1744,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * Sets the log message format version
-     *
-     * @param logMessageFormatVersion       Log message format version
-     */
-    public void setLogMessageFormatVersion(String logMessageFormatVersion) {
-        configuration.setConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, logMessageFormatVersion);
-    }
-
-    /**
      * @return  Kafka's inter-broker protocol configuration
      */
     public String getInterBrokerProtocolVersion() {
@@ -1739,29 +1751,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * Sets the inter-broker protocol version
-     *
-     * @param interBrokerProtocolVersion    Inter-broker protocol version
-     */
-    public void setInterBrokerProtocolVersion(String interBrokerProtocolVersion) {
-        configuration.setConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, interBrokerProtocolVersion);
-    }
-
-    /**
      * @return  Kafka's desired metadata version
      */
     public String getMetadataVersion() {
         return metadataVersion;
-    }
-
-    /**
-     * Sets the KRaft metadata version
-     *
-     * @param metadataVersion   KRaft metadata version
-     */
-    public void setMetadataVersion(String metadataVersion)   {
-        KRaftUtils.validateMetadataVersion(metadataVersion);
-        this.metadataVersion = metadataVersion;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -287,7 +287,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         result.kafkaVersion = versions.supportedVersion(kafkaClusterSpec.getVersion());
 
         // Validates and sets the metadata version used in KRaft
-        if (useKRaft && versionChange.metadataVersion() != null) {
+        if (versionChange.metadataVersion() != null) {
             KRaftUtils.validateMetadataVersion(versionChange.metadataVersion());
             result.metadataVersion = versionChange.metadataVersion();
         }
@@ -329,14 +329,14 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         result.configuration = configuration;
 
         // We set the user-configured inter.broker.protocol.version if needed (when not set by the user)
-        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
-        if (!useKRaft && versionChange.interBrokerProtocolVersion() != null) {
+        // In KRaft mode, it should be always null
+        if (versionChange.interBrokerProtocolVersion() != null) {
             result.configuration.setConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION, versionChange.interBrokerProtocolVersion());
         }
 
         // We set the user-configured log.message.format.version if needed (when not set by the user)
-        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
-        if (!useKRaft && versionChange.logMessageFormatVersion() != null) {
+        // In KRaft mode, it should be always null.
+        if (versionChange.logMessageFormatVersion() != null) {
             result.configuration.setConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION, versionChange.logMessageFormatVersion());
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersionChange.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersionChange.java
@@ -6,104 +6,19 @@ package io.strimzi.operator.cluster.model;
 
 /**
  * Represents the change from one Kafka version to another
+ *
+ * @param from                          Current Kafka version
+ * @param to                            Desired Kafka version
+ * @param interBrokerProtocolVersion    Inter-broker protocol version
+ * @param logMessageFormatVersion       Log-message format version
+ * @param metadataVersion               KRaft metadata version
  */
-public class KafkaVersionChange {
-    private final KafkaVersion from;
-    private final KafkaVersion to;
-    private final String logMessageFormatVersion;
-    private final String interBrokerProtocolVersion;
-    private final String metadataVersion;
-    private final int compare;
-
-    /**
-     * Constructor
-     *
-     * @param from                          Current Kafka version
-     * @param to                            Desired Kafka version
-     * @param interBrokerProtocolVersion    Inter-broker protocol version
-     * @param logMessageFormatVersion       Log-message format version
-     * @param metadataVersion               KRaft metadata version
-     */
-    public KafkaVersionChange(KafkaVersion from, KafkaVersion to, String interBrokerProtocolVersion, String logMessageFormatVersion, String metadataVersion) {
-        this.from = from;
-        this.to = to;
-        this.logMessageFormatVersion = logMessageFormatVersion;
-        this.interBrokerProtocolVersion = interBrokerProtocolVersion;
-        this.metadataVersion = metadataVersion;
-        this.compare = from.compareTo(to);
-    }
-
-    /**
-     * The version being changed from.
-     * @return The version being changed from.
-     */
-    public KafkaVersion from() {
-        return from;
-    }
-
-    /**
-     * The version being changed to.
-     * @return The version being changed to.
-     */
-    public KafkaVersion to() {
-        return to;
-    }
-
-    /**
-     * @return  Returns the Log Message Format Version which should be used
-     */
-    public String logMessageFormatVersion() {
-        return logMessageFormatVersion;
-    }
-
-    /**
-     * @return  Returns the Inter Broker Protocol Version which should be used
-     */
-    public String interBrokerProtocolVersion() {
-        return interBrokerProtocolVersion;
-    }
-
-    /**
-     * @return  Returns the KRaft metadata version which should be used
-     */
-    public String metadataVersion() {
-        return metadataVersion;
-    }
-
-    /**
-     * true if changing Kafka from {@link #from()} to {@code to} requires changing the Zookeeper version.
-     * @return true if changing Kafka from {@link #from()} to {@code to} requires upgrading the Zookeeper version.
-     */
-    public boolean requiresZookeeperChange() {
-        return !from.zookeeperVersion().equals(to.zookeeperVersion());
-    }
-
-    /**
-     * @return true if this is an upgrade.
-     */
-    public boolean isUpgrade() {
-        return compare < 0;
-    }
-
-    /**
-     * @return true if this is a downgrade.
-     */
-    public boolean isDowngrade() {
-        return compare > 0;
-    }
-
-    /**
-     * @return true if there is no version change.
-     */
-    public boolean isNoop() {
-        return compare == 0;
-    }
-
+public record KafkaVersionChange(KafkaVersion from, KafkaVersion to, String interBrokerProtocolVersion, String logMessageFormatVersion, String metadataVersion) {
     @Override
     public String toString() {
-        if (isUpgrade()) {
+        if (from.compareTo(to) < 0) {
             return "Kafka version upgrade from " + from + " to " + to;
-        } else if (isDowngrade()) {
+        } else if (from.compareTo(to) > 0) {
             return "Kafka version downgrade from " + from + " to " + to;
         } else {
             return "Kafka version=" + from + " (no version change)";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -200,24 +200,7 @@ public class KafkaReconciler {
         // We prepare the KafkaPool models and create the KafkaCluster model
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(reconciliation, kafkaCr, nodePools, oldStorage, currentPods, isKRaftEnabled, supplier.sharedEnvironmentProvider);
         String clusterId = isKRaftEnabled ? NodePoolUtils.getOrGenerateKRaftClusterId(kafkaCr, nodePools) : NodePoolUtils.getClusterIdIfSet(kafkaCr, nodePools);
-        this.kafka = KafkaCluster.fromCrd(reconciliation, kafkaCr, pools, config.versions(), isKRaftEnabled, clusterId, supplier.sharedEnvironmentProvider);
-
-        // We set the user-configured inter.broker.protocol.version if needed (when not set by the user)
-        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
-        if (!isKRaftEnabled && versionChange.interBrokerProtocolVersion() != null) {
-            this.kafka.setInterBrokerProtocolVersion(versionChange.interBrokerProtocolVersion());
-        }
-
-        // We set the user-configured log.message.format.version if needed (when not set by the user)
-        // It is set only in ZooKeeper-mode since in Kraft mode it is ignored and throws warnings
-        if (!isKRaftEnabled && versionChange.logMessageFormatVersion() != null) {
-            this.kafka.setLogMessageFormatVersion(versionChange.logMessageFormatVersion());
-        }
-
-        // Sets the metadata version used in KRaft
-        if (isKRaftEnabled && versionChange.metadataVersion() != null) {
-            this.kafka.setMetadataVersion(versionChange.metadataVersion());
-        }
+        this.kafka = KafkaCluster.fromCrd(reconciliation, kafkaCr, pools, config.versions(), versionChange, isKRaftEnabled, clusterId, supplier.sharedEnvironmentProvider);
 
         this.clusterCa = clusterCa;
         this.clientsCa = clientsCa;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -319,18 +319,20 @@ public class ZooKeeperReconciler {
      * @return  Completes when the upgrade / downgrade information is logged
      */
     private Future<Void> logVersionChange() {
-        if (versionChange.isNoop()) {
+        int versionCompare = versionChange.from().compareTo(versionChange.to());
+
+        if (versionCompare == 0) {
             LOGGER.debugCr(reconciliation, "Kafka.spec.kafka.version is unchanged therefore no change to Zookeeper is required");
         } else {
             String versionChangeType;
 
-            if (versionChange.isDowngrade()) {
+            if (versionCompare > 0) {
                 versionChangeType = "downgrade";
             } else {
                 versionChangeType = "upgrade";
             }
 
-            if (versionChange.requiresZookeeperChange()) {
+            if (versionChange.from().zookeeperVersion().equals(versionChange.to().zookeeperVersion())) {
                 LOGGER.infoCr(reconciliation, "Kafka {} from {} to {} requires Zookeeper {} from {} to {}",
                         versionChangeType,
                         versionChange.from().version(),
@@ -343,7 +345,6 @@ public class ZooKeeperReconciler {
                         versionChangeType,
                         versionChange.from().version(),
                         versionChange.to().version());
-
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreator.java
@@ -366,13 +366,6 @@ public class ZooKeeperVersionChangeCreator implements VersionChangeCreator {
         // For that, we need to set the metadata version even in the ZooKeeperVersionChangeCreator class even through it
         // is not used in KRaft mode. As the controllers will be new, we set it based on the Kafka CR or based on the
         // Kafka version used (which will be always the versionTo on the newly deployed controllers).
-        String metadataVersion;
-        if (metadataVersionFromCr != null)  {
-            metadataVersion = metadataVersionFromCr;
-        } else {
-            metadataVersion = versionTo.metadataVersion();
-        }
-
-        return Future.succeededFuture(new KafkaVersionChange(versionFrom, versionTo, interBrokerProtocolVersion, logMessageFormatVersion, metadataVersion));
+        return Future.succeededFuture(new KafkaVersionChange(versionFrom, versionTo, interBrokerProtocolVersion, logMessageFormatVersion, metadataVersionFromCr != null ? metadataVersionFromCr : versionTo.metadataVersion()));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreator.java
@@ -47,6 +47,7 @@ public class ZooKeeperVersionChangeCreator implements VersionChangeCreator {
 
     // Information about Kafka version from the Kafka custom resource
     private final KafkaVersion versionFromCr;
+    private final String metadataVersionFromCr;
     private final String interBrokerProtocolVersionFromCr;
     private final String logMessageFormatVersionFromCr;
 
@@ -82,6 +83,7 @@ public class ZooKeeperVersionChangeCreator implements VersionChangeCreator {
 
         // Collect information from the Kafka CR
         this.versionFromCr = config.versions().supportedVersion(kafkaCr.getSpec().getKafka().getVersion());
+        this.metadataVersionFromCr = kafkaCr.getSpec().getKafka().getMetadataVersion();
         KafkaConfiguration configuration = new KafkaConfiguration(reconciliation, kafkaCr.getSpec().getKafka().getConfig().entrySet());
         this.interBrokerProtocolVersionFromCr = configuration.getConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION);
         this.logMessageFormatVersionFromCr = configuration.getConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION);
@@ -360,6 +362,17 @@ public class ZooKeeperVersionChangeCreator implements VersionChangeCreator {
             }
         }
 
-        return Future.succeededFuture(new KafkaVersionChange(versionFrom, versionTo, interBrokerProtocolVersion, logMessageFormatVersion, null));
+        // For migration from ZooKeeper to KRaft, we need to configure the metadata version on the new controller nodes.
+        // For that, we need to set the metadata version even in the ZooKeeperVersionChangeCreator class even through it
+        // is not used in KRaft mode. As the controllers will be new, we set it based on the Kafka CR or based on the
+        // Kafka version used (which will be always the versionTo on the newly deployed controllers).
+        String metadataVersion;
+        if (metadataVersionFromCr != null)  {
+            metadataVersion = metadataVersionFromCr;
+        } else {
+            metadataVersion = versionTo.metadataVersion();
+        }
+
+        return Future.succeededFuture(new KafkaVersionChange(versionFrom, versionTo, interBrokerProtocolVersion, logMessageFormatVersion, metadataVersion));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster;
 
 import io.strimzi.operator.cluster.model.KafkaVersion;
+import io.strimzi.operator.cluster.model.KafkaVersionChange;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,6 +49,9 @@ public class KafkaVersionTestUtils {
     public static final String DEFAULT_KAFKA_IMAGE = LATEST_KAFKA_IMAGE;
     public static final String DEFAULT_KAFKA_CONNECT_IMAGE = LATEST_KAFKA_CONNECT_IMAGE;
     public static final String DEFAULT_KAFKA_MIRROR_MAKER_IMAGE = LATEST_KAFKA_MIRROR_MAKER_IMAGE;
+
+    public static final KafkaVersionChange DEFAULT_ZOOKEEPER_VERSION_CHANGE = new KafkaVersionChange(getKafkaVersionLookup().defaultVersion(), getKafkaVersionLookup().defaultVersion(), getKafkaVersionLookup().defaultVersion().protocolVersion(), getKafkaVersionLookup().defaultVersion().messageVersion(), null);
+    public static final KafkaVersionChange DEFAULT_KRAFT_VERSION_CHANGE = new KafkaVersionChange(getKafkaVersionLookup().defaultVersion(), getKafkaVersionLookup().defaultVersion(), null, null, getKafkaVersionLookup().defaultVersion().metadataVersion());
 
     private static Map<String, String> getKafkaImageMap() {
         return getImageMap(KAFKA_IMAGE_STR);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterOAuthValidationTest.java
@@ -114,7 +114,7 @@ public class KafkaClusterOAuthValidationTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
     }
 
     @ParallelTest
@@ -156,7 +156,7 @@ public class KafkaClusterOAuthValidationTest {
                     .build();
 
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -103,7 +103,7 @@ public class KafkaClusterPodSetTest {
             .build();
 
     private final static List<KafkaPool> POOLS = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-    private static final KafkaCluster KC = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+    private static final KafkaCluster KC = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
     @ParallelTest
     public void testPodSet()   {
@@ -361,7 +361,7 @@ public class KafkaClusterPodSetTest {
 
         // Test the resources
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet ps = kc.generatePodSets(true, null, null, brokerId -> Map.of("special", "annotation")).get(0);
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.kafkaStatefulSetName(CLUSTER)));
@@ -455,7 +455,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet ps = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>()).get(0);
 
         // We need to loop through the pods to make sure they have the right values
@@ -506,7 +506,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet ps = kc.generatePodSets(true, null, List.of(secret1), brokerId -> new HashMap<>()).get(0);
 
         // We need to loop through the pods to make sure they have the right values
@@ -562,7 +562,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSets(false, null, null, brokerId -> new HashMap<>()).get(0);
@@ -584,7 +584,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSets(false, null, null, brokerId -> new HashMap<>()).get(0);
@@ -606,7 +606,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Test generated SPS
         StrimziPodSet ps = kc.generatePodSets(false, null, null, brokerId -> new HashMap<>()).get(0);
@@ -624,7 +624,7 @@ public class KafkaClusterPodSetTest {
     @ParallelTest
     public void testRestrictedSecurityContext() {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         kc.securityProvider = new RestrictedPodSecurityProvider();
         kc.securityProvider.configure(new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION));
 
@@ -651,7 +651,7 @@ public class KafkaClusterPodSetTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Test generated SPS
         StrimziPodSet sps = kc.generatePodSets(false, null, null, brokerId -> new HashMap<>()).get(0);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -163,7 +163,7 @@ public class KafkaClusterTest {
             .endSpec()
             .build();
     private static final List<KafkaPool> POOLS = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-    private final static KafkaCluster KC = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+    private final static KafkaCluster KC = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
     //////////
     // Utility methods
@@ -241,7 +241,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<ConfigMap> cms = kc.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(metricsCm, null), advertisedHostnames, advertisedPorts);
 
@@ -264,7 +264,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.getEnvVars(pools.get(0)).get(3).getName(), is("STRIMZI_JAVA_SYSTEM_PROPERTIES"));
         assertThat(kc.getEnvVars(pools.get(0)).get(3).getValue(), is("-Djavax.net.debug=verbose -Dsomething.else=42"));
@@ -282,7 +282,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check container
         assertThat(kc.createContainer(null, pools.get(0)).getImage(), is("my-image:my-tag"));
@@ -314,7 +314,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check container
         Container cont = kc.createContainer(null, pools.get(0));
@@ -358,7 +358,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         assertThat(kc.createInitContainer(null, pools.get(0)),
                 allOf(
                         hasProperty("name", equalTo(KafkaCluster.INIT_NAME)),
@@ -403,7 +403,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Service headful = kc.generateService();
 
@@ -440,7 +440,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Service headless = kc.generateHeadlessService();
 
@@ -481,7 +481,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ContainerPort jmxContainerPort = ContainerUtils.createContainerPort(JMX_PORT_NAME, JMX_PORT);
         assertThat(kc.createContainer(ImagePullPolicy.IFNOTPRESENT, pools.get(0)).getPorts().contains(jmxContainerPort), is(true));
@@ -596,7 +596,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check Service
         Service svc = kc.generateService();
@@ -679,7 +679,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Secret jmxSecret = kc.jmx().jmxSecret(null);
 
@@ -705,7 +705,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Secret jmxSecret = kc.jmx().jmxSecret(null);
 
@@ -766,7 +766,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
 
@@ -786,7 +786,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         pvcs = kc.generatePersistentVolumeClaims();
 
@@ -812,7 +812,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -838,7 +838,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -873,7 +873,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -921,7 +921,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -972,7 +972,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -1023,7 +1023,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Container cont = kc.createContainer(null, pools.get(0));
 
@@ -1074,7 +1074,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Container cont = kc.createContainer(null, pools.get(0));
 
@@ -1181,7 +1181,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         Container cont = kc.createContainer(null, pools.get(0));
 
@@ -1262,7 +1262,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Volume mounts
         Container cont = kc.createContainer(null, pools.get(0));
@@ -1307,7 +1307,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<Volume> volumes = kc.getNonDataVolumes(false, kafkaAssembly.getMetadata().getName() + "-1", null);
         Volume vol = volumes.stream().filter(v -> "custom-external-9094-certs".equals(v.getName())).findFirst().orElse(null);
@@ -1353,7 +1353,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<Volume> volumes = kc.getNonDataVolumes(false, kafkaAssembly.getMetadata().getName() + "-1", null);
         Volume vol = volumes.stream().filter(v -> "custom-tls-9093-certs".equals(v.getName())).findFirst().orElse(null);
@@ -1421,7 +1421,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Volume mounts
         Container cont = kc.createContainer(null, pools.get(0));
@@ -1448,7 +1448,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -1471,7 +1471,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -1502,7 +1502,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
         List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
@@ -1597,7 +1597,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check bootstrap route
         Route brt = kc.generateExternalBootstrapRoutes().get(0);
@@ -1654,7 +1654,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check bootstrap route
         Route brt = kc.generateExternalBootstrapRoutes().get(0);
@@ -1690,7 +1690,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
         List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
@@ -1755,7 +1755,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check external bootstrap service
         assertThat(kc.generateExternalBootstrapServices().isEmpty(), is(true));
@@ -1779,7 +1779,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -1812,7 +1812,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -1847,7 +1847,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -1882,7 +1882,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -1933,7 +1933,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com.")));
@@ -1981,7 +1981,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getLoadBalancerIP(), is("10.0.0.1"));
@@ -2010,7 +2010,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check Service Class
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -2060,7 +2060,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check annotations
         assertThat(kc.generateExternalBootstrapServices().get(0).getMetadata().getAnnotations(), is(Collections.singletonMap("external-dns.alpha.kubernetes.io/hostname", "bootstrap.myingress.com.")));
@@ -2092,7 +2092,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
         List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
@@ -2147,7 +2147,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check Init container
         Container initCont = kc.createInitContainer(null, pools.get(0));
@@ -2182,7 +2182,7 @@ public class KafkaClusterTest {
             .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check port
         List<ContainerPort> ports = kc.getContainerPortList(pools.get(0));
@@ -2256,7 +2256,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().size(), is(1));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getName(), is(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME));
@@ -2295,7 +2295,7 @@ public class KafkaClusterTest {
             .endSpec()
             .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.generatePerPodServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
@@ -2330,7 +2330,7 @@ public class KafkaClusterTest {
             .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.generatePerPodServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32101));
         assertThat(kc.generateExternalBootstrapServices().get(0).getSpec().getPorts().get(0).getNodePort(), is(32001));
@@ -2574,7 +2574,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check Network Policies
         NetworkPolicy np = kc.generateNetworkPolicy(null, null);
@@ -2621,7 +2621,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check Network Policies
         NetworkPolicy np = kc.generateNetworkPolicy(null, null);
@@ -2670,7 +2670,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         PodDisruptionBudget pdb = kc.generatePodDisruptionBudget();
 
         assertThat(pdb.getMetadata().getLabels().entrySet().containsAll(pdbLabels.entrySet()), is(true));
@@ -2710,7 +2710,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<Service> services = new ArrayList<>();
         services.addAll(kc.generateExternalBootstrapServices());
@@ -2756,7 +2756,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 0), is(10000));
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is("my-host-0.cz"));
@@ -2784,7 +2784,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 0), is(nullValue()));
         assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is(nullValue()));
@@ -2828,7 +2828,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Check PVCs
         List<PersistentVolumeClaim> pvcs = kc.generatePersistentVolumeClaims();
@@ -2855,7 +2855,7 @@ public class KafkaClusterTest {
                     .build();
 
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -2876,7 +2876,7 @@ public class KafkaClusterTest {
                     .build();
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", oldStorage),
                 Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", IntStream.range(0, REPLICAS).mapToObj(i -> kafkaAssembly.getMetadata().getName() + "-kafka-" + i).toList()), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -2903,7 +2903,7 @@ public class KafkaClusterTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", ephemeral),
             Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", IntStream.range(0, REPLICAS).mapToObj(i -> CLUSTER + "-kafka-" + i).toList()), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Storage is reverted
         assertThat(kc.getStorageByPoolName(), is(Map.of("kafka", ephemeral)));
@@ -2922,7 +2922,7 @@ public class KafkaClusterTest {
                 .build();
         pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", persistent),
             Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", IntStream.range(0, REPLICAS).mapToObj(i -> CLUSTER + "-kafka-" + i).toList()), false, SHARED_ENV_PROVIDER);
-        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Storage is reverted
         assertThat(kc.getStorageByPoolName(), is(Map.of("kafka", persistent)));
@@ -2941,7 +2941,7 @@ public class KafkaClusterTest {
                 .build();
         pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", jbod),
             Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", IntStream.range(0, REPLICAS).mapToObj(i -> CLUSTER + "-kafka-" + i).toList()), false, SHARED_ENV_PROVIDER);
-        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Storage is reverted
         assertThat(kc.getStorageByPoolName(), is(Map.of("kafka", jbod)));
@@ -2960,7 +2960,7 @@ public class KafkaClusterTest {
                 .build();
         pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", jbod),
             Map.of(kafkaAssembly.getMetadata().getName() + "-kafka", IntStream.range(0, REPLICAS).mapToObj(i -> CLUSTER + "-kafka-" + i).toList()), false, SHARED_ENV_PROVIDER);
-        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         // Storage is reverted
         assertThat(kc.getStorageByPoolName(), is(Map.of("kafka", jbod)));
@@ -3015,7 +3015,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.isExposedWithIngress(), is(true));
 
@@ -3131,7 +3131,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
          // Check bootstrap ingress
         Ingress bing = kc.generateExternalBootstrapIngresses().get(0);
@@ -3175,7 +3175,7 @@ public class KafkaClusterTest {
 
         assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -3220,7 +3220,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.isExposedWithClusterIP(), is(true));
 
@@ -3282,7 +3282,7 @@ public class KafkaClusterTest {
 
         assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
     @ParallelTest
@@ -3308,7 +3308,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ClusterRoleBinding crb = kc.generateClusterRoleBinding(testNamespace);
 
@@ -3334,7 +3334,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ClusterRoleBinding crb = kc.generateClusterRoleBinding(testNamespace);
 
@@ -3384,7 +3384,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<EnvVar> kafkaEnvVars = kc.getEnvVars(pools.get(0));
 
@@ -3431,7 +3431,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<EnvVar> kafkaEnvVars = kc.getEnvVars(pools.get(0));
 
@@ -3474,7 +3474,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<EnvVar> kafkaEnvVars = kafkaCluster.getInitContainerEnvVars(pools.get(0));
 
@@ -3525,7 +3525,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCLuster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCLuster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         List<EnvVar> kafkaEnvVars = kafkaCLuster.getInitContainerEnvVars(pools.get(0));
 
@@ -3552,7 +3552,7 @@ public class KafkaClusterTest {
                     .build();
 
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -3604,7 +3604,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(1, advertisedHostnames, advertisedPorts);
 
@@ -3644,7 +3644,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(1, advertisedHostnames, advertisedPorts);
 
         assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=" + partitions));
@@ -3679,7 +3679,7 @@ public class KafkaClusterTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         String brokerConfig = kc.generatePerBrokerConfiguration(1, advertisedHostnames, advertisedPorts);
 
@@ -3706,7 +3706,7 @@ public class KafkaClusterTest {
 
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(ex.getMessage(), is("Kafka " + NAMESPACE + "/" + CLUSTER + " has invalid configuration. " +
@@ -3733,7 +3733,7 @@ public class KafkaClusterTest {
 
         assertThrows(IllegalArgumentException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -3755,7 +3755,7 @@ public class KafkaClusterTest {
 
         assertThrows(IllegalArgumentException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -3776,7 +3776,7 @@ public class KafkaClusterTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics().isEnabled(), is(true));
         assertThat(kc.metrics().getConfigMapName(), is("my-metrics-configuration"));
@@ -3816,7 +3816,7 @@ public class KafkaClusterTest {
             .endSpec()
             .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceRequirements initContainersResources = kc.createInitContainer(ImagePullPolicy.IFNOTPRESENT, pools.get(0)).getResources();
         assertThat(initContainersResources.getRequests(), is(requirements));
@@ -3835,7 +3835,7 @@ public class KafkaClusterTest {
 
         InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 6.6.6. Supported versions are:"));
@@ -3853,7 +3853,7 @@ public class KafkaClusterTest {
 
         InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
@@ -3872,7 +3872,7 @@ public class KafkaClusterTest {
 
         InvalidResourceException exc = assertThrows(KafkaVersion.UnsupportedKafkaVersionException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(exc.getMessage(), containsString("Unsupported Kafka.spec.kafka.version: 2.6.0. Supported versions are:"));
@@ -3891,7 +3891,7 @@ public class KafkaClusterTest {
                 2, Map.of("PLAIN_9092", "9092", "TLS_9093", "9093")
         );
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, true, "my-cluster-id", SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, "my-cluster-id", SHARED_ENV_PROVIDER);
 
         // Test that the broker configuration is with KRaft
         String config = kc.generatePerBrokerConfiguration(2, advertisedHostnames, advertisedPorts);
@@ -3920,7 +3920,7 @@ public class KafkaClusterTest {
 
         String clusterId = Uuid.randomUuid().toString();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, true, clusterId, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, clusterId, SHARED_ENV_PROVIDER);
 
         // Test that the broker configuration is with KRaft
         String config = kc.generatePerBrokerConfiguration(2, advertisedHostnames, advertisedPorts);
@@ -3941,7 +3941,7 @@ public class KafkaClusterTest {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
             pool.set(pools.get(0));
-            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, false, null, SHARED_ENV_PROVIDER);
+            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         }, this.getClass().getSimpleName() + ".withAffinityWithoutRack");
 
         resourceTester.assertDesiredModel(".yaml", model -> model.getMergedAffinity(pool.get()));
@@ -3954,7 +3954,7 @@ public class KafkaClusterTest {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
             pool.set(pools.get(0));
-            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, false, null, SHARED_ENV_PROVIDER);
+            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         }, this.getClass().getSimpleName() + ".withRackWithoutAffinity");
 
         resourceTester.assertDesiredModel(".yaml", model -> model.getMergedAffinity(pool.get()));
@@ -3967,7 +3967,7 @@ public class KafkaClusterTest {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
             pool.set(pools.get(0));
-            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, false, null, SHARED_ENV_PROVIDER);
+            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         }, this.getClass().getSimpleName() + ".withRackAndAffinityWithMoreTerms");
 
         resourceTester.assertDesiredModel(".yaml", model -> model.getMergedAffinity(pool.get()));
@@ -3980,7 +3980,7 @@ public class KafkaClusterTest {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
             pool.set(pools.get(0));
-            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, false, null, SHARED_ENV_PROVIDER);
+            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, versions, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         }, this.getClass().getSimpleName() + ".withRackAndAffinity");
 
         resourceTester.assertDesiredModel(".yaml", model -> model.getMergedAffinity(pool.get()));
@@ -3990,7 +3990,7 @@ public class KafkaClusterTest {
     public void withTolerations() throws IOException {
         ResourceTester<Kafka, KafkaCluster> resourceTester = new ResourceTester<>(Kafka.class, VERSIONS, (kafkaAssembly1, versions) -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            return KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly1, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         }, this.getClass().getSimpleName() + ".withTolerations");
 
         resourceTester.assertDesiredResource(".yaml", cr -> cr.getSpec().getKafka().getTemplate().getPod().getTolerations());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -144,6 +144,7 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null, SHARED_ENV_PROVIDER
         );
@@ -188,6 +189,7 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -213,6 +215,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -238,6 +241,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -276,6 +280,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -305,6 +310,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -337,6 +343,7 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 "my-cluster-id",
                 SHARED_ENV_PROVIDER
@@ -372,6 +379,7 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null, SHARED_ENV_PROVIDER
         );
@@ -414,7 +422,7 @@ public class KafkaClusterWithKRaftTest {
         // Test exception being raised when only one broker is present
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, poolBrokers), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(ex.getMessage(), is("Kafka " + NAMESPACE + "/" + CLUSTER_NAME + " has invalid configuration. " +
@@ -424,7 +432,7 @@ public class KafkaClusterWithKRaftTest {
         // Test if works fine with controller pool and broker pool with more than 1 node
         assertDoesNotThrow(() -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_BROKERS), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         });
     }
 
@@ -440,6 +448,7 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null, SHARED_ENV_PROVIDER
         );
@@ -511,6 +520,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -553,11 +563,11 @@ public class KafkaClusterWithKRaftTest {
                 KAFKA,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 "dummy-cluster-id",
                 SHARED_ENV_PROVIDER
         );
-        kc.setMetadataVersion(VERSIONS.defaultVersion().metadataVersion());
 
         List<ConfigMap> cms = kc.generatePerBrokerConfigurationConfigMaps(new MetricsAndLogging(null, null), advertisedHostnames, advertisedPorts);
 
@@ -605,6 +615,7 @@ public class KafkaClusterWithKRaftTest {
                 kafka,
                 List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null,
                 SHARED_ENV_PROVIDER
@@ -634,10 +645,17 @@ public class KafkaClusterWithKRaftTest {
                     .endKafka()
                 .endSpec()
                 .build();
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS), VERSIONS, true, null, SHARED_ENV_PROVIDER);
 
         InvalidResourceException ex = assertThrows(InvalidResourceException.class,
-                () -> kc.setMetadataVersion("3.6-IV9"));
+                () -> KafkaCluster.fromCrd(
+                        Reconciliation.DUMMY_RECONCILIATION,
+                        kafka,
+                        List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
+                        VERSIONS,
+                        new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), null, null, "3.6-IV9"),
+                        true,
+                        null,
+                        SHARED_ENV_PROVIDER));
         assertThat(ex.getMessage(), containsString("Metadata version 3.6-IV9 is invalid"));
     }
 
@@ -651,8 +669,15 @@ public class KafkaClusterWithKRaftTest {
                 .endSpec()
                 .build();
 
-        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS), VERSIONS, true, null, SHARED_ENV_PROVIDER);
-        kc.setMetadataVersion("3.5-IV1");
+        KafkaCluster kc = KafkaCluster.fromCrd(
+                Reconciliation.DUMMY_RECONCILIATION,
+                kafka,
+                List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
+                VERSIONS,
+                new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), null, null, "3.5-IV1"),
+                true,
+                null,
+                SHARED_ENV_PROVIDER);
 
         assertThat(kc.getMetadataVersion(), is("3.5-IV1"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
@@ -128,6 +128,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -170,6 +171,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -194,6 +196,7 @@ public class KafkaClusterWithPoolsTest {
                 kafka,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -218,6 +221,7 @@ public class KafkaClusterWithPoolsTest {
                 kafka,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -257,6 +261,7 @@ public class KafkaClusterWithPoolsTest {
                 kafka,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -285,6 +290,7 @@ public class KafkaClusterWithPoolsTest {
                 kafka,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -305,6 +311,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -320,6 +327,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -359,6 +367,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE,
                 true,
                 null, SHARED_ENV_PROVIDER
         );
@@ -391,6 +400,7 @@ public class KafkaClusterWithPoolsTest {
                 KAFKA,
                 List.of(KAFKA_POOL_A, KAFKA_POOL_B),
                 VERSIONS,
+                KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE,
                 false,
                 null, SHARED_ENV_PROVIDER
         );
@@ -433,7 +443,7 @@ public class KafkaClusterWithPoolsTest {
         // Test exception being raised when only one broker is present
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(poolA), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
 
         assertThat(ex.getMessage(), is("Kafka " + NAMESPACE + "/" + CLUSTER_NAME + " has invalid configuration. " +
@@ -449,7 +459,7 @@ public class KafkaClusterWithPoolsTest {
 
         assertDoesNotThrow(() -> {
             List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(poolA, poolB), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+            KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         });
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
@@ -38,9 +38,9 @@ public class KafkaSpecCheckerTest {
     private static final int HEALTH_DELAY = 120;
     private static final int HEALTH_TIMEOUT = 30;
 
-    private KafkaSpecChecker generateChecker(Kafka kafka) {
+    private KafkaSpecChecker generateChecker(Kafka kafka, KafkaVersionChange versionChange) {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, versionChange, false, null, SHARED_ENV_PROVIDER);
 
         return new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
     }
@@ -55,7 +55,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         assertThat(checker.run(false), empty());
     }
 
@@ -71,7 +71,7 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -94,7 +94,7 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -120,7 +120,7 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION, null));
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -140,7 +140,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), KafkaVersionTestUtils.PREVIOUS_FORMAT_VERSION, null));
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -160,7 +160,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -176,7 +176,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -199,7 +199,7 @@ public class KafkaSpecCheckerTest {
                 .endSpec()
             .build();
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION, VERSIONS.defaultVersion().messageVersion(), null));
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -219,7 +219,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), KafkaVersionTestUtils.PREVIOUS_PROTOCOL_VERSION, VERSIONS.defaultVersion().messageVersion(), null));
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(1));
         Condition warning = warnings.get(0);
@@ -239,7 +239,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -255,7 +255,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
             new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -266,7 +266,7 @@ public class KafkaSpecCheckerTest {
                 null, emptyMap(), emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(2));
     }
@@ -281,7 +281,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -296,7 +296,7 @@ public class KafkaSpecCheckerTest {
                 null, kafkaOptions, emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(0));
     }
@@ -307,7 +307,7 @@ public class KafkaSpecCheckerTest {
                 null, emptyMap(), emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         // One warning is generated, but not the one we are testing here
         assertThat(warnings, hasSize(1));
@@ -321,7 +321,7 @@ public class KafkaSpecCheckerTest {
                 null, emptyMap(), emptyMap(),
                 new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
 
-        KafkaSpecChecker checker = generateChecker(kafka);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
         List<Condition> warnings = checker.run(false);
         assertThat(warnings, hasSize(2));
         assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR)), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
@@ -90,7 +90,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_A, POOL_B), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         KafkaSpecChecker checker = new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
 
         List<Condition> warnings = checker.run(false);
@@ -125,7 +125,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(poolA, poolB), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         KafkaSpecChecker checker = new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
 
         List<Condition> warnings = checker.run(true);
@@ -144,7 +144,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(poolA), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         KafkaSpecChecker checker = new KafkaSpecChecker(KAFKA.getSpec(), VERSIONS, kafkaCluster);
 
         List<Condition> warnings = checker.run(true);
@@ -164,7 +164,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(poolA), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         KafkaSpecChecker checker = new KafkaSpecChecker(KAFKA.getSpec(), VERSIONS, kafkaCluster);
 
         List<Condition> warnings = checker.run(true);
@@ -192,7 +192,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(poolA, poolB), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, true, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
         KafkaSpecChecker checker = new KafkaSpecChecker(KAFKA.getSpec(), VERSIONS, kafkaCluster);
 
         List<Condition> warnings = checker.run(true);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -118,9 +118,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -138,9 +135,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -158,9 +152,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -182,9 +173,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -202,9 +190,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -222,9 +207,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -242,9 +224,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is("3.6"));
@@ -262,9 +241,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
@@ -282,9 +258,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is("3.4-IV2"));
@@ -322,9 +295,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -342,9 +312,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -362,9 +329,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -382,9 +346,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -422,9 +383,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -442,9 +400,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));
@@ -462,9 +417,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.metadataVersion(), is("3.4-IV2"));
@@ -482,9 +434,6 @@ public class KRaftVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION)));
             assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION).metadataVersion()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -137,7 +137,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -233,7 +233,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -343,7 +343,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
                 .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
@@ -486,7 +486,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
             .build();
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(poolA, poolB), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -129,7 +129,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .endSpec()
                 .build();
     private static final List<KafkaPool> POOLS = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-    private static final KafkaCluster KAFKA_CLUSTER = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+    private static final KafkaCluster KAFKA_CLUSTER = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
     private static final Map<Integer, Map<String, String>> ADVERTISED_HOSTNAMES = Map.of(
             0, Map.of("PLAIN_9092", "broker-0"),
@@ -439,7 +439,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null).get(0);
 
         ZookeeperCluster newZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -558,7 +558,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null).get(0);
 
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -698,7 +698,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null).get(0);
 
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -886,7 +886,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .build();
 
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null).get(0);
 
 
@@ -996,7 +996,7 @@ public class KafkaAssemblyOperatorPodSetTest {
                 .build();
 
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         StrimziPodSet oldKafkaPodSet = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null).get(0);
 
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -391,7 +391,7 @@ public class KafkaAssemblyOperatorTest {
     @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     private void createCluster(VertxTestContext context, Kafka kafka, List<Secret> secrets) {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
         EntityOperator entityOperator = EntityOperator.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, VERSIONS, SHARED_ENV_PROVIDER);
 
@@ -865,9 +865,9 @@ public class KafkaAssemblyOperatorTest {
     @SuppressWarnings({"checkstyle:NPathComplexity", "checkstyle:JavaNCSS", "checkstyle:MethodLength"})
     private void updateCluster(VertxTestContext context, Kafka originalAssembly, Kafka updatedAssembly) {
         List<KafkaPool> originalPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, originalAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, originalAssembly, originalPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster originalKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, originalAssembly, originalPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         List<KafkaPool> updatedPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, updatedAssembly, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, updatedAssembly, updatedPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster updatedKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, updatedAssembly, updatedPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         ZookeeperCluster originalZookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, originalAssembly, VERSIONS, SHARED_ENV_PROVIDER);
         ZookeeperCluster updatedZookeeperCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, updatedAssembly, VERSIONS, SHARED_ENV_PROVIDER);
         EntityOperator originalEntityOperator = EntityOperator.fromCrd(new Reconciliation("test", originalAssembly.getKind(), originalAssembly.getMetadata().getNamespace(), originalAssembly.getMetadata().getName()), originalAssembly, VERSIONS, SHARED_ENV_PROVIDER);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -179,7 +179,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
             .endSpec()
             .build();
     private static final List<KafkaPool> POOLS = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(POOL_A, POOL_B), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-    private static final KafkaCluster KAFKA_CLUSTER = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+    private static final KafkaCluster KAFKA_CLUSTER = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, POOLS, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
     private static final Map<Integer, Map<String, String>> ADVERTISED_HOSTNAMES = Map.of(
             0, Map.of("PLAIN_9092", "broker-0"),
@@ -526,7 +526,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         //List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, null, Map.of(), Map.of(), false);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, POOLS, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, POOLS, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> oldKafkaPodSets = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null);
 
         ZookeeperCluster newZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -653,7 +653,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, List.of(POOL_A, oldPoolB), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> oldKafkaPodSets = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null);
 
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -824,7 +824,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(oldKafka.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, oldKafka, List.of(POOL_A, oldPoolB), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, oldKafka, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> oldKafkaPodSets = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null);
 
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
@@ -1169,7 +1169,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         ZookeeperCluster oldZkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);
         StrimziPodSet oldZkPodSet = oldZkCluster.generatePodSet(KAFKA.getSpec().getZookeeper().getReplicas(), false, null, null, podNum -> null);
         List<KafkaPool> oldPools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(POOL_A, POOL_B, poolC), Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, oldPools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster oldKafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, oldPools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> oldKafkaPodSets = oldKafkaCluster.generatePodSets(false, null, null, brokerId -> null);
 
         ZookeeperCluster zkCluster = ZookeeperCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KAFKA, VERSIONS, SHARED_ENV_PROVIDER);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerClusterIPTest.java
@@ -103,7 +103,7 @@ public class KafkaListenerReconcilerClusterIPTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 
@@ -183,7 +183,7 @@ public class KafkaListenerReconcilerClusterIPTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 
@@ -284,7 +284,7 @@ public class KafkaListenerReconcilerClusterIPTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerSkipBootstrapLoadBalancerTest.java
@@ -98,7 +98,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 
@@ -173,7 +173,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 
@@ -242,7 +242,7 @@ public class KafkaListenerReconcilerSkipBootstrapLoadBalancerTest {
                 .endSpec()
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), false, SHARED_ENV_PROVIDER);
-        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, false, null, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, null, SHARED_ENV_PROVIDER);
 
         ResourceOperatorSupplier supplier = prepareResourceOperatorSupplier();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreatorTest.java
@@ -65,10 +65,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -87,10 +83,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
@@ -109,10 +101,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
@@ -131,10 +119,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -153,10 +137,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -187,10 +167,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -217,10 +193,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
@@ -247,10 +219,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
@@ -277,10 +245,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -307,10 +271,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -337,10 +297,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -367,10 +323,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
@@ -397,10 +349,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -427,10 +375,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
-            assertThat(c.requiresZookeeperChange(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -465,9 +409,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -496,9 +437,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -525,9 +463,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -556,9 +491,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -587,9 +519,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -620,9 +549,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -653,9 +579,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -686,9 +609,6 @@ public class ZooKeeperVersionChangeCreatorTest {
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
             // Upgrade is finished, only the protocol versions should be rolled
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -715,9 +635,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(true));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.defaultVersion()));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(nullValue())); // Is null because it is set in the Kafka CR
@@ -748,9 +665,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -779,9 +693,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -812,9 +723,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -869,9 +777,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(false));
-            assertThat(c.isUpgrade(), is(true));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -906,9 +811,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.version(kafkaVersion)));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -937,9 +839,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.version(kafkaVersion)));
             assertThat(c.interBrokerProtocolVersion(), is(oldInterBrokerProtocolVersion));
@@ -970,9 +869,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.version(kafkaVersion)));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
@@ -1003,9 +899,6 @@ public class ZooKeeperVersionChangeCreatorTest {
 
         Checkpoint async = context.checkpoint();
         vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
-            assertThat(c.isNoop(), is(false));
-            assertThat(c.isDowngrade(), is(true));
-            assertThat(c.isUpgrade(), is(false));
             assertThat(c.from(), is(VERSIONS.version(oldKafkaVersion)));
             assertThat(c.to(), is(VERSIONS.version(kafkaVersion)));
             assertThat(c.interBrokerProtocolVersion(), nullValue());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperVersionChangeCreatorTest.java
@@ -69,6 +69,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -87,6 +88,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
             assertThat(c.logMessageFormatVersion(), is(VERSIONS.defaultVersion().messageVersion()));
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -105,6 +107,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
             assertThat(c.logMessageFormatVersion(), is(VERSIONS.defaultVersion().messageVersion()));
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -123,6 +126,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -141,6 +145,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -171,6 +176,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -197,6 +203,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
             assertThat(c.logMessageFormatVersion(), is(VERSIONS.defaultVersion().messageVersion()));
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -223,6 +230,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
             assertThat(c.logMessageFormatVersion(), is(VERSIONS.defaultVersion().messageVersion()));
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -249,6 +257,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -275,6 +284,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -301,6 +311,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -327,6 +338,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), is(VERSIONS.defaultVersion().protocolVersion()));
             assertThat(c.logMessageFormatVersion(), is(VERSIONS.defaultVersion().messageVersion()));
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -353,6 +365,7 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
 
             async.flag();
         })));
@@ -379,6 +392,42 @@ public class ZooKeeperVersionChangeCreatorTest {
             assertThat(c.to(), is(VERSIONS.defaultVersion()));
             assertThat(c.interBrokerProtocolVersion(), nullValue());
             assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is(VERSIONS.defaultVersion().metadataVersion()));
+
+            async.flag();
+        })));
+    }
+
+    @Test
+    public void testNoopWithCustomMetadataVersion(VertxTestContext context) {
+        String kafkaVersion = VERSIONS.defaultVersion().version();
+        String interBrokerProtocolVersion = VERSIONS.defaultVersion().protocolVersion();
+        String logMessageFormatVersion = VERSIONS.defaultVersion().messageVersion();
+
+        Kafka kafka  = new KafkaBuilder(mockKafka(kafkaVersion, interBrokerProtocolVersion, logMessageFormatVersion))
+                .editSpec()
+                    .editKafka()
+                        .withMetadataVersion("3.5-IV2")
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        VersionChangeCreator vcc = mockVersionChangeCreator(
+                kafka,
+                mockNewCluster(
+                        null,
+                        mockSps(kafkaVersion),
+                        mockUniformPods(kafkaVersion, interBrokerProtocolVersion, logMessageFormatVersion)
+                )
+        );
+
+        Checkpoint async = context.checkpoint();
+        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
+            assertThat(c.from(), is(VERSIONS.defaultVersion()));
+            assertThat(c.to(), is(VERSIONS.defaultVersion()));
+            assertThat(c.interBrokerProtocolVersion(), nullValue());
+            assertThat(c.logMessageFormatVersion(), nullValue());
+            assertThat(c.metadataVersion(), is("3.5-IV2"));
 
             async.flag();
         })));


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors the `KafkaVErsionChange` class and how it is used in the reconcilers and model classes.

As a first change, it changes the KafkaVersionChange from a class to a record. As part of it, it also removes several methods that were used mostly only in tests + in a single place in the actual production code and seem to be unnecessary (e.g. the `isUpgrade()` etc. methods).

It also changes how `KafkaVersionChange` is used in the `KafkaReconciler`. Right now, we extract the version information inside the `KafkaReconciler` constructor and pass it into `KafkaCluster` using setters. This PR moves this logic into the `KafkaCluster.fromCrd(...)` method and removes the setters. That seems to better encapsulate how the version is set and should move us in the direction to achieve https://github.com/strimzi/strimzi-kafka-operator/issues/8658 in the future.

It also changes the `ZooKeeperVersionChangeCreator` class to set the KRaft metadata version as well as it is needed for the ZooKeeper to KRaft migration.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging