### PR TITLE
Renaming context handler variable on creation

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
@@ -79,11 +79,11 @@ public class HealthCheckAndMetricsServer {
 
     private static ContextHandler contextHandler(String path, Handler handler) {
         LOGGER.debug("Configuring path {} with handler {}", path, handler);
-        ContextHandler metricsContext = new ContextHandler();
-        metricsContext.setContextPath(path);
-        metricsContext.setHandler(handler);
-        metricsContext.setAllowNullPathInfo(true);
-        return metricsContext;
+        ContextHandler contextHandler = new ContextHandler();
+        contextHandler.setContextPath(path);
+        contextHandler.setHandler(handler);
+        contextHandler.setAllowNullPathInfo(true);
+        return contextHandler;
     }
 
     /**


### PR DESCRIPTION
Trivial PR to rename a context handler variable which is declared in a general purpose method and it's not just for metrics handling.