### PR TITLE
Update Fabric8 to 6.10.0

### DIFF
--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -150,6 +150,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -203,6 +211,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -260,6 +276,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -313,6 +337,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -712,6 +744,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -765,6 +805,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -822,6 +870,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -875,6 +931,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -156,6 +156,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -209,6 +217,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -266,6 +282,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -319,6 +343,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -718,6 +750,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -771,6 +811,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -828,6 +876,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -881,6 +937,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -150,6 +150,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -203,6 +211,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -260,6 +276,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -313,6 +337,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -705,6 +737,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -758,6 +798,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:
@@ -815,6 +863,14 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
+                            matchLabelKeys:
+                              type: array
+                              items:
+                                type: string
+                            mismatchLabelKeys:
+                              type: array
+                              items:
+                                type: string
                             namespaceSelector:
                               type: object
                               properties:
@@ -868,6 +924,14 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
+                        matchLabelKeys:
+                          type: array
+                          items:
+                            type: string
+                        mismatchLabelKeys:
+                          type: array
+                          items:
+                            type: string
                         namespaceSelector:
                           type: object
                           properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1088,6 +1088,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -1141,6 +1149,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -1198,6 +1214,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -1251,6 +1275,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -2268,6 +2300,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -2321,6 +2361,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -2378,6 +2426,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -2431,6 +2487,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -3410,6 +3474,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -3463,6 +3535,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -3520,6 +3600,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -3573,6 +3661,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -4465,6 +4561,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -4518,6 +4622,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -4575,6 +4687,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -4628,6 +4748,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -5339,6 +5467,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -5392,6 +5528,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -5449,6 +5593,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -5502,6 +5654,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -5973,6 +6133,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -6026,6 +6194,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -6083,6 +6259,14 @@ spec:
                                                     additionalProperties:
                                                       type: string
                                                     type: object
+                                              matchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              mismatchLabelKeys:
+                                                type: array
+                                                items:
+                                                  type: string
                                               namespaceSelector:
                                                 type: object
                                                 properties:
@@ -6136,6 +6320,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -635,6 +635,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -688,6 +696,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -745,6 +761,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -798,6 +822,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -1373,6 +1405,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -1426,6 +1466,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -1483,6 +1531,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -1536,6 +1592,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -777,6 +777,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -830,6 +838,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -887,6 +903,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -940,6 +964,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -641,6 +641,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -694,6 +702,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -751,6 +767,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -804,6 +828,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -780,6 +780,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -833,6 +841,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -890,6 +906,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -943,6 +967,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -1518,6 +1550,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -1571,6 +1611,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:
@@ -1628,6 +1676,14 @@ spec:
                                                 additionalProperties:
                                                   type: string
                                                 type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
                                           namespaceSelector:
                                             type: object
                                             properties:
@@ -1681,6 +1737,14 @@ spec:
                                             additionalProperties:
                                               type: string
                                             type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
                                       namespaceSelector:
                                         type: object
                                         properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -418,6 +418,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -471,6 +479,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -528,6 +544,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -581,6 +605,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1087,6 +1087,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -1140,6 +1148,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -1197,6 +1213,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -1250,6 +1274,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -2267,6 +2299,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -2320,6 +2360,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -2377,6 +2425,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -2430,6 +2486,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -3409,6 +3473,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -3462,6 +3534,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -3519,6 +3599,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -3572,6 +3660,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -4464,6 +4560,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -4517,6 +4621,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -4574,6 +4686,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -4627,6 +4747,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -5338,6 +5466,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -5391,6 +5527,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -5448,6 +5592,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -5501,6 +5653,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -5972,6 +6132,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -6025,6 +6193,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -6082,6 +6258,14 @@ spec:
                                                   additionalProperties:
                                                     type: string
                                                   type: object
+                                            matchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
+                                            mismatchLabelKeys:
+                                              type: array
+                                              items:
+                                                type: string
                                             namespaceSelector:
                                               type: object
                                               properties:
@@ -6135,6 +6319,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -634,6 +634,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -687,6 +695,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -744,6 +760,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -797,6 +821,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -1372,6 +1404,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -1425,6 +1465,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -1482,6 +1530,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -1535,6 +1591,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -776,6 +776,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -829,6 +837,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -886,6 +902,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -939,6 +963,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -640,6 +640,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -693,6 +701,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -750,6 +766,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -803,6 +827,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -779,6 +779,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -832,6 +840,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -889,6 +905,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -942,6 +966,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -1517,6 +1549,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -1570,6 +1610,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -1627,6 +1675,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -1680,6 +1736,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -418,6 +418,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -471,6 +479,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:
@@ -528,6 +544,14 @@ spec:
                                               additionalProperties:
                                                 type: string
                                               type: object
+                                        matchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
+                                        mismatchLabelKeys:
+                                          type: array
+                                          items:
+                                            type: string
                                         namespaceSelector:
                                           type: object
                                           properties:
@@ -581,6 +605,14 @@ spec:
                                           additionalProperties:
                                             type: string
                                           type: object
+                                    matchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
+                                    mismatchLabelKeys:
+                                      type: array
+                                      items:
+                                        type: string
                                     namespaceSelector:
                                       type: object
                                       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
         <lombok.version>1.18.24</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.9.2</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.9.2</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.9.2</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.10.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.10.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.10.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.15.3</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.15.3</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Fabric8 to new version 6.10.0. It also updates the embedded Kubernetes types in our custom resources to Kube 1.29 level (hence the new fields in the CRDs)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally