### PR TITLE
Validate minimal supported KRaft metadata version

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -57,7 +57,15 @@ public class KRaftUtils {
      */
     public static void validateMetadataVersion(String metadataVersion)   {
         try {
-            MetadataVersion.fromVersionString(metadataVersion);
+            MetadataVersion version = MetadataVersion.fromVersionString(metadataVersion);
+
+            // KRaft is supposed to be supported from metadata version 3.0-IV1. But only from metadata version 3.3-IV0,
+            // the initial metadata version can be set using the kafka-storage.sh utility. And since most metadata
+            // versions do not support downgrade, that means 3.3-IV0 is the oldest metadata version that can be used
+            // with Strimzi.
+            if (version.isLessThan(MetadataVersion.IBP_3_3_IV0)) {
+                throw new InvalidResourceException("The oldest supported metadata version is 3.3-IV0");
+            }
         } catch (IllegalArgumentException e)    {
             throw new InvalidResourceException("Metadata version " + metadataVersion + " is invalid", e);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -149,11 +149,21 @@ public class KRaftUtilsTest {
         assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.6"));
         assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.6-IV2"));
 
+        // Minimum supported versions
+        assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.3"));
+        assertDoesNotThrow(() -> KRaftUtils.validateMetadataVersion("3.3-IV0"));
+
         // Invalid Values
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3.6-IV9"));
         assertThat(e.getMessage(), containsString("Metadata version 3.6-IV9 is invalid"));
 
         e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3"));
         assertThat(e.getMessage(), containsString("Metadata version 3 is invalid"));
+
+        e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3.2"));
+        assertThat(e.getMessage(), containsString("The oldest supported metadata version is 3.3-IV0"));
+
+        e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateMetadataVersion("3.2-IV0"));
+        assertThat(e.getMessage(), containsString("The oldest supported metadata version is 3.3-IV0"));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds validation for the minimal supported KRaft metadata version that Strimzi supports which is 3.3-IV0. When an older version is used, an `InvalidResourceException` will be thrown

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally