### PR TITLE
[ST] Followup cleaning of AbstractST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -164,8 +164,8 @@ public class MultipleListenersST extends AbstractST {
     }
 
     private void runListenersTest(ExtensionContext extensionContext, List<GenericKafkaListener> listeners, String clusterName) {
-        final TestStorage testStorage = storageMap.get(extensionContext);
         LOGGER.info("These are listeners to be verified: {}", listeners);
+        final TestStorage testStorage = storageMap.get(extensionContext);
 
         // exercise phase
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(clusterName, 3)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/CustomResourceStatusST.java
@@ -109,8 +109,8 @@ class CustomResourceStatusST extends AbstractST {
     @Tag(NODEPORT_SUPPORTED)
     @Tag(EXTERNAL_CLIENTS_USED)
     void testKafkaStatus(ExtensionContext extensionContext) {
-        final TestStorage testStorage = storageMap.get(extensionContext);
         LOGGER.info("Checking status of deployed Kafka cluster");
+        final TestStorage testStorage = storageMap.get(extensionContext);
         KafkaUtils.waitForKafkaReady(Environment.TEST_SUITE_NAMESPACE, CUSTOM_RESOURCE_STATUS_CLUSTER_NAME);
 
         ExternalKafkaClient externalKafkaClient = new ExternalKafkaClient.Builder()


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is next part of the cleaning of AbstractST class which moves methods into different classes, that should make the code cleaner.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

