### PR TITLE
Add current roles to the node pool status

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
@@ -23,7 +23,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "nodeIds", "clusterId", "replicas", "labelSelector" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "nodeIds", "clusterId", "roles", "replicas", "labelSelector" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolStatus extends Status {
@@ -31,6 +31,7 @@ public class KafkaNodePoolStatus extends Status {
 
     private List<Integer> nodeIds;
     private String clusterId;
+    private List<ProcessRoles> roles;
 
     // Replicas and label selector are required for scale subresource
     private int replicas;
@@ -52,6 +53,15 @@ public class KafkaNodePoolStatus extends Status {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    @Description("The roles currently assigned to this pool.")
+    public List<ProcessRoles> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<ProcessRoles> roles) {
+        this.roles = roles;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -302,6 +302,7 @@ public class KafkaPool extends AbstractModel {
         return new KafkaNodePoolStatusBuilder()
                 .withClusterId(clusterId)
                 .withNodeIds(new ArrayList<>(idAssignment.desired()))
+                .withRoles(processRoles.stream().sorted().toList())
                 .withReplicas(idAssignment.desired().size())
                 .withLabelSelector(getSelectorLabels().toSelectorString())
                 .withConditions(warningConditions)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/VirtualNodePoolConverter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/VirtualNodePoolConverter.java
@@ -57,6 +57,7 @@ public class VirtualNodePoolConverter {
                 .endSpec()
                 .withNewStatus()
                     .withNodeIds(nodeIds)
+                    .withRoles(ProcessRoles.BROKER)
                 .endStatus()
                 .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -176,10 +176,14 @@ public class KafkaClusterWithKRaftTest {
         assertThat(statuses.get("controllers").getLabelSelector(), is("strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-kafka,strimzi.io/kind=Kafka,strimzi.io/pool-name=controllers"));
         assertThat(statuses.get("controllers").getNodeIds().size(), is(3));
         assertThat(statuses.get("controllers").getNodeIds(), hasItems(0, 1, 2));
+        assertThat(statuses.get("controllers").getRoles().size(), is(1));
+        assertThat(statuses.get("controllers").getRoles(), hasItems(ProcessRoles.CONTROLLER));
         assertThat(statuses.get("brokers").getReplicas(), is(3));
         assertThat(statuses.get("brokers").getLabelSelector(), is("strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-kafka,strimzi.io/kind=Kafka,strimzi.io/pool-name=brokers"));
         assertThat(statuses.get("brokers").getNodeIds().size(), is(3));
         assertThat(statuses.get("brokers").getNodeIds(), hasItems(1000, 1001, 1002));
+        assertThat(statuses.get("brokers").getRoles().size(), is(1));
+        assertThat(statuses.get("brokers").getRoles(), hasItems(ProcessRoles.BROKER));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithPoolsTest.java
@@ -158,10 +158,14 @@ public class KafkaClusterWithPoolsTest {
         assertThat(statuses.get("pool-a").getLabelSelector(), is("strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-kafka,strimzi.io/kind=Kafka,strimzi.io/pool-name=pool-a"));
         assertThat(statuses.get("pool-a").getNodeIds().size(), is(3));
         assertThat(statuses.get("pool-a").getNodeIds(), hasItems(0, 1, 2));
+        assertThat(statuses.get("pool-a").getRoles().size(), is(1));
+        assertThat(statuses.get("pool-a").getRoles(), hasItems(ProcessRoles.BROKER));
         assertThat(statuses.get("pool-b").getReplicas(), is(2));
         assertThat(statuses.get("pool-b").getLabelSelector(), is("strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-kafka,strimzi.io/kind=Kafka,strimzi.io/pool-name=pool-b"));
         assertThat(statuses.get("pool-b").getNodeIds().size(), is(2));
         assertThat(statuses.get("pool-b").getNodeIds(), hasItems(10, 11));
+        assertThat(statuses.get("pool-b").getRoles().size(), is(1));
+        assertThat(statuses.get("pool-b").getRoles(), hasItems(ProcessRoles.BROKER));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaPoolTest.java
@@ -123,6 +123,8 @@ public class KafkaPoolTest {
         assertThat(status.getLabelSelector(), is("strimzi.io/cluster=my-cluster,strimzi.io/name=my-cluster-kafka,strimzi.io/kind=Kafka,strimzi.io/pool-name=pool"));
         assertThat(status.getNodeIds().size(), is(3));
         assertThat(status.getNodeIds(), hasItems(10, 11, 13));
+        assertThat(status.getRoles().size(), is(1));
+        assertThat(status.getRoles(), hasItems(ProcessRoles.BROKER));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/VirtualNodePoolConverterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/nodepools/VirtualNodePoolConverterTest.java
@@ -182,6 +182,8 @@ public class VirtualNodePoolConverterTest {
 
         // Status
         assertThat(pool.getStatus().getNodeIds(), is(nullValue()));
+        assertThat(pool.getStatus().getRoles().size(), is(1));
+        assertThat(pool.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
     }
 
     @Test
@@ -206,6 +208,8 @@ public class VirtualNodePoolConverterTest {
         // Status
         assertThat(pool.getStatus().getNodeIds().size(), is(3));
         assertThat(pool.getStatus().getNodeIds(), hasItems(0, 1, 2));
+        assertThat(pool.getStatus().getRoles().size(), is(1));
+        assertThat(pool.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
     }
 
     @Test
@@ -267,5 +271,7 @@ public class VirtualNodePoolConverterTest {
         // Status
         assertThat(pool.getStatus().getNodeIds().size(), is(3));
         assertThat(pool.getStatus().getNodeIds(), hasItems(0, 1, 2));
+        assertThat(pool.getStatus().getRoles().size(), is(1));
+        assertThat(pool.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
@@ -501,10 +501,14 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
                 KafkaNodePool poolA = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-a").get();
                 assertThat(poolA.getStatus().getReplicas(), is(2));
                 assertThat(poolA.getStatus().getNodeIds(), is(List.of(0, 1)));
+                assertThat(poolA.getStatus().getRoles().size(), is(1));
+                assertThat(poolA.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolB = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-b").get();
                 assertThat(poolB.getStatus().getReplicas(), is(2));
                 assertThat(poolB.getStatus().getNodeIds(), is(List.of(3, 4)));
+                assertThat(poolB.getStatus().getRoles().size(), is(1));
+                assertThat(poolB.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 async.flag();
             })));
@@ -543,10 +547,14 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
                 KafkaNodePool poolA = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-a").get();
                 assertThat(poolA.getStatus().getReplicas(), is(4));
                 assertThat(poolA.getStatus().getNodeIds(), is(List.of(0, 1, 2, 5)));
+                assertThat(poolA.getStatus().getRoles().size(), is(1));
+                assertThat(poolA.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolB = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-b").get();
                 assertThat(poolB.getStatus().getReplicas(), is(2));
                 assertThat(poolB.getStatus().getNodeIds(), is(List.of(3, 4)));
+                assertThat(poolB.getStatus().getRoles().size(), is(1));
+                assertThat(poolB.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 async.flag();
             })));
@@ -601,14 +609,20 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
                 KafkaNodePool poolA = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-a").get();
                 assertThat(poolA.getStatus().getReplicas(), is(3));
                 assertThat(poolA.getStatus().getNodeIds(), is(List.of(0, 1, 2)));
+                assertThat(poolA.getStatus().getRoles().size(), is(1));
+                assertThat(poolA.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolB = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-b").get();
                 assertThat(poolB.getStatus().getReplicas(), is(2));
                 assertThat(poolB.getStatus().getNodeIds(), is(List.of(3, 4)));
+                assertThat(poolB.getStatus().getRoles().size(), is(1));
+                assertThat(poolB.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolC = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-c").get();
                 assertThat(poolC.getStatus().getReplicas(), is(2));
                 assertThat(poolC.getStatus().getNodeIds(), is(List.of(5, 6)));
+                assertThat(poolC.getStatus().getRoles().size(), is(1));
+                assertThat(poolC.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 async.flag();
             })));
@@ -658,14 +672,20 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
                 KafkaNodePool poolA = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-a").get();
                 assertThat(poolA.getStatus().getReplicas(), is(3));
                 assertThat(poolA.getStatus().getNodeIds(), is(List.of(0, 1, 2)));
+                assertThat(poolA.getStatus().getRoles().size(), is(1));
+                assertThat(poolA.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolB = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-b").get();
                 assertThat(poolB.getStatus().getReplicas(), is(2));
                 assertThat(poolB.getStatus().getNodeIds(), is(List.of(3, 4)));
+                assertThat(poolB.getStatus().getRoles().size(), is(1));
+                assertThat(poolB.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 KafkaNodePool poolC = Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-c").get();
                 assertThat(poolC.getStatus().getReplicas(), is(2));
                 assertThat(poolC.getStatus().getNodeIds(), is(List.of(5, 6)));
+                assertThat(poolC.getStatus().getRoles().size(), is(1));
+                assertThat(poolC.getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
 
                 // Remove pool-b
                 Crds.kafkaNodePoolOperation(client).inNamespace(NAMESPACE).withName("pool-b").withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -359,9 +360,13 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getReplicas(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getNodeIds(), is(List.of(0, 1, 2)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getNodeIds(), is(List.of(3, 4)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
@@ -778,9 +783,13 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getReplicas(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getNodeIds(), is(List.of(0, 1, 2)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getNodeIds(), is(List.of(3, 4)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
@@ -955,9 +964,13 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getReplicas(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getNodeIds(), is(List.of(0, 1, 2)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getNodeIds(), is(List.of(3, 4)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control
@@ -1119,11 +1132,17 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().size(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getReplicas(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getNodeIds(), is(List.of(0, 1, 2)));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getNodeIds(), is(List.of(3, 4)));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(2).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(2).getStatus().getNodeIds(), is(List.of(5, 6)));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(2).getStatus().getObservedGeneration(), is(1L));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(2).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(2).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b", "pool-c")));
 
                     // Assert the info passed over for Cruise Control
@@ -1295,8 +1314,12 @@ public class KafkaAssemblyOperatorWithPoolsTest {
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().size(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getReplicas(), is(3));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getNodeIds(), is(List.of(0, 1, 2)));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(0).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getReplicas(), is(2));
                     assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getNodeIds(), is(List.of(3, 4)));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles().size(), is(1));
+                    assertThat(kafkaNodePoolStatusCaptor.getAllValues().get(1).getStatus().getRoles(), hasItems(ProcessRoles.BROKER));
                     assertThat(kao.state.kafkaStatus.getKafkaNodePools().stream().map(UsedNodePoolStatus::getName).toList(), is(List.of("pool-a", "pool-b")));
 
                     // Assert the info passed over for Cruise Control

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3499,6 +3499,8 @@ Used in: xref:type-KafkaNodePool-{context}[`KafkaNodePool`]
 |integer array
 |clusterId           1.2+<.<a|Kafka cluster ID.
 |string
+|roles               1.2+<.<a|The roles currently assigned to this pool.
+|string (one or more of [controller, broker]) array
 |replicas            1.2+<.<a|The current number of pods being used to provide this resource.
 |integer
 |labelSelector       1.2+<.<a|Label selector for pods providing this resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -921,6 +921,14 @@ spec:
               clusterId:
                 type: string
                 description: Kafka cluster ID.
+              roles:
+                type: array
+                items:
+                  type: string
+                  enum:
+                  - controller
+                  - broker
+                description: The roles currently assigned to this pool.
               replicas:
                 type: integer
                 description: The current number of pods being used to provide this resource.

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -921,6 +921,14 @@ spec:
               clusterId:
                 type: string
                 description: Kafka cluster ID.
+              roles:
+                type: array
+                items:
+                  type: string
+                  enum:
+                  - controller
+                  - broker
+                description: The roles currently assigned to this pool.
               replicas:
                 type: integer
                 description: The current number of pods being used to provide this resource.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds a new field `roles` to the `status of the `KafkaNodePool` resource which is used to track the roles assigned to given node pool. This field is also set as part of the reconciliation. The information it self is not used for anything in this PR - but it will be used in the future to address #9436 an possibly also #9434. It is done in a separate Pr to get it into the codebase before the 0.39 release to make sure we avoid any issues with upgrade later.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging