### PR TITLE
Overriding gauva version in kafka-thirdparty-libs

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -28,6 +28,7 @@
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+        <guava.version>32.1.3-jre</guava.version>
     </properties>
 
     <repositories>
@@ -53,6 +54,11 @@
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -28,6 +28,7 @@
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.19.0</opentelemetry.version>
         <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+        <guava.version>32.1.3-jre</guava.version>
     </properties>
 
     <repositories>
@@ -53,6 +54,14 @@
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!--
+            Override guava version coming from org.openpolicyagent.kafka:opa-authorizer
+            -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixing CVE-2023-2976 and CVE-2020-8908

### Type of change

- Bugfix

### Description

guava cve fix of kafka images

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

