### PR TITLE
KafkaNodePoolST and FeatureGateST node pool related tests refactor and broker scale down check

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -30,13 +30,6 @@ public class KafkaNodePoolTemplates {
             .endSpec();
     }
 
-    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRole(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
-        return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER)
-            .endSpec();
-    }
-
     /**
      * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with roles based
      * on the environment setting (TestConstants.USE_KRAFT_MODE) having BROKER role in Zookeeper and Kraft mode alike
@@ -47,14 +40,14 @@ public class KafkaNodePoolTemplates {
      * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
      * @return KafkaNodePoolBuilder configured with the appropriate (environment variable based) roles based on.
      */
-    public static KafkaNodePoolBuilder fGBasedRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+    public static KafkaNodePoolBuilder kafkaBasedNodePoolWithFgBasedRole(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
         List<ProcessRoles> roles = new ArrayList<>();
         roles.add(ProcessRoles.BROKER);
 
         if (Environment.isKRaftModeEnabled()) {
             roles.add(ProcessRoles.CONTROLLER);
         }
-        return nodePoolOfKafka(nodePoolName, kafka, roles, kafkaNodePoolReplicas);
+        return kafkaBasedNodePoolWithRole(nodePoolName, kafka, roles, kafkaNodePoolReplicas);
     }
 
     /**
@@ -65,8 +58,8 @@ public class KafkaNodePoolTemplates {
      * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
      * @return KafkaNodePoolBuilder configured with the BROKER role.
      */
-    public static KafkaNodePoolBuilder brokerRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
-        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.BROKER), kafkaNodePoolReplicas);
+    public static KafkaNodePoolBuilder kafkaBasedNodePoolWithBrokerRole(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return kafkaBasedNodePoolWithRole(nodePoolName, kafka, List.of(ProcessRoles.BROKER), kafkaNodePoolReplicas);
     }
 
     /**
@@ -77,8 +70,8 @@ public class KafkaNodePoolTemplates {
      * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
      * @return KafkaNodePoolBuilder configured with the CONTROLLER role.
      */
-    public static KafkaNodePoolBuilder controllerRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
-        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
+    public static KafkaNodePoolBuilder kafkaBasedNodePoolWithControllerRole(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return kafkaBasedNodePoolWithRole(nodePoolName, kafka, List.of(ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
     }
 
     /**
@@ -89,8 +82,8 @@ public class KafkaNodePoolTemplates {
      * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
      * @return KafkaNodePoolBuilder configured with both BROKER and CONTROLLER roles.
      */
-    public static KafkaNodePoolBuilder allRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
-        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
+    public static KafkaNodePoolBuilder kafkaBasedNodePoolWithDualRole(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return kafkaBasedNodePoolWithRole(nodePoolName, kafka, List.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
     }
 
     /**
@@ -103,7 +96,7 @@ public class KafkaNodePoolTemplates {
      * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
      * @return KafkaNodePoolBuilder configured with the given roles and specifications.
      */
-    private static KafkaNodePoolBuilder nodePoolOfKafka(String nodePoolName, Kafka kafka, List<ProcessRoles> roles, int kafkaNodePoolReplicas) {
+    private static KafkaNodePoolBuilder kafkaBasedNodePoolWithRole(String nodePoolName, Kafka kafka, List<ProcessRoles> roles, int kafkaNodePoolReplicas) {
         return new KafkaNodePoolBuilder()
             .withNewMetadata()
                 .withName(nodePoolName)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -4,10 +4,14 @@
  */
 package io.strimzi.systemtest.templates.crd;
 
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.Environment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaNodePoolTemplates {
@@ -30,6 +34,88 @@ public class KafkaNodePoolTemplates {
         return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
             .editOrNewSpec()
                 .addToRoles(ProcessRoles.BROKER)
+            .endSpec();
+    }
+
+    /**
+     * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with roles based
+     * on the environment setting (TestConstants.USE_KRAFT_MODE) having BROKER role in Zookeeper and Kraft mode alike
+     * adding CONTROLLER role as well if Kraft is enabled.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with the appropriate (environment variable based) roles based on.
+     */
+    public static KafkaNodePoolBuilder fGBasedRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        List<ProcessRoles> roles = new ArrayList<>();
+        roles.add(ProcessRoles.BROKER);
+
+        if (Environment.isKRaftModeEnabled()) {
+            roles.add(ProcessRoles.CONTROLLER);
+        }
+        return nodePoolOfKafka(nodePoolName, kafka, roles, kafkaNodePoolReplicas);
+    }
+
+    /**
+     * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with only the BROKER role.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with the BROKER role.
+     */
+    public static KafkaNodePoolBuilder brokerRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.BROKER), kafkaNodePoolReplicas);
+    }
+
+    /**
+     * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with only the CONTROLLER role.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with the CONTROLLER role.
+     */
+    public static KafkaNodePoolBuilder controllerRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
+    }
+
+    /**
+     * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with both BROKER and CONTROLLER roles.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with both BROKER and CONTROLLER roles.
+     */
+    public static KafkaNodePoolBuilder allRoleNodePoolOfKafka(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return nodePoolOfKafka(nodePoolName, kafka, List.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
+    }
+
+    /**
+     * Private helper method to create a KafkaNodePoolBuilder with specified roles, besides that completely mirroring all
+     * necessary (mandatory) specification from Kafka Custom Resource.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param roles The roles to be assigned to the node pool.
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with the given roles and specifications.
+     */
+    private static KafkaNodePoolBuilder nodePoolOfKafka(String nodePoolName, Kafka kafka, List<ProcessRoles> roles, int kafkaNodePoolReplicas) {
+        return new KafkaNodePoolBuilder()
+            .withNewMetadata()
+                .withName(nodePoolName)
+                .withNamespace(kafka.getMetadata().getNamespace())
+                .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, kafka.getMetadata().getName()))
+            .endMetadata()
+            .withNewSpec()
+                .withRoles(roles)
+                .withReplicas(kafkaNodePoolReplicas)
+                .withStorage(kafka.getSpec().getKafka().getStorage())
+                .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
+                .withResources(kafka.getSpec().getKafka().getResources())
             .endSpec();
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -42,14 +42,14 @@ public class KafkaNodePoolST extends AbstractST {
      * @description This test case verifies the management of broker IDs in Kafka Node Pools using annotations.
      *
      * @steps
-     *  1. - Deploy a Kafka instance with annotations to manage Node Pools and two KafkaNodePools (A and B) with node ids annotations set.
-     *     - Kafka instance is deployed according to Kafka and KafkaNodePools custom resources.
-     *  2. - Verify that the NodePools contain the correct broker IDs as specified.
-     *     - Correct broker IDs are present in NodePools A and B.
-     *  3. - Verify scaling up NodePool A and scaling down NodePool B with annotations for next node IDs and removing node IDs.
-     *     - NodePool A is scaled up and B is scaled down with correct node IDs after scaling.
-     *  4. - Verify missing ID for downscale (NodePool A), already used ID for upscale (NodePool B).
-     *     - NodePool A and B are correctly scaled with appropriate broker IDs assigned.
+     *  1. - Deploy a Kafka instance with annotations to manage Node Pools and Initial NodePool (C) to hold Topics; this node is also controller.
+     *     - Kafka instance is deployed according to Kafka and KafkaNodePool custom resource, with IDs 90, 91, 92.
+     *  2. - Deploy additional 2 NodePools (A,B) with 1 and 2 replicas, and preset 'next-node-ids' annotations holding resp. values ([5],[6]).
+     *     - NodePools are deployed, NodePool A contains ID 5, NodePoolB contains Ids 6, 0.
+     *  3. - Annotate NodePool A 'next-node-ids' and NodePool B 'remove-node-ids' respectively ([20-21],[6,55]) afterward scale to 4 and 1 replica resp.
+     *     - NodePools are scaled, NodePool A contains IDs 5, 20, 21, 1. NodePool B contains ID 0.
+     *  4. - Annotate NodePool A 'remove-node-ids' and NodePool B 'next-node-ids' respectively ([20],[1]) afterward scale to 2 and 6 replica resp.
+     *     - NodePools are scaled, NodePool A contains IDs 1, 5. NodePool B contains ID 2, 3, 4, 6, 7.
      *
      * @usecase
      *  - kafka-node-pool
@@ -61,42 +61,32 @@ public class KafkaNodePoolST extends AbstractST {
         String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";
         String nodePoolNameB = testStorage.getKafkaNodePoolName() + "-b";
 
-        // We have disabled the broker scale down check for now since the test fails at the moment
-        // due to partition replicas being present on the broker during scale down. We can enable this check
-        // once the issue is resolved
-        // https://github.com/strimzi/strimzi-kafka-operator/issues/9134
-        Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1, 1)
+        Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1, 1).build();
+        LOGGER.info("Testing deployment of NodePools with pre-configured annotation: {} is creating Brokers with correct IDs", Annotations.ANNO_STRIMZI_IO_NODE_POOLS);
+
+        // Deploy Initial NodePool (which will hold initial topics and will never be scaled down) with Ids far from those that will be used in test
+        final KafkaNodePool poolC = KafkaNodePoolTemplates.allRoleNodePoolOfKafka("initial-brokers", kafka, 2)
             .editOrNewMetadata()
-                .addToAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled", Annotations.ANNO_STRIMZI_IO_SKIP_BROKER_SCALEDOWN_CHECK, "true"))
+                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[91-93]"))
             .endMetadata()
             .build();
 
-        LOGGER.info("Testing deployment of NodePools with pre-configured annotation: {} is creating Brokers with correct IDs", Annotations.ANNO_STRIMZI_IO_NODE_POOLS);
-        // Deploy NodePool A with only 1 replica and give it annotation with 1 ID
-        KafkaNodePool poolA =  KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRole(testStorage.getNamespaceName(), nodePoolNameA, testStorage.getClusterName(), 1)
+        // Deploy NodePool A with only 1 replica and give it annotation with 1 ID (5) resulting in 1 broker (5)
+        final KafkaNodePool poolA = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(nodePoolNameA, kafka, 1)
             .editOrNewMetadata()
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[5]"))
             .endMetadata()
-            .editOrNewSpec()
-                .withStorage(kafka.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
-                .withResources(kafka.getSpec().getKafka().getResources())
-            .endSpec()
             .build();
 
-        // Deploy NodePool B with 2 replicas and give it annotation with only  1 ID
-        KafkaNodePool poolB =  KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRole(testStorage.getNamespaceName(), nodePoolNameB, testStorage.getClusterName(), 2)
+        // Deploy NodePool B with 2 replicas and give it annotation with only  1 ID (6) resulting in 2 brokers (6,0)
+        final KafkaNodePool poolB = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(nodePoolNameB, kafka, 2)
             .editOrNewMetadata()
                 .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS, "[6]"))
             .endMetadata()
-            .editOrNewSpec()
-                .withStorage(kafka.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
-                .withResources(kafka.getSpec().getKafka().getResources())
-            .endSpec()
             .build();
 
-        resourceManager.createResourceWithWait(extensionContext, poolA, poolB, kafka);
+        resourceManager.createResourceWithWait(extensionContext, poolC, kafka);
+        resourceManager.createResourceWithWait(extensionContext, poolA, poolB);
         PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), nodePoolNameA), 1);
         PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(testStorage.getClusterName(), nodePoolNameB), 2);
 
@@ -110,8 +100,8 @@ public class KafkaNodePoolST extends AbstractST {
                     "and downscaling NodePool B (more IDs than needed to be scaled down. This redundant ID is not present)");
         // Annotate NodePool A for scale up with fewer IDs than needed -> this should cause addition of non-used ID starting from [0] in ASC order, which is in this case [1]
         KafkaNodePoolUtils.setKafkaNodePoolAnnotation(testStorage.getNamespaceName(), nodePoolNameA, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS,  "[20-21]"));
-        // Annotate NodePool B for scale down with more IDs than needed - > this should not matter as ID [99] is not present so only ID [6] is removed
-        KafkaNodePoolUtils.setKafkaNodePoolAnnotation(testStorage.getNamespaceName(), nodePoolNameB, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[6, 99]"));
+        // Annotate NodePool B for scale down with more IDs than needed - > this should not matter as ID [55] is not present so only ID [6] is removed
+        KafkaNodePoolUtils.setKafkaNodePoolAnnotation(testStorage.getNamespaceName(), nodePoolNameB, Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, "[6, 55]"));
         // Scale NodePool A up + NodePool B down
         KafkaNodePoolUtils.scaleKafkaNodePool(testStorage.getNamespaceName(), nodePoolNameA, 4);
         KafkaNodePoolUtils.scaleKafkaNodePool(testStorage.getNamespaceName(), nodePoolNameB, 1);
@@ -145,10 +135,10 @@ public class KafkaNodePoolST extends AbstractST {
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
-        assumeTrue(Environment.isKRaftModeEnabled() && Environment.isKafkaNodePoolsEnabled());
+        assumeTrue(Environment.isKRaftModeEnabled());
 
         List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+UseKRaft,+KafkaNodePools", null));
 
         this.clusterOperator = this.clusterOperator.defaultInstallation(extensionContext)
             .withExtraEnvVars(coEnvVars)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Tag;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import java.util.ArrayList;
@@ -38,12 +39,24 @@ public class KafkaNodePoolST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaNodePoolST.class);
 
     /**
-     * @description This test case verifies KafkaNodePools scaling up and down with correct NodePool IDs, with different NodePools.
-     * @param extensionContext
+     * @description This test case verifies the management of broker IDs in Kafka Node Pools using annotations.
+     *
+     * @steps
+     *  1. - Deploy a Kafka instance with annotations to manage Node Pools and two KafkaNodePools (A and B) with node ids annotations set.
+     *     - Kafka instance is deployed according to Kafka and KafkaNodePools custom resources.
+     *  2. - Verify that the NodePools contain the correct broker IDs as specified.
+     *     - Correct broker IDs are present in NodePools A and B.
+     *  3. - Verify scaling up NodePool A and scaling down NodePool B with annotations for next node IDs and removing node IDs.
+     *     - NodePool A is scaled up and B is scaled down with correct node IDs after scaling.
+     *  4. - Verify missing ID for downscale (NodePool A), already used ID for upscale (NodePool B).
+     *     - NodePool A and B are correctly scaled with appropriate broker IDs assigned.
+     *
+     * @usecase
+     *  - kafka-node-pool
+     *  - broker-id-management
      */
     @ParallelNamespaceTest
     void testKafkaNodePoolBrokerIdsManagementUsingAnnotations(ExtensionContext extensionContext) {
-
         final TestStorage testStorage = new TestStorage(extensionContext);
         String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";
         String nodePoolNameB = testStorage.getKafkaNodePoolName() + "-b";
@@ -132,6 +145,7 @@ public class KafkaNodePoolST extends AbstractST {
     @BeforeAll
     void setup(ExtensionContext extensionContext) {
         assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
+        assumeTrue(Environment.isKRaftModeEnabled() && Environment.isKafkaNodePoolsEnabled());
 
         List<EnvVar> coEnvVars = new ArrayList<>();
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, "+KafkaNodePools", null));

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -89,7 +89,7 @@ public class FeatureGatesST extends AbstractST {
             .build();
         kafkaCr.getSpec().getEntityOperator().setTopicOperator(null); // The builder cannot disable the EO. It has to be done this way.
 
-        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.allRoleNodePoolOfKafka(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
 
         resourceManager.createResourceWithWait(extensionContext,
             kafkaNodePoolCr,
@@ -135,7 +135,7 @@ public class FeatureGatesST extends AbstractST {
             .endMetadata()
             .build();
 
-        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.kafkaBasedNodePoolWithBrokerRole(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
 
         resourceManager.createResourceWithWait(extensionContext, kafkaNodePoolCr, kafkaCr);
 
@@ -201,7 +201,7 @@ public class FeatureGatesST extends AbstractST {
             .build();
 
         // as the only FG set in the CO is 'KafkaNodePools' (kraft is never included) Broker role is the only one that can be taken
-        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(kafkaNodePoolName, kafkaCr, 3).build();
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.kafkaBasedNodePoolWithBrokerRole(kafkaNodePoolName, kafkaCr, 3).build();
 
         resourceManager.createResourceWithWait(extensionContext,
             kafkaNodePoolCr,

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -9,10 +9,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
-import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.Annotations;
-import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.Environment;
@@ -80,31 +77,23 @@ public class FeatureGatesST extends AbstractST {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final int kafkaReplicas = 3;
 
+        // as kraft is included in CO Feature gates, kafka broker can take both roles (Controller and Broker)
         setupClusterOperatorWithFeatureGate(extensionContext, "+UseKRaft");
 
-        final Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas)
+        final Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas)
             .editOrNewMetadata()
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .build();
-        kafka.getSpec().getEntityOperator().setTopicOperator(null); // The builder cannot disable the EO. It has to be done this way.
+        kafkaCr.getSpec().getEntityOperator().setTopicOperator(null); // The builder cannot disable the EO. It has to be done this way.
 
-        KafkaNodePool kafkaNodePool = KafkaNodePoolResource.convertKafkaResourceToKafkaNodePool(kafka);
-        kafkaNodePool = new KafkaNodePoolBuilder(kafkaNodePool)
-            .editOrNewMetadata()
-                .addToLabels(Labels.STRIMZI_CLUSTER_LABEL, testStorage.getClusterName())
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER, ProcessRoles.CONTROLLER)
-            .endSpec()
-            .build();
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.allRoleNodePoolOfKafka(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
 
         resourceManager.createResourceWithWait(extensionContext,
-            kafkaNodePool,
-            kafka
+            kafkaNodePoolCr,
+            kafkaCr
         );
 
         // Check that there is no ZooKeeper
@@ -135,6 +124,7 @@ public class FeatureGatesST extends AbstractST {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final int kafkaReplicas = 3;
 
+        // as the only FG set in the CO is 'KafkaNodePools' (kraft not included) Broker role is the only one that kafka broker can take
         setupClusterOperatorWithFeatureGate(extensionContext, "+KafkaNodePools");
 
         LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getKafkaNodePoolName());
@@ -145,17 +135,7 @@ public class FeatureGatesST extends AbstractST {
             .endMetadata()
             .build();
 
-        final KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), testStorage.getKafkaNodePoolName(), testStorage.getClusterName(), 3)
-            .editOrNewMetadata()
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER)
-                .withStorage(kafkaCr.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafkaCr.getSpec().getKafka().getJvmOptions())
-                .withResources(kafkaCr.getSpec().getKafka().getResources())
-            .endSpec()
-            .build();
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(testStorage.getKafkaNodePoolName(), kafkaCr, kafkaReplicas).build();
 
         resourceManager.createResourceWithWait(extensionContext, kafkaNodePoolCr, kafkaCr);
 
@@ -195,6 +175,7 @@ public class FeatureGatesST extends AbstractST {
         final int nodePoolIncreasedKafkaReplicaCount = 5;
         final String kafkaNodePoolName = "kafka";
 
+        // as the only FG set in the CO is 'KafkaNodePools' (kraft not included) Broker role is the only one that kafka broker can take
         setupClusterOperatorWithFeatureGate(extensionContext, "+KafkaNodePools");
 
         // setup clients
@@ -219,17 +200,8 @@ public class FeatureGatesST extends AbstractST {
             .endMetadata()
             .build();
 
-        final KafkaNodePool kafkaNodePoolCr =  KafkaNodePoolTemplates.defaultKafkaNodePool(testStorage.getNamespaceName(), kafkaNodePoolName, testStorage.getClusterName(), 3)
-            .editOrNewMetadata()
-                .withNamespace(testStorage.getNamespaceName())
-            .endMetadata()
-            .editOrNewSpec()
-                .addToRoles(ProcessRoles.BROKER)
-                .withStorage(kafkaCr.getSpec().getKafka().getStorage())
-                .withJvmOptions(kafkaCr.getSpec().getKafka().getJvmOptions())
-                .withResources(kafkaCr.getSpec().getKafka().getResources())
-            .endSpec()
-            .build();
+        // as the only FG set in the CO is 'KafkaNodePools' (kraft is never included) Broker role is the only one that can be taken
+        final KafkaNodePool kafkaNodePoolCr = KafkaNodePoolTemplates.brokerRoleNodePoolOfKafka(kafkaNodePoolName, kafkaCr, 3).build();
 
         resourceManager.createResourceWithWait(extensionContext,
             kafkaNodePoolCr,


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

- addition of new templates when creating KafkaNodePools (so it would not be so wordy, these will obtain all necessary specification from provided Kafka resource) and explicit formulation what role I want the Node Pool to stand for.
- refactor of Feature Gate and Kafka Node Pools to use these templates. 
- added documentation to test in KafkaNodePool (currently just 1)  and afterwards change in implementation to be able to run in Kraft as well as small changes in scaling size due to addition of new node pool (so it would not need extra resources) 
- Solution of older "TODO"  (disabled the broker scale down check) in `testKafkaNodePoolBrokerIdsManagementUsingAnnotations` 


### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation


