### PR TITLE
Add support for Kafka 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.39.0
 
-* Add support for Apache Kafka 3.6.1
+* Add support for Apache Kafka 3.5.2 and 3.6.1
 * The `StableConnectIdentities` feature gate moves to GA stage and is now permanently enabled without the possibility to disable it.
   All Connect and Mirror Maker 2 operands will now use StrimziPodSets.
 * The `KafkaNodePools` feature gate moves to beta stage and is enabled by default.

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -8,6 +8,7 @@
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.5.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.5.1
+* {DockerOrg}/kafka:{DockerTag}-kafka-3.5.2
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.1
 

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -8,6 +8,7 @@
 |Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
 | 3.5.0 | 3.5 | 3.5 | 3.6.4
 | 3.5.1 | 3.5 | 3.5 | 3.6.4
+| 3.5.2 | 3.5 | 3.5 | 3.6.4
 | 3.6.0 | 3.6 | 3.6 | 3.8.2
 | 3.6.1 | 3.6 | 3.6 | 3.8.3
 |=================

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -275,6 +275,16 @@
   third-party-libs: 3.5.x
   supported: true
   default: false
+- version: 3.5.2
+  format: 3.5
+  protocol: 3.5
+  metadata: 3.5
+  url: https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz
+  checksum: 229CCC5E3E6B3B9845F59F6E829D70711C5A5A2293F32B6BCABC37350666F874BC7D8F08130F712A1B32915205C10F2847F04908C20D5F7FDB4B62D058C9DEFE
+  zookeeper: 3.6.4
+  third-party-libs: 3.5.x
+  supported: true
+  default: false
 - version: 3.6.0
   format: 3.6
   protocol: 3.6

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -15,24 +15,28 @@
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.0")) }}
                 3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.1")) }}
+                3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.1")) }}
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -57,24 +57,28 @@ spec:
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
                 3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
+                3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for Kafka 3.5.2 that brings various bugfixes.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md