### PR TITLE
Fix handling of connector state for Mirror Maker 2 connectors

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -350,6 +350,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                                 .withClassName(className)
                                 .withConfig(mm2ConnectorSpec.getConfig())
                                 .withPause(mm2ConnectorSpec.getPause())
+                                .withState(mm2ConnectorSpec.getState())
                                 .withTasksMax(mm2ConnectorSpec.getTasksMax())
                                 .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In Strimzi 0.38 we added support for stopping connectors. This includes also MM2. But it does not seem to work in MM2 because the state is not passed to the connector operator. This PR tries to fix it. 

It seems there are no tests covering much of the MM2 reconciliation and the code is not very easy to test. This PR aims to fix the main issue. I opened a separate issue to improve the test coverage and possible refactoring of the `KafkaMirrorMaker2AssemblyOperator` class: #9419

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging