### PR TITLE
Remove support for Kafka 3.5.0 and 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.0
 
+* Remove support for Apache Kafka 3.5.0 and 3.5.1
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -33,7 +33,7 @@ public class KafkaVersionTestUtils {
     public static final String LATEST_KAFKA_MIRROR_MAKER_IMAGE = KAFKA_MIRROR_MAKER_IMAGE_STR + LATEST_KAFKA_VERSION;
     public static final String LATEST_KAFKA_MIRROR_MAKER_2_IMAGE = KAFKA_MIRROR_MAKER_2_IMAGE_STR + LATEST_KAFKA_VERSION;
 
-    public static final String PREVIOUS_KAFKA_VERSION = "3.5.1";
+    public static final String PREVIOUS_KAFKA_VERSION = "3.5.2";
     public static final String PREVIOUS_FORMAT_VERSION = "3.5";
     public static final String PREVIOUS_PROTOCOL_VERSION = "3.5";
     public static final String PREVIOUS_METADATA_VERSION = "3.5-IV2";

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -6,8 +6,6 @@
 
 |Kafka
 a|
-* {DockerOrg}/kafka:{DockerTag}-kafka-3.5.0
-* {DockerOrg}/kafka:{DockerTag}-kafka-3.5.1
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.5.2
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.1

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -6,8 +6,6 @@
 [options="header"]
 |=================
 |Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
-| 3.5.0 | 3.5 | 3.5 | 3.6.4
-| 3.5.1 | 3.5 | 3.5 | 3.6.4
 | 3.5.2 | 3.5 | 3.5 | 3.6.4
 | 3.6.0 | 3.6 | 3.6 | 3.8.2
 | 3.6.1 | 3.6 | 3.6 | 3.8.3

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -263,7 +263,7 @@
   checksum: 7B79BD0844DB683C06C3491955BB183D48A47FA4639D2E241B9F4FF4060C4B70814DAC7D96BEA87DFFCA0C8AE038278C4FABF68D4EA1194228D67D9C3B1D247C
   zookeeper: 3.6.4
   third-party-libs: 3.5.x
-  supported: true
+  supported: false
   default: false
 - version: 3.5.1
   format: 3.5
@@ -273,7 +273,7 @@
   checksum: B6CEB010A5FE1791843CBC53D34D35993E97E03F9518344B4B5BDF7146D0A4E866CD2D4760CAB319D8B3323A5BF53037A78FED88C9384381AEA2CD0366877763
   zookeeper: 3.6.4
   third-party-libs: 3.5.x
-  supported: true
+  supported: false
   default: false
 - version: 3.5.2
   format: 3.5

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -13,29 +13,21 @@
               value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
-                3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.0")) }}
-                3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.1")) }}
                 3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
-                3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.0")) }}
-                3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.1")) }}
                 3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
-                3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.0")) }}
-                3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.1")) }}
                 3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
-                3.5.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.0")) }}
-                3.5.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.1")) }}
                 3.5.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.5.2")) }}
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.1")) }}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -55,29 +55,21 @@ spec:
               value: quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_IMAGES
               value: |
-                3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
-                3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
                 3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
-                3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
-                3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
                 3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
-                3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
-                3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
                 3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
-                3.5.0=quay.io/strimzi/kafka:latest-kafka-3.5.0
-                3.5.1=quay.io/strimzi/kafka:latest-kafka-3.5.1
                 3.5.2=quay.io/strimzi/kafka:latest-kafka-3.5.2
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1


### PR DESCRIPTION
### Type of change

- Task

### Description

We currently support 5 different Kafka versions in the main branch. Given that the next release is expected to be after Kafka 3.7.0 release, we will likely remove all 3.5.x Kafka versions before it happens. This PR in the meantime removes the support for 3.5.0 and 3.5.1. It speeds up the builds but keeps 2 different minor versions supported. And if needed, we will still have Kafka 3.5.2 to provide continuity with 0.39. This was also discussed in https://cloud-native.slack.com/archives/C018247K8T0/p1703184182628109

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md