### PR TITLE
Fix `netstat` command in KRaft controller readiness to work with TCP6

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
@@ -6,7 +6,7 @@ test -f $file
 roles=$(awk -F "process.roles=" '{print $2}' "$file")
 if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
   # For controller only mode, check if it is listening on port 9090 (configured in controller.listener.names).
-  netstat -lnt | grep -E 'tcp?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090+[[:space:]]+[^ ]+[[:space:]]+LISTEN*'
+  netstat -lnt | grep -Eq 'tcp6?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090.*LISTEN[[:space:]]*'
 else
   # For combined or broker only mode, check readiness via HTTP endpoint exposed by Kafka Agent.
   # The endpoint returns 204 when broker state is 3 (RUNNING).


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `netstat` command used with controller readiness  introduced in #8892 does not seem to work well on TCP6 networks as it is unbale to parse this output:
```
$ netstat -lnt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State      
tcp6       0      0 :::39755                :::*                    LISTEN     
tcp6       0      0 :::8080                 :::*                    LISTEN     
tcp6       0      0 :::8443                 :::*                    LISTEN     
tcp6       0      0 :::9090                 :::*                    LISTEN     
tcp6       0      0 :::9404                 :::*                    LISTEN
```

This PR replaces it with the `netstat` command we already use for liveness of ZooKeeper-based brokers that seems to work well everywhere.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging