### PR TITLE
bump kroxylicious-testing to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <rest-assured.version>4.4.0</rest-assured.version>
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
         <bouncycastle.version>1.76</bouncycastle.version>
-        <kroxylicious-testing.version>0.4.0</kroxylicious-testing.version>
+        <kroxylicious-testing.version>0.8.1</kroxylicious-testing.version>
 
         <!-- properties to skip surefire tests during failsafe execution -->
         <skipTests>false</skipTests>


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Bumps the io.kroxylicious.testing dependencies to the 0.8.1 release which includes support for Apache Kafka 3.7.0 and thus fixes issues encountered in the unary topic operator as part of https://github.com/strimzi/strimzi-kafka-operator/pull/9548

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

