### PR TITLE
Improve KafkaQuorumCheckTest test coverage

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -70,7 +70,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -70,6 +70,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -702,6 +703,33 @@ public class KafkaRollerTest {
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8), // brokers, combined, controllers
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
+    }
+
+    @Test
+    public void testRollbackAfterFailedRestart(VertxTestContext context) {
+        // Mock PodOperator to simulate pod restart behavior
+        PodOperator podOps = mockPodOps(podId -> {
+            if (podId == 1) {
+                // Simulate failure for pod 1 leading to a rollback requirement
+                return failedFuture(new RuntimeException("Failed restart"));
+            } else {
+                return succeededFuture();
+            }
+        });
+
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(null, null, addPodNames(REPLICAS), podOps,
+                noException(), null, noException(), noException(), noException(),
+                brokerId -> succeededFuture(true), false, new DefaultAdminClientProvider(), false, null, 2);
+
+        // Start rolling restart
+        kafkaRoller.rollingRestart(pod -> RestartReasons.of(RestartReason.MANUAL_ROLLING_UPDATE))
+                .onComplete(context.failing(e -> context.verify(() -> {
+                    // Assert that rollback was triggered due to failure
+                    assertTrue(e instanceof KafkaRoller.ForceableProblem);
+                    assertEquals("Failed restart", e.getMessage());
+                    // Further assertions to check the rollback state
+                    context.completeNow();
+                })));
     }
 
     private TestingKafkaRoller rollerWithControllers(PodOperator podOps, int... controllers) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

During my testing of KafkaRoller, I spotted a few test cases which could improve test coverage but such test cases would not make any sense at the system level so I have managed to write some UTs inside `KafkaQuorumCheckTest.java`. I don't want such a change to be inside my KafkaRoller STs PR, so created a separate PR for it.

### Checklist

- [x] Make sure all tests pass


