### PR TITLE
Refactor cert handling

### DIFF
--- a/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/SecretCertProviderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.certs;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SecretCertProviderTest {
+
+    @Test
+    public void testExistingCertificatesDiffer()   {
+        Secret defaultSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret sameAsDefaultSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret scaleDownSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .build();
+
+        Secret scaleUpSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .addToData("my-cluster-kafka-3.crt", "Certificate3")
+                .addToData("my-cluster-kafka-3.key", "Key3")
+                .addToData("my-cluster-kafka-4.crt", "Certificate4")
+                .addToData("my-cluster-kafka-4.key", "Key4")
+                .build();
+
+        Secret changedSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "NewKey1")
+                .addToData("my-cluster-kafka-2.crt", "Certificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .build();
+
+        Secret changedScaleUpSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "Certificate0")
+                .addToData("my-cluster-kafka-0.key", "Key0")
+                .addToData("my-cluster-kafka-1.crt", "Certificate1")
+                .addToData("my-cluster-kafka-1.key", "Key1")
+                .addToData("my-cluster-kafka-2.crt", "NewCertificate2")
+                .addToData("my-cluster-kafka-2.key", "Key2")
+                .addToData("my-cluster-kafka-3.crt", "Certificate3")
+                .addToData("my-cluster-kafka-3.key", "Key3")
+                .addToData("my-cluster-kafka-4.crt", "Certificate4")
+                .addToData("my-cluster-kafka-4.key", "Key4")
+                .build();
+
+        Secret changedScaleDownSecret = new SecretBuilder()
+                .withNewMetadata()
+                .withName("my-secret")
+                .endMetadata()
+                .addToData("my-cluster-kafka-0.crt", "NewCertificate0")
+                .addToData("my-cluster-kafka-0.key", "NewKey0")
+                .build();
+
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, defaultSecret), is(false));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, sameAsDefaultSecret), is(false));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, scaleDownSecret), is(false));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, scaleUpSecret), is(false));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, changedSecret), is(true));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, changedScaleUpSecret), is(true));
+        assertThat(SecretCertProvider.doExistingCertificatesDiffer(defaultSecret, changedScaleDownSecret), is(true));
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -471,24 +471,8 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         }
         LOGGER.debugCr(reconciliation, "End generating certificates");
 
-        String keyCertName = "cruise-control";
-        Map<String, String> data = new HashMap<>(4);
-
-        CertAndKey cert = ccCerts.get(keyCertName);
-        data.put(keyCertName + ".key", cert.keyAsBase64String());
-        data.put(keyCertName + ".crt", cert.certAsBase64String());
-        data.put(keyCertName + ".p12", cert.keyStoreAsBase64String());
-        data.put(keyCertName + ".password", cert.storePasswordAsBase64String());
-
-        return ModelUtils.createSecret(
-                CruiseControlResources.secretName(cluster),
-                namespace,
-                labels,
-                ownerReference,
-                data,
-                Map.of(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())),
-                Map.of()
-        );
+        return ModelUtils.buildSecret(namespace, CruiseControlResources.secretName(cluster), ccCerts,
+                labels, ownerReference, clusterCa.caCertGenerationFullAnnotation(), Map.of());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.model.template.DeploymentTemplate;
 import io.strimzi.api.kafka.model.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
@@ -471,8 +472,8 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         }
         LOGGER.debugCr(reconciliation, "End generating certificates");
 
-        return ModelUtils.buildSecret(namespace, CruiseControlResources.secretName(cluster), ccCerts,
-                labels, ownerReference, clusterCa.caCertGenerationFullAnnotation(), Map.of());
+        return ModelUtils.createSecret(CruiseControlResources.secretName(cluster), namespace, labels, ownerReference,
+                SecretCertProvider.buildSecretData(ccCerts), clusterCa.caCertGenerationFullAnnotation(), Map.of());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -259,7 +259,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
      */
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.entityTopicOperatorSecret();
-        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityTopicOperatorSecretName(cluster), componentName,
+        return clusterCa.buildTrustedCertificateSecret(secret, namespace, KafkaResources.entityTopicOperatorSecretName(cluster), componentName,
             CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -265,7 +265,7 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
      */
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.entityUserOperatorSecret();
-        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityUserOperatorSecretName(cluster), componentName,
+        return clusterCa.buildTrustedCertificateSecret(secret, namespace, KafkaResources.entityUserOperatorSecretName(cluster), componentName,
             CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1117,22 +1117,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             throw new RuntimeException("Failed to prepare Kafka certificates", e);
         }
 
-        Map<String, String> data = new HashMap<>();
-
-        for (NodeRef node : nodes)  {
-            CertAndKey cert = brokerCerts.get(node.podName());
-            data.put(node.podName() + ".key", cert.keyAsBase64String());
-            data.put(node.podName() + ".crt", cert.certAsBase64String());
-            data.put(node.podName() + ".p12", cert.keyStoreAsBase64String());
-            data.put(node.podName() + ".password", cert.storePasswordAsBase64String());
-        }
-
-        return ModelUtils.createSecret(
-                KafkaResources.kafkaSecretName(cluster),
-                namespace,
-                labels,
-                ownerReference,
-                data,
+        return ModelUtils.buildSecret(namespace, KafkaResources.kafkaSecretName(cluster), brokerCerts,
+                labels, ownerReference,
                 Map.of(
                         clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration()),
                         clientsCa.caCertGenerationAnnotation(), String.valueOf(clientsCa.certGeneration())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -64,6 +64,7 @@ import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.ResourceTemplate;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
@@ -1117,8 +1118,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             throw new RuntimeException("Failed to prepare Kafka certificates", e);
         }
 
-        return ModelUtils.buildSecret(namespace, KafkaResources.kafkaSecretName(cluster), brokerCerts,
-                labels, ownerReference,
+        return ModelUtils.createSecret(KafkaResources.kafkaSecretName(cluster), namespace, labels, ownerReference,
+                SecretCertProvider.buildSecretData(brokerCerts),
                 Map.of(
                         clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration()),
                         clientsCa.caCertGenerationAnnotation(), String.valueOf(clientsCa.certGeneration())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -267,7 +267,7 @@ public class KafkaExporter extends AbstractModel {
      */
     public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
         Secret secret = clusterCa.kafkaExporterSecret();
-        return ModelUtils.buildSecret(reconciliation, clusterCa, secret, namespace, KafkaExporterResources.secretName(cluster), componentName,
+        return clusterCa.buildTrustedCertificateSecret(secret, namespace, KafkaExporterResources.secretName(cluster), componentName,
                 "kafka-exporter", labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -24,27 +24,18 @@ import io.strimzi.api.kafka.model.CertificateAuthority;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.TlsSidecarLogLevel;
 import io.strimzi.api.kafka.model.storage.Storage;
-import io.strimzi.certs.CertAndKey;
-import io.strimzi.operator.common.Annotations;
-import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
-import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static java.util.Collections.emptyMap;
 
 /**
  * ModelUtils is a utility class that holds generic static helper functions
@@ -58,6 +49,8 @@ public class ModelUtils {
     protected static final String TLS_SIDECAR_LOG_LEVEL = "TLS_SIDECAR_LOG_LEVEL";
 
     /**
+     * Extract certificate validity days from cluster CA configuration
+     *
      * @param certificateAuthority The CA configuration.
      * @return The cert validity.
      */
@@ -71,6 +64,8 @@ public class ModelUtils {
     }
 
     /**
+     * Extract certificate renewal days from cluster CA configuration
+     *
      * @param certificateAuthority The CA configuration.
      * @return The renewal days.
      */
@@ -100,89 +95,6 @@ public class ModelUtils {
         return ContainerUtils.createEnvVar(TLS_SIDECAR_LOG_LEVEL,
                 (tlsSidecar != null && tlsSidecar.getLogLevel() != null ?
                         tlsSidecar.getLogLevel() : TlsSidecarLogLevel.NOTICE).toValue());
-    }
-
-    /**
-     * Builds a certificate secret for the different Strimzi components (TO, UO, KE, ...)
-     *
-     * @param reconciliation                        Reconciliation marker
-     * @param clusterCa                             The Cluster CA
-     * @param secret                                Kubernetes Secret
-     * @param namespace                             Namespace
-     * @param secretName                            Name of the Kubernetes secret
-     * @param commonName                            Common Name of the certificate
-     * @param keyCertName                           Key under which the certificate will be stored in the new Secret
-     * @param labels                                Labels
-     * @param ownerReference                        Owner reference
-     * @param isMaintenanceTimeWindowsSatisfied     Flag whether we are inside a maintenance window or not
-     *
-     * @return  Newly built Secret
-     */
-    public static Secret buildSecret(Reconciliation reconciliation, ClusterCa clusterCa, Secret secret, String namespace, String secretName,
-                                     String commonName, String keyCertName, Labels labels, OwnerReference ownerReference, boolean isMaintenanceTimeWindowsSatisfied) {
-        CertAndKey certAndKey = null;
-        boolean shouldBeRegenerated = false;
-        List<String> reasons = new ArrayList<>(2);
-
-        if (secret == null) {
-            reasons.add("certificate doesn't exist yet");
-            shouldBeRegenerated = true;
-        } else {
-            if (clusterCa.keyCreated() || clusterCa.certRenewed() ||
-                    (isMaintenanceTimeWindowsSatisfied && clusterCa.isExpiring(secret, keyCertName + ".crt")) ||
-                    clusterCa.hasCaCertGenerationChanged(secret)) {
-                reasons.add("certificate needs to be renewed");
-                shouldBeRegenerated = true;
-            }
-        }
-
-        if (shouldBeRegenerated) {
-            LOGGER.debugCr(reconciliation, "Certificate for pod {} need to be regenerated because: {}", keyCertName, String.join(", ", reasons));
-
-            try {
-                certAndKey = clusterCa.generateSignedCert(commonName, Ca.IO_STRIMZI);
-            } catch (IOException e) {
-                LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
-            }
-
-            LOGGER.debugCr(reconciliation, "End generating certificates");
-        } else {
-            if (secret.getData().get(keyCertName + ".p12") != null &&
-                    !secret.getData().get(keyCertName + ".p12").isEmpty() &&
-                    secret.getData().get(keyCertName + ".password") != null &&
-                    !secret.getData().get(keyCertName + ".password").isEmpty()) {
-                certAndKey = new CertAndKey(
-                        decodeFromSecret(secret, keyCertName + ".key"),
-                        decodeFromSecret(secret, keyCertName + ".crt"),
-                        null,
-                        decodeFromSecret(secret, keyCertName + ".p12"),
-                        new String(decodeFromSecret(secret, keyCertName + ".password"), StandardCharsets.US_ASCII)
-                );
-            } else {
-                try {
-                    // coming from an older operator version, the secret exists but without keystore and password
-                    certAndKey = clusterCa.addKeyAndCertToKeyStore(commonName,
-                            decodeFromSecret(secret, keyCertName + ".key"),
-                            decodeFromSecret(secret, keyCertName + ".crt"));
-                } catch (IOException e) {
-                    LOGGER.errorCr(reconciliation, "Error generating the keystore for {}", keyCertName, e);
-                }
-            }
-        }
-
-        return buildSecret(namespace, secretName, Collections.singletonMap(keyCertName, certAndKey), labels, ownerReference, clusterCa.caCertGenerationFullAnnotation(), emptyMap());
-    }
-
-    public static Secret buildSecret(String namespace, String secretName, Map<String, CertAndKey> certificates,
-                                     Labels labels, OwnerReference ownerReference, Map<String, String> customAnnotations, Map<String, String> customLabels) {
-        Map<String, String> data = new HashMap<>(certificates.size() * 4);
-        certificates.forEach((keyCertName, certAndKey) -> {;
-            data.put(keyCertName + ".key", certAndKey.keyAsBase64String());
-            data.put(keyCertName + ".crt", certAndKey.certAsBase64String());
-            data.put(keyCertName + ".p12", certAndKey.keyStoreAsBase64String());
-            data.put(keyCertName + ".password", certAndKey.storePasswordAsBase64String());
-        });
-        return createSecret(secretName, namespace, labels, ownerReference, data, customAnnotations, customLabels);
     }
 
     /**
@@ -265,41 +177,6 @@ public class ModelUtils {
      */
     public static Map<String, String> getCustomLabelsOrAnnotations(String envVarName)   {
         return Util.parseMap(System.getenv().get(envVarName));
-    }
-
-    private static byte[] decodeFromSecret(Secret secret, String key) {
-        return Base64.getDecoder().decode(secret.getData().get(key));
-    }
-
-    /**
-     * Compares two Secrets with certificates and checks whether any value for a key which exists in both Secrets
-     * changed. This method is used to evaluate whether rolling update of existing brokers is needed when secrets with
-     * certificates change. It separates changes for existing certificates with other changes to the secret such as
-     * added or removed certificates (scale-up or scale-down).
-     *
-     * @param current   Existing secret
-     * @param desired   Desired secret
-     *
-     * @return  True if there is a key which exists in the data sections of both secrets and which changed.
-     */
-    public static boolean doExistingCertificatesDiffer(Secret current, Secret desired) {
-        Map<String, String> currentData = current.getData();
-        Map<String, String> desiredData = desired.getData();
-
-        if (currentData == null) {
-            return true;
-        } else {
-            for (Map.Entry<String, String> entry : currentData.entrySet()) {
-                String desiredValue = desiredData.get(entry.getKey());
-                if (entry.getValue() != null
-                        && desiredValue != null
-                        && !entry.getValue().equals(desiredValue)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -425,27 +302,6 @@ public class ModelUtils {
         } else {
             return false;
         }
-    }
-
-    /**
-     * Extracts the CA generation from the CA
-     *
-     * @param ca    CA from which the generation should be extracted
-     *
-     * @return      CA generation or the initial generation if no generation is set
-     */
-    public static int caCertGeneration(Ca ca) {
-        return Annotations.intAnnotation(ca.caCertSecret(), Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, Ca.INIT_GENERATION);
-    }
-
-    /**
-     * Extract the CA key generation from the CA
-     *
-     * @param ca CA from which the generation should be extracted
-     * @return CA key generation or the initial generation if no generation is set
-     */
-    public static int caKeyGeneration(Ca ca) {
-        return Annotations.intAnnotation(ca.caKeySecret(), Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, Ca.INIT_GENERATION);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -442,7 +442,6 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
      * @return The generated Secret with the ZooKeeper node certificates
      */
     public Secret generateCertificatesSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        Map<String, String> secretData = new HashMap<>(replicas * 4);
         Map<String, CertAndKey> certs;
 
         try {
@@ -452,23 +451,8 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
             throw new RuntimeException("Failed to prepare ZooKeeper certificates", e);
         }
 
-        for (int i = 0; i < replicas; i++) {
-            CertAndKey cert = certs.get(KafkaResources.zookeeperPodName(cluster, i));
-            secretData.put(KafkaResources.zookeeperPodName(cluster, i) + ".key", cert.keyAsBase64String());
-            secretData.put(KafkaResources.zookeeperPodName(cluster, i) + ".crt", cert.certAsBase64String());
-            secretData.put(KafkaResources.zookeeperPodName(cluster, i) + ".p12", cert.keyStoreAsBase64String());
-            secretData.put(KafkaResources.zookeeperPodName(cluster, i) + ".password", cert.storePasswordAsBase64String());
-        }
-
-        return ModelUtils.createSecret(
-                KafkaResources.zookeeperSecretName(cluster),
-                namespace,
-                labels,
-                ownerReference,
-                secretData,
-                Map.of(clusterCa.caCertGenerationAnnotation(), String.valueOf(clusterCa.certGeneration())),
-                emptyMap()
-        );
+        return ModelUtils.buildSecret(namespace, KafkaResources.zookeeperSecretName(cluster), certs,
+                labels, ownerReference, clusterCa.caCertGenerationFullAnnotation(), emptyMap());
     }
 
     /* test */ Container createContainer(ImagePullPolicy imagePullPolicy) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -35,6 +35,7 @@ import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.ResourceTemplate;
 import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
 import io.strimzi.certs.CertAndKey;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
@@ -451,8 +452,8 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
             throw new RuntimeException("Failed to prepare ZooKeeper certificates", e);
         }
 
-        return ModelUtils.buildSecret(namespace, KafkaResources.zookeeperSecretName(cluster), certs,
-                labels, ownerReference, clusterCa.caCertGenerationFullAnnotation(), emptyMap());
+        return ModelUtils.createSecret(KafkaResources.zookeeperSecretName(cluster), namespace, labels, ownerReference,
+                SecretCertProvider.buildSecretData(certs), clusterCa.caCertGenerationFullAnnotation(), emptyMap());
     }
 
     /* test */ Container createContainer(ImagePullPolicy imagePullPolicy) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -329,9 +329,7 @@ public class CaReconciler {
             LOGGER.warnCr(reconciliation, "Cluster CA needs to be fully trusted across the cluster, keeping current CO secret and certs");
             return Future.succeededFuture();
         }
-        Secret secret = ModelUtils.buildSecret(
-                reconciliation,
-                clusterCa,
+        Secret secret = clusterCa.buildTrustedCertificateSecret(
                 clusterCa.clusterOperatorSecret(),
                 reconciliation.namespace(),
                 KafkaResources.secretName(reconciliation.name()),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -12,13 +12,13 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.CruiseControlResources;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
@@ -207,7 +207,7 @@ public class CruiseControlReconciler {
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred
-                                        existingCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                        existingCertsChanged = SecretCertProvider.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
                                     } else {
                                         existingCertsChanged = false;
                                     }
@@ -272,10 +272,10 @@ public class CruiseControlReconciler {
         if (cruiseControl != null) {
             Deployment deployment = cruiseControl.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
 
-            int caCertGeneration = ModelUtils.caCertGeneration(clusterCa);
+            int caCertGeneration = clusterCa.caCertGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
-            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            int caKeyGeneration = clusterCa.caKeyGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -9,13 +9,13 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaResources;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.EntityOperator;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -349,7 +349,7 @@ public class EntityOperatorReconciler {
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred
-                                        existingEntityTopicOperatorCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                        existingEntityTopicOperatorCertsChanged = SecretCertProvider.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
                                     } else {
                                         existingEntityTopicOperatorCertsChanged = false;
                                     }
@@ -382,7 +382,7 @@ public class EntityOperatorReconciler {
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred
-                                        existingEntityUserOperatorCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                        existingEntityUserOperatorCertsChanged = SecretCertProvider.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
                                     } else {
                                         existingEntityUserOperatorCertsChanged = false;
                                     }
@@ -423,9 +423,9 @@ public class EntityOperatorReconciler {
     protected Future<Void> deployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         if (entityOperator != null) {
             Deployment deployment = entityOperator.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
-            int caCertGeneration = ModelUtils.caCertGeneration(clusterCa);
+            int caCertGeneration = clusterCa.caCertGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
-            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            int caKeyGeneration = clusterCa.caKeyGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 
             return deploymentOperator

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -8,13 +8,13 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaExporterResources;
+import io.strimzi.certs.SecretCertProvider;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaExporter;
 import io.strimzi.operator.cluster.model.KafkaVersion;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
@@ -134,7 +134,7 @@ public class KafkaExporterReconciler {
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred
-                                        existingKafkaExporterCertsChanged = ModelUtils.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
+                                        existingKafkaExporterCertsChanged = SecretCertProvider.doExistingCertificatesDiffer(oldSecret, patchResult.resource());
                                     } else {
                                         existingKafkaExporterCertsChanged = false;
                                     }
@@ -180,10 +180,10 @@ public class KafkaExporterReconciler {
     private Future<Void> deployment(boolean isOpenShift, ImagePullPolicy imagePullPolicy, List<LocalObjectReference> imagePullSecrets) {
         if (kafkaExporter != null) {
             Deployment deployment = kafkaExporter.generateDeployment(isOpenShift, imagePullPolicy, imagePullSecrets);
-            int caCertGeneration = ModelUtils.caCertGeneration(this.clusterCa);
+            int caCertGeneration = clusterCa.caCertGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(caCertGeneration));
-            int caKeyGeneration = ModelUtils.caKeyGeneration(clusterCa);
+            int caKeyGeneration = clusterCa.caKeyGeneration();
             Annotations.annotations(deployment.getSpec().getTemplate()).put(
                     Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(caKeyGeneration));
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -42,7 +42,6 @@ import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.cluster.model.KafkaPool;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
 import io.strimzi.operator.cluster.model.ListenersUtils;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.common.model.NodeUtils;
 import io.strimzi.operator.cluster.model.PodSetUtils;
@@ -762,9 +761,9 @@ public class KafkaReconciler {
      */
     private Map<String, String> podSetPodAnnotations(int nodeId) {
         Map<String, String> podAnnotations = new LinkedHashMap<>(9);
-        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clusterCa)));
-        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(ModelUtils.caKeyGeneration(this.clusterCa)));
-        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clientsCa)));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(this.clusterCa.caCertGeneration()));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(this.clusterCa.caKeyGeneration()));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(this.clusterCa.caCertGeneration()));
         podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, loggingHash);
         podAnnotations.put(KafkaCluster.ANNO_STRIMZI_BROKER_CONFIGURATION_HASH, brokerConfigurationHash.get(nodeId));
         podAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafka.getKafkaVersion().version());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -15,7 +15,6 @@ import io.strimzi.api.kafka.model.StrimziPodSet;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.ClientsCa;
 import io.strimzi.operator.cluster.model.KafkaCluster;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.model.RestartReason;
@@ -193,7 +192,7 @@ public class ReconcilerUtils {
      * @return      True when the generations match, false otherwise
      */
     private static boolean isPodCaCertUpToDate(Pod pod, Ca ca) {
-        return ModelUtils.caCertGeneration(ca) == Annotations.intAnnotation(pod, getCaCertAnnotation(ca), Ca.INIT_GENERATION);
+        return ca.caCertGeneration() == Annotations.intAnnotation(pod, getCaCertAnnotation(ca), Ca.INIT_GENERATION);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -22,7 +22,6 @@ import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.DnsNameGenerator;
 import io.strimzi.operator.cluster.model.ImagePullPolicy;
 import io.strimzi.operator.cluster.model.KafkaVersionChange;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.ZookeeperCluster;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.StatefulSetOperator;
@@ -514,8 +513,8 @@ public class ZooKeeperReconciler {
      */
     public Map<String, String> zkPodSetPodAnnotations(int podNum) {
         Map<String, String> podAnnotations = new LinkedHashMap<>((int) Math.ceil(podNum / 0.75));
-        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(ModelUtils.caCertGeneration(this.clusterCa)));
-        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(ModelUtils.caKeyGeneration(this.clusterCa)));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(this.clusterCa.caCertGeneration()));
+        podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(this.clusterCa.caKeyGeneration()));
         podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, loggingHash);
         podAnnotations.put(ANNO_STRIMZI_SERVER_CERT_HASH, zkCertificateHash.get(podNum));
         return podAnnotations;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ModelUtilsTest.java
@@ -9,8 +9,6 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.StrimziPodSet;
@@ -86,101 +84,6 @@ public class ModelUtilsTest {
         assertThat(ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(jbod)), is(jbod));
         assertThat(ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(ephemeral)), is(ephemeral));
         assertThat(ModelUtils.decodeStorageFromJson(ModelUtils.encodeStorageToJson(persistent)), is(persistent));
-    }
-
-    @ParallelTest
-    public void testExistingCertificatesDiffer()   {
-        Secret defaultSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .addToData("my-cluster-kafka-1.crt", "Certificate1")
-                .addToData("my-cluster-kafka-1.key", "Key1")
-                .addToData("my-cluster-kafka-2.crt", "Certificate2")
-                .addToData("my-cluster-kafka-2.key", "Key2")
-                .build();
-
-        Secret sameAsDefaultSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .addToData("my-cluster-kafka-1.crt", "Certificate1")
-                .addToData("my-cluster-kafka-1.key", "Key1")
-                .addToData("my-cluster-kafka-2.crt", "Certificate2")
-                .addToData("my-cluster-kafka-2.key", "Key2")
-                .build();
-
-        Secret scaleDownSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .build();
-
-        Secret scaleUpSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .addToData("my-cluster-kafka-1.crt", "Certificate1")
-                .addToData("my-cluster-kafka-1.key", "Key1")
-                .addToData("my-cluster-kafka-2.crt", "Certificate2")
-                .addToData("my-cluster-kafka-2.key", "Key2")
-                .addToData("my-cluster-kafka-3.crt", "Certificate3")
-                .addToData("my-cluster-kafka-3.key", "Key3")
-                .addToData("my-cluster-kafka-4.crt", "Certificate4")
-                .addToData("my-cluster-kafka-4.key", "Key4")
-                .build();
-
-        Secret changedSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .addToData("my-cluster-kafka-1.crt", "Certificate1")
-                .addToData("my-cluster-kafka-1.key", "NewKey1")
-                .addToData("my-cluster-kafka-2.crt", "Certificate2")
-                .addToData("my-cluster-kafka-2.key", "Key2")
-                .build();
-
-        Secret changedScaleUpSecret = new SecretBuilder()
-                .withNewMetadata()
-                    .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "Certificate0")
-                .addToData("my-cluster-kafka-0.key", "Key0")
-                .addToData("my-cluster-kafka-1.crt", "Certificate1")
-                .addToData("my-cluster-kafka-1.key", "Key1")
-                .addToData("my-cluster-kafka-2.crt", "NewCertificate2")
-                .addToData("my-cluster-kafka-2.key", "Key2")
-                .addToData("my-cluster-kafka-3.crt", "Certificate3")
-                .addToData("my-cluster-kafka-3.key", "Key3")
-                .addToData("my-cluster-kafka-4.crt", "Certificate4")
-                .addToData("my-cluster-kafka-4.key", "Key4")
-                .build();
-
-        Secret changedScaleDownSecret = new SecretBuilder()
-                .withNewMetadata()
-                .withName("my-secret")
-                .endMetadata()
-                .addToData("my-cluster-kafka-0.crt", "NewCertificate0")
-                .addToData("my-cluster-kafka-0.key", "NewKey0")
-                .build();
-
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, defaultSecret), is(false));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, sameAsDefaultSecret), is(false));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, scaleDownSecret), is(false));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, scaleUpSecret), is(false));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedSecret), is(true));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleUpSecret), is(true));
-        assertThat(ModelUtils.doExistingCertificatesDiffer(defaultSecret, changedScaleDownSecret), is(true));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CertificateRenewalTest.java
@@ -9,8 +9,6 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.cluster.model.ClusterCa;
-import io.strimzi.operator.cluster.model.ModelUtils;
-import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.vertx.junit5.VertxExtension;
 import org.junit.jupiter.api.Test;
@@ -40,7 +38,7 @@ public class CertificateRenewalTest {
         Labels labels = Labels.forStrimziCluster("my-cluster");
         OwnerReference ownerReference = new OwnerReference();
 
-        Secret newSecret = ModelUtils.buildSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, null, namespace, secretName, commonName,
+        Secret newSecret = clusterCaMock.buildTrustedCertificateSecret(null, namespace, secretName, commonName,
                 keyCertName, labels, ownerReference, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
@@ -73,7 +71,7 @@ public class CertificateRenewalTest {
         Labels labels = Labels.forStrimziCluster("my-cluster");
         OwnerReference ownerReference = new OwnerReference();
 
-        Secret newSecret = ModelUtils.buildSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
+        Secret newSecret = clusterCaMock.buildTrustedCertificateSecret(initialSecret, namespace, secretName, commonName,
                 keyCertName, labels, ownerReference, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
@@ -106,7 +104,7 @@ public class CertificateRenewalTest {
         Labels labels = Labels.forStrimziCluster("my-cluster");
         OwnerReference ownerReference = new OwnerReference();
 
-        Secret newSecret = ModelUtils.buildSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
+        Secret newSecret = clusterCaMock.buildTrustedCertificateSecret(initialSecret, namespace, secretName, commonName,
                 keyCertName, labels, ownerReference, true);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", newCertAndKey.certAsBase64String()));
@@ -139,7 +137,7 @@ public class CertificateRenewalTest {
         Labels labels = Labels.forStrimziCluster("my-cluster");
         OwnerReference ownerReference = new OwnerReference();
 
-        Secret newSecret = ModelUtils.buildSecret(Reconciliation.DUMMY_RECONCILIATION, clusterCaMock, initialSecret, namespace, secretName, commonName,
+        Secret newSecret = clusterCaMock.buildTrustedCertificateSecret(initialSecret, namespace, secretName, commonName,
                 keyCertName, labels, ownerReference, false);
 
         assertThat(newSecret.getData(), hasEntry("deployment.crt", Base64.getEncoder().encodeToString("old-cert".getBytes())));

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -37,6 +37,7 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -776,6 +777,13 @@ public abstract class Ca {
             return Annotations.intAnnotation(caCertSecret, ANNO_STRIMZI_IO_CA_CERT_GENERATION, INIT_GENERATION);
         }
         return INIT_GENERATION;
+    }
+
+    /**
+     * @return the generation of the current CA certificate as an annotation
+     */
+    public Map<String, String> caCertGenerationFullAnnotation() {
+        return Collections.singletonMap(caCertGenerationAnnotation(), String.valueOf(certGeneration()));
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -336,6 +336,24 @@ public abstract class Ca {
         this.clock = clock;
     }
 
+    /**
+     * Extracts the CA generation from the CA
+     *
+     * @return CA generation or the initial generation if no generation is set
+     */
+    public int caCertGeneration() {
+        return Annotations.intAnnotation(caCertSecret(), ANNO_STRIMZI_IO_CA_CERT_GENERATION, INIT_GENERATION);
+    }
+
+    /**
+     * Extracts the CA key generation from the CA
+     *
+     * @return CA key generation or the initial generation if no generation is set
+     */
+    public int caKeyGeneration() {
+        return Annotations.intAnnotation(caKeySecret(), ANNO_STRIMZI_IO_CA_KEY_GENERATION, INIT_GENERATION);
+    }
+
     protected static void delete(Reconciliation reconciliation, File file) {
         if (!file.delete()) {
             LOGGER.warnCr(reconciliation, "{} cannot be deleted", file.getName());


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

Tidy up certificate code:
 - Remove duplicated logic to create Map for Secret data
 - Remove certificate logic from ModelUtils class

This PR contributes to https://github.com/strimzi/strimzi-kafka-operator/issues/5630. I have created this as a separate PR to make it easier to review, this change reduces the number of places that are handling certificates to make it easier to remove the dependence on Kubernetes Secrets in a future PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

