### PR TITLE
Add warning about incompleted upgrade when metadata version is not updated

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaSpecChecker.java
@@ -55,15 +55,20 @@ public class KafkaSpecChecker {
     List<Condition> run(boolean useKRaft) {
         List<Condition> warnings = new ArrayList<>();
 
-        checkKafkaLogMessageFormatVersion(warnings);
-        checkKafkaInterBrokerProtocolVersion(warnings);
         checkKafkaReplicationConfig(warnings);
         checkKafkaBrokersStorage(warnings);
 
-        // Additional checks done for KRaft clusters
         if (useKRaft)   {
+            // Additional checks done for KRaft clusters
             checkKRaftControllerStorage(warnings);
             checkKRaftControllerCount(warnings);
+            checkKafkaMetadataVersion(warnings);
+            checkInterBrokerProtocolVersionInKRaft(warnings);
+            checkLogMessageFormatVersionInKRaft(warnings);
+        } else {
+            // Additional checks done for ZooKeeper-based clusters
+            checkKafkaLogMessageFormatVersion(warnings);
+            checkKafkaInterBrokerProtocolVersion(warnings);
         }
 
         return warnings;
@@ -180,6 +185,55 @@ public class KafkaSpecChecker {
         } else if (controllerCount % 2 == 0) {
             warnings.add(StatusUtils.buildWarningCondition("KafkaKRaftControllerNodeCount",
                     "Running KRaft controller quorum with an odd number of nodes is recommended."));
+        }
+    }
+
+    /**
+     * Checks if the version of the Kafka brokers matches any custom metadata version config. Updating this is the final
+     * step in upgrading Kafka version in KRaft, so if this doesn't match it is possibly an indication that a user has
+     * updated their Kafka cluster and is unaware that they also should update their metadata version to match.
+     *
+     * @param warnings List to add a warning to, if appropriate.
+     */
+    private void checkKafkaMetadataVersion(List<Condition> warnings) {
+        String metadataVersion = kafkaCluster.getMetadataVersion();
+
+        if (metadataVersion != null) {
+            Matcher m = MAJOR_MINOR_REGEX.matcher(metadataVersion);
+            if (m.matches() && !kafkaBrokerVersion.startsWith(m.group(1))) {
+                warnings.add(StatusUtils.buildWarningCondition("KafkaMetadataVersion",
+                        "Metadata version is older than the Kafka version used by the cluster, which suggests that an upgrade is incomplete."));
+            }
+        }
+    }
+
+    /**
+     * inter.broker.protocol.version should not be used in KRaft. This method checks if it is set and in case it is, it
+     * raises the warning.
+     *
+     * @param warnings List to add a warning to, if appropriate.
+     */
+    private void checkInterBrokerProtocolVersionInKRaft(List<Condition> warnings) {
+        String interBrokerProtocolVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.INTERBROKER_PROTOCOL_VERSION);
+
+        if (interBrokerProtocolVersion != null) {
+            warnings.add(StatusUtils.buildWarningCondition("KafkaInterBrokerProtocolVersionInKRaft",
+                    "inter.broker.protocol.version is not used in KRaft-based Kafka clusters and should be removed from the Kafka custom resource."));
+        }
+    }
+
+    /**
+     * log.message.format.version should not be used in KRaft. This method checks if it is set and in case it is, it
+     * raises the warning.
+     *
+     * @param warnings List to add a warning to, if appropriate.
+     */
+    private void checkLogMessageFormatVersionInKRaft(List<Condition> warnings) {
+        String interBrokerProtocolVersion = kafkaCluster.getConfiguration().getConfigOption(KafkaConfiguration.LOG_MESSAGE_FORMAT_VERSION);
+
+        if (interBrokerProtocolVersion != null) {
+            warnings.add(StatusUtils.buildWarningCondition("KafkaLogMessageFormatVersionInKRaft",
+                    "log.message.format.version is not used in KRaft-based Kafka clusters and should be removed from the Kafka custom resource."));
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
@@ -51,6 +51,20 @@ public class KafkaSpecCheckerWithNodePoolsTest {
                 .endSpec()
                 .build();
 
+    private static final KafkaNodePool CONTROLLERS = new KafkaNodePoolBuilder()
+            .withNewMetadata()
+                .withName("controllers")
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(3)
+                .withRoles(ProcessRoles.CONTROLLER)
+                .withNewJbodStorage()
+                    .withVolumes(new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build())
+                .endJbodStorage()
+            .endSpec()
+            .build();
+
     private static final KafkaNodePool POOL_A = new KafkaNodePoolBuilder()
             .withNewMetadata()
                 .withName("pool-a")
@@ -201,5 +215,70 @@ public class KafkaSpecCheckerWithNodePoolsTest {
         assertThat(warnings, hasSize(1));
         assertThat(warnings.get(0).getReason(), is("KafkaStorage"));
         assertThat(warnings.get(0).getMessage(), is("A Kafka cluster with a single controller node and ephemeral storage will lose data after any restart or rolling update."));
+    }
+
+    @Test
+    public void testOldMetadataVersion() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withVersion(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)
+                        .withMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION)
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(CONTROLLERS, POOL_A, POOL_B), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), null, null, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION), true, null, SHARED_ENV_PROVIDER);
+        KafkaSpecChecker checker = new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
+
+        List<Condition> warnings = checker.run(true);
+
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0).getReason(), is("KafkaMetadataVersion"));
+        assertThat(warnings.get(0).getMessage(), is("Metadata version is older than the Kafka version used by the cluster, which suggests that an upgrade is incomplete."));
+    }
+
+    @Test
+    public void testSameMetadataVersion() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withVersion(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)
+                        .withMetadataVersion(KafkaVersionTestUtils.LATEST_METADATA_VERSION)
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(CONTROLLERS, POOL_A, POOL_B), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), null, null, KafkaVersionTestUtils.LATEST_METADATA_VERSION), true, null, SHARED_ENV_PROVIDER);
+        KafkaSpecChecker checker = new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
+
+        List<Condition> warnings = checker.run(true);
+
+        assertThat(warnings, hasSize(0));
+    }
+
+    @Test
+    public void testZooKeeperBasedVersionsInKRaft() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .addToConfig(Map.of("inter.broker.protocol.version", "3.5", "log.message.format.version", "3.5"))
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(CONTROLLERS, POOL_A, POOL_B), Map.of(), Map.of(), true, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, null, SHARED_ENV_PROVIDER);
+        KafkaSpecChecker checker = new KafkaSpecChecker(kafka.getSpec(), VERSIONS, kafkaCluster);
+
+        List<Condition> warnings = checker.run(true);
+
+        assertThat(warnings, hasSize(2));
+        assertThat(warnings.get(0).getReason(), is("KafkaInterBrokerProtocolVersionInKRaft"));
+        assertThat(warnings.get(0).getMessage(), is("inter.broker.protocol.version is not used in KRaft-based Kafka clusters and should be removed from the Kafka custom resource."));
+        assertThat(warnings.get(1).getReason(), is("KafkaLogMessageFormatVersionInKRaft"));
+        assertThat(warnings.get(1).getMessage(), is("log.message.format.version is not used in KRaft-based Kafka clusters and should be removed from the Kafka custom resource."));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerWithNodePoolsTest.java
@@ -218,7 +218,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
     }
 
     @Test
-    public void testOldMetadataVersion() {
+    public void testMetadataVersionIsOlderThanKafkaVersion() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
@@ -240,7 +240,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
     }
 
     @Test
-    public void testSameMetadataVersion() {
+    public void testMetadataVersionMatchesKafkaVersion() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
@@ -260,7 +260,7 @@ public class KafkaSpecCheckerWithNodePoolsTest {
     }
 
     @Test
-    public void testZooKeeperBasedVersionsInKRaft() {
+    public void testUnusedConfigInKRaftBasedClusters() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds some additional KRaft-related warnings to the Kafka spec checker tool that creates warnings for the status conditions. It adds:
* Warnings when the Kafka cluster is using an older metadata version than what would correspond to the Kafka version. This is similar to the warnings we have today for `inter.broker.protocol.version` and `log.message.format.version` in ZooKeeper-based clusters.
* Adds warnings when `inter.broker.protocol.version` and `log.message.format.version` are configured in a KRaft-based cluster as they are not relevant for KRaft anymore.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally