### PR TITLE
docs(drain cleaner): considerations when using anti-affinity

### DIFF
--- a/documentation/modules/managing/proc-drain-cleaner-using.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-using.adoc
@@ -14,6 +14,12 @@ The Cluster Operator performs rolling updates based on the annotation.
 
 * You have xref:proc-drain-cleaner-deploying-{context}[deployed the Strimzi Drain Cleaner].
 
+.Considerations when using anti-affinity configuration 
+
+If using xref:assembly-scheduling-str[anti-affinity] with your Kafka or ZooKeeper pods, consider adding a spare worker node to your cluster or allowing pod rescheduling on the master node.
+Including spare nodes ensures that your cluster has the capacity to reschedule pods, especially during node draining or temporary unavailability of other nodes.
+When a worker node is drained, and anti-affinity rules restrict pod rescheduling on alternative nodes, spare nodes help prevent restarted pods from becoming unschedulable on other worker nodes.  This mitigates the risk of the draining operation failing.
+
 .Procedure
 
 . Drain a specified Kubernetes node hosting the Kafka broker or ZooKeeper pods.

--- a/documentation/modules/managing/proc-drain-cleaner-using.adoc
+++ b/documentation/modules/managing/proc-drain-cleaner-using.adoc
@@ -16,9 +16,9 @@ The Cluster Operator performs rolling updates based on the annotation.
 
 .Considerations when using anti-affinity configuration 
 
-If using xref:assembly-scheduling-str[anti-affinity] with your Kafka or ZooKeeper pods, consider adding a spare worker node to your cluster or allowing pod rescheduling on the master node.
-Including spare nodes ensures that your cluster has the capacity to reschedule pods, especially during node draining or temporary unavailability of other nodes.
-When a worker node is drained, and anti-affinity rules restrict pod rescheduling on alternative nodes, spare nodes help prevent restarted pods from becoming unschedulable on other worker nodes.  This mitigates the risk of the draining operation failing.
+When using xref:assembly-scheduling-str[anti-affinity] with your Kafka or ZooKeeper pods, consider adding a spare worker node to your cluster.
+Including spare nodes ensures that your cluster has the capacity to reschedule pods during node draining or temporary unavailability of other nodes.
+When a worker node is drained, and anti-affinity rules restrict pod rescheduling on alternative nodes, spare nodes help prevent restarted pods from becoming unschedulable.  This mitigates the risk of the draining operation failing.
 
 .Procedure
 


### PR DESCRIPTION
**Documentation**

Updates the procedure for using the Drain Cleaner to include some general considerations when using anti-affinity on nodes.
Suggests using a spare worker node in case anti-affinity restrictions result in a pod being unschedulable and drain cleaner operation failing.   

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

