### PR TITLE
Update Cruise Control and Kaniko versions

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.128</cruise-control.version>
+        <cruise-control.version>2.5.132</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.128</cruise-control.version>
+        <cruise-control.version>2.5.132</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.128</cruise-control.version>
+        <cruise-control.version>2.5.132</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.18.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.19.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -76,7 +76,7 @@ public class CruiseControlApiST extends AbstractST {
         response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REBALANCE,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/rebalance'\n" +
-            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD, PERMISSIONS]\n"));
 
         LOGGER.info("Waiting for CC will have for enough metrics to be recorded to make a proposal ");
         CruiseControlUtils.waitForRebalanceEndpointIsReady(testStorage.getNamespaceName());
@@ -93,7 +93,7 @@ public class CruiseControlApiST extends AbstractST {
         response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/stop_proposal_execution'\n" +
-            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD, PERMISSIONS]\n"));
 
         response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.POST, CruiseControlEndpoints.STOP, CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
@@ -167,12 +167,12 @@ public class CruiseControlApiST extends AbstractST {
         String response = CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.ADD_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/add_broker'\n" +
-            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD, PERMISSIONS]\n"));
 
         response =  CruiseControlUtils.callApi(testStorage.getNamespaceName(), CruiseControlUtils.SupportedHttpMethods.GET, CruiseControlEndpoints.REMOVE_BROKER,  CruiseControlUtils.SupportedSchemes.HTTPS, true);
 
         assertThat(response, is("Unrecognized endpoint in request '/remove_broker'\n" +
-            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD]\n"));
+            "Supported GET endpoints: [BOOTSTRAP, TRAIN, LOAD, PARTITION_LOAD, PROPOSALS, STATE, KAFKA_CLUSTER_STATE, USER_TASKS, REVIEW_BOARD, PERMISSIONS]\n"));
 
         LOGGER.info("Waiting for CC will have for enough metrics to be recorded to make a proposal ");
         CruiseControlUtils.waitForRebalanceEndpointIsReady(testStorage.getNamespaceName());


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kaniko and Cruise Control versions to have them up to date as we are getting closer to a possible release date.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally