### PR TITLE
ISSUE-9231 Makes Kafka Exporter offset.show-all configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.40.0
 
 * Fix NullPointerException from missing listenerConfig when using custom auth
+* Added support for Kafka Exporter `offset.show-all` parameter
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -45,7 +45,7 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
     private Probe readinessProbe;
     private String logging = "info";
     private boolean enableSaramaLogging;
-    private boolean offsetShowAll = true;
+    private boolean showAllOffsets = true;
     private KafkaExporterTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -115,12 +115,12 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
 
     @Description("Enable/disable offset show all option.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public boolean getOffsetShowAll() {
-        return offsetShowAll;
+    public boolean getShowAllOffsets() {
+        return showAllOffsets;
     }
 
-    public void setOffsetShowAll(boolean offsetShowAll) {
-        this.offsetShowAll = offsetShowAll;
+    public void setShowAllOffsets(boolean showAllOffsets) {
+        this.showAllOffsets = showAllOffsets;
     }
 
     @Description("Only log messages with the given severity or above. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -113,7 +113,7 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
         this.enableSaramaLogging = enableSaramaLogging;
     }
 
-    @Description("Enable/disable offset show all option.")
+    @Description("Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean getShowAllOffsets() {
         return showAllOffsets;

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -29,7 +29,7 @@ import java.util.Map;
     "image", "groupRegex", "topicRegex", 
     "groupExcludeRegex", "topicExcludeRegex",
     "resources", "logging",
-    "enableSaramaLogging", "template"})
+    "enableSaramaLogging", "offsetShowAll", "template"})
 @EqualsAndHashCode
 public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
@@ -45,6 +45,7 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
     private Probe readinessProbe;
     private String logging = "info";
     private boolean enableSaramaLogging;
+    private boolean offsetShowAll = true;
     private KafkaExporterTemplate template;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -110,6 +111,16 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
 
     public void setEnableSaramaLogging(boolean enableSaramaLogging) {
         this.enableSaramaLogging = enableSaramaLogging;
+    }
+
+    @Description("Enable/disable offset show all option.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean getOffsetShowAll() {
+        return offsetShowAll;
+    }
+
+    public void setOffsetShowAll(boolean offsetShowAll) {
+        this.offsetShowAll = offsetShowAll;
     }
 
     @Description("Only log messages with the given severity or above. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaExporterSpec.java
@@ -29,7 +29,7 @@ import java.util.Map;
     "image", "groupRegex", "topicRegex", 
     "groupExcludeRegex", "topicExcludeRegex",
     "resources", "logging",
-    "enableSaramaLogging", "offsetShowAll", "template"})
+    "enableSaramaLogging", "showAllOffsets", "template"})
 @EqualsAndHashCode
 public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -64,6 +64,7 @@ public class KafkaExporter extends AbstractModel {
     protected static final String ENV_VAR_KAFKA_EXPORTER_TOPIC_EXCLUDE_REGEX = "KAFKA_EXPORTER_TOPIC_EXCLUDE_REGEX";
     protected static final String ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER = "KAFKA_EXPORTER_KAFKA_SERVER";
     protected static final String ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA = "KAFKA_EXPORTER_ENABLE_SARAMA";
+    protected static final String ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL = "KAFKA_EXPORTER_OFFSET_SHOW_ALL";
 
     protected static final String CO_ENV_VAR_CUSTOM_KAFKA_EXPORTER_POD_LABELS = "STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS";
 
@@ -72,6 +73,7 @@ public class KafkaExporter extends AbstractModel {
     protected String groupExcludeRegex;
     protected String topicExcludeRegex;
     protected boolean saramaLoggingEnabled;
+    protected boolean offsetShowAll;
     /* test */ String exporterLogging;
     protected String version;
 
@@ -96,6 +98,7 @@ public class KafkaExporter extends AbstractModel {
         super(reconciliation, resource, KafkaExporterResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE, sharedEnvironmentProvider);
 
         this.saramaLoggingEnabled = false;
+        this.offsetShowAll = true;
     }
 
     /**
@@ -132,6 +135,7 @@ public class KafkaExporter extends AbstractModel {
 
             result.exporterLogging = spec.getLogging();
             result.saramaLoggingEnabled = spec.getEnableSaramaLogging();
+            result.offsetShowAll = spec.getOffsetShowAll();
 
             if (spec.getTemplate() != null) {
                 KafkaExporterTemplate template = spec.getTemplate();
@@ -224,6 +228,7 @@ public class KafkaExporter extends AbstractModel {
         }
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER, KafkaResources.bootstrapServiceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA, String.valueOf(saramaLoggingEnabled)));
+        varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL, String.valueOf(offsetShowAll)));
 
         // Add shared environment variables used for all containers
         varList.addAll(sharedEnvironmentProvider.variables());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -73,7 +73,7 @@ public class KafkaExporter extends AbstractModel {
     protected String groupExcludeRegex;
     protected String topicExcludeRegex;
     protected boolean saramaLoggingEnabled;
-    protected boolean offsetShowAll;
+    protected boolean showAllOffsets;
     /* test */ String exporterLogging;
     protected String version;
 
@@ -98,7 +98,7 @@ public class KafkaExporter extends AbstractModel {
         super(reconciliation, resource, KafkaExporterResources.deploymentName(resource.getMetadata().getName()), COMPONENT_TYPE, sharedEnvironmentProvider);
 
         this.saramaLoggingEnabled = false;
-        this.offsetShowAll = true;
+        this.showAllOffsets = true;
     }
 
     /**
@@ -135,7 +135,7 @@ public class KafkaExporter extends AbstractModel {
 
             result.exporterLogging = spec.getLogging();
             result.saramaLoggingEnabled = spec.getEnableSaramaLogging();
-            result.offsetShowAll = spec.getOffsetShowAll();
+            result.showAllOffsets = spec.getShowAllOffsets();
 
             if (spec.getTemplate() != null) {
                 KafkaExporterTemplate template = spec.getTemplate();
@@ -228,7 +228,7 @@ public class KafkaExporter extends AbstractModel {
         }
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER, KafkaResources.bootstrapServiceName(cluster) + ":" + KafkaCluster.REPLICATION_PORT));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA, String.valueOf(saramaLoggingEnabled)));
-        varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL, String.valueOf(offsetShowAll)));
+        varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL, String.valueOf(showAllOffsets)));
 
         // Add shared environment variables used for all containers
         varList.addAll(sharedEnvironmentProvider.variables());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -93,7 +93,7 @@ public class KafkaExporterTest {
     private final String topicRegex = "my-topic-.*";
     private final String groupExcludeRegex = "my-group-exclude-.*";
     private final String topicExcludeRegex = "my-topic-exclude-.*";
-    private final boolean offsetShowAll = false;
+    private final boolean showAllOffsets = false;
 
     private final KafkaExporterSpec exporterOperator = new KafkaExporterSpecBuilder()
             .withLogging(exporterOperatorLogging)
@@ -103,7 +103,7 @@ public class KafkaExporterTest {
             .withTopicExcludeRegex(topicExcludeRegex)
             .withImage(keImage)
             .withEnableSaramaLogging(true)
-            .withOffsetShowAll(offsetShowAll)
+            .withShowAllOffsets(showAllOffsets)
             .withNewTemplate()
                 .withNewPod()
                     .withTmpDirSizeLimit("100Mi")
@@ -137,7 +137,7 @@ public class KafkaExporterTest {
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_TOPIC_EXCLUDE_REGEX).withValue(topicExcludeRegex).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER).withValue("foo-kafka-bootstrap:" + KafkaCluster.REPLICATION_PORT).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA).withValue("true").build());
-        expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL).withValue(String.valueOf(offsetShowAll)).build());
+        expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL).withValue(String.valueOf(showAllOffsets)).build());
         return expected;
     }
 
@@ -155,7 +155,7 @@ public class KafkaExporterTest {
         assertNull(ke.groupExcludeRegex);
         assertNull(ke.topicExcludeRegex);
         assertThat(ke.saramaLoggingEnabled, is(false));
-        assertThat(ke.offsetShowAll, is(true));
+        assertThat(ke.showAllOffsets, is(true));
     }
 
     @ParallelTest
@@ -169,6 +169,7 @@ public class KafkaExporterTest {
         assertThat(ke.groupExcludeRegex, is("my-group-exclude-.*"));
         assertThat(ke.topicExcludeRegex, is("my-topic-exclude-.*"));
         assertThat(ke.saramaLoggingEnabled, is(true));
+        assertThat(ke.showAllOffsets, is(false));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -93,6 +93,7 @@ public class KafkaExporterTest {
     private final String topicRegex = "my-topic-.*";
     private final String groupExcludeRegex = "my-group-exclude-.*";
     private final String topicExcludeRegex = "my-topic-exclude-.*";
+    private final boolean offsetShowAll = false;
 
     private final KafkaExporterSpec exporterOperator = new KafkaExporterSpecBuilder()
             .withLogging(exporterOperatorLogging)
@@ -102,6 +103,7 @@ public class KafkaExporterTest {
             .withTopicExcludeRegex(topicExcludeRegex)
             .withImage(keImage)
             .withEnableSaramaLogging(true)
+            .withOffsetShowAll(offsetShowAll)
             .withNewTemplate()
                 .withNewPod()
                     .withTmpDirSizeLimit("100Mi")
@@ -135,6 +137,7 @@ public class KafkaExporterTest {
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_TOPIC_EXCLUDE_REGEX).withValue(topicExcludeRegex).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_KAFKA_SERVER).withValue("foo-kafka-bootstrap:" + KafkaCluster.REPLICATION_PORT).build());
         expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_ENABLE_SARAMA).withValue("true").build());
+        expected.add(new EnvVarBuilder().withName(KafkaExporter.ENV_VAR_KAFKA_EXPORTER_OFFSET_SHOW_ALL).withValue(String.valueOf(offsetShowAll)).build());
         return expected;
     }
 
@@ -152,6 +155,7 @@ public class KafkaExporterTest {
         assertNull(ke.groupExcludeRegex);
         assertNull(ke.topicExcludeRegex);
         assertThat(ke.saramaLoggingEnabled, is(false));
+        assertThat(ke.offsetShowAll, is(true));
     }
 
     @ParallelTest

--- a/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -30,7 +30,7 @@ if [ "$KAFKA_EXPORTER_ENABLE_SARAMA" = "true" ]; then
     saramaenable="--log.enable-sarama"
 fi
 
-if [ "$KAFKA_EXPORTER_OFFSET_SHOW_ALL" != "false" ]; then
+if [ "$KAFKA_EXPORTER_OFFSET_SHOW_ALL" = "true" ]; then
     allgroups="--offset.show-all"
 fi
 

--- a/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -30,7 +30,7 @@ if [ "$KAFKA_EXPORTER_ENABLE_SARAMA" = "true" ]; then
     saramaenable="--log.enable-sarama"
 fi
 
-if [ "KAFKA_EXPORTER_OFFSET_SHOW_ALL" != "false" ]; then
+if [ "$KAFKA_EXPORTER_OFFSET_SHOW_ALL" != "false" ]; then
     allgroups="--offset.show-all"
 fi
 

--- a/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -30,6 +30,10 @@ if [ "$KAFKA_EXPORTER_ENABLE_SARAMA" = "true" ]; then
     saramaenable="--log.enable-sarama"
 fi
 
+if [ "KAFKA_EXPORTER_OFFSET_SHOW_ALL" != "false" ]; then
+    allgroups="--offset.show-all"
+fi
+
 if [ -n "$KAFKA_EXPORTER_LOGGING" ]; then
     loglevel="--verbosity=${KAFKA_EXPORTER_LOGGING}"
 fi
@@ -47,8 +51,6 @@ version="--kafka.version=\""$KAFKA_EXPORTER_KAFKA_VERSION"\""
 kafkaserver="--kafka.server="$KAFKA_EXPORTER_KAFKA_SERVER
 
 listenaddress="--web.listen-address=:9404"
-
-allgroups="--offset.show-all"
 
 tls="--tls.enabled --tls.ca-file=$CA_CERTS --tls.cert-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.crt  --tls.key-file=/etc/kafka-exporter/kafka-exporter-certs/kafka-exporter.key"
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1578,14 +1578,14 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |enableSaramaLogging  1.2+<.<a|Enable Sarama logging, a Go client library used by the Kafka Exporter.
 |boolean
+|showAllOffsets       1.2+<.<a|Enable/disable offset show all option.
+|boolean
 |template             1.2+<.<a|Customization of deployment templates and pods.
 |xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`]
 |livenessProbe        1.2+<.<a|Pod liveness check.
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe       1.2+<.<a|Pod readiness check.
 |xref:type-Probe-{context}[`Probe`]
-|showAllOffsets       1.2+<.<a|Enable/disable offset show all option.
-|boolean
 |====
 
 [id='type-KafkaExporterTemplate-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1578,7 +1578,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |string
 |enableSaramaLogging  1.2+<.<a|Enable Sarama logging, a Go client library used by the Kafka Exporter.
 |boolean
-|showAllOffsets       1.2+<.<a|Enable/disable offset show all option.
+|showAllOffsets       1.2+<.<a|Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups.
 |boolean
 |template             1.2+<.<a|Customization of deployment templates and pods.
 |xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`]

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1584,6 +1584,8 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-Probe-{context}[`Probe`]
 |readinessProbe       1.2+<.<a|Pod readiness check.
 |xref:type-Probe-{context}[`Probe`]
+|showAllOffsets       1.2+<.<a|Enable/disable offset show all option.
+|boolean
 |====
 
 [id='type-KafkaExporterTemplate-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5601,7 +5601,7 @@ spec:
                       description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
                     showAllOffsets:
                       type: boolean
-                      description: Enable/disable offset show all option.
+                      description: "Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups."
                     template:
                       type: object
                       properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -5599,6 +5599,9 @@ spec:
                     enableSaramaLogging:
                       type: boolean
                       description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
+                    showAllOffsets:
+                      type: boolean
+                      description: Enable/disable offset show all option.
                     template:
                       type: object
                       properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -6233,6 +6233,9 @@ spec:
                         minimum: 1
                         description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
+                  showAllOffsets:
+                    type: boolean
+                    description: Enable/disable offset show all option.
                 description: "Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition."
               maintenanceTimeWindows:
                 type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -5598,6 +5598,9 @@ spec:
                   enableSaramaLogging:
                     type: boolean
                     description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
+                  showAllOffsets:
+                    type: boolean
+                    description: Enable/disable offset show all option.
                   template:
                     type: object
                     properties:
@@ -6233,9 +6236,6 @@ spec:
                         minimum: 1
                         description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     description: Pod readiness check.
-                  showAllOffsets:
-                    type: boolean
-                    description: Enable/disable offset show all option.
                 description: "Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition."
               maintenanceTimeWindows:
                 type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -5600,7 +5600,7 @@ spec:
                     description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
                   showAllOffsets:
                     type: boolean
-                    description: Enable/disable offset show all option.
+                    description: "Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups."
                   template:
                     type: object
                     properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Allow to configure Kafka Exporter `offset.show-all` [#9231](https://github.com/strimzi/strimzi-kafka-operator/issues/9231)

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

