### PR TITLE
[ST] Fix detecting kind in systemtests

### DIFF
--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
@@ -45,9 +45,9 @@ public class Kind implements KubeCluster {
      */
     @Override
     public boolean isClusterUp() {
-        List<String> cmd = Arrays.asList(CMD, "status");
+        List<String> cmd = Arrays.asList("kubectl", "get", "nodes", "-o", "jsonpath='{.items[*].spec.providerID}'");
         try {
-            return Exec.exec(cmd).exitStatus();
+            return Exec.exec(cmd).out().startsWith("kind");
         } catch (KubeClusterException e) {
             LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
             LOGGER.debug(e);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is just a small fix to correctly detect the kind cluster type only when kind cluster is present and then act accordingly when running STs. This change should avoid selecting kind during STs run - when no kind cluster was available and tester was on different cluster type.

### Checklist

- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

