### PR TITLE
Set UTO as default standalone deployment

### DIFF
--- a/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -35,8 +35,6 @@ spec:
               value: my-cluster-kafka-bootstrap:9092
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
-            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS
-              value: "6"
             - name: STRIMZI_LOG_LEVEL
               value: INFO
             - name: STRIMZI_TLS_ENABLED

--- a/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -33,10 +33,6 @@ spec:
               value: "strimzi.io/cluster=my-cluster"
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
               value: my-cluster-kafka-bootstrap:9092
-            - name: STRIMZI_ZOOKEEPER_CONNECT
-              value: my-cluster-zookeeper-client:2181
-            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS
-              value: "18000"
             - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
             - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS


### PR DESCRIPTION
The UTO is now in beta phase, which means enabled by default with the Cluster Operator deployment. This change makes the UTO enabled by default also with the standalone deployment.

No need to update the documentation, because the procedure to switch back to standalone BTO is already documented.
