### PR TITLE
Added DCO information on the contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,36 @@ If you want to get in touch with us first before contributing, you can use:
 - [#strimzi channel on CNCF Slack](https://slack.cncf.io/)
 - [Strimzi Dev mailing list](https://lists.cncf.io/g/cncf-strimzi-dev/topics)
 
+## Developer Certificate Of Origin
+
+The [Developer Certificate of Origin (DCO)][dco] is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+
+Contributors to the Strimzi project sign-off that they adhere to these requirements by adding a Signed-off-by line to commit messages.
+
+```shell
+This is my commit message
+
+Signed-off-by: John Doe <JohnDoe@somewhere.org>
+```
+
+Git even has a -s command line option to append this automatically to your commit message:
+
+```shell
+git commit -s -m 'This is my commit message'
+```
+
+If you have already made a commit and forgot to include the sign-off, you can amend your last commit to add the sign-off with the following command, which can then be force pushed.
+
+```shell
+git commit --amend -s
+```
+
 [issues]: https://github.com/strimzi/strimzi-kafka-operator/issues
 [newbie-issues]: https://github.com/strimzi/strimzi-kafka-operator/labels/good-start
 [development-guide]: development-docs/DEV_GUIDE.md
 [release-list]: development-docs/RELEASE.md
 [doc-contrib-guide]: https://strimzi.io/contributing/guide/
+[dco]: https://developercertificate.org/
 
 # How to become a maintainer
 


### PR DESCRIPTION
While working on the due diligence for incubation proposal, it seems we are missing information about the need for DCO on our Contributing page.
I have got some content from the OpenFeature repo which seems to cover it pretty well.