### PR TITLE
Fix NullPointerException From Missing listenerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.0
 
+* Fix NullPointerException from missing listenerConfig when using custom auth
 
 ## 0.39.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -32,6 +32,7 @@ import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -502,7 +503,11 @@ public class KafkaBrokerConfigurationBuilder {
             writer.println();
         } else if (auth instanceof KafkaListenerAuthenticationCustom customAuth) {
             securityProtocol.add(String.format("%s:%s", listenerName, getSecurityProtocol(tls, customAuth.isSasl())));
-            KafkaListenerCustomAuthConfiguration config = new KafkaListenerCustomAuthConfiguration(reconciliation, customAuth.getListenerConfig().entrySet());
+            Map<String, Object> listenerConfig = customAuth.getListenerConfig();
+            if (listenerConfig == null) {
+                listenerConfig = new HashMap<String, Object>();
+            }
+            KafkaListenerCustomAuthConfiguration config = new KafkaListenerCustomAuthConfiguration(reconciliation, listenerConfig.entrySet());
             config.asOrderedProperties().asMap().forEach((key, value) -> writer.println(String.format("listener.name.%s.%s=%s", listenerNameInProperty, key, value)));
         } else {
             securityProtocol.add(String.format("%s:%s", listenerName, getSecurityProtocol(tls, false)));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix for #9398. 

An empty hashmap is instantiated and used if `listenerConfig` is not supplied when using custom auth.

I could not run written test cases due to issue #8526 but I was able to test this locally and verified that the issue is resolved. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] <s>Write tests</s>
- [ ] Make sure all tests pass
- [ ] <s>Update documentation</s>
- [ ] <s>Check RBAC rights for Kubernetes / OpenShift roles</s>
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] <s>Reference relevant issue(s) and close them after merging</s>
- [x] Update CHANGELOG.md
- [ ] <s>Supply screenshots for visual changes, such as Grafana dashboards</s>

