### PR TITLE
Use separate logger for Jetty in Topic Operator

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
+++ b/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
@@ -10,6 +10,10 @@ rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
+logger.jetty.name = org.eclipse.jetty
+logger.jetty.level = INFO
+logger.jetty.additivity = false
+
 logger.clients.name = org.apache.kafka.clients
 logger.clients.level = INFO
 logger.clients.additivity = false

--- a/topic-operator/src/main/resources/log4j2.properties
+++ b/topic-operator/src/main/resources/log4j2.properties
@@ -9,3 +9,7 @@ rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
+
+logger.jetty.name = org.eclipse.jetty
+logger.jetty.level = INFO
+logger.jetty.additivity = false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds a separate logger for Jetty in the logging configurations of the Topic Operator. That helps to make sure that when the user enables the DEBUG logging for the root logger of the TO, Jetty will by default stay at the INFO level. This helps to reduce the number of messages that do not seem very useful such as the various Jetty threading logs etc.

This contributes to #9465 (but does not address all parts of it).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging