### PR TITLE
Remove the probe configurations from the metrics example YAML

### DIFF
--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -15,12 +15,6 @@ spec:
         port: 9093
         type: internal
         tls: true
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -43,12 +37,6 @@ spec:
           key: kafka-metrics-config.yml
   zookeeper:
     replicas: 3
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
     storage:
       type: persistent-claim
       size: 100Gi


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Metrics example YAML seems to have a configuration of the liveness and readiness probes in it. That does not seem useful and relevant to the example and it is anyway set to the defaults. This PR removes it to make the example smaller and easier to read / understand.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally