### PR TITLE
[system test] - KafkaRollerST managing rolling updates across mixed, broker, and controller node

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -163,7 +163,7 @@ public class ResourceManager {
     }
 
     @SafeVarargs
-    private final <T extends HasMetadata> void createResource(ExtensionContext testContext, boolean waitReady, T... resources) {
+    private <T extends HasMetadata> void createResource(ExtensionContext testContext, boolean waitReady, T... resources) {
         for (T resource : resources) {
             ResourceType<T> type = findResourceType(resource);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -12,7 +12,6 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
-import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.systemtest.TestConstants;
 
 import java.time.Duration;
@@ -29,7 +28,6 @@ public class ResourceOperation {
 
         switch (kind) {
             case Kafka.RESOURCE_KIND:
-            case KafkaNodePool.RESOURCE_KIND:
                 timeout = Duration.ofMinutes(14).toMillis();
                 break;
             case KafkaConnect.RESOURCE_KIND:

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.api.kafka.model.balancing.KafkaRebalanceState;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.systemtest.TestConstants;
 
 import java.time.Duration;
@@ -28,6 +29,7 @@ public class ResourceOperation {
 
         switch (kind) {
             case Kafka.RESOURCE_KIND:
+            case KafkaNodePool.RESOURCE_KIND:
                 timeout = Duration.ofMinutes(14).toMillis();
                 break;
             case KafkaConnect.RESOURCE_KIND:

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -21,7 +21,6 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,12 +70,7 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
 
     @Override
     public boolean waitForReadiness(KafkaNodePool resource) {
-        final LabelSelector kafkaNodePoolSelector = KafkaNodePoolResource.getLabelSelector(resource.getMetadata().getName(), resource.getSpec().getRoles().get(0));
-
-        // here we wait for readiness of the Kafka pods related to KafkaNodePools
-        PodUtils.waitForPodsReady(resource.getMetadata().getNamespace(), kafkaNodePoolSelector, resource.getSpec().getReplicas(), true);
-
-        return true;
+        return resource != null;
     }
 
     public static MixedOperation<KafkaNodePool, KafkaNodePoolList, Resource<KafkaNodePool>> kafkaNodePoolClient() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -453,10 +453,11 @@ public class KafkaRollerST extends AbstractST {
 
         final Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1, 1).build();
         final KafkaNodePool mixedPool = KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(mixedPoolName, kafka, mixedPoolReplicas).build();
-
-        resourceManager.createResourceWithWait(extensionContext, mixedPool, kafka);
-
         final LabelSelector mixedPoolSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), mixedPoolName, ProcessRoles.CONTROLLER);
+
+        resourceManager.createResourceWithoutWait(extensionContext, mixedPool, kafka);
+
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), mixedPoolSelector, mixedPoolReplicas, true);
 
         Map<String, String> mixedPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), mixedPoolSelector);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -339,7 +339,7 @@ public class KafkaRollerST extends AbstractST {
      *
      * @steps
      *  1. - Assume that KRaft mode is enabled and the installation method is bundle only.
-     *  2. - Create and deploy a Kafka node pool with broker roles (brokerPool) and another with controller roles (controllerPool), each with 3 replicas.
+     *  2. - Create and deploy a Kafka node pool with broker role (brokerPool) and another with controller role (controllerPool), each with 3 replicas.
      *  3. - Take snapshots of the broker and controller pods for later comparison.
      *  4. - Update a specific Kafka configuration that affects only controller nodes and verify the rolling update behavior.
      *     - Ensure that only controller nodes undergo a rolling update, while broker nodes remain unaffected.
@@ -379,7 +379,7 @@ public class KafkaRollerST extends AbstractST {
         Map<String, String> brokerPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), brokerPoolSelector);
         Map<String, String> controllerPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), controllerPoolSelector);
 
-        // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only mixed and controller pods rolls
+        // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only controller pods rolls
         KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "controller.quorum.election.timeout.ms", 10000);
 
         // only controller-role nodes rolls
@@ -422,7 +422,6 @@ public class KafkaRollerST extends AbstractST {
 
         // Verify that broker nodes do not roll due to the controller node pool affinity change
         RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), brokerPoolSelector, brokerPoolPodsSnapshot);
-
     }
 
     /**
@@ -461,7 +460,7 @@ public class KafkaRollerST extends AbstractST {
 
         Map<String, String> mixedPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), mixedPoolSelector);
 
-        // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only mixed and controller pods rolls
+        // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that all mixed pods rolls
         KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "controller.quorum.fetch.timeout.ms", 10000);
 
         // all mixed nodes rolls

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -326,8 +326,27 @@ public class KafkaRollerST extends AbstractST {
         KafkaUtils.waitForKafkaDeletion(namespaceName, clusterName);
     }
 
+    /**
+     * @description This test case examines the behavior of Kafka rollers under various node pool configurations, focusing on how rolling updates are triggered or prevented in different scenarios.
+     *
+     * @steps
+     *  1. - Initialize test environment and create node pools with different roles (mixed, broker, controller) and varying replica counts.
+     *     - Create Kafka instance with a single replica and deploy mixed node pool 'A' with 1 replica.
+     *  2. - Deploy two additional broker node pools 'B1' and 'B2' with 1 and 2 replicas, respectively.
+     *     - Verify that the creation of these broker nodes does not trigger a rolling update in the existing node pool 'A'.
+     *  3. - In KRaft mode, deploy two controller node pools 'C1' and 'C2' with 2 and 1 replicas, respectively.
+     *     - Expect a rolling update for mixed-role and broker-role nodes, but not for the controller nodes initially.
+     *  4. - After creating controller node pools, verify rolling updates across different node pools as they adjust to the new configuration.
+     *     - Check that the controller nodes roll only when their specific pool is modified.
+     *  5. - Change controller-only configuration and verify that only mixed and controller node pools are affected, while broker nodes remain unchanged.
+     *  6. - Modify broker-only configuration and observe that only mixed-role and broker-role node pools roll, leaving controller-role nodes unaffected.
+     *
+     * @usecase
+     *  - kafka-node-pool-rolling-update
+     *  - kafka-roller
+     *  - kafka-configuration-management
+     */
     @ParallelNamespaceTest
-    @SuppressWarnings({"checkstyle:MethodLength"})
     void testKafkaRollerBehaviorUnderVariousScenarios(ExtensionContext extensionContext) {
         final TestStorage testStorage = new TestStorage(extensionContext);
         final String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -453,7 +453,7 @@ public class KafkaRollerST extends AbstractST {
         // ######################################################################################################################################################
 
         // ii. change broker-only configuration so broker/mixed nodes will roll but controllers nodes will not!
-        KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "jakub.is.best", "true");
+        KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "broker.only.configuration", "true");
 
         // only mixed-role and broker-role nodes rolls
         kafkaPoolAPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -14,12 +14,20 @@ import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
 import io.strimzi.api.kafka.model.KafkaTopic;
 import io.strimzi.api.kafka.model.StrimziPodSet;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolTemplate;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolTemplateBuilder;
+import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplateBuilder;
 import io.strimzi.api.kafka.model.template.PodTemplate;
+import io.strimzi.api.kafka.model.template.PodTemplateBuilder;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.TestConstants;
@@ -33,11 +41,13 @@ import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.kafkaUtils.KafkaNodePoolUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -63,6 +73,7 @@ import static io.strimzi.systemtest.k8s.Events.Started;
 import static io.strimzi.systemtest.matchers.Matchers.hasAllOfReasons;
 import static io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils.waitForPodsReady;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -321,6 +332,129 @@ public class KafkaRollerST extends AbstractST {
         KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
         KafkaUtils.waitForKafkaDeletion(namespaceName, clusterName);
     }
+
+    @ParallelNamespaceTest
+    void testKafkaRollerBehaviorUnderVariousScenarios(ExtensionContext extensionContext) {
+        final TestStorage testStorage = new TestStorage(extensionContext);
+        final String nodePoolNameA = testStorage.getKafkaNodePoolName() + "-a";
+        final String nodePoolNameB1 = testStorage.getKafkaNodePoolName() + "-b1";
+        final String nodePoolNameB2 = testStorage.getKafkaNodePoolName() + "-b2";
+        final String nodePoolNameC1 = testStorage.getKafkaNodePoolName() + "-c1";
+        final String nodePoolNameC2 = testStorage.getKafkaNodePoolName() + "-c2";
+
+        final int mixedPoolAReplicas = 1, brokerPoolB1Replicas = 1, brokerPoolB2Replicas = 2, controllerPoolC1Replicas = 2, controllerPoolC2Replicas = 1;
+
+        final Kafka kafka = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1, 1).build();
+        final KafkaNodePool mixedPoolA = KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(nodePoolNameA, kafka, mixedPoolAReplicas).build();
+
+        resourceManager.createResourceWithWait(extensionContext, mixedPoolA, kafka);
+
+        final LabelSelector kafkaPoolASelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameA, ProcessRoles.CONTROLLER);
+        Map<String, String> kafkaPoolAPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaPoolASelector);
+
+        final KafkaNodePool brokerPoolB1 = KafkaNodePoolTemplates.kafkaBasedNodePoolWithBrokerRole(nodePoolNameB1, kafka, brokerPoolB1Replicas).build();
+        final KafkaNodePool brokerPoolB2 = KafkaNodePoolTemplates.kafkaBasedNodePoolWithBrokerRole(nodePoolNameB2, kafka, brokerPoolB2Replicas).build();
+
+        // TODO: I pod has old revision need to roll make this track D:
+
+        resourceManager.createResourceWithWait(extensionContext, brokerPoolB1);
+        resourceManager.createResourceWithWait(extensionContext, brokerPoolB2);
+
+        if (Environment.isKRaftModeEnabled()) {
+            final KafkaNodePool controllerPoolC1 = KafkaNodePoolTemplates.kafkaBasedNodePoolWithControllerRole(nodePoolNameC1, kafka, controllerPoolC1Replicas).build();
+            final KafkaNodePool controllerPoolC2 = KafkaNodePoolTemplates.kafkaBasedNodePoolWithControllerRole(nodePoolNameC2, kafka, controllerPoolC2Replicas).build();
+
+            resourceManager.createResourceWithWait(extensionContext, controllerPoolC1);
+            resourceManager.createResourceWithWait(extensionContext, controllerPoolC2);
+        }
+
+        // for KNP A Controller/Broker role it does not matter in this case
+        final LabelSelector kafkaPoolB1Selector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameB1, ProcessRoles.BROKER);
+        final LabelSelector kafkaPoolB2Selector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameB2, ProcessRoles.BROKER);
+        final LabelSelector kafkaPoolC1Selector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameC1, ProcessRoles.CONTROLLER);
+        final LabelSelector kafkaPoolC2Selector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), nodePoolNameC2, ProcessRoles.CONTROLLER);
+
+        Map<String, String> kafkaPoolB1PodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaPoolB1Selector);
+        Map<String, String> kafkaPoolB2PodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaPoolB2Selector);
+        Map<String, String> kafkaPoolC1PodsSnapshot  = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaPoolC1Selector);
+        Map<String, String> kafkaPoolC2PodsSnapshot  = PodUtils.podSnapshot(testStorage.getNamespaceName(), kafkaPoolC2Selector);
+
+        // 1 Test Scenario, where we change configuration only when +UseKRaft
+        if (Environment.isKRaftModeEnabled()) {
+            // i.) change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only mixed and controller pods rolls
+            // ######################################################################################################################################################
+            KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "controller.quorum.election.backoff.max.ms", 10000);
+
+            // only mixed-role and controller-role nodes rolls
+            kafkaPoolAPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                    kafkaPoolASelector, mixedPoolAReplicas, kafkaPoolAPodsSnapshot);
+
+            // then controller-role
+            kafkaPoolC1PodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                    kafkaPoolC1Selector, controllerPoolC1Replicas, kafkaPoolC1PodsSnapshot);
+            kafkaPoolC2PodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                    kafkaPoolC2Selector, controllerPoolC2Replicas, kafkaPoolC2PodsSnapshot);
+
+            // broker-role nodes does not roll
+            RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), kafkaPoolB1Selector, kafkaPoolB1PodsSnapshot);
+            RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), kafkaPoolB2Selector, kafkaPoolB2PodsSnapshot);
+        }
+
+        // ######################################################################################################################################################
+
+        // ii. change broker-only configuration so broker/mixed nodes will roll but controllers nodes will not!
+        KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "jakub.is.best", "true");
+
+        // only mixed-role and broker-role nodes rolls
+        kafkaPoolAPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                kafkaPoolASelector, mixedPoolAReplicas, kafkaPoolAPodsSnapshot);
+
+        // then broker-role
+        kafkaPoolB1PodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                kafkaPoolB1Selector, controllerPoolC1Replicas, kafkaPoolB1PodsSnapshot);
+        kafkaPoolB2PodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(),
+                kafkaPoolB2Selector, controllerPoolC2Replicas, kafkaPoolB2PodsSnapshot);
+
+        if (Environment.isKRaftModeEnabled()) {
+            // controller-role nodes does not roll
+            RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), kafkaPoolC1Selector, kafkaPoolC1PodsSnapshot);
+            RollingUpdateUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), kafkaPoolC2Selector, kafkaPoolC2PodsSnapshot);
+        }
+
+        // ######################################################################################################################################################
+
+        // 2 Test Scenario, where we move a controllers pods to pending
+        NodeSelectorRequirement nsr = new NodeSelectorRequirementBuilder()
+            .withKey("dedicated_test")
+            .withOperator("In")
+            .withValues("Kafka")
+            .build();
+
+        KafkaNodePoolTemplate kafkaNodePoolTemplate = new KafkaNodePoolTemplateBuilder()
+            .withPod(new PodTemplateBuilder().withAffinity(new AffinityBuilder()
+                        .withNewNodeAffinity()
+                            .withNewRequiredDuringSchedulingIgnoredDuringExecution()
+                            .withNodeSelectorTerms(
+                                new NodeSelectorTermBuilder()
+                                    .withMatchExpressions(nsr)
+                                    .build())
+                            .endRequiredDuringSchedulingIgnoredDuringExecution()
+                        .endNodeAffinity()
+                        .build())
+                    .build())
+            .build();
+
+        KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(nodePoolNameC1, knp -> knp.getSpec().setTemplate(kafkaNodePoolTemplate), testStorage.getNamespaceName());
+
+        // pods are stable in the Pending state
+        PodUtils.waitUntilPodStabilityReplicasCount(testStorage.getNamespaceName(), KafkaNodePoolUtils.getKafkaNodePool(testStorage.getNamespaceName(), testStorage.getClusterName()).getMetadata().getName(), 3);
+
+        // TODO: make other thigs....
+    }
+
+    // TODO: make a test case where KafkaCR configuration is propagated to the KafkaNodePools (which does not have that specific conf:
+    //          i) for NodePools which has identical as KafkaCR - do nothing
+    //          ii) for NodePools which has not identical as KafkaCR - it would do something, probably trigger RollingUpdate i don't know...
 
     boolean checkIfExactlyOneKafkaPodIsNotReady(String namespaceName, String clusterName) {
         List<Pod> kafkaPods = kubeClient(namespaceName).listPodsByPrefixInName(KafkaResource.getStrimziPodSetName(clusterName));

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -374,7 +374,6 @@ public class KafkaRollerST extends AbstractST {
         Map<String, String> controllerPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), controllerPoolSelector);
 
         // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only mixed and controller pods rolls
-        // ######################################################################################################################################################
         KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "controller.quorum.election.timeout.ms", 10000);
 
         // only controller-role nodes rolls
@@ -423,7 +422,6 @@ public class KafkaRollerST extends AbstractST {
         Map<String, String> mixedPoolPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), mixedPoolSelector);
 
         // change Controller-only configuration inside shared Kafka configuration between KafkaNodePools and see that only mixed and controller pods rolls
-        // ######################################################################################################################################################
         KafkaUtils.updateSpecificConfiguration(testStorage.getNamespaceName(), testStorage.getClusterName(), "controller.quorum.fetch.timeout.ms", 10000);
 
         // all mixed nodes rolls


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adds a two test case:
1. testKafkaRollingUpdatesOfControllerNodes - verifies the rolling update behaviour of Kafka controller nodes under specific conditions. It ensures that changes in Kafka configuration and node pool properties affect only the intended node pools, particularly the controller nodes, while leaving others like broker nodes unaffected.
2. testKafkaRollingUpdatesOfMixedNodes - assesses the rolling update behaviour of Kafka nodes in mixed-role configurations.
The main focus is to verify that configuration changes impacting controller roles result in rolling updates of nodes serving mixed roles while ensuring compatibility with KRaft mode and excluding OLM or Helm installations.
### Checklist

- [x] Write tests
- [ ] Make sure all tests pass