### PR TITLE
[ST] Update upgrade/downgrade files after 0.39.0 release and enable KRaftStrimziDowngradeST

### DIFF
--- a/.azure/templates/steps/default_variables.yaml
+++ b/.azure/templates/steps/default_variables.yaml
@@ -29,3 +29,4 @@ variables:
   components_image_pull_policy: IfNotPresent
   MVN_CACHE_FOLDER: $(HOME)/.m2/repository
   test_log_dir: systemtest/target/logs
+  connectImage: ""

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -96,6 +96,8 @@ jobs:
       env:
         BASE_IMAGE: '$(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-KAFKA_VERSION'
         KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
+      # we want to let Connect image build for different versions of Kafka inside the upgrade/downgrade STs
+      condition: not(contains('${{ parameters.profile }}', 'upgrade'))
 
     # We need to set DOCKER_REGISTRY to IP and port of service, which is created by minikube registry addon, port is always 80
     # Default value for PRs is localhost:5000 because we need to push built images into minikube registry and make them available for pods

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -66,6 +66,23 @@ public class KafkaTemplates {
             .endSpec();
     }
 
+    /**
+     * Overloads {@link #kafkaPersistent(String, int)}, but the difference is that it removes LMFV and IBPV from the Kafka
+     * config
+     * @param name of the Kafka cluster
+     * @param kafkaReplicas number of Kafka replicas
+     * @return KafkaBuilder for Kafka with persistent storage
+     */
+    public static KafkaBuilder kafkaPersistentKRaft(String name, int kafkaReplicas) {
+        return kafkaPersistent(name, kafkaReplicas)
+            .editSpec()
+                .editKafka()
+                    .removeFromConfig("log.message.format.version")
+                    .removeFromConfig("inter.broker.protocol.version")
+                .endKafka()
+            .endSpec();
+    }
+
     public static KafkaBuilder kafkaJBOD(String name, int kafkaReplicas, JbodStorage jbodStorage) {
         return kafkaJBOD(name, kafkaReplicas, 3, jbodStorage);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -142,6 +142,23 @@ public class VersionModificationDataLoader {
         return acrossUpgradeData;
     }
 
+    public BundleVersionModificationData buildDataForDowngradeUsingFirstScenarioForKRaft() {
+        return buildDataForDowngradeUsingFirstScenario(KRAFT_UPGRADE_FEATURE_GATES);
+    }
+
+    /**
+     * Picks first downgrade scenario from whole list, adds needed feature gates (if there are some) and returns this updated single scenario.
+     * This is used in test cases where we don't want to go through the whole list of downgrade scenarios from BundleDowngrade.yaml file.
+     *
+     * @param featureGates feature gates that should be added to the whole test scenario
+     * @return data for particular downgrade scenario
+     */
+    public BundleVersionModificationData buildDataForDowngradeUsingFirstScenario(String featureGates) {
+        BundleVersionModificationData downgradeData = bundleVersionModificationDataList.get(0);
+
+        return updateUpgradeDataWithFeatureGates(downgradeData, featureGates);
+    }
+
     public static Stream<Arguments> loadYamlDowngradeData() {
         return loadYamlDowngradeDataWithFeatureGates(null);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -43,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -548,5 +550,28 @@ public class StUtils {
     public static void waitUntilSupplierIsSatisfied(final BooleanSupplier sup) {
         TestUtils.waitFor(sup.getAsBoolean() + " is satisfied", TestConstants.GLOBAL_POLL_INTERVAL,
                 TestConstants.GLOBAL_STATUS_TIMEOUT, sup);
+    }
+
+    /**
+     * Checks env variables of Topic operator container (inside EO Pod) and based on that determines, if BTO or UTO is used.
+     * Normally we can determine that based on {@link Environment#isUnidirectionalTopicOperatorEnabled()}, but in case that the
+     * FG is changed during test, we have no other way to check it.
+     *
+     * @param namespaceName name of the Namespace, where the EO Pod is running
+     * @param eoLabelSelector LabelSelector of EO
+     * @return boolean determining if UTO is used or not
+     */
+    public static boolean isUnidirectionalTopicOperatorUsed(String namespaceName, LabelSelector eoLabelSelector) {
+        Optional<Container> topicOperatorContainer = kubeClient().listPods(namespaceName, eoLabelSelector).get(0).getSpec().getContainers()
+            .stream().filter(container -> container.getName().equals("topic-operator")).findFirst();
+
+        if (topicOperatorContainer.isPresent()) {
+            return topicOperatorContainer.get().getEnv()
+                // ZK related env vars are only present in BTO mode -> because of that we can determine which of the TOs is used
+                .stream().noneMatch(envVar -> envVar.getName().contains("ZOOKEEPER"));
+        }
+
+        LOGGER.warn("Cannot determine if UTO is used or not, because the EO Pod doesn't exist, gonna assume that it's not");
+        return false;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -28,6 +28,7 @@ import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.crd.KafkaTopicResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
@@ -46,6 +47,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -60,6 +62,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 
+import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.DEFAULT_SINK_FILE_PATH;
 import static io.strimzi.systemtest.TestConstants.PATH_TO_KAFKA_TOPIC_CONFIG;
 import static io.strimzi.systemtest.TestConstants.PATH_TO_PACKAGING_EXAMPLES;
@@ -68,6 +71,7 @@ import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractUpgradeST extends AbstractST {
@@ -97,12 +101,27 @@ public class AbstractUpgradeST extends AbstractST {
     protected final String topicName = "my-topic";
     protected final String userName = "my-user";
     protected final int upgradeTopicCount = 40;
+    protected final int btoKafkaTopicsOnlyCount = 3;
+
     // ExpectedTopicCount contains additionally consumer-offset topic, my-topic and continuous-topic
-    protected final int expectedTopicCount = upgradeTopicCount + 3;
     protected File kafkaYaml;
 
-    protected int getExpectedTopicCount() {
-        return expectedTopicCount;
+    /**
+     * Based on {@param isUTOUsed} and {@param wasUTOUsedBefore} it returns the expected count of KafkaTopics.
+     * In case that UTO was used before and after, the expected number of KafkaTopics is {@link #upgradeTopicCount}.
+     * In other cases - BTO was used before or after the upgrade/downgrade - the expected number of KafkaTopics is {@link #upgradeTopicCount}
+     * with {@link #btoKafkaTopicsOnlyCount}.
+     * @param isUTOUsed boolean value determining if UTO is used after upgrade/downgrade of the CO
+     * @param wasUTOUsedBefore boolean value determining if UTO was used before upgrade/downgrade of the CO
+     * @return expected number of KafkaTopics
+     */
+    protected int getExpectedTopicCount(boolean isUTOUsed, boolean wasUTOUsedBefore) {
+        if (isUTOUsed && wasUTOUsedBefore) {
+            // topics that are just present in Kafka itself are not created as CRs in UTO, thus -3 topics in comparison to regular upgrade
+            return upgradeTopicCount;
+        }
+
+        return upgradeTopicCount + btoKafkaTopicsOnlyCount;
     }
 
     protected void makeSnapshots() {
@@ -250,6 +269,8 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     protected void copyModifyApply(File root, String namespace, final String strimziFeatureGatesValue) {
+        KubeClusterResource.getInstance().setNamespace(namespace);
+
         Arrays.stream(Objects.requireNonNull(root.listFiles())).sorted().forEach(f -> {
             if (f.getName().matches(".*RoleBinding.*")) {
                 cmdKubeClient().replaceContent(TestUtils.changeRoleBindingSubject(f, namespace));
@@ -363,6 +384,7 @@ public class AbstractUpgradeST extends AbstractST {
                 .withTopicName(testStorage.getTopicName())
                 .withMessageCount(upgradeData.getContinuousClientsMessages())
                 .withAdditionalConfig(producerAdditionConfiguration)
+                .withNamespaceName(namespace)
                 .withDelayMs(1000)
                 .build();
 
@@ -374,13 +396,15 @@ public class AbstractUpgradeST extends AbstractST {
         makeSnapshots();
     }
 
-    protected void verifyProcedure(BundleVersionModificationData upgradeData, String producerName, String consumerName, String namespace) {
+    protected void verifyProcedure(BundleVersionModificationData upgradeData, String producerName, String consumerName, String namespace, boolean wasUTOUsedBefore) {
 
         if (upgradeData.getAdditionalTopics() != null) {
+            boolean isUTOUsed = StUtils.isUnidirectionalTopicOperatorUsed(namespace, eoSelector);
+
             // Check that topics weren't deleted/duplicated during upgrade procedures
             String listedTopics = cmdKubeClient().getResources(getResourceApiVersion(KafkaTopic.RESOURCE_PLURAL));
             int additionalTopics = upgradeData.getAdditionalTopics();
-            assertThat("KafkaTopic list doesn't have expected size", Long.valueOf(listedTopics.lines().count() - 1).intValue(), is(getExpectedTopicCount() + additionalTopics));
+            assertThat("KafkaTopic list doesn't have expected size", Long.valueOf(listedTopics.lines().count() - 1).intValue(), greaterThanOrEqualTo(getExpectedTopicCount(isUTOUsed, wasUTOUsedBefore) + additionalTopics));
             assertThat("KafkaTopic " + topicName + " is not in expected Topic list",
                     listedTopics.contains(topicName), is(true));
             for (int x = 0; x < upgradeTopicCount; x++) {
@@ -396,6 +420,7 @@ public class AbstractUpgradeST extends AbstractST {
             // ##############################
         }
     }
+
     protected String getResourceApiVersion(String resourcePlural) {
         return resourcePlural + "." + Constants.V1BETA2 + "." + Constants.RESOURCE_GROUP_NAME;
     }
@@ -623,5 +648,19 @@ public class AbstractUpgradeST extends AbstractST {
             File dir = FileUtils.downloadAndUnzip(versionModificationData.getToUrl());
             return dir.getAbsolutePath() + "/" + versionModificationData.getToExamples() + "/examples";
         }
+    }
+
+    protected void cleanUpKafkaTopics() {
+        List<KafkaTopic> topics = KafkaTopicResource.kafkaTopicClient().inNamespace(CO_NAMESPACE).list().getItems();
+        boolean finalizersAreSet = topics.stream().anyMatch(kafkaTopic -> kafkaTopic.getFinalizers() != null);
+
+        // in case that we are upgrading/downgrading from UTO to BTO, we have to set finalizers on topics to null before deleting them
+        if (!StUtils.isUnidirectionalTopicOperatorUsed(CO_NAMESPACE, eoSelector) && finalizersAreSet) {
+            KafkaTopicUtils.setFinalizersInAllTopicsToNull(CO_NAMESPACE);
+        }
+
+        // delete all topics created in test
+        cmdKubeClient(TestConstants.CO_NAMESPACE).deleteAllByResource(KafkaTopic.RESOURCE_KIND);
+        KafkaTopicUtils.waitForTopicWithPrefixDeletion(TestConstants.CO_NAMESPACE, topicName);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -24,7 +23,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.List;
 
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
@@ -37,10 +35,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Metadata for the following tests are collected from systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
  */
 @Tag(KRAFT_UPGRADE)
-@Disabled("The tests are currently disabled, as the KRaft to KRaft downgrade (with operator downgrade) is not handled in Strimzi 0.38.0")
 public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziDowngradeST.class);
-    private final List<BundleVersionModificationData> bundleDowngradeMetadata = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_DOWNGRADE).getBundleUpgradeOrDowngradeDataList();
+    private final BundleVersionModificationData bundleDowngradeVersionData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_DOWNGRADE).buildDataForDowngradeUsingFirstScenarioForKRaft();
 
     @ParameterizedTest(name = "testDowngradeStrimziVersion-{0}-{1}")
     @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeDataForKRaft")
@@ -56,12 +53,9 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     @Test
     void testDowngradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
         final TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
-        final BundleVersionModificationData bundleDowngradeDataWithFeatureGates = bundleDowngradeMetadata.stream()
-            .filter(bundleMetadata -> bundleMetadata.getFeatureGatesBefore() != null && !bundleMetadata.getFeatureGatesBefore().isEmpty() ||
-                bundleMetadata.getFeatureGatesAfter() != null && !bundleMetadata.getFeatureGatesAfter().isEmpty()).toList().get(0);
-        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeDataWithFeatureGates.getDeployKafkaVersion());
+        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeVersionData.getDeployKafkaVersion());
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(extensionContext, bundleDowngradeDataWithFeatureGates, testStorage, upgradeKafkaVersion);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(extensionContext, bundleDowngradeVersionData, testStorage, upgradeKafkaVersion);
     }
 
     @SuppressWarnings("MethodLength")
@@ -78,6 +72,8 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
         setupEnvAndUpgradeClusterOperator(extensionContext, downgradeData, testStorage, testUpgradeKafkaVersion, TestConstants.CO_NAMESPACE);
 
         logPodImages(TestConstants.CO_NAMESPACE);
+
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TestConstants.CO_NAMESPACE, eoSelector);
 
         // Downgrade CO
         changeClusterOperator(downgradeData, TestConstants.CO_NAMESPACE, extensionContext);
@@ -96,7 +92,7 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
         checkAllImages(downgradeData, TestConstants.CO_NAMESPACE);
 
         // Verify upgrade
-        verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE);
+        verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @BeforeEach
@@ -106,6 +102,7 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
 
     @AfterEach
     void afterEach() {
+        cleanUpKafkaTopics();
         deleteInstalledYamls(coDir, TestConstants.CO_NAMESPACE);
         NamespaceManager.getInstance().deleteNamespaceWithWait(CO_NAMESPACE);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.upgrade.kraft;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.resources.NamespaceManager;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.upgrade.regular;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.resources.NamespaceManager;

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -26,19 +26,19 @@
 # --- Structure ---
   
 - fromVersion: HEAD
-  toVersion: 0.38.0
+  toVersion: 0.39.0
   fromExamples: HEAD
-  toExamples: strimzi-0.38.0
+  toExamples: strimzi-0.39.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.38.0-kafka-3.6.0
-    kafka: strimzi/kafka:0.38.0-kafka-3.6.0
-    topicOperator: strimzi/operator:0.38.0
-    userOperator: strimzi/operator:0.38.0
-  deployKafkaVersion: 3.6.0
+    zookeeper: strimzi/kafka:0.39.0-kafka-3.5.0
+    kafka: strimzi/kafka:0.39.0-kafka-3.5.0
+    topicOperator: strimzi/operator:0.39.0
+    userOperator: strimzi/operator:0.39.0
+  deployKafkaVersion: 3.6.1
   client:
     continuousClientsMessages: 500
   environmentInfo:
@@ -46,22 +46,22 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
-  featureGatesBefore: "-KafkaNodePools"
-  featureGatesAfter: "-StableConnectIdentities,-UnidirectionalTopicOperator"
+  featureGatesBefore: ""
+  featureGatesAfter: "-UnidirectionalTopicOperator"
 - fromVersion: HEAD
-  toVersion: 0.38.0
+  toVersion: 0.39.0
   fromExamples: HEAD
-  toExamples: strimzi-0.38.0
+  toExamples: strimzi-0.39.0
   fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
   fromKafkaVersionsUrl: HEAD
   additionalTopics: 2
   imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.38.0-kafka-3.5.1
-    kafka: strimzi/kafka:0.38.0-kafka-3.5.1
-    topicOperator: strimzi/operator:0.38.0
-    userOperator: strimzi/operator:0.38.0
-  deployKafkaVersion: 3.5.1
+    zookeeper: strimzi/kafka:0.39.0-kafka-3.5.0
+    kafka: strimzi/kafka:0.39.0-kafka-3.5.0
+    topicOperator: strimzi/operator:0.39.0
+    userOperator: strimzi/operator:0.39.0
+  deployKafkaVersion: 3.6.1
   client:
     continuousClientsMessages: 500
   environmentInfo:
@@ -69,5 +69,5 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
-  featureGatesBefore: "-KafkaNodePools"
+  featureGatesBefore: ""
   featureGatesAfter: ""

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -24,11 +24,11 @@
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
 #  --- Structure ---
 
-- fromVersion: 0.38.0
-  fromExamples: strimzi-0.38.0
+- fromVersion: 0.39.0
+  fromExamples: strimzi-0.39.0
   oldestKafka: 3.5.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.38.0/kafka-versions.yaml
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.39.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.6.1
@@ -44,11 +44,11 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: ""
   featureGatesAfter: ""
-- fromVersion: 0.38.0
-  fromExamples: strimzi-0.38.0
+- fromVersion: 0.39.0
+  fromExamples: strimzi-0.39.0
   oldestKafka: 3.5.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.38.0/kafka-versions.yaml
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.39.0/kafka-versions.yaml
   additionalTopics: 2
   imagesAfterOperations:
     zookeeper: strimzi/kafka:latest-kafka-3.6.1
@@ -62,5 +62,5 @@
     status: stable
     flakyEnvVariable: none
     reason: Test is working on environment, where k8s server version is < 1.22
-  featureGatesBefore: "-StableConnectIdentities,-UnidirectionalTopicOperator"
+  featureGatesBefore: "-UnidirectionalTopicOperator"
   featureGatesAfter: ""

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -13,8 +13,8 @@
 #  Kubernetes cluster.
 #  --- Prerequisites ---
 
-fromVersion: 0.38.0
-fromOlmChannelName: strimzi-0.38.x
-fromExamples: strimzi-0.38.0
-fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip
-fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.38.0/kafka-versions.yaml
+fromVersion: 0.39.0
+fromOlmChannelName: strimzi-0.39.x
+fromExamples: strimzi-0.39.0
+fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
+fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.39.0/kafka-versions.yaml


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates upgrade/downgrade files after the 0.39.0 release. It also enables `KRaftStrimziDowngradeST`, which was blocked until new version of Strimzi, which supports KRaft to KRaft upgrade/(safe) downgrade is not released.

### Checklist

- [ ] Make sure all tests pass

