### PR TITLE
Avoid `NullPointerException` in PVC deletion

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
@@ -182,7 +182,8 @@ public class PvcReconciler {
     private Future<Void> considerPersistentClaimDeletion(String pvcName)   {
         return pvcOperator.getAsync(reconciliation.namespace(), pvcName)
                 .compose(pvc -> {
-                    if (Annotations.booleanAnnotation(pvc, Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, false)) {
+                    // The PVC might be null in case it was deleted in the mean time by something else such as garbage collection
+                    if (pvc != null && Annotations.booleanAnnotation(pvc, Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, false)) {
                         LOGGER.infoCr(reconciliation, "Deleting PVC {}", pvcName);
                         return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), pvcName, null)
                                 .map((Void) null);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When deleting PVCs after scale-down / node pool deletion, we currently don't check if the PVC still exists and as a result, we might run into NPE when the PVC is garbage collected by Kubernetes int he meantime:

```
2023-12-05 15:32:35 INFO  PvcReconciler:186 - Reconciliation #836(watch) Kafka(myproject/my-cluster): Deleting PVC data-0-my-cluster-aston-1000
2023-12-05 15:32:35 INFO  PvcReconciler:186 - Reconciliation #836(watch) Kafka(myproject/my-cluster): Deleting PVC data-0-my-cluster-aston-1001
2023-12-05 15:32:36 ERROR AbstractOperator:284 - Reconciliation #836(watch) Kafka(myproject/my-cluster): createOrUpdate failed
    java.lang.NullPointerException: Cannot invoke "io.fabric8.kubernetes.api.model.HasMetadata.getMetadata()" because "resource" is null
        at io.strimzi.operator.common.Annotations.booleanAnnotation(Annotations.java:148) ~[io.strimzi.operator-common-0.39.0-SNAPSHOT.jar:0.39.0-SNAPSHOT]
        at io.strimzi.operator.cluster.operator.assembly.PvcReconciler.lambda$considerPersistentClaimDeletion$4(PvcReconciler.java:185) ~[io.strimzi.cluster-operator-0.39.0-SNAPSHOT.jar:0.39.0-SNAPSHOT]
        at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.5.0.jar:4.5.0]
        at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.0.jar:4.5.0]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
2023-12-05 15:32:36 INFO  CrdOperator:122 - Reconciliation #836(watch) Kafka(myproject/my-cluster): Status of Kafka my-cluster in namespace myproject has been updated
2023-12-05 15:32:36 INFO  AbstractOperator:511 - Reconciliation #838(watch) Kafka(myproject/my-cluster): Kafka my-cluster in namespace myproject was MODIFIED
2023-12-05 15:32:36 WARN  AbstractOperator:557 - Reconciliation #836(watch) Kafka(myproject/my-cluster): Failed to reconcile
    java.lang.NullPointerException: Cannot invoke "io.fabric8.kubernetes.api.model.HasMetadata.getMetadata()" because "resource" is null
        at io.strimzi.operator.common.Annotations.booleanAnnotation(Annotations.java:148) ~[io.strimzi.operator-common-0.39.0-SNAPSHOT.jar:0.39.0-SNAPSHOT]
        at io.strimzi.operator.cluster.operator.assembly.PvcReconciler.lambda$considerPersistentClaimDeletion$4(PvcReconciler.java:185) ~[io.strimzi.cluster-operator-0.39.0-SNAPSHOT.jar:0.39.0-SNAPSHOT]
        at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.5.0.jar:4.5.0]
        at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.0.jar:4.5.0]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.100.Final.jar:4.1.100.Final]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

This seems to be rare and does not have any lasting impact. But it is always nice to avoid unnecessary NPEs. This PR adds an additional null check to avoid it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally