### PR TITLE
[DOC] Fix small typo in sed command in `Document Conventions`

### DIFF
--- a/documentation/shared/ref-document-conventions.adoc
+++ b/documentation/shared/ref-document-conventions.adoc
@@ -15,5 +15,5 @@ For example, the following code shows that `_<my_namespace>_` must be replaced b
 
 [source, subs="+quotes"]
 ----
-sed -i 's/namespace: .\*/namespace: <my_namespace>' install/cluster-operator/*RoleBinding*.yaml
+sed -i 's/namespace: .\*/namespace: <my_namespace>/' install/cluster-operator/*RoleBinding*.yaml
 ----


### PR DESCRIPTION
### Type of change

- Fix of typo

### Description

This small PR fixes typo I found during reading through the documentation in the example `sed` command, where it throws error:

```
sed: -e expression #1, char 32: unterminated `s' command
```

### Checklist

- [x] Update documentation
