### PR TITLE
Fixed process.roles detection in the KRaft readiness

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_readiness_kraft.sh
@@ -3,7 +3,7 @@ set -e
 
 file=/tmp/strimzi.properties
 test -f $file
-roles=$(awk -F "process.roles=" '{print $2}' "$file")
+roles=$(grep -Po '(?<=^process.roles=).+' "$file")
 if [[ "$roles" =~ "controller" ]] && [[ ! "$roles" =~ "broker" ]]; then
   # For controller only mode, check if it is listening on port 9090 (configured in controller.listener.names).
   netstat -lnt | grep -Eq 'tcp6?[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[^ ]+:9090.*LISTEN[[:space:]]*'


### PR DESCRIPTION
The `kafka_readiness_kraft.sh` script is detecting the `process.roles` field value in the Kafka configuration using the `awk` command like this:

```shell
awk -F "process.roles=" '{print $2}'
```

Anyway it's possible that its output is much longer then needed. For example, it happens when using a Kafka properties file as provided by the upstream project like this https://github.com/apache/kafka/blob/trunk/config/kraft/controller.properties, the output of the current `awk` command will be:

```shell























controller










controller`, and this listener should be consistent with `controller.quorum.voters` value.
























































































```

The output gets a lot of blank lines and also that "controller" (which is the right value for the `process.roles` field), and this "listener should be consistent with `controller.quorum.voters` value.`" because of the following comment which matches the `awk` request.

```shell
# Note that only the controller listeners are allowed here when `process.roles=controller`, and this listener should be consistent with `controller.quorum.voters` value.
```

Of course the current script code works because it looks just for `controller` which exists anyway in the previous result.
The code could provide a false positive if the `process.roles` is not in the file as field but in a comment for example.
It's anyway true that the strimzi.properties file is generated by the operator and cannot suffer by this problem, but maybe a simple grep with a regex like the following is better, as the current PR provides:

```shell
grep -Po '(?<=^process.roles=).+'
```

It's looking for a line beginning with `process.roles` so only the actual field (any comment would start with `#` and would be avoided)