### PR TITLE
[ST] KRaft to KRaft upgrades/downgrades in STs

### DIFF
--- a/.azure/templates/jobs/system-tests/upgrade_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/upgrade_jobs.yaml
@@ -18,3 +18,13 @@ jobs:
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'strimzi_upgrade_kraft'
+      display_name: 'strimzi-upgrade-kraft-bundle'
+      profile: 'azp_kraft_upgrade'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -355,6 +355,14 @@
         </profile>
 
         <profile>
+            <id>kraft_upgrade</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>kraftupgrade</groups>
+            </properties>
+        </profile>
+
+        <profile>
             <id>operators</id>
             <properties>
                 <skipTests>false</skipTests>
@@ -527,12 +535,24 @@
         </profile>
 
         <profile>
+            <id>azp_kraft_upgrade</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>kraftupgrade</groups>
+                <it.test>
+                    !KRaftKafkaUpgradeDowngradeST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
             <id>azp_kafka_upgrade</id>
             <properties>
                 <skipTests>false</skipTests>
-                <groups>upgrade</groups>
+                <groups>upgrade,kraftupgrade</groups>
                 <it.test>
-                    KafkaUpgradeDowngradeST
+                    KafkaUpgradeDowngradeST,
+                    KRaftKafkaUpgradeDowngradeST
                 </it.test>
             </properties>
         </profile>

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -201,7 +201,10 @@ public interface TestConstants {
      */
     String USE_KRAFT_MODE = "+UseKRaft";
     String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
+    // kept for upgrade/downgrade tests in KRaft
+    String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
     String DONT_USE_UNIDIRECTIONAL_TOPIC_OPERATOR = "-UnidirectionalTopicOperator";
+    String USE_UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
 
     /**
      * Default value which allows execution of tests with any tags
@@ -222,6 +225,11 @@ public interface TestConstants {
      * Tag for upgrade tests.
      */
     String UPGRADE = "upgrade";
+
+    /**
+     * Tag for KRaft to KRaft tests.
+     */
+    String KRAFT_UPGRADE = "kraftupgrade";
 
     /**
      * Tag for olm upgrade tests

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.resources.crd;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
@@ -21,7 +23,9 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.strimzi.operator.common.Util.hashStub;
@@ -110,5 +114,22 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
         }
 
         return builder.build();
+    }
+
+    public static LabelSelector getLabelSelector(String clusterName, String poolName, ProcessRoles processRole) {
+        Map<String, String> matchLabels = new HashMap<>();
+        matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
+        matchLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
+        matchLabels.put(Labels.STRIMZI_POOL_NAME_LABEL, poolName);
+
+        switch (processRole) {
+            case BROKER -> matchLabels.put(Labels.STRIMZI_BROKER_ROLE_LABEL, "true");
+            case CONTROLLER -> matchLabels.put(Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true");
+            default -> throw new RuntimeException("No role for KafkaNodePool specified");
+        }
+
+        return new LabelSelectorBuilder()
+            .withMatchLabels(matchLabels)
+            .build();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -4,10 +4,14 @@
  */
 package io.strimzi.systemtest.templates.crd;
 
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.systemtest.Environment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaNodePoolTemplates {
@@ -47,6 +51,19 @@ public class KafkaNodePoolTemplates {
         return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
             .editOrNewSpec()
                 .addToRoles(ProcessRoles.BROKER)
+            .endSpec();
+    }
+
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return kafkaNodePoolWithBrokerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
+                .withNewPersistentClaimStorage()
+                    .withSize("1Gi")
+                    .withDeleteClaim(true)
+                .endPersistentClaimStorage()
+            .endSpec();
+    }
+
     /**
      * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with roles based
      * on the environment setting (TestConstants.USE_KRAFT_MODE) having BROKER role in Zookeeper and Kraft mode alike
@@ -126,16 +143,6 @@ public class KafkaNodePoolTemplates {
                 .withStorage(kafka.getSpec().getKafka().getStorage())
                 .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
                 .withResources(kafka.getSpec().getKafka().getResources())
-            .endSpec();
-    }
-
-    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
-        return kafkaNodePoolWithBrokerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
-            .editOrNewSpec()
-                .withNewPersistentClaimStorage()
-                    .withSize("1Gi")
-                    .withDeleteClaim(true)
-                .endPersistentClaimStorage()
             .endSpec();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaNodePoolTemplates.java
@@ -4,14 +4,10 @@
  */
 package io.strimzi.systemtest.templates.crd;
 
-import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.systemtest.Environment;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class KafkaNodePoolTemplates {
@@ -30,6 +26,27 @@ public class KafkaNodePoolTemplates {
             .endSpec();
     }
 
+    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRole(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
+                .addToRoles(ProcessRoles.CONTROLLER)
+            .endSpec();
+    }
+
+    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return kafkaNodePoolWithControllerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
+                .withNewPersistentClaimStorage()
+                    .withSize("1Gi")
+                    .withDeleteClaim(true)
+                .endPersistentClaimStorage()
+            .endSpec();
+    }
+
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRole(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
+                .addToRoles(ProcessRoles.BROKER)
     /**
      * Creates a KafkaNodePoolBuilder for a Kafka instance (mirroring its mandatory specification) with roles based
      * on the environment setting (TestConstants.USE_KRAFT_MODE) having BROKER role in Zookeeper and Kraft mode alike
@@ -109,6 +126,16 @@ public class KafkaNodePoolTemplates {
                 .withStorage(kafka.getSpec().getKafka().getStorage())
                 .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
                 .withResources(kafka.getSpec().getKafka().getResources())
+            .endSpec();
+    }
+
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return kafkaNodePoolWithBrokerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+            .editOrNewSpec()
+                .withNewPersistentClaimStorage()
+                    .withSize("1Gi")
+                    .withDeleteClaim(true)
+                .endPersistentClaimStorage()
             .endSpec();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
@@ -15,12 +15,18 @@ public class UpgradeKafkaVersion {
     private String version;
     private String logMessageVersion;
     private String interBrokerVersion;
+    private String metadataVersion;
 
-    UpgradeKafkaVersion(TestKafkaVersion testKafkaVersion) {
+    public UpgradeKafkaVersion(TestKafkaVersion testKafkaVersion) {
         this(testKafkaVersion.version(), testKafkaVersion.messageVersion(), testKafkaVersion.protocolVersion());
     }
 
-    UpgradeKafkaVersion(String version) {
+    public UpgradeKafkaVersion(String version, String desiredMetadataVersion) {
+        this.version = version;
+        this.metadataVersion = desiredMetadataVersion;
+    }
+
+    public UpgradeKafkaVersion(String version) {
         String shortVersion = version;
 
         if (version != null && !version.equals("")) {
@@ -31,17 +37,18 @@ public class UpgradeKafkaVersion {
         this.version = version;
         this.logMessageVersion = shortVersion;
         this.interBrokerVersion = shortVersion;
+        this.metadataVersion = shortVersion;
     }
 
     /**
      * Leaving empty, so original Kafka version in `kafka-persistent.yaml` will be used
      * LMFV and IBPV should be null, so the test steps will for updating the config will be skipped
      */
-    UpgradeKafkaVersion() {
+    public UpgradeKafkaVersion() {
         this("", null, null);
     }
 
-    UpgradeKafkaVersion(String version, String logMessageVersion, String interBrokerVersion) {
+    public UpgradeKafkaVersion(String version, String logMessageVersion, String interBrokerVersion) {
         this.version = version;
         this.logMessageVersion = logMessageVersion;
         this.interBrokerVersion = interBrokerVersion;
@@ -61,6 +68,10 @@ public class UpgradeKafkaVersion {
 
     public String getInterBrokerVersion() {
         return this.interBrokerVersion;
+    }
+
+    public String getMetadataVersion() {
+        return this.metadataVersion;
     }
 
     public static UpgradeKafkaVersion getKafkaWithVersionFromUrl(String kafkaVersionsUrl, String kafkaVersion) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/RollingUpdateUtils.java
@@ -71,7 +71,10 @@ public class RollingUpdateUtils {
      * @return The snapshot of the  component (StrimziPodSet, Deployment) after rolling update with Uid for every pod
      */
     public static Map<String, String> waitTillComponentHasRolled(String namespaceName, LabelSelector selector, Map<String, String> snapshot) {
+        String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
+        componentName = componentName == null ? clusterName + "-" + selector.getMatchLabels().get(Labels.STRIMZI_POOL_NAME_LABEL) : componentName;
 
         LOGGER.info("Waiting for component matching {} -> {}/{} rolling update", selector, namespaceName, componentName);
         TestUtils.waitFor("rolling update of component: " + namespaceName + "/" + componentName,
@@ -91,6 +94,8 @@ public class RollingUpdateUtils {
     public static Map<String, String> waitTillComponentHasRolledAndPodsReady(String namespaceName, LabelSelector selector, int expectedPods, Map<String, String> snapshot) {
         String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
+        componentName = componentName == null ? clusterName + "-" + selector.getMatchLabels().get(Labels.STRIMZI_POOL_NAME_LABEL) : componentName;
 
         waitTillComponentHasRolled(namespaceName, selector, snapshot);
 
@@ -116,8 +121,10 @@ public class RollingUpdateUtils {
      * @return The new Snapshot of actually present Pods after the first successful roll
      */
     public static Map<String, String> waitTillComponentHasStartedRolling(String namespaceName, LabelSelector selector, Map<String, String> snapshot) {
+        String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_CONTROLLER_NAME_LABEL);
 
-        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+        componentName = componentName == null ? clusterName + "-" + selector.getMatchLabels().get(Labels.STRIMZI_POOL_NAME_LABEL) : componentName;
 
         LOGGER.info("Waiting for component matching {} -> {}/{} first rolled Pod", selector, namespaceName, componentName);
         TestUtils.waitFor("first pod's roll : " + namespaceName + "/" + componentName,
@@ -156,7 +163,9 @@ public class RollingUpdateUtils {
 
     public static void waitForComponentAndPodsReady(String namespaceName, LabelSelector selector, int expectedPods) {
         final String clusterName = selector.getMatchLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
-        final String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+        String componentName = selector.getMatchLabels().get(Labels.STRIMZI_NAME_LABEL);
+
+        componentName = componentName == null ? clusterName + "-" + selector.getMatchLabels().get(Labels.STRIMZI_POOL_NAME_LABEL) : componentName;
 
         LOGGER.info("Waiting for {} Pod(s) of {}/{} to be ready", expectedPods, namespaceName, componentName);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -56,6 +56,9 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
     @JsonProperty("format")
     String messageVersion;
 
+    @JsonProperty("metadata")
+    String metadataVersion;
+
     @JsonProperty("zookeeper")
     String zookeeperVersion;
 
@@ -87,6 +90,10 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
     public String messageVersion() {
         return messageVersion;
+    }
+
+    public String metadataVersion() {
+        return metadataVersion;
     }
 
     public String zookeeperVersion() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -527,12 +527,13 @@ public class KafkaUtils {
                 kafkaNode.put("metadataVersion", metadataVersion);
             }
 
-            String output = "";
+            StringBuilder output = new StringBuilder();
+
             for (ObjectNode objectNode : objects) {
-                output += yamlMapper.writeValueAsString(objectNode);
+                output.append(yamlMapper.writeValueAsString(objectNode));
             }
 
-            return output;
+            return output.toString();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -516,14 +516,21 @@ public class KafkaUtils {
             ObjectNode entity = (ObjectNode) kafkaResourceNode.at("/spec/entityOperator");
             entity.set("topicOperator", mapper.createObjectNode());
 
+            // workaround for current Strimzi upgrade (before we will have release containing metadataVersion in examples + CRDs)
+            boolean metadataVersionFieldSupported = !cmdKubeClient().exec(false, "explain", "kafka.spec.kafka.metadataVersion").err().contains("does not exist");
+
             if (version == null) {
                 kafkaNode.remove("version");
                 kafkaNode.remove("metadataVersion");
             } else if (!version.equals("")) {
                 kafkaNode.put("version", version);
-                kafkaNode.put("metadataVersion", TestKafkaVersion.getSpecificVersion(version).messageVersion());
+
+                if (metadataVersionFieldSupported) {
+                    kafkaNode.put("metadataVersion", TestKafkaVersion.getSpecificVersion(version).messageVersion());
+                }
             }
-            if (metadataVersion != null) {
+
+            if (metadataVersion != null && metadataVersionFieldSupported) {
                 kafkaNode.put("metadataVersion", metadataVersion);
             }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.upgrade.kraft;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
+import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
+import io.strimzi.systemtest.upgrade.CommonVersionModificationData;
+import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
+
+    private static final Logger LOGGER = LogManager.getLogger(AbstractKRaftUpgradeST.class);
+
+    protected Map<String, String> brokerPods;
+    protected Map<String, String> controllerPods;
+
+    protected static final String CONTROLLER_NODE_NAME = "controller";
+    protected static final String BROKER_NODE_NAME = "broker";
+
+    protected final LabelSelector controllerSelector = KafkaNodePoolResource.getLabelSelector(clusterName, CONTROLLER_NODE_NAME, ProcessRoles.CONTROLLER);
+    protected final LabelSelector brokerSelector = KafkaNodePoolResource.getLabelSelector(clusterName, BROKER_NODE_NAME, ProcessRoles.BROKER);
+
+    // topics that are just present in Kafka itself are not created as CRs in UTO, thus -3 topics in comparison to regular upgrade
+    protected final int expectedTopicCount = upgradeTopicCount;
+
+    protected int getExpectedTopicCount() {
+        return expectedTopicCount;
+    }
+
+    @Override
+    protected void makeSnapshots() {
+        coPods = DeploymentUtils.depSnapshot(TestConstants.CO_NAMESPACE, ResourceManager.getCoDeploymentName());
+        eoPods = DeploymentUtils.depSnapshot(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName));
+        controllerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
+        brokerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+        connectPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, connectLabelSelector);
+    }
+
+    @Override
+    protected void deployKafkaClusterWithWaitForReadiness(final ExtensionContext extensionContext, final BundleVersionModificationData upgradeData,
+                                                          final UpgradeKafkaVersion upgradeKafkaVersion) {
+        LOGGER.info("Deploying Kafka: {} in Namespace: {}", clusterName, kubeClient().getNamespace());
+
+        if (!cmdKubeClient().getResources(getResourceApiVersion(Kafka.RESOURCE_PLURAL)).contains(clusterName)) {
+            // Deploy a Kafka cluster
+            if (upgradeData.getFromExamples().equals("HEAD")) {
+                resourceManager.createResourceWithWait(extensionContext,
+                    KafkaNodePoolTemplates.kafkaNodePoolWithControllerRoleAndPersistentStorage(TestConstants.CO_NAMESPACE, CONTROLLER_NODE_NAME, clusterName, 3).build(),
+                    KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRoleAndPersistentStorage(TestConstants.CO_NAMESPACE, BROKER_NODE_NAME, clusterName, 3).build(),
+                    KafkaTemplates.kafkaPersistent(clusterName, 3, 3)
+                        .editMetadata()
+                            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                        .endMetadata()
+                        .editSpec()
+                            .editKafka()
+                                .withVersion(upgradeKafkaVersion.getVersion())
+                                .withMetadataVersion(upgradeKafkaVersion.getMetadataVersion())
+                            .endKafka()
+                        .endSpec()
+                        .build());
+            } else {
+                kafkaYaml = new File(dir, upgradeData.getFromExamples() + "/examples/kafka/nodepools/kafka-with-kraft.yaml");
+                LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
+                // Change kafka version of it's empty (null is for remove the version)
+                if (upgradeKafkaVersion == null) {
+                    cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaInKRaft(kafkaYaml, null));
+                } else {
+                    cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaConfigurationInKRaft(kafkaYaml, upgradeKafkaVersion.getVersion(), upgradeKafkaVersion.getMetadataVersion()));
+                }
+                // Wait for readiness
+                waitForReadinessOfKafkaCluster();
+            }
+        }
+    }
+
+    @Override
+    protected void waitForKafkaClusterRollingUpdate() {
+        LOGGER.info("Waiting for Kafka Pods with controller role to be rolled");
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerPods);
+        LOGGER.info("Waiting for Kafka Pods with broker role to be rolled");
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerPods);
+        LOGGER.info("Waiting for EO Deployment to be rolled");
+        // Check the TO and UO also got upgraded
+        eoPods = DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
+    }
+
+    @Override
+    protected void waitForReadinessOfKafkaCluster() {
+        LOGGER.info("Waiting for Kafka Pods with controller role to be ready");
+        RollingUpdateUtils.waitForComponentAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3);
+        LOGGER.info("Waiting for Kafka Pods with broker role to be ready");
+        RollingUpdateUtils.waitForComponentAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3);
+        LOGGER.info("Waiting for EO Deployment");
+        DeploymentUtils.waitForDeploymentAndPodsReady(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
+    }
+
+    protected void changeKafkaAndMetadataVersion(CommonVersionModificationData versionModificationData, ExtensionContext extensionContext) throws IOException {
+        changeKafkaAndMetadataVersion(versionModificationData, false, extensionContext);
+    }
+
+    /**
+     * Method for changing Kafka `version` and `metadataVersion` fields in Kafka CR based on the current scenario
+     * @param versionModificationData data structure holding information about the desired steps/versions that should be applied
+     * @param replaceEvenIfMissing current workaround for the situation when `metadataVersion` is not set in Kafka CR -> that's because previous version of operator
+     *     doesn't contain this kind of field, so even if we set this field in the Kafka CR, it is removed by the operator
+     *     this is needed for correct functionality of the `testUpgradeAcrossVersionsWithUnsupportedKafkaVersion` test
+     * @param extensionContext context of the test
+     * @throws IOException exception during application of YAML files
+     */
+    @SuppressWarnings("CyclomaticComplexity")
+    protected void changeKafkaAndMetadataVersion(CommonVersionModificationData versionModificationData, boolean replaceEvenIfMissing, ExtensionContext extensionContext) throws IOException {
+        // Get Kafka version
+        String kafkaVersionFromCR = cmdKubeClient().getResourceJsonPath(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, ".spec.kafka.version");
+        kafkaVersionFromCR = kafkaVersionFromCR.equals("") ? null : kafkaVersionFromCR;
+        // Get Kafka metadata version
+        String currentMetadataVersion = cmdKubeClient().getResourceJsonPath(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, ".spec.kafka.metadataVersion");
+
+        String kafkaVersionFromProcedure = versionModificationData.getProcedures().getVersion();
+
+        // #######################################################################
+        // #################    Update CRs to latest version   ###################
+        // #######################################################################
+        String examplesPath = downloadExamplesAndGetPath(versionModificationData);
+
+        applyCustomResourcesFromPath(examplesPath, kafkaVersionFromCR);
+
+        // #######################################################################
+
+        if (versionModificationData.getProcedures() != null && (!currentMetadataVersion.isEmpty() || replaceEvenIfMissing)) {
+
+            if (kafkaVersionFromProcedure != null && !kafkaVersionFromProcedure.isEmpty() && !kafkaVersionFromCR.contains(kafkaVersionFromProcedure)) {
+                LOGGER.info("Set Kafka version to " + kafkaVersionFromProcedure);
+                cmdKubeClient().patchResource(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, "/spec/kafka/version", kafkaVersionFromProcedure);
+
+                waitForKafkaControllersAndBrokersFinishRollingUpdate();
+            }
+
+            String metadataVersion = versionModificationData.getProcedures().getMetadataVersion();
+
+            if (metadataVersion != null && !metadataVersion.isEmpty()) {
+                LOGGER.info("Set metadata version to {} (current version is {})", metadataVersion, currentMetadataVersion);
+                cmdKubeClient().patchResource(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, "/spec/kafka/metadataVersion", metadataVersion);
+
+                makeSnapshots();
+            }
+        }
+    }
+
+    @Override
+    protected void checkAllImages(BundleVersionModificationData versionModificationData, String namespaceName) {
+        if (versionModificationData.getImagesAfterOperations().isEmpty()) {
+            fail("There are no expected images");
+        }
+
+        checkContainerImages(controllerSelector, versionModificationData.getKafkaImage());
+        checkContainerImages(brokerSelector, versionModificationData.getKafkaImage());
+        checkContainerImages(eoSelector, versionModificationData.getTopicOperatorImage());
+        checkContainerImages(eoSelector, 1, versionModificationData.getUserOperatorImage());
+    }
+
+    @Override
+    protected void logPodImages(String namespaceName) {
+        logPodImages(namespaceName, controllerSelector, brokerSelector, eoSelector, coSelector);
+    }
+
+    @Override
+    protected void logPodImagesWithConnect(String namespaceName) {
+        logPodImages(namespaceName, controllerSelector, brokerSelector, eoSelector, coSelector);
+    }
+
+    protected void waitForKafkaControllersAndBrokersFinishRollingUpdate() {
+        LOGGER.info("Waiting for Kafka rolling update to finish");
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerPods);
+    }
+
+    protected void applyKafkaCustomResourceFromPath(String examplesPath, String kafkaVersionFromCR) {
+        // Change kafka version of it's empty (null is for remove the version)
+        String metadataVersion = kafkaVersionFromCR == null ? null : TestKafkaVersion.getSpecificVersion(kafkaVersionFromCR).metadataVersion();
+
+        kafkaYaml = new File(examplesPath + "/kafka/nodepools/kafka-with-kraft.yaml");
+        LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
+        cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaConfigurationInKRaft(kafkaYaml, kafkaVersionFromCR, metadataVersion));
+    }
+
+    protected void applyCustomResourcesFromPath(String examplesPath, String kafkaVersionFromCR) {
+        applyKafkaCustomResourceFromPath(examplesPath, kafkaVersionFromCR);
+
+        kafkaUserYaml = new File(examplesPath + "/user/kafka-user.yaml");
+        LOGGER.info("Deploying KafkaUser from: {}", kafkaUserYaml.getPath());
+        cmdKubeClient().applyContent(KafkaUserUtils.removeKafkaUserPart(kafkaUserYaml, "authorization"));
+
+        kafkaTopicYaml = new File(examplesPath + "/topic/kafka-topic.yaml");
+        LOGGER.info("Deploying KafkaTopic from: {}", kafkaTopicYaml.getPath());
+        cmdKubeClient().applyContent(TestUtils.readFile(kafkaTopicYaml));
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.upgrade.kraft;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.KafkaBuilder;
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.systemtest.TestConstants.KRAFT_UPGRADE;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * This test class contains tests for Kafka upgrade/downgrade from version X to X +/- 1, running in KRaft mode.
+ * Metadata for upgrade/downgrade procedure are loaded from kafka-versions.yaml in root dir of this repository.
+ */
+@Tag(KRAFT_UPGRADE)
+public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
+    private static final Logger LOGGER = LogManager.getLogger(KRaftKafkaUpgradeDowngradeST.class);
+
+    private final String continuousTopicName = "continuous-topic";
+    private final int continuousClientsMessageCount = 1000;
+
+    @IsolatedTest
+    void testKafkaClusterUpgrade(ExtensionContext testContext) {
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
+
+        String producerName = clusterName + "-producer";
+        String consumerName = clusterName + "-consumer";
+
+        for (int x = 0; x < sortedVersions.size() - 1; x++) {
+            TestKafkaVersion initialVersion = sortedVersions.get(x);
+            TestKafkaVersion newVersion = sortedVersions.get(x + 1);
+
+            // If it is an upgrade test we keep the message format as the lower version number
+            String metadataVersion = initialVersion.metadataVersion();
+
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, metadataVersion, 3, 3, testContext);
+        }
+
+        // ##############################
+        // Validate that continuous clients finished successfully
+        // ##############################
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        // ##############################
+    }
+
+    @IsolatedTest
+    void testKafkaClusterDowngrade(ExtensionContext testContext) {
+        final TestStorage testStorage = storageMap.get(testContext);
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
+
+        String clusterName = testStorage.getClusterName();
+        String producerName = clusterName + "-producer";
+        String consumerName = clusterName + "-consumer";
+
+        for (int x = sortedVersions.size() - 1; x > 0; x--) {
+            TestKafkaVersion initialVersion = sortedVersions.get(x);
+            TestKafkaVersion newVersion = sortedVersions.get(x - 1);
+
+            // If it is a downgrade then we make sure to use the lower version number for the message format
+            String metadataVersion = newVersion.metadataVersion();
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, metadataVersion, 3, 3, testContext);
+        }
+
+        // ##############################
+        // Validate that continuous clients finished successfully
+        // ##############################
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        // ##############################
+    }
+
+    @IsolatedTest
+    @Disabled("This is currently not possible - missing support for unsafe downgrades")
+    void testKafkaClusterDowngradeToOlderMetadataVersion(ExtensionContext testContext) {
+        final TestStorage testStorage = storageMap.get(testContext);
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
+
+        String clusterName = testStorage.getClusterName();
+        String producerName = clusterName + "-producer";
+        String consumerName = clusterName + "-consumer";
+
+        String initMetadataVersion = sortedVersions.get(0).metadataVersion();
+
+        for (int x = sortedVersions.size() - 1; x > 0; x--) {
+            TestKafkaVersion initialVersion = sortedVersions.get(x);
+            TestKafkaVersion newVersion = sortedVersions.get(x - 1);
+
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, initMetadataVersion, 3, 3, testContext);
+        }
+
+        // ##############################
+        // Validate that continuous clients finished successfully
+        // ##############################
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        // ##############################
+    }
+
+    @IsolatedTest
+    void testUpgradeWithNoMetadataVersionSet(ExtensionContext testContext) {
+        List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
+
+        String producerName = clusterName + "-producer";
+        String consumerName = clusterName + "-consumer";
+
+        for (int x = 0; x < sortedVersions.size() - 1; x++) {
+            TestKafkaVersion initialVersion = sortedVersions.get(x);
+            TestKafkaVersion newVersion = sortedVersions.get(x + 1);
+
+            runVersionChange(initialVersion, newVersion, producerName, consumerName, null, 3, 3, testContext);
+        }
+
+        // ##############################
+        // Validate that continuous clients finished successfully
+        // ##############################
+        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        // ##############################
+    }
+
+    @BeforeAll
+    void setupEnvironment(final ExtensionContext extensionContext) {
+        List<EnvVar> coEnvVars = new ArrayList<>();
+        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, String.join(",",
+            TestConstants.USE_KRAFT_MODE, TestConstants.USE_KAFKA_NODE_POOLS, TestConstants.USE_UNIDIRECTIONAL_TOPIC_OPERATOR), null));
+
+        clusterOperator
+            .defaultInstallation(extensionContext)
+            .withExtraEnvVars(coEnvVars)
+            .createInstallation()
+            .runInstallation();
+    }
+
+    @SuppressWarnings({"checkstyle:MethodLength"})
+    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String producerName, String consumerName, String initMetadataVersion, int controllerReplicas, int brokerReplicas, ExtensionContext testContext) {
+        boolean isUpgrade = initialVersion.isUpgrade(newVersion);
+        Map<String, String> controllerPods;
+        Map<String, String> brokerPods;
+
+        boolean sameMinorVersion = initialVersion.protocolVersion().equals(newVersion.protocolVersion());
+
+        if (KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get() == null) {
+            LOGGER.info("Deploying initial Kafka version {} with metadataVersion={}", initialVersion.version(), initMetadataVersion);
+
+            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(clusterName, controllerReplicas, brokerReplicas)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                .endMetadata()
+                .editSpec()
+                    .editKafka()
+                        .withVersion(initialVersion.version())
+                        .withConfig(null)
+                    .endKafka()
+                .endSpec();
+
+            // Do not set metadataVersion if it's not passed to method
+            if (initMetadataVersion != null) {
+                kafka
+                    .editSpec()
+                        .editKafka()
+                            .withMetadataVersion(initMetadataVersion)
+                        .endKafka()
+                    .endSpec();
+            }
+
+            resourceManager.createResourceWithWait(testContext,
+                KafkaNodePoolTemplates.kafkaNodePoolWithControllerRoleAndPersistentStorage(TestConstants.CO_NAMESPACE, CONTROLLER_NODE_NAME, clusterName, controllerReplicas).build(),
+                KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRoleAndPersistentStorage(TestConstants.CO_NAMESPACE, BROKER_NODE_NAME, clusterName, brokerReplicas).build(),
+                kafka.build()
+            );
+
+            // ##############################
+            // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
+            // ##############################
+            // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
+            resourceManager.createResourceWithWait(testContext, KafkaTopicTemplates.topic(clusterName, continuousTopicName, 3, 3, 2, TestConstants.CO_NAMESPACE).build());
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+
+            KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
+                .withProducerName(producerName)
+                .withConsumerName(consumerName)
+                .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+                .withTopicName(continuousTopicName)
+                .withMessageCount(continuousClientsMessageCount)
+                .withAdditionalConfig(producerAdditionConfiguration)
+                .withDelayMs(1000)
+                .build();
+
+            resourceManager.createResourceWithWait(testContext, kafkaBasicClientJob.producerStrimzi());
+            resourceManager.createResourceWithWait(testContext, kafkaBasicClientJob.consumerStrimzi());
+            // ##############################
+
+        } else {
+            LOGGER.info("Initial Kafka version (" + initialVersion.version() + ") is already ready");
+            controllerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
+            brokerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+
+            // Wait for metadataVersion change
+            if (!sameMinorVersion
+                && !isUpgrade
+                && !testContext.getDisplayName().contains("DowngradeToOlderMetadataVersion")) {
+
+                // In case that init config was set, which means that CR was updated and CO won't do any changes
+                KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+                    LOGGER.info("Kafka config before updating '{}'", kafka.getSpec().getKafka().toString());
+
+                    kafka.getSpec().getKafka().setMetadataVersion(newVersion.metadataVersion());
+
+                    LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().toString());
+                }, TestConstants.CO_NAMESPACE);
+
+                RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, controllerSelector, controllerReplicas, controllerPods);
+                RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerReplicas, brokerPods);
+            }
+        }
+
+        LOGGER.info("Deployment of initial Kafka version (" + initialVersion.version() + ") complete");
+
+        String controllerVersionResult = KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get().getStatus().getKafkaVersion();
+        LOGGER.info("Pre-change Kafka version: " + controllerVersionResult);
+
+        controllerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
+        brokerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+
+        LOGGER.info("Updating Kafka CR version field to " + newVersion.version());
+
+        // Change the version in Kafka CR
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+            kafka.getSpec().getKafka().setVersion(newVersion.version());
+        }, TestConstants.CO_NAMESPACE);
+
+        LOGGER.info("Waiting for readiness of new Kafka version (" + newVersion.version() + ") to complete");
+
+        // Wait for the controllers' version change roll
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, controllerSelector, controllerReplicas, controllerPods);
+        LOGGER.info("1st Controllers roll (image change) is complete");
+
+        // Wait for the brokers' version change roll
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerReplicas, brokerPods);
+        LOGGER.info("1st Brokers roll (image change) is complete");
+
+        String currentMetadataVersion = KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get().getSpec().getKafka().getMetadataVersion();
+
+        LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");
+
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+
+        String controllerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
+        String brokerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
+
+        // Extract the Kafka version number from the jars in the lib directory
+        controllerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(controllerPodName);
+        LOGGER.info("Post-change Kafka version query returned: " + controllerVersionResult);
+
+        assertThat("Kafka container had version " + controllerVersionResult + " where " + newVersion.version() +
+            " was expected", controllerVersionResult, is(newVersion.version()));
+
+        // Extract the Kafka version number from the jars in the lib directory
+        String brokerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(brokerPodName);
+        LOGGER.info("Post-change Kafka version query returned: " + brokerVersionResult);
+
+        assertThat("Kafka container had version " + brokerVersionResult + " where " + newVersion.version() +
+            " was expected", brokerVersionResult, is(newVersion.version()));
+
+        if (isUpgrade && !sameMinorVersion) {
+            LOGGER.info("Updating Kafka config attribute 'metadataVersion' from '{}' to '{}' version", initialVersion.metadataVersion(), newVersion.metadataVersion());
+
+            KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
+                LOGGER.info("Kafka config before updating '{}'", kafka.getSpec().getKafka().toString());
+
+                kafka.getSpec().getKafka().setMetadataVersion(newVersion.metadataVersion());
+
+                LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().toString());
+            }, TestConstants.CO_NAMESPACE);
+
+            LOGGER.info("Metadata version changed, it doesn't require rolling update, so the Pods should be stable");
+            PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+            assertFalse(RollingUpdateUtils.componentHasRolled(TestConstants.CO_NAMESPACE, controllerSelector, controllerPods));
+            assertFalse(RollingUpdateUtils.componentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerPods));
+        }
+
+        if (!isUpgrade) {
+            LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", initMetadataVersion);
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+                .get().getStatus().getKafkaMetadataVersion().contains(initMetadataVersion), is(true));
+        } else {
+            if (currentMetadataVersion != null) {
+                LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", newVersion.metadataVersion());
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+                    .get().getStatus().getKafkaMetadataVersion().contains(newVersion.metadataVersion()), is(true));
+            }
+        }
+
+        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", TestConstants.CO_NAMESPACE, clusterName, newVersion.version());
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(clusterName, TestConstants.CO_NAMESPACE, newVersion.version());
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.upgrade.kraft;
+
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
+import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
+import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
+import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.TestConstants.KRAFT_UPGRADE;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Class for testing downgrade process of Strimzi with its components when running in KRaft mode
+ *      -> KRaft to KRaft downgrades
+ * Metadata for the following tests are collected from systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+ */
+@Tag(KRAFT_UPGRADE)
+@Disabled("The tests are currently disabled, as the KRaft to KRaft downgrade (with operator downgrade) is not handled in Strimzi 0.38.0")
+public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
+    private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziDowngradeST.class);
+    private final List<BundleVersionModificationData> bundleDowngradeMetadata = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_DOWNGRADE).getBundleUpgradeOrDowngradeDataList();
+
+    @ParameterizedTest(name = "testDowngradeStrimziVersion-{0}-{1}")
+    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeDataForKRaft")
+    @Tag(INTERNAL_CLIENTS_USED)
+    void testDowngradeStrimziVersion(String from, String to, BundleVersionModificationData parameters, ExtensionContext extensionContext) throws Exception {
+        assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getEnvFlakyVariable()));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getEnvMaxK8sVersion()));
+
+        LOGGER.debug("Running downgrade test from version {} to {}", from, to);
+        performDowngrade(parameters, extensionContext);
+    }
+
+    @Test
+    void testDowngradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
+        final TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
+        final BundleVersionModificationData bundleDowngradeDataWithFeatureGates = bundleDowngradeMetadata.stream()
+            .filter(bundleMetadata -> bundleMetadata.getFeatureGatesBefore() != null && !bundleMetadata.getFeatureGatesBefore().isEmpty() ||
+                bundleMetadata.getFeatureGatesAfter() != null && !bundleMetadata.getFeatureGatesAfter().isEmpty()).toList().get(0);
+        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeDataWithFeatureGates.getDeployKafkaVersion());
+
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(extensionContext, bundleDowngradeDataWithFeatureGates, testStorage, upgradeKafkaVersion);
+    }
+
+    @SuppressWarnings("MethodLength")
+    private void performDowngrade(BundleVersionModificationData downgradeData, ExtensionContext extensionContext) throws IOException {
+        TestStorage testStorage = new TestStorage(extensionContext);
+
+        String lowerMetadataVersion = downgradeData.getProcedures().getMetadataVersion();
+        UpgradeKafkaVersion testUpgradeKafkaVersion = new UpgradeKafkaVersion(downgradeData.getDeployKafkaVersion(), lowerMetadataVersion);
+
+        // Setup env
+        // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
+        // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
+
+        setupEnvAndUpgradeClusterOperator(extensionContext, downgradeData, testStorage, testUpgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
+        // Downgrade CO
+        changeClusterOperator(downgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+
+        // Wait for Kafka cluster rolling update
+        waitForKafkaClusterRollingUpdate();
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
+        // Downgrade kafka
+        changeKafkaAndMetadataVersion(downgradeData, extensionContext);
+
+        // Verify that pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+
+        checkAllImages(downgradeData, TestConstants.CO_NAMESPACE);
+
+        // Verify upgrade
+        verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+    }
+
+    @BeforeEach
+    void setupEnvironment() {
+        cluster.createNamespace(TestConstants.CO_NAMESPACE);
+        StUtils.copyImagePullSecrets(TestConstants.CO_NAMESPACE);
+    }
+
+    @AfterEach
+    void afterEach() {
+        deleteInstalledYamls(coDir, TestConstants.CO_NAMESPACE);
+        NamespaceUtils.deleteNamespaceWithWait(CO_NAMESPACE);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -2,14 +2,18 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest.upgrade;
+package io.strimzi.systemtest.upgrade.kraft;
 
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
+import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
@@ -22,48 +26,43 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import io.strimzi.systemtest.upgrade.VersionModificationDataLoader.ModificationType;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
-import static io.strimzi.systemtest.TestConstants.UPGRADE;
+import static io.strimzi.systemtest.TestConstants.KRAFT_UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * This test class contains tests for Strimzi upgrade from version X to version X + 1.
- * Metadata for upgrade procedure are available in resource file StrimziUpgrade.json
- * Kafka upgrade is done as part of those tests as well, but the tests for Kafka upgrade/downgrade are in {@link KafkaUpgradeDowngradeST}.
+ * Class for testing upgrade process of Strimzi with its components when running in KRaft mode
+ *      -> KRaft to KRaft upgrades
+ * Metadata for the following tests are collected from systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
  */
-@Tag(UPGRADE)
-@KRaftNotSupported("Strimzi and Kafka upgrade is not supported with KRaft mode")
-public class StrimziUpgradeST extends AbstractUpgradeST {
+@Tag(KRAFT_UPGRADE)
+public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
-    private static final Logger LOGGER = LogManager.getLogger(StrimziUpgradeST.class);
-    private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersions();
+    private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziUpgradeST.class);
+    private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersionsForKRaft();
 
     @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>) ")
-    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeData")
+    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeDataForKRaft")
     @Tag(INTERNAL_CLIENTS_USED)
     void testUpgradeStrimziVersion(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws Exception {
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(upgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(upgradeData.getEnvMaxK8sVersion()));
 
-        LOGGER.debug("Running upgrade test from version {} to {} (FG: {} -> {})",
-                fromVersion, toVersion, fgBefore, fgAfter);
         performUpgrade(upgradeData, extensionContext);
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeKafkaWithoutVersion(ExtensionContext extensionContext) throws IOException {
         UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
         upgradeKafkaVersion.setVersion(null);
@@ -73,9 +72,9 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
 
-        Map<String, String> zooSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, zkSelector);
-        Map<String, String> kafkaSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, zkSelector);
-        Map<String, String> eoSnapshot = DeploymentUtils.depSnapshot(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName));
+        Map<String, String> controllerSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
+        Map<String, String> brokerSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+        Map<String, String> eoSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, eoSelector);
 
         // Make snapshots of all Pods
         makeSnapshots();
@@ -83,23 +82,28 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Upgrade CO
         changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
 
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
 
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, zkSelector, 3, zooSnapshot);
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, zkSelector, 3, kafkaSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerSnapshot);
         DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoSnapshot);
 
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
         checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
 
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
-        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0)), containsString(acrossUpgradeData.getProcedures().getVersion()));
+
+        String controllerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
+        String brokerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
+
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(controllerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(brokerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeAcrossVersionsWithUnsupportedKafkaVersion(ExtensionContext extensionContext) throws IOException {
         TestStorage testStorage = new TestStorage(extensionContext);
         UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
@@ -112,42 +116,58 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
         // Upgrade CO
         changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
-        logPodImages(clusterName);
-        //  Upgrade kafka
-        changeKafkaAndLogFormatVersion(acrossUpgradeData, extensionContext);
-        logPodImages(clusterName);
+
+        waitForKafkaClusterRollingUpdate();
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
+        // Upgrade kafka
+        changeKafkaAndMetadataVersion(acrossUpgradeData, true, extensionContext);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
         checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeAcrossVersionsWithNoKafkaVersion(ExtensionContext extensionContext) throws IOException {
         TestStorage testStorage = new TestStorage(extensionContext);
+
         // Setup env
         setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, testStorage, null, TestConstants.CO_NAMESPACE);
+
         // Upgrade CO
         changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+
         // Wait till first upgrade finished
-        zkPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, zkSelector, 3, zkPods);
-        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, kafkaSelector, 3, kafkaPods);
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerPods);
         eoPods = DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
 
         LOGGER.info("Rolling to new images has finished!");
-        logPodImages(clusterName);
-        //  Upgrade kafka
-        changeKafkaAndLogFormatVersion(acrossUpgradeData, extensionContext);
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
+
+        // Upgrade kafka
+        changeKafkaAndMetadataVersion(acrossUpgradeData, extensionContext);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
         checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+
         // Verify upgrade
         verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
     }
 
-    @Test
+    @IsolatedTest
     void testUpgradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
         final TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
         final UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(acrossUpgradeData.getDefaultKafka());
@@ -157,6 +177,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
     private void performUpgrade(BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws IOException {
         TestStorage testStorage = new TestStorage(extensionContext);
+
         // leave empty, so the original Kafka version from appropriate Strimzi's yaml will be used
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion();
 
@@ -164,21 +185,26 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         setupEnvAndUpgradeClusterOperator(extensionContext, upgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
 
         // Upgrade CO to HEAD
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
+
         changeClusterOperator(upgradeData, TestConstants.CO_NAMESPACE, extensionContext);
 
         if (TestKafkaVersion.supportedVersionsContainsVersion(upgradeData.getDefaultKafkaVersionPerStrimzi())) {
             waitForKafkaClusterRollingUpdate();
         }
 
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
+
         // Upgrade kafka
-        changeKafkaAndLogFormatVersion(upgradeData, extensionContext);
-        logPodImages(clusterName);
+        changeKafkaAndMetadataVersion(upgradeData, extensionContext);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
         checkAllImages(upgradeData, TestConstants.CO_NAMESPACE);
 
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+
         // Verify upgrade
         verifyProcedure(upgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
     }
@@ -195,6 +221,6 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         KafkaTopicUtils.waitForTopicWithPrefixDeletion(TestConstants.CO_NAMESPACE, topicName);
 
         ResourceManager.getInstance().deleteResources(extensionContext);
-        NamespaceUtils.deleteNamespaceWithWait(CO_NAMESPACE);
+        NamespaceUtils.deleteNamespaceWithWait(TestConstants.CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -196,7 +196,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         logPodImages(TestConstants.CO_NAMESPACE);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(upgradeData, extensionContext);
+        changeKafkaAndMetadataVersion(upgradeData, true, extensionContext);
 
         logPodImages(TestConstants.CO_NAMESPACE);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest.upgrade;
+package io.strimzi.systemtest.upgrade.regular;
 
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -16,6 +16,7 @@ import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest.upgrade;
+package io.strimzi.systemtest.upgrade.regular;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.strimzi.api.kafka.model.KafkaResources;
@@ -17,6 +17,9 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.operator.configuration.OlmConfiguration;
 import io.strimzi.systemtest.resources.operator.configuration.OlmConfigurationBuilder;
 import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
+import io.strimzi.systemtest.upgrade.OlmVersionModificationData;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
@@ -139,9 +142,9 @@ public class OlmUpgradeST extends AbstractUpgradeST {
         // ======== Cluster Operator upgrade ends ========
 
         // ======== Kafka upgrade starts ========
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
         changeKafkaAndLogFormatVersion(olmUpgradeData, extensionContext);
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
         // ======== Kafka upgrade ends ========
 
         // Wait for messages of previously created clients

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -2,11 +2,15 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.systemtest.upgrade;
+package io.strimzi.systemtest.upgrade.regular;
 
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
+import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
+import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -71,12 +75,12 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
         // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
         // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
         setupEnvAndUpgradeClusterOperator(extensionContext, downgradeData, testStorage, testUpgradeKafkaVersion, TestConstants.CO_NAMESPACE);
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
         // Downgrade CO
         changeClusterOperator(downgradeData, TestConstants.CO_NAMESPACE, extensionContext);
         // Wait for Kafka cluster rolling update
         waitForKafkaClusterRollingUpdate();
-        logPodImages(clusterName);
+        logPodImages(TestConstants.CO_NAMESPACE);
         // Verify that pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         checkAllImages(downgradeData, TestConstants.CO_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.upgrade.regular;
+
+import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.KRaftNotSupported;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
+import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
+import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
+import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.NamespaceUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import io.strimzi.systemtest.upgrade.VersionModificationDataLoader.ModificationType;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
+import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
+import static io.strimzi.systemtest.TestConstants.UPGRADE;
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * This test class contains tests for Strimzi upgrade from version X to version X + 1.
+ * Metadata for upgrade procedure are available in resource file StrimziUpgrade.json
+ * Kafka upgrade is done as part of those tests as well, but the tests for Kafka upgrade/downgrade are in {@link KafkaUpgradeDowngradeST}.
+ */
+@Tag(UPGRADE)
+@KRaftNotSupported("Strimzi and Kafka upgrade is not supported with KRaft mode")
+public class StrimziUpgradeST extends AbstractUpgradeST {
+
+    private static final Logger LOGGER = LogManager.getLogger(StrimziUpgradeST.class);
+    private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersions();
+
+    @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>) ")
+    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeData")
+    @Tag(INTERNAL_CLIENTS_USED)
+    void testUpgradeStrimziVersion(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws Exception {
+        assumeTrue(StUtils.isAllowOnCurrentEnvironment(upgradeData.getEnvFlakyVariable()));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(upgradeData.getEnvMaxK8sVersion()));
+
+        LOGGER.debug("Running upgrade test from version {} to {} (FG: {} -> {})",
+                fromVersion, toVersion, fgBefore, fgAfter);
+        performUpgrade(upgradeData, extensionContext);
+    }
+
+    @Test
+    void testUpgradeKafkaWithoutVersion(ExtensionContext extensionContext) throws IOException {
+        UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
+        upgradeKafkaVersion.setVersion(null);
+
+        TestStorage testStorage = new TestStorage(extensionContext);
+
+        // Setup env
+        setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+
+        Map<String, String> zooSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, zkSelector);
+        Map<String, String> kafkaSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, kafkaSelector);
+        Map<String, String> eoSnapshot = DeploymentUtils.depSnapshot(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName));
+
+        // Make snapshots of all Pods
+        makeSnapshots();
+
+        // Upgrade CO
+        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, zkSelector, 3, zooSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, kafkaSelector, 3, kafkaSnapshot);
+        DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoSnapshot);
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+
+        // Verify that Pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        // Verify upgrade
+        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0)), containsString(acrossUpgradeData.getProcedures().getVersion()));
+    }
+
+    @Test
+    void testUpgradeAcrossVersionsWithUnsupportedKafkaVersion(ExtensionContext extensionContext) throws IOException {
+        TestStorage testStorage = new TestStorage(extensionContext);
+        UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
+
+        // Setup env
+        setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+
+        // Make snapshots of all Pods
+        makeSnapshots();
+
+        // Upgrade CO
+        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+        logPodImages(TestConstants.CO_NAMESPACE);
+        //  Upgrade kafka
+        changeKafkaAndLogFormatVersion(acrossUpgradeData, extensionContext);
+        logPodImages(TestConstants.CO_NAMESPACE);
+        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        // Verify that Pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        // Verify upgrade
+        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+    }
+
+    @Test
+    void testUpgradeAcrossVersionsWithNoKafkaVersion(ExtensionContext extensionContext) throws IOException {
+        TestStorage testStorage = new TestStorage(extensionContext);
+        // Setup env
+        setupEnvAndUpgradeClusterOperator(extensionContext, acrossUpgradeData, testStorage, null, TestConstants.CO_NAMESPACE);
+        // Upgrade CO
+        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+        // Wait till first upgrade finished
+        zkPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, zkSelector, 3, zkPods);
+        kafkaPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, kafkaSelector, 3, kafkaPods);
+        eoPods = DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
+
+        LOGGER.info("Rolling to new images has finished!");
+        logPodImages(TestConstants.CO_NAMESPACE);
+        //  Upgrade kafka
+        changeKafkaAndLogFormatVersion(acrossUpgradeData, extensionContext);
+        logPodImages(TestConstants.CO_NAMESPACE);
+        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        // Verify that Pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        // Verify upgrade
+        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+    }
+
+    @Test
+    void testUpgradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
+        final TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
+        final UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(acrossUpgradeData.getDefaultKafka());
+
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(extensionContext, acrossUpgradeData, testStorage, upgradeKafkaVersion);
+    }
+
+    private void performUpgrade(BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws IOException {
+        TestStorage testStorage = new TestStorage(extensionContext);
+        // leave empty, so the original Kafka version from appropriate Strimzi's yaml will be used
+        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion();
+
+        // Setup env
+        setupEnvAndUpgradeClusterOperator(extensionContext, upgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+
+        // Upgrade CO to HEAD
+        logPodImages(TestConstants.CO_NAMESPACE);
+        changeClusterOperator(upgradeData, TestConstants.CO_NAMESPACE, extensionContext);
+
+        if (TestKafkaVersion.supportedVersionsContainsVersion(upgradeData.getDefaultKafkaVersionPerStrimzi())) {
+            waitForKafkaClusterRollingUpdate();
+        }
+
+        logPodImages(TestConstants.CO_NAMESPACE);
+        // Upgrade kafka
+        changeKafkaAndLogFormatVersion(upgradeData, extensionContext);
+        logPodImages(TestConstants.CO_NAMESPACE);
+        checkAllImages(upgradeData, TestConstants.CO_NAMESPACE);
+
+        // Verify that Pods are stable
+        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        // Verify upgrade
+        verifyProcedure(upgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+    }
+
+    @BeforeEach
+    void setupEnvironment() {
+        cluster.createNamespace(TestConstants.CO_NAMESPACE);
+        StUtils.copyImagePullSecrets(TestConstants.CO_NAMESPACE);
+    }
+
+    protected void afterEachMayOverride(ExtensionContext extensionContext) {
+        // delete all topics created in test
+        cmdKubeClient(TestConstants.CO_NAMESPACE).deleteAllByResource(KafkaTopic.RESOURCE_KIND);
+        KafkaTopicUtils.waitForTopicWithPrefixDeletion(TestConstants.CO_NAMESPACE, topicName);
+
+        ResourceManager.getInstance().deleteResources(extensionContext);
+        NamespaceUtils.deleteNamespaceWithWait(CO_NAMESPACE);
+    }
+}

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -70,3 +70,4 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   featureGatesBefore: "-KafkaNodePools"
+  featureGatesAfter: ""


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds STs for KRaft to KRaft upgrades/downgrades.
I decided to make a copy of our current tests that we have in our suite and create new package `kraft` for the KRaft to KRaft STs. As part of that, I moved the "regular" tests into the `regular` package.

As for the regular tests, for KRaft upgrades/downgrades I'm using the `AbstractKRaftUpgradeST` class, which extends the `AbstractUpgradeST`. To keep the methods same as much as possible, I moved some parts to separate methods, which are then overriden in the `AbstractKRaftUpgradeST`. So even if we are executing some method in the `AbstractUpgradeST`, if there is some method in the `AbstractKRaftUpgradeST` that overrides it, the test uses that one.

`KRaftKafkaUpgradeDowngradeST` works as expected, it does testing of just Kafka upgrade/downgrade. The two classes that are testing the Strimzi & Kafka upgrades/downgrades are implemented as well, the `KRaftStrimziUpgradeST` works, but the `KRaftStrimziDowngradeST` is currently disabled, as `0.38.0` version of Strimzi doesn't support KRaft to KRaft upgrades/downgrades, so that scenario will not currently work. But after `0.39.0` is released, it should be enabled -> and from my testing the tests inside the downgrade suite should work.

As part of this PR I'm changing few classes regarding Kafka version (adding the `metadataVersion`), loaders for the upgrade/downgrade tests (possibility to specify "always enabled" FG -> used for KRaft, UTO, and KafkaNodePools FGs), 
and also adding some helper methods for the NodePools creation to the templates or LabelSelector for getting Pods for particular NodePool.

Finally, I'm adding these STs to AZP and updating our `pom.xml` with `kraft_upgrade` profile + adding `KRaftKafkaUpgradeDowngradeST` to `azp_kafka_upgrade` profile.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass


