### PR TITLE
Update Cruise Control to 2.5.133 and Kaniko to 1.19.1

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.132</cruise-control.version>
+        <cruise-control.version>2.5.133</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.132</cruise-control.version>
+        <cruise-control.version>2.5.133</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.132</cruise-control.version>
+        <cruise-control.version>2.5.133</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.19.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.19.1
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the versions of Cruise Control and Kaniko. The new Cruise Control version brings several additional CVE fixes in its dependencies. Kaniko fixes bug when running on AWS and using the AWS integration.

If we do another 0.39.0 RC, this is a candidate for inclusion.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally