### PR TITLE
 Set default replication factor for CC sample topics

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.PasswordGenerator;
+import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
@@ -67,7 +68,8 @@ public class CruiseControlReconcilerTest {
             new NodeRef(NAME + "kafka-2", 2, "kafka", false, true));
     private final CruiseControlSpec cruiseControlSpec = new CruiseControlSpecBuilder()
             .withBrokerCapacity(new BrokerCapacityBuilder().withInboundNetwork("10000KB/s").withOutboundNetwork("10000KB/s").build())
-            .withConfig(Map.of("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal"))
+            .withConfig(Map.of("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal",
+                    CruiseControlConfigurationParameters.SAMPLE_STORE_TOPIC_REPLICATION_FACTOR.getValue(), "3"))
             .build();
 
     @Test
@@ -152,7 +154,7 @@ public class CruiseControlReconcilerTest {
                     // Verify deployment
                     assertThat(deployCaptor.getAllValues().size(), is(1));
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("f6dc41c7"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("fc0ad847"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("27ada64b"));
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlConfigurationParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlConfigurationParameters.java
@@ -79,6 +79,11 @@ public enum CruiseControlConfigurationParameters {
     BROKER_METRIC_TOPIC_NAME("broker.metric.sample.store.topic"),
 
     /**
+     * Replication factor of Kafka sample store topics
+     */
+    SAMPLE_STORE_TOPIC_REPLICATION_FACTOR("sample.store.topic.replication.factor"),
+
+    /**
      * Metrics reporter topic
      */
     METRIC_REPORTER_TOPIC_NAME("metric.reporter.topic"),


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Addresses https://github.com/strimzi/strimzi-kafka-operator/issues/9469

At this time, Cruise Control does not provide a `min.insync.replicas` configuration for sample store topics in its properties file. Therefore, to set the  `min.insync.replicas` configuration for sample store topics, a user must either:

1. Create the topics manually with the desired `min.insync.replicas` configuration value
2. Use the Kafka cluster's `min.insync.replica` configuration 

The issue here is that Cruise Control sets the replication factor of sample store topics  to `2` by default and the Strimzi example files set the `min.insync.replica` of the Kafka clusters to `2`.  This causes issues when Strimzi preforms rolling updates on the cluster as the sample store topics easily become under replicated.

This PR sets the default replication factor of sample store topics, `sample.store.topic.replication.factor`, to match that of the Kafka cluster's `default.replication.factor`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

