### PR TITLE
[ST] Upgrade/downgrade - specify file path for Kafka in the YAML files

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -171,8 +171,9 @@ public interface TestConstants {
     /**
      * Basic paths to examples
      */
-    String PATH_TO_PACKAGING_EXAMPLES = TestUtils.USER_PATH + "/../packaging/examples";
-    String PATH_TO_PACKAGING_INSTALL_FILES = TestUtils.USER_PATH + "/../packaging/install";
+    String PATH_TO_PACKAGING = TestUtils.USER_PATH + "/../packaging";
+    String PATH_TO_PACKAGING_EXAMPLES = PATH_TO_PACKAGING + "/examples";
+    String PATH_TO_PACKAGING_INSTALL_FILES = PATH_TO_PACKAGING + "/install";
 
     /**
      * File paths for metrics YAMLs

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/CommonVersionModificationData.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/CommonVersionModificationData.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.systemtest.upgrade;
 
+import java.util.Map;
+
 /**
  * This class contains all the common fields needed for upgrade and downgrade tests from which specific classes
  * inherit these values and extending them further for specific needs of the process.
@@ -17,6 +19,7 @@ public class CommonVersionModificationData {
     private String toExamples;
     private String toUrl;
     private UpgradeKafkaVersion procedures;
+    private Map<String, String> filePaths;
 
     public String getFromVersion() {
         return fromVersion;
@@ -80,6 +83,30 @@ public class CommonVersionModificationData {
 
     public void setProcedures(UpgradeKafkaVersion procedures) {
         this.procedures = procedures;
+    }
+
+    public void setFilePaths(Map<String, String> filePaths) {
+        this.filePaths = filePaths;
+    }
+
+    public Map<String, String> getFilePaths() {
+        return filePaths;
+    }
+
+    public String getKafkaFilePathBefore() {
+        return getFilePaths().get("kafkaBefore");
+    }
+
+    public String getKafkaFilePathAfter() {
+        return getFilePaths().get("kafkaAfter");
+    }
+
+    public String getKafkaKRaftFilePathBefore() {
+        return getFilePaths().get("kafkaKRaftBefore");
+    }
+
+    public String getKafkaKRaftFilePathAfter() {
+        return getFilePaths().get("kafkaKRaftAfter");
     }
 
     @Override

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -644,7 +644,7 @@ public class AbstractUpgradeST extends AbstractST {
 
     protected String downloadExamplesAndGetPath(CommonVersionModificationData versionModificationData) throws IOException {
         if (versionModificationData.getToUrl().equals("HEAD")) {
-            return PATH_TO_PACKAGING_EXAMPLES;
+            return PATH_TO_PACKAGING;
         } else {
             File dir = FileUtils.downloadAndUnzip(versionModificationData.getToUrl());
             return dir.getAbsolutePath() + "/" + versionModificationData.getToExamples();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -161,11 +161,11 @@ public class AbstractUpgradeST extends AbstractST {
         String defaultValueForVersions = kafkaVersionFromCR == null ? null : TestKafkaVersion.getSpecificVersion(kafkaVersionFromCR).messageVersion();
         cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaConfiguration(kafkaYaml, kafkaVersionFromCR, defaultValueForVersions, defaultValueForVersions));
 
-        kafkaUserYaml = new File(examplesPath + "/user/kafka-user.yaml");
+        kafkaUserYaml = new File(examplesPath + "/examples/user/kafka-user.yaml");
         LOGGER.info("Deploying KafkaUser from: {}", kafkaUserYaml.getPath());
         cmdKubeClient().applyContent(KafkaUserUtils.removeKafkaUserPart(kafkaUserYaml, "authorization"));
 
-        kafkaTopicYaml = new File(examplesPath + "/topic/kafka-topic.yaml");
+        kafkaTopicYaml = new File(examplesPath + "/examples/topic/kafka-topic.yaml");
         LOGGER.info("Deploying KafkaTopic from: {}", kafkaTopicYaml.getPath());
         cmdKubeClient().applyContent(TestUtils.readFile(kafkaTopicYaml));
         // #######################################################################

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -65,6 +65,7 @@ import java.util.Random;
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.DEFAULT_SINK_FILE_PATH;
 import static io.strimzi.systemtest.TestConstants.PATH_TO_KAFKA_TOPIC_CONFIG;
+import static io.strimzi.systemtest.TestConstants.PATH_TO_PACKAGING;
 import static io.strimzi.systemtest.TestConstants.PATH_TO_PACKAGING_EXAMPLES;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -148,13 +149,13 @@ public class AbstractUpgradeST extends AbstractST {
         // #######################################################################
         String examplesPath = "";
         if (versionModificationData.getToUrl().equals("HEAD")) {
-            examplesPath = PATH_TO_PACKAGING_EXAMPLES + "";
+            examplesPath = PATH_TO_PACKAGING;
         } else {
             File dir = FileUtils.downloadAndUnzip(versionModificationData.getToUrl());
-            examplesPath = dir.getAbsolutePath() + "/" + versionModificationData.getToExamples() + "/examples";
+            examplesPath = dir.getAbsolutePath() + "/" + versionModificationData.getToExamples();
         }
 
-        kafkaYaml = new File(examplesPath + "/kafka/kafka-persistent.yaml");
+        kafkaYaml = new File(examplesPath + versionModificationData.getKafkaFilePathAfter());
         LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
         // Change kafka version of it's empty (null is for remove the version)
         String defaultValueForVersions = kafkaVersionFromCR == null ? null : TestKafkaVersion.getSpecificVersion(kafkaVersionFromCR).messageVersion();
@@ -463,7 +464,7 @@ public class AbstractUpgradeST extends AbstractST {
                     .endSpec()
                     .build());
             } else {
-                kafkaYaml = new File(dir, upgradeData.getFromExamples() + "/examples/kafka/kafka-persistent.yaml");
+                kafkaYaml = new File(dir, upgradeData.getFromExamples() + upgradeData.getKafkaFilePathBefore());
                 LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
                 // Change kafka version of it's empty (null is for remove the version)
                 if (upgradeKafkaVersion == null) {
@@ -646,7 +647,7 @@ public class AbstractUpgradeST extends AbstractST {
             return PATH_TO_PACKAGING_EXAMPLES;
         } else {
             File dir = FileUtils.downloadAndUnzip(versionModificationData.getToUrl());
-            return dir.getAbsolutePath() + "/" + versionModificationData.getToExamples() + "/examples";
+            return dir.getAbsolutePath() + "/" + versionModificationData.getToExamples();
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
@@ -82,7 +82,7 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
                         .endSpec()
                         .build());
             } else {
-                kafkaYaml = new File(dir, upgradeData.getFromExamples() + "/examples/kafka/nodepools/kafka-with-kraft.yaml");
+                kafkaYaml = new File(dir, upgradeData.getFromExamples() + upgradeData.getKafkaKRaftFilePathBefore());
                 LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
                 // Change kafka version of it's empty (null is for remove the version)
                 if (upgradeKafkaVersion == null) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
@@ -144,8 +144,9 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
         // #################    Update CRs to latest version   ###################
         // #######################################################################
         String examplesPath = downloadExamplesAndGetPath(versionModificationData);
+        String kafkaFilePath = examplesPath + versionModificationData.getKafkaKRaftFilePathAfter();
 
-        applyCustomResourcesFromPath(examplesPath, kafkaVersionFromCR, currentMetadataVersion);
+        applyCustomResourcesFromPath(examplesPath, kafkaFilePath, kafkaVersionFromCR, currentMetadataVersion);
 
         // #######################################################################
 
@@ -197,23 +198,23 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
         brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerPods);
     }
 
-    protected void applyKafkaCustomResourceFromPath(String examplesPath, String kafkaVersionFromCR, String kafkaMetadataVersion) {
+    protected void applyKafkaCustomResourceFromPath(String kafkaFilePath, String kafkaVersionFromCR, String kafkaMetadataVersion) {
         // Change kafka version of it's empty (null is for remove the version)
         String metadataVersion = kafkaVersionFromCR == null ? null : kafkaMetadataVersion;
 
-        kafkaYaml = new File(examplesPath + "/kafka/nodepools/kafka-with-kraft.yaml");
+        kafkaYaml = new File(kafkaFilePath);
         LOGGER.info("Deploying Kafka from: {}", kafkaYaml.getPath());
         cmdKubeClient().applyContent(KafkaUtils.changeOrRemoveKafkaConfigurationInKRaft(kafkaYaml, kafkaVersionFromCR, metadataVersion));
     }
 
-    protected void applyCustomResourcesFromPath(String examplesPath, String kafkaVersionFromCR, String kafkaMetadataVersion) {
-        applyKafkaCustomResourceFromPath(examplesPath, kafkaVersionFromCR, kafkaMetadataVersion);
+    protected void applyCustomResourcesFromPath(String examplesPath, String kafkaFilePath, String kafkaVersionFromCR, String kafkaMetadataVersion) {
+        applyKafkaCustomResourceFromPath(kafkaFilePath, kafkaVersionFromCR, kafkaMetadataVersion);
 
-        kafkaUserYaml = new File(examplesPath + "/user/kafka-user.yaml");
+        kafkaUserYaml = new File(examplesPath + "/examples/user/kafka-user.yaml");
         LOGGER.info("Deploying KafkaUser from: {}", kafkaUserYaml.getPath());
         cmdKubeClient().applyContent(KafkaUserUtils.removeKafkaUserPart(kafkaUserYaml, "authorization"));
 
-        kafkaTopicYaml = new File(examplesPath + "/topic/kafka-topic.yaml");
+        kafkaTopicYaml = new File(examplesPath + "/examples/topic/kafka-topic.yaml");
         LOGGER.info("Deploying KafkaTopic from: {}", kafkaTopicYaml.getPath());
         cmdKubeClient().applyContent(TestUtils.readFile(kafkaTopicYaml));
     }

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -48,6 +48,11 @@
     reason: Test is working on all environment used by QE.
   featureGatesBefore: ""
   featureGatesAfter: "-UnidirectionalTopicOperator"
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
+    kafkaKRaftAfter: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
 - fromVersion: HEAD
   toVersion: 0.39.0
   fromExamples: HEAD
@@ -71,3 +76,8 @@
     reason: Test is working on all environment used by QE.
   featureGatesBefore: ""
   featureGatesAfter: ""
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
+    kafkaKRaftAfter: "/examples/kafka/nodepools/kafka-with-kraft.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -23,6 +23,11 @@
 #    reason: String - reason why we skip / not skip the test case (information, not propagated to test itself)
 #  featureGatesBefore: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on initial deploy of CO
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
+#  filePaths: path to example files for particular resources
+#    kafkaBefore: path to Kafka resource (ZK mode) in the version of Strimzi, from which we are doing the downgrade
+#    kafkaAfter: path to Kafka resource (ZK mode) in the version of Strimzi, to which we are doing the downgrade
+#    kafkaKRaftBefore: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, from which we are doing the downgrade
+#    kafkaKRaftAfter: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, to which we are doing the downgrade
 # --- Structure ---
   
 - fromVersion: HEAD

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -44,6 +44,11 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: ""
   featureGatesAfter: ""
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
+    kafkaKRaftAfter: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
 - fromVersion: 0.39.0
   fromExamples: strimzi-0.39.0
   oldestKafka: 3.5.0
@@ -64,3 +69,8 @@
     reason: Test is working on environment, where k8s server version is < 1.22
   featureGatesBefore: "-UnidirectionalTopicOperator"
   featureGatesAfter: ""
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
+    kafkaKRaftAfter: "/examples/kafka/nodepools/kafka-with-kraft.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -22,6 +22,11 @@
 #    reason:  #  String - reason why we skip / not skip the test case
 #  featureGatesBefore: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on initial deploy of CO
 #  featureGatesAfter: String - FG added to `STRIMZI_FEATURE_GATES` environment variable, on upgrade of CO
+#  filePaths: path to example files for particular resources
+#    kafkaBefore: path to Kafka resource (ZK mode) in the version of Strimzi, from which we are doing the upgrade
+#    kafkaAfter: path to Kafka resource (ZK mode) in the version of Strimzi, to which we are doing the upgrade
+#    kafkaKRaftBefore: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, from which we are doing the upgrade
+#    kafkaKRaftAfter: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, to which we are doing the upgrade
 #  --- Structure ---
 
 - fromVersion: 0.39.0

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -18,3 +18,8 @@ fromOlmChannelName: strimzi-0.39.x
 fromExamples: strimzi-0.39.0
 fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.39.0/strimzi-0.39.0.zip
 fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.39.0/kafka-versions.yaml
+filePaths:
+  kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+  kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+  kafkaKRaftBefore: "/examples/kafka/nodepools/kafka-with-kraft.yaml"
+  kafkaKRaftAfter: "/examples/kafka/nodepools/kafka-with-kraft.yaml"

--- a/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/OlmUpgrade.yaml
@@ -4,6 +4,11 @@
 #  fromExamples: String - Folder name which contains examples to deploy. Downloaded from "fromUrl"
 #  fromUrl: String - url, from which examples are downloaded
 #  fromKafkaVersionsUrl: String - url, from which is kafka-versions.yaml file downloaded
+#  filePaths: path to example files for particular resources
+#    kafkaBefore: path to Kafka resource (ZK mode) in the version of Strimzi, from which we are doing the upgrade
+#    kafkaAfter: path to Kafka resource (ZK mode) in the version of Strimzi, to which we are doing the upgrade
+#    kafkaKRaftBefore: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, from which we are doing the upgrade
+#    kafkaKRaftAfter: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, to which we are doing the upgrade
 #  --- Structure ---
 #
 #  --- Prerequisites ---


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

The file paths to the examples of Kafka are currently hard-coded inside the upgrade/downgrade tests, which can be a problem in case that the file path is changed between versions.

This PR adds new fields to upgrade/downgrade YAML files, making possible to specify full path to Kafka YAML files.

### Checklist

- [ ] Make sure all tests pass

