### PR TITLE
Use `additionalProperties` instead of `x-kubernetes-preserve-unknown-fields` for `Map<String, String>` fields

### DIFF
--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -52,7 +52,7 @@ import java.util.Map;
         }
     )
 )
-@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or"))})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or")), @OneOf.Alternative({@OneOf.Alternative.Property("mapStringString"), @OneOf.Alternative.Property("mapStringObject")})})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource {
 
@@ -152,7 +152,9 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         }
     }
 
-    private Map<String, Object> mapProperty;
+    private Map<String, Object> mapStringObject;
+
+    private Map<String, String> mapStringString;
 
     private PolymorphicTop polymorphicProperty;
 
@@ -278,12 +280,20 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.objectProperty = objectProperty;
     }
 
-    public Map<String, Object> getMapProperty() {
-        return mapProperty;
+    public Map<String, Object> getMapStringObject() {
+        return mapStringObject;
     }
 
-    public void setMapProperty(Map<String, Object> mapProperty) {
-        this.mapProperty = mapProperty;
+    public void setMapStringObject(Map<String, Object> mapStringObject) {
+        this.mapStringObject = mapStringObject;
+    }
+
+    public Map<String, String> getMapStringString() {
+        return mapStringString;
+    }
+
+    public void setMapStringString(Map<String, String> mapStringString) {
+        this.mapStringString = mapStringString;
     }
 
     public PolymorphicTop getPolymorphicProperty() {

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -67,7 +67,9 @@
 |xref:type-Number-{context}[`Number`] array of dimension 2
 |longProperty            1.2+<.<a|An example long property.
 |integer
-|mapProperty             1.2+<.<a|
+|mapStringObject         1.2+<.<a|
+|map
+|mapStringString         1.2+<.<a|
 |map
 |normalEnum              1.2+<.<a|
 |string (one of [BAR, FOO])

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -139,7 +139,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -158,7 +159,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -190,7 +192,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -209,7 +212,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -245,7 +249,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -264,7 +269,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -296,7 +302,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -315,7 +322,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -491,8 +499,12 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -549,6 +561,12 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty
   - name: v1beta1
@@ -675,7 +693,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -694,7 +713,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -726,7 +746,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -745,7 +766,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -781,7 +803,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -800,7 +823,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -832,7 +856,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -851,7 +876,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -1027,8 +1053,12 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -1085,5 +1115,11 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -145,7 +145,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -164,7 +165,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -196,7 +198,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -215,7 +218,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -251,7 +255,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -270,7 +275,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -302,7 +308,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -321,7 +328,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -497,8 +505,12 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -555,6 +567,12 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty
   - name: v1beta1
@@ -681,7 +699,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -700,7 +719,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -732,7 +752,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -751,7 +772,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -787,7 +809,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -806,7 +829,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -838,7 +862,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -857,7 +882,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -1033,8 +1059,12 @@ spec:
             example: 42
             minimum: 42
             description: An example long property.
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -1091,5 +1121,11 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -139,7 +139,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -158,7 +159,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -190,7 +192,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -209,7 +212,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -245,7 +249,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -264,7 +269,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -296,7 +302,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -315,7 +322,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -486,8 +494,12 @@ spec:
             type: integer
             example: 42
             minimum: 42
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -542,6 +554,12 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty
   - name: v1beta1
@@ -668,7 +686,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -687,7 +706,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -719,7 +739,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -738,7 +759,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -774,7 +796,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaceSelector:
                               type: object
@@ -793,7 +816,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             namespaces:
                               type: array
@@ -825,7 +849,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaceSelector:
                           type: object
@@ -844,7 +869,8 @@ spec:
                                     items:
                                       type: string
                             matchLabels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                         namespaces:
                           type: array
@@ -1015,8 +1041,12 @@ spec:
             type: integer
             example: 42
             minimum: 42
-          mapProperty:
+          mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
             type: object
           normalEnum:
             type: string
@@ -1071,5 +1101,11 @@ spec:
             or: {}
           required:
           - or
+        - properties:
+            mapStringString: {}
+            mapStringObject: {}
+          required:
+          - mapStringString
+          - mapStringObject
         required:
         - stringProperty

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -314,11 +314,13 @@ spec:
                                     type: string
                                     description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
                                   annotations:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                                     description: "Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                                   labels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                                     description: "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                                 description: Bootstrap configuration.
@@ -346,11 +348,13 @@ spec:
                                       type: string
                                       description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
                                     annotations:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                       description: "Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners."
                                     labels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                       description: "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                                   required:
@@ -441,7 +445,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 podSelector:
                                   type: object
@@ -460,7 +465,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                             description: "List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list."
                         required:
@@ -499,7 +505,8 @@ spec:
                                 description: Id of the kafka broker (broker identifier).
                           description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                         selector:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                         size:
@@ -544,7 +551,8 @@ spec:
                                       description: Id of the kafka broker (broker identifier).
                                 description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                               selector:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                               size:
@@ -736,7 +744,8 @@ spec:
                       type: object
                       properties:
                         "-XX":
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A map of -XX options to the JVM.
                         "-Xms":
@@ -825,7 +834,8 @@ spec:
                       type: object
                       properties:
                         loggers:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A Map from logger name to logger level.
                         type:
@@ -861,11 +871,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -883,11 +895,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1063,7 +1077,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -1082,7 +1097,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -1114,7 +1130,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1133,7 +1150,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1169,7 +1187,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -1188,7 +1207,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -1220,7 +1240,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1239,7 +1260,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1311,7 +1333,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -1338,11 +1361,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1369,11 +1394,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1400,11 +1427,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1416,11 +1445,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1432,11 +1463,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1448,11 +1481,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1464,11 +1499,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1480,11 +1517,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1496,11 +1535,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1512,11 +1553,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1680,11 +1723,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1696,11 +1741,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1712,11 +1759,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1728,11 +1777,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1744,11 +1795,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -1795,7 +1848,8 @@ spec:
                                 description: Id of the kafka broker (broker identifier).
                           description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                         selector:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                         size:
@@ -1870,7 +1924,8 @@ spec:
                       type: object
                       properties:
                         "-XX":
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A map of -XX options to the JVM.
                         "-Xms":
@@ -1959,7 +2014,8 @@ spec:
                       type: object
                       properties:
                         loggers:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A Map from logger name to logger level.
                         type:
@@ -1995,11 +2051,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2017,11 +2075,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2197,7 +2257,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -2216,7 +2277,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -2248,7 +2310,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -2267,7 +2330,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -2303,7 +2367,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -2322,7 +2387,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -2354,7 +2420,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -2373,7 +2440,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -2445,7 +2513,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -2472,11 +2541,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2503,11 +2574,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2534,11 +2607,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2550,11 +2625,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -2644,11 +2721,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2660,11 +2739,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2676,11 +2757,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -2807,7 +2890,8 @@ spec:
                           type: object
                           properties:
                             loggers:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: A Map from logger name to logger level.
                             type:
@@ -2837,7 +2921,8 @@ spec:
                           type: object
                           properties:
                             "-XX":
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: A map of -XX options to the JVM.
                             "-Xms":
@@ -2954,7 +3039,8 @@ spec:
                           type: object
                           properties:
                             loggers:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: A Map from logger name to logger level.
                             type:
@@ -2984,7 +3070,8 @@ spec:
                           type: object
                           properties:
                             "-XX":
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: A map of -XX options to the JVM.
                             "-Xms":
@@ -3106,11 +3193,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -3128,11 +3217,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -3308,7 +3399,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -3327,7 +3419,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -3359,7 +3452,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -3378,7 +3472,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -3414,7 +3509,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -3433,7 +3529,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -3465,7 +3562,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -3484,7 +3582,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -3556,7 +3655,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -3805,11 +3905,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -3821,11 +3923,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -3837,11 +3941,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -3853,11 +3959,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -4071,7 +4179,8 @@ spec:
                       type: object
                       properties:
                         "-XX":
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A map of -XX options to the JVM.
                         "-Xms":
@@ -4102,7 +4211,8 @@ spec:
                       type: object
                       properties:
                         loggers:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: A Map from logger name to logger level.
                         type:
@@ -4138,11 +4248,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -4160,11 +4272,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -4340,7 +4454,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -4359,7 +4474,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -4391,7 +4507,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -4410,7 +4527,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -4446,7 +4564,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -4465,7 +4584,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -4497,7 +4617,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -4516,7 +4637,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -4588,7 +4710,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -4615,11 +4738,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -4646,11 +4771,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -4814,11 +4941,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -4993,11 +5122,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -5015,11 +5146,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -5195,7 +5328,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -5214,7 +5348,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -5246,7 +5381,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -5265,7 +5401,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -5301,7 +5438,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -5320,7 +5458,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -5352,7 +5491,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -5371,7 +5511,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -5443,7 +5584,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -5544,11 +5686,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -5612,11 +5756,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -5634,11 +5780,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -5814,7 +5962,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -5833,7 +5982,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -5865,7 +6015,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -5884,7 +6035,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -5920,7 +6072,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaceSelector:
                                                 type: object
@@ -5939,7 +6092,8 @@ spec:
                                                           items:
                                                             type: string
                                                   matchLabels:
-                                                    x-kubernetes-preserve-unknown-fields: true
+                                                    additionalProperties:
+                                                      type: string
                                                     type: object
                                               namespaces:
                                                 type: array
@@ -5971,7 +6125,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -5990,7 +6145,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -6062,7 +6218,8 @@ spec:
                                               items:
                                                 type: string
                                       matchLabels:
-                                        x-kubernetes-preserve-unknown-fields: true
+                                        additionalProperties:
+                                          type: string
                                         type: object
                                   matchLabelKeys:
                                     type: array
@@ -6089,11 +6246,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
@@ -6179,11 +6338,13 @@ spec:
                               type: object
                               properties:
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Labels added to the Kubernetes resource.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -291,7 +291,8 @@ spec:
                   type: object
                   properties:
                     "-XX":
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A map of -XX options to the JVM.
                     "-Xms":
@@ -337,7 +338,8 @@ spec:
                   type: object
                   properties:
                     loggers:
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A Map from logger name to logger level.
                     type:
@@ -398,11 +400,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -420,11 +424,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -436,11 +442,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -616,7 +624,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -635,7 +644,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -667,7 +677,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -686,7 +697,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -722,7 +734,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -741,7 +754,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -773,7 +787,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -792,7 +807,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -864,7 +880,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -891,11 +908,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -922,11 +941,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1101,11 +1122,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1121,11 +1144,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1137,11 +1162,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1153,11 +1180,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1333,7 +1362,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1352,7 +1382,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1384,7 +1415,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -1403,7 +1435,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1439,7 +1472,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1458,7 +1492,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1490,7 +1525,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -1509,7 +1545,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1581,7 +1618,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -1682,11 +1720,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1701,11 +1741,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1717,11 +1759,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
@@ -67,7 +67,8 @@ spec:
                             items:
                               type: string
                     matchLabels:
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                   description: "Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored."
                 pods:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -197,11 +197,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -418,11 +420,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -639,11 +643,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -453,7 +453,8 @@ spec:
                   type: object
                   properties:
                     "-XX":
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A map of -XX options to the JVM.
                     "-Xms":
@@ -484,7 +485,8 @@ spec:
                   type: object
                   properties:
                     loggers:
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A Map from logger name to logger level.
                     type:
@@ -558,11 +560,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -580,11 +584,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -760,7 +766,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -779,7 +786,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -811,7 +819,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -830,7 +839,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -866,7 +876,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -885,7 +896,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -917,7 +929,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -936,7 +949,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1008,7 +1022,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -1035,11 +1050,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1129,11 +1146,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -291,7 +291,8 @@ spec:
                   type: object
                   properties:
                     "-XX":
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A map of -XX options to the JVM.
                     "-Xms":
@@ -322,7 +323,8 @@ spec:
                   type: object
                   properties:
                     loggers:
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A Map from logger name to logger level.
                     type:
@@ -422,11 +424,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -444,11 +448,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -624,7 +630,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -643,7 +650,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -675,7 +683,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -694,7 +703,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -730,7 +740,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -749,7 +760,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -781,7 +793,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -800,7 +813,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -872,7 +886,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -899,11 +914,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -930,11 +947,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1024,11 +1043,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1040,11 +1061,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -436,7 +436,8 @@ spec:
                   type: object
                   properties:
                     "-XX":
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A map of -XX options to the JVM.
                     "-Xms":
@@ -482,7 +483,8 @@ spec:
                   type: object
                   properties:
                     loggers:
-                      x-kubernetes-preserve-unknown-fields: true
+                      additionalProperties:
+                        type: string
                       type: object
                       description: A Map from logger name to logger level.
                     type:
@@ -543,11 +545,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -565,11 +569,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -581,11 +587,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -761,7 +769,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -780,7 +789,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -812,7 +822,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -831,7 +842,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -867,7 +879,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -886,7 +899,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -918,7 +932,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -937,7 +952,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1009,7 +1025,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -1036,11 +1053,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1067,11 +1086,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1246,11 +1267,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1266,11 +1289,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1282,11 +1307,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1298,11 +1325,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1478,7 +1507,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1497,7 +1527,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1529,7 +1560,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -1548,7 +1580,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1584,7 +1617,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaceSelector:
                                             type: object
@@ -1603,7 +1637,8 @@ spec:
                                                       items:
                                                         type: string
                                               matchLabels:
-                                                x-kubernetes-preserve-unknown-fields: true
+                                                additionalProperties:
+                                                  type: string
                                                 type: object
                                           namespaces:
                                             type: array
@@ -1635,7 +1670,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaceSelector:
                                         type: object
@@ -1654,7 +1690,8 @@ spec:
                                                   items:
                                                     type: string
                                           matchLabels:
-                                            x-kubernetes-preserve-unknown-fields: true
+                                            additionalProperties:
+                                              type: string
                                             type: object
                                       namespaces:
                                         type: array
@@ -1726,7 +1763,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               matchLabelKeys:
                                 type: array
@@ -1827,11 +1865,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1846,11 +1886,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
@@ -1862,11 +1904,13 @@ spec:
                           type: object
                           properties:
                             labels:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Labels added to the Kubernetes resource.
                             annotations:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -71,7 +71,8 @@ spec:
                           description: Id of the kafka broker (broker identifier).
                     description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                   selector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                   size:
@@ -116,7 +117,8 @@ spec:
                                 description: Id of the kafka broker (broker identifier).
                           description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                         selector:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                         size:
@@ -167,7 +169,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -204,11 +207,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -220,11 +225,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -400,7 +407,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -419,7 +427,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -451,7 +460,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -470,7 +480,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -506,7 +517,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -525,7 +537,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -557,7 +570,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -576,7 +590,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -648,7 +663,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -675,11 +691,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -691,11 +709,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -707,11 +727,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -723,11 +745,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -313,11 +313,13 @@ spec:
                                   type: string
                                   description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
                                 annotations:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: "Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                                 labels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                                   description: "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                               description: Bootstrap configuration.
@@ -345,11 +347,13 @@ spec:
                                     type: string
                                     description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
                                   annotations:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                                     description: "Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners."
                                   labels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                                     description: "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
                                 required:
@@ -440,7 +444,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                               podSelector:
                                 type: object
@@ -459,7 +464,8 @@ spec:
                                           items:
                                             type: string
                                   matchLabels:
-                                    x-kubernetes-preserve-unknown-fields: true
+                                    additionalProperties:
+                                      type: string
                                     type: object
                           description: "List of peers which should be able to connect to this listener. Peers in this list are combined using a logical OR operation. If this field is empty or missing, all connections will be allowed for this listener. If this field is present and contains at least one item, the listener only allows the traffic which matches at least one item in this list."
                       required:
@@ -498,7 +504,8 @@ spec:
                               description: Id of the kafka broker (broker identifier).
                         description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                       selector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                       size:
@@ -543,7 +550,8 @@ spec:
                                     description: Id of the kafka broker (broker identifier).
                               description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                             selector:
-                              x-kubernetes-preserve-unknown-fields: true
+                              additionalProperties:
+                                type: string
                               type: object
                               description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                             size:
@@ -735,7 +743,8 @@ spec:
                     type: object
                     properties:
                       "-XX":
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A map of -XX options to the JVM.
                       "-Xms":
@@ -824,7 +833,8 @@ spec:
                     type: object
                     properties:
                       loggers:
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A Map from logger name to logger level.
                       type:
@@ -860,11 +870,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -882,11 +894,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1062,7 +1076,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -1081,7 +1096,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -1113,7 +1129,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1132,7 +1149,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1168,7 +1186,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -1187,7 +1206,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -1219,7 +1239,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1238,7 +1259,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1310,7 +1332,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -1337,11 +1360,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1368,11 +1393,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1399,11 +1426,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1415,11 +1444,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1431,11 +1462,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1447,11 +1480,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1463,11 +1498,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1479,11 +1516,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1495,11 +1534,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1511,11 +1552,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1679,11 +1722,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1695,11 +1740,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1711,11 +1758,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1727,11 +1776,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1743,11 +1794,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -1794,7 +1847,8 @@ spec:
                               description: Id of the kafka broker (broker identifier).
                         description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                       selector:
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                       size:
@@ -1869,7 +1923,8 @@ spec:
                     type: object
                     properties:
                       "-XX":
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A map of -XX options to the JVM.
                       "-Xms":
@@ -1958,7 +2013,8 @@ spec:
                     type: object
                     properties:
                       loggers:
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A Map from logger name to logger level.
                       type:
@@ -1994,11 +2050,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2016,11 +2074,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2196,7 +2256,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -2215,7 +2276,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -2247,7 +2309,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -2266,7 +2329,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -2302,7 +2366,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -2321,7 +2386,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -2353,7 +2419,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -2372,7 +2439,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -2444,7 +2512,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -2471,11 +2540,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2502,11 +2573,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2533,11 +2606,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2549,11 +2624,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -2643,11 +2720,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2659,11 +2738,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2675,11 +2756,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -2806,7 +2889,8 @@ spec:
                         type: object
                         properties:
                           loggers:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: A Map from logger name to logger level.
                           type:
@@ -2836,7 +2920,8 @@ spec:
                         type: object
                         properties:
                           "-XX":
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: A map of -XX options to the JVM.
                           "-Xms":
@@ -2953,7 +3038,8 @@ spec:
                         type: object
                         properties:
                           loggers:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: A Map from logger name to logger level.
                           type:
@@ -2983,7 +3069,8 @@ spec:
                         type: object
                         properties:
                           "-XX":
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: A map of -XX options to the JVM.
                           "-Xms":
@@ -3105,11 +3192,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -3127,11 +3216,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -3307,7 +3398,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -3326,7 +3418,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -3358,7 +3451,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -3377,7 +3471,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -3413,7 +3508,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -3432,7 +3528,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -3464,7 +3561,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -3483,7 +3581,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -3555,7 +3654,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -3804,11 +3904,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -3820,11 +3922,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -3836,11 +3940,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -3852,11 +3958,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -4070,7 +4178,8 @@ spec:
                     type: object
                     properties:
                       "-XX":
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A map of -XX options to the JVM.
                       "-Xms":
@@ -4101,7 +4210,8 @@ spec:
                     type: object
                     properties:
                       loggers:
-                        x-kubernetes-preserve-unknown-fields: true
+                        additionalProperties:
+                          type: string
                         type: object
                         description: A Map from logger name to logger level.
                       type:
@@ -4137,11 +4247,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -4159,11 +4271,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -4339,7 +4453,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -4358,7 +4473,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -4390,7 +4506,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -4409,7 +4526,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -4445,7 +4563,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -4464,7 +4583,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -4496,7 +4616,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -4515,7 +4636,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -4587,7 +4709,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -4614,11 +4737,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -4645,11 +4770,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -4813,11 +4940,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -4992,11 +5121,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -5014,11 +5145,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -5194,7 +5327,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -5213,7 +5347,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -5245,7 +5380,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -5264,7 +5400,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -5300,7 +5437,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -5319,7 +5457,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -5351,7 +5490,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -5370,7 +5510,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -5442,7 +5583,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -5543,11 +5685,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -5611,11 +5755,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -5633,11 +5779,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -5813,7 +5961,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -5832,7 +5981,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -5864,7 +6014,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -5883,7 +6034,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -5919,7 +6071,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaceSelector:
                                               type: object
@@ -5938,7 +6091,8 @@ spec:
                                                         items:
                                                           type: string
                                                 matchLabels:
-                                                  x-kubernetes-preserve-unknown-fields: true
+                                                  additionalProperties:
+                                                    type: string
                                                   type: object
                                             namespaces:
                                               type: array
@@ -5970,7 +6124,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -5989,7 +6144,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -6061,7 +6217,8 @@ spec:
                                             items:
                                               type: string
                                     matchLabels:
-                                      x-kubernetes-preserve-unknown-fields: true
+                                      additionalProperties:
+                                        type: string
                                       type: object
                                 matchLabelKeys:
                                   type: array
@@ -6088,11 +6245,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
@@ -6178,11 +6337,13 @@ spec:
                             type: object
                             properties:
                               labels:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Labels added to the Kubernetes resource.
                               annotations:
-                                x-kubernetes-preserve-unknown-fields: true
+                                additionalProperties:
+                                  type: string
                                 type: object
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -290,7 +290,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -336,7 +337,8 @@ spec:
                 type: object
                 properties:
                   loggers:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A Map from logger name to logger level.
                   type:
@@ -397,11 +399,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -419,11 +423,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -435,11 +441,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -615,7 +623,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -634,7 +643,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -666,7 +676,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -685,7 +696,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -721,7 +733,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -740,7 +753,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -772,7 +786,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -791,7 +806,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -863,7 +879,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -890,11 +907,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -921,11 +940,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1100,11 +1121,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1120,11 +1143,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1136,11 +1161,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1152,11 +1179,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1332,7 +1361,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1351,7 +1381,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1383,7 +1414,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -1402,7 +1434,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1438,7 +1471,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1457,7 +1491,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1489,7 +1524,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -1508,7 +1544,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1580,7 +1617,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -1681,11 +1719,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1700,11 +1740,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1716,11 +1758,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
+++ b/packaging/install/cluster-operator/042-Crd-strimzipodset.yaml
@@ -66,7 +66,8 @@ spec:
                           items:
                             type: string
                   matchLabels:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                 description: "Selector is a label query which matches all the pods managed by this `StrimziPodSet`. Only `matchLabels` is supported. If `matchExpressions` is set, it will be ignored."
               pods:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -196,11 +196,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -417,11 +419,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -638,11 +642,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -452,7 +452,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -483,7 +484,8 @@ spec:
                 type: object
                 properties:
                   loggers:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A Map from logger name to logger level.
                   type:
@@ -557,11 +559,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -579,11 +583,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -759,7 +765,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -778,7 +785,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -810,7 +818,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -829,7 +838,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -865,7 +875,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -884,7 +895,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -916,7 +928,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -935,7 +948,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1007,7 +1021,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -1034,11 +1049,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1128,11 +1145,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -290,7 +290,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -321,7 +322,8 @@ spec:
                 type: object
                 properties:
                   loggers:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A Map from logger name to logger level.
                   type:
@@ -421,11 +423,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -443,11 +447,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -623,7 +629,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -642,7 +649,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -674,7 +682,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -693,7 +702,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -729,7 +739,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -748,7 +759,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -780,7 +792,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -799,7 +812,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -871,7 +885,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -898,11 +913,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -929,11 +946,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1023,11 +1042,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1039,11 +1060,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -435,7 +435,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -481,7 +482,8 @@ spec:
                 type: object
                 properties:
                   loggers:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A Map from logger name to logger level.
                   type:
@@ -542,11 +544,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -564,11 +568,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -580,11 +586,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -760,7 +768,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -779,7 +788,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -811,7 +821,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -830,7 +841,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -866,7 +878,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -885,7 +898,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -917,7 +931,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -936,7 +951,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1008,7 +1024,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -1035,11 +1052,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1066,11 +1085,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1245,11 +1266,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1265,11 +1288,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1281,11 +1306,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1297,11 +1324,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1477,7 +1506,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1496,7 +1526,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1528,7 +1559,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -1547,7 +1579,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1583,7 +1616,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -1602,7 +1636,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -1634,7 +1669,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -1653,7 +1689,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -1725,7 +1762,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -1826,11 +1864,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata to apply to the `PodDisruptionBudgetTemplate` resource.
@@ -1845,11 +1885,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -1861,11 +1903,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -71,7 +71,8 @@ spec:
                           description: Id of the kafka broker (broker identifier).
                     description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                   selector:
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                   size:
@@ -116,7 +117,8 @@ spec:
                                 description: Id of the kafka broker (broker identifier).
                           description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
                         selector:
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           type: object
                           description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
                         size:
@@ -167,7 +169,8 @@ spec:
                 type: object
                 properties:
                   "-XX":
-                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
                     type: object
                     description: A map of -XX options to the JVM.
                   "-Xms":
@@ -204,11 +207,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -220,11 +225,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -400,7 +407,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -419,7 +427,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -451,7 +460,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -470,7 +480,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -506,7 +517,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaceSelector:
                                           type: object
@@ -525,7 +537,8 @@ spec:
                                                     items:
                                                       type: string
                                             matchLabels:
-                                              x-kubernetes-preserve-unknown-fields: true
+                                              additionalProperties:
+                                                type: string
                                               type: object
                                         namespaces:
                                           type: array
@@ -557,7 +570,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaceSelector:
                                       type: object
@@ -576,7 +590,8 @@ spec:
                                                 items:
                                                   type: string
                                         matchLabels:
-                                          x-kubernetes-preserve-unknown-fields: true
+                                          additionalProperties:
+                                            type: string
                                           type: object
                                     namespaces:
                                       type: array
@@ -648,7 +663,8 @@ spec:
                                         items:
                                           type: string
                                 matchLabels:
-                                  x-kubernetes-preserve-unknown-fields: true
+                                  additionalProperties:
+                                    type: string
                                   type: object
                             matchLabelKeys:
                               type: array
@@ -675,11 +691,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -691,11 +709,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -707,11 +727,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -723,11 +745,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -196,11 +196,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -417,11 +419,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
@@ -638,11 +642,13 @@ spec:
                         type: object
                         properties:
                           labels:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Labels added to the Kubernetes resource.
                           annotations:
-                            x-kubernetes-preserve-unknown-fields: true
+                            additionalProperties:
+                              type: string
                             type: object
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR changes how we generate the CRD schema for fields with type `Map<String, String>` where this PR uses the `additionalProeprties` field instead of `x-kubernetes-preserve-unknown-fields`. That should help users using toosl such as Terraform that seem to have some weird behavior when dealing with the `x-kubernetes-preserve-unknown-fields` flag. However, this can be applied only to `Map<String, String>` and not to `Map<String, Object>`, so it is not completely clear how much it will help.

This should resolve #7985.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging