### PR TITLE
Add UnlockExperimentalVMOptions to priority JVM options

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JvmOptionUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JvmOptionUtils.java
@@ -29,7 +29,7 @@ public final class JvmOptionUtils  {
     /**
      * Set of JVM performance options to be prioritized in sorting.
      */
-    private static final Set<String> JVM_PERFORMANCE_PRIORITY_OPTIONS = Set.of("UnlockDiagnosticVMOptions");
+    private static final Set<String> JVM_PERFORMANCE_PRIORITY_OPTIONS = Set.of("UnlockDiagnosticVMOptions", "UnlockExperimentalVMOptions");
 
     private static final String X_MS = "-Xms";
     private static final String X_MX = "-Xmx";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionUtilsTest.java
@@ -225,6 +225,29 @@ class JvmOptionUtilsTest {
     }
 
     @ParallelTest
+    void testThatUnlockExperimentalVMOptionsPerformanceOptionIsAlwaysSetFirst() {
+        // when
+        var envVars = new ArrayList<EnvVar>();
+        var jvmOptions = new JvmOptions();
+        jvmOptions.setXx(Map.of(
+                "a", "1",
+                "b", "false",
+                "c", "true",
+                "UnlockExperimentalVMOptions", "true",
+                "z", "anything"));
+
+        // when
+        JvmOptionUtils.jvmPerformanceOptions(envVars, jvmOptions);
+
+        // then
+        var expectedPerformanceOpts = new EnvVarBuilder()
+                .withName(AbstractModel.ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS)
+                .withValue("-XX:+UnlockExperimentalVMOptions -XX:a=1 -XX:-b -XX:+c -XX:z=anything")
+                .build();
+        assertThat(envVars, equalTo(List.of(expectedPerformanceOpts)));
+    }
+
+    @ParallelTest
     void testThatJavaOptionsAreIgnoredOnNullJvmOptions() {
         // given
         var envVars = new ArrayList<EnvVar>();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature (see https://github.com/orgs/strimzi/discussions/9475)

### Description

This PR adds `UnlockExperimentalVMOptions` to priority JVM options. It means in the final list of options this option will come first.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

