### PR TITLE
Enable TO in KRaft examples

### DIFF
--- a/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-dual-role-kraft-nodes.yaml
@@ -65,4 +65,5 @@ spec:
       size: 100Gi
       deleteClaim: false
   entityOperator:
+    topicOperator: {}
     userOperator: {}

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft-ephemeral.yaml
@@ -66,4 +66,5 @@ spec:
     storage:
       type: ephemeral
   entityOperator:
+    topicOperator: {}
     userOperator: {}

--- a/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
+++ b/packaging/examples/kafka/nodepools/kafka-with-kraft.yaml
@@ -83,4 +83,5 @@ spec:
       size: 100Gi
       deleteClaim: false
   entityOperator:
+    topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As the UnidirectionaTopicOperator feature gate is now enabled by default, we can now also enable Topic Operator in our KRaft examples to have them match the examples we have for ZooKeeper based Kafka clusters.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally