### PR TITLE
Remove Cruise Control's cluster.configs.file and related code

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -102,9 +102,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
 
     // Configuration defaults
     protected static final boolean DEFAULT_CRUISE_CONTROL_METRICS_ENABLED = false;
-
-
-    private String minInsyncReplicas = "1";
+    
     private boolean sslEnabled;
     private boolean authEnabled;
     @SuppressFBWarnings({"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}) // This field is initialized in the fromCrd method
@@ -129,7 +127,6 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
     // Cruise Control configuration keys (EnvVariables)
     protected static final String ENV_VAR_CRUISE_CONTROL_CONFIGURATION = "CRUISE_CONTROL_CONFIGURATION";
     protected static final String ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
-    protected static final String ENV_VAR_MIN_INSYNC_REPLICAS = "MIN_INSYNC_REPLICAS";
 
     protected static final String ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION = "CRUISE_CONTROL_CAPACITY_CONFIGURATION";
 
@@ -205,11 +202,6 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
             CruiseControlConfiguration ccConfiguration = result.configuration;
             result.sslEnabled = ccConfiguration.isApiSslEnabled();
             result.authEnabled = ccConfiguration.isApiAuthEnabled();
-
-            KafkaConfiguration configuration = new KafkaConfiguration(reconciliation, kafkaClusterSpec.getConfig().entrySet());
-            if (configuration.getConfigOption(MIN_INSYNC_REPLICAS) != null) {
-                result.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);
-            }
 
             // To avoid illegal storage configurations provided by the user,
             // we rely on the storage configuration provided by the KafkaAssemblyOperator
@@ -387,7 +379,6 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_METRICS_ENABLED, String.valueOf(metrics.isEnabled())));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS, KafkaResources.bootstrapServiceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
-        varList.add(ContainerUtils.createEnvVar(ENV_VAR_MIN_INSYNC_REPLICAS, String.valueOf(minInsyncReplicas)));
 
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION, capacity.toString()));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -220,7 +220,6 @@ public class CruiseControlTest {
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_CRUISE_CONTROL_METRICS_ENABLED).withValue(Boolean.toString(CruiseControl.DEFAULT_CRUISE_CONTROL_METRICS_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS).withValue(KafkaResources.bootstrapServiceName(CLUSTER) + ":" + KafkaCluster.REPLICATION_PORT).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED).withValue(Boolean.toString(JvmOptions.DEFAULT_GC_LOGGING_ENABLED)).build());
-        expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_MIN_INSYNC_REPLICAS).withValue(MIN_INSYNC_REPLICAS).build());
         expected.add(new EnvVarBuilder().withName(ENV_VAR_CRUISE_CONTROL_CAPACITY_CONFIGURATION).withValue(cc.capacity.toString()).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_SSL_ENABLED).withValue(Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)).build());
         expected.add(new EnvVarBuilder().withName(CruiseControl.ENV_VAR_API_AUTH_ENABLED).withValue(Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SECURITY_ENABLED)).build());

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -2,18 +2,10 @@
 set -e
 
 CC_CAPACITY_FILE="/tmp/capacity.json"
-CC_CLUSTER_CONFIG_FILE="/tmp/clusterConfig.json"
 CC_ACCESS_LOG="/tmp/access.log"
 
 # Generate capacity file
 echo "${CRUISE_CONTROL_CAPACITY_CONFIGURATION}" > "${CC_CAPACITY_FILE}"
-
-# Generate cluster config
-cat <<EOF > $CC_CLUSTER_CONFIG_FILE
-{
-min.insync.replicas=$MIN_INSYNC_REPLICAS
-}
-EOF
 
 # Write all webserver access logs to stdout
 ln -sf /dev/stdout $CC_ACCESS_LOG
@@ -22,7 +14,6 @@ ln -sf /dev/stdout $CC_ACCESS_LOG
 cat <<EOF
 bootstrap.servers=$STRIMZI_KAFKA_BOOTSTRAP_SERVERS
 capacity.config.file=$CC_CAPACITY_FILE
-cluster.configs.file=$CC_CLUSTER_CONFIG_FILE
 webserver.accesslog.path=$CC_ACCESS_LOG
 webserver.http.address=0.0.0.0
 webserver.http.cors.allowmethods=OPTIONS,GET


### PR DESCRIPTION
The `cluster.configs.file` configuration property is never used. The `KafkaTopicConfigProvider` is now deprecated, and `KafkaAdminTopicConfigProvider` is used by default. The `KafkaAdminTopicConfigProvider` retrieves cluster configs via the Kafka admin client rather than reading them from a file.

https://github.com/linkedin/cruise-control/pull/1622
