### PR TITLE
Add warnings when unused fields are set when Node Pools or Kraft are used

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -4,9 +4,12 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaSpec;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityOperatorSpec;
 import io.strimzi.operator.common.model.InvalidResourceException;
+import io.strimzi.operator.common.model.StatusUtils;
 import org.apache.kafka.server.common.MetadataVersion;
 
 import java.util.HashSet;
@@ -104,6 +107,46 @@ public class KRaftUtils {
 
         if (!errors.isEmpty())  {
             throw new InvalidResourceException("Kafka configuration is not valid: " + errors);
+        }
+    }
+
+    /**
+     * Generates Kafka CR status warnings about the fields ignored in Kraft mode if they are set - the ZooKeeper section
+     * and Kafka replicas and storage configuration.
+     *
+     * @param kafkaCr       The Kafka custom resource
+     * @param kafkaStatus   The Kafka Status to add the warnings to
+     */
+    public static void kraftWarnings(Kafka kafkaCr, KafkaStatus kafkaStatus)   {
+        if (kafkaCr.getSpec().getZookeeper() != null)   {
+            kafkaStatus.addCondition(StatusUtils.buildWarningCondition("UnusedZooKeeperConfiguration",
+                    "The .spec.zookeeper section in the Kafka custom resource is ignored in KRaft mode and " +
+                            "should be removed from the custom resource."));
+        }
+
+        nodePoolWarnings(kafkaCr, kafkaStatus);
+    }
+
+    /**
+     * Generates Kafka CR status warnings about the fields ignored when node pools are used if they are set - the
+     * replicas and storage configuration.
+     *
+     * @param kafkaCr       The Kafka custom resource
+     * @param kafkaStatus   The Kafka Status to add the warnings to
+     */
+    public static void nodePoolWarnings(Kafka kafkaCr, KafkaStatus kafkaStatus)   {
+        if (kafkaCr.getSpec().getKafka() != null
+                && kafkaCr.getSpec().getKafka().getReplicas() > 0) {
+            kafkaStatus.addCondition(StatusUtils.buildWarningCondition("UnusedReplicasConfiguration",
+                    "The .spec.kafka.replicas property in the Kafka custom resource is ignored when node pools " +
+                            "are used and should be removed from the custom resource."));
+        }
+
+        if (kafkaCr.getSpec().getKafka() != null
+                && kafkaCr.getSpec().getKafka().getStorage() != null) {
+            kafkaStatus.addCondition(StatusUtils.buildWarningCondition("UnusedStorageConfiguration",
+                    "The .spec.kafka.storage section in the Kafka custom resource is ignored when node pools " +
+                            "are used and should be removed from the custom resource."));
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -220,6 +220,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // Validates features which are currently not supported in KRaft mode
             try {
                 KRaftUtils.validateKafkaCrForKRaft(reconcileState.kafkaAssembly.getSpec(), featureGates.unidirectionalTopicOperatorEnabled());
+                KRaftUtils.kraftWarnings(reconcileState.kafkaAssembly, reconcileState.kafkaStatus);
             } catch (InvalidResourceException e)    {
                 return Future.failedFuture(e);
             }
@@ -227,6 +228,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             // Validates the properties required for a ZooKeeper based Kafka cluster
             try {
                 KRaftUtils.validateKafkaCrForZooKeeper(reconcileState.kafkaAssembly.getSpec(), nodePoolsEnabled);
+
+                if (nodePoolsEnabled)   {
+                    KRaftUtils.nodePoolWarnings(reconcileState.kafkaAssembly, reconcileState.kafkaStatus);
+                }
             } catch (InvalidResourceException e)    {
                 return Future.failedFuture(e);
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -359,7 +359,7 @@ public class KRaftUtilsTest {
         KafkaStatus status = new KafkaStatus();
         KRaftUtils.nodePoolWarnings(kafka, status);
 
-        assertThat(status.getConditions().size(), is(3));
+        assertThat(status.getConditions().size(), is(2));
 
         Condition condition = status.getConditions().stream().filter(c -> "UnusedReplicasConfiguration".equals(c.getReason())).findFirst().orElseThrow();
         assertThat(condition.getMessage(), is("The .spec.kafka.replicas property in the Kafka custom resource is ignored when node pools are used and should be removed from the custom resource."));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -4,8 +4,12 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaSpecBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityOperatorSpec;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityOperatorSpecBuilder;
@@ -273,5 +277,98 @@ public class KRaftUtilsTest {
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateKafkaCrForZooKeeper(spec, false));
         assertThat(e.getMessage(), containsString("The .spec.kafka.replicas property of the Kafka custom resource is missing. This property is required for a ZooKeeper-based Kafka cluster that is not using Node Pools."));
         assertThat(e.getMessage(), containsString("The .spec.kafka.storage section of the Kafka custom resource is missing. This section is required for a ZooKeeper-based Kafka cluster that is not using Node Pools."));
+    }
+
+    @ParallelTest
+    public void testKRaftWarnings() {
+        Kafka kafka = new KafkaBuilder()
+                .withNewSpec()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("listener")
+                                .withPort(9092)
+                                .withTls(true)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                                .build())
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                        .withNewKafkaAuthorizationOpa()
+                            .withUrl("http://opa:8080")
+                        .endKafkaAuthorizationOpa()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaStatus status = new KafkaStatus();
+        KRaftUtils.kraftWarnings(kafka, status);
+
+        assertThat(status.getConditions().size(), is(3));
+
+        Condition condition = status.getConditions().stream().filter(c -> "UnusedZooKeeperConfiguration".equals(c.getReason())).findFirst().orElseThrow();
+        assertThat(condition.getMessage(), is("The .spec.zookeeper section in the Kafka custom resource is ignored in KRaft mode and should be removed from the custom resource."));
+        assertThat(condition.getType(), is("Warning"));
+        assertThat(condition.getStatus(), is("True"));
+
+        condition = status.getConditions().stream().filter(c -> "UnusedReplicasConfiguration".equals(c.getReason())).findFirst().orElseThrow();
+        assertThat(condition.getMessage(), is("The .spec.kafka.replicas property in the Kafka custom resource is ignored when node pools are used and should be removed from the custom resource."));
+        assertThat(condition.getType(), is("Warning"));
+        assertThat(condition.getStatus(), is("True"));
+
+        condition = status.getConditions().stream().filter(c -> "UnusedStorageConfiguration".equals(c.getReason())).findFirst().orElseThrow();
+        assertThat(condition.getMessage(), is("The .spec.kafka.storage section in the Kafka custom resource is ignored when node pools are used and should be removed from the custom resource."));
+        assertThat(condition.getType(), is("Warning"));
+        assertThat(condition.getStatus(), is("True"));
+    }
+
+    @ParallelTest
+    public void testZooKeeperWarnings() {
+        Kafka kafka = new KafkaBuilder()
+                .withNewSpec()
+                    .withNewZookeeper()
+                        .withReplicas(3)
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                    .endZookeeper()
+                    .withNewKafka()
+                        .withReplicas(3)
+                        .withListeners(new GenericKafkaListenerBuilder()
+                                .withName("listener")
+                                .withPort(9092)
+                                .withTls(true)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withNewKafkaListenerAuthenticationTlsAuth()
+                                .endKafkaListenerAuthenticationTlsAuth()
+                                .build())
+                        .withNewEphemeralStorage()
+                        .endEphemeralStorage()
+                        .withNewKafkaAuthorizationOpa()
+                            .withUrl("http://opa:8080")
+                        .endKafkaAuthorizationOpa()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        KafkaStatus status = new KafkaStatus();
+        KRaftUtils.nodePoolWarnings(kafka, status);
+
+        assertThat(status.getConditions().size(), is(3));
+
+        Condition condition = status.getConditions().stream().filter(c -> "UnusedReplicasConfiguration".equals(c.getReason())).findFirst().orElseThrow();
+        assertThat(condition.getMessage(), is("The .spec.kafka.replicas property in the Kafka custom resource is ignored when node pools are used and should be removed from the custom resource."));
+        assertThat(condition.getType(), is("Warning"));
+        assertThat(condition.getStatus(), is("True"));
+
+        condition = status.getConditions().stream().filter(c -> "UnusedStorageConfiguration".equals(c.getReason())).findFirst().orElseThrow();
+        assertThat(condition.getMessage(), is("The .spec.kafka.storage section in the Kafka custom resource is ignored when node pools are used and should be removed from the custom resource."));
+        assertThat(condition.getType(), is("Warning"));
+        assertThat(condition.getStatus(), is("True"));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -130,7 +130,7 @@ public class SpecificST extends AbstractST {
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(testStorage.getClusterName(), Environment.TEST_SUITE_NAMESPACE,
                 ".*code=403.*");
 
-        final Condition condition = KafkaResource.kafkaClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getClusterName()).get().getStatus().getConditions().stream().findFirst().get();
+        final Condition condition = KafkaResource.kafkaClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getClusterName()).get().getStatus().getConditions().stream().filter(c -> "NotReady".equals(c.getType())).findFirst().orElseThrow();
 
         assertThat(condition.getReason(), CoreMatchers.is("KubernetesClientException"));
         assertThat(condition.getStatus(), CoreMatchers.is("True"));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

With `UseKRaft` now being enabled by default, users are not required to set the following sections in the Kafka CR:
* `.spec.kafka.replicas`
* `.spec.kafka.storage`
* `.spec.zookeeper`

When Node Pools are used, the storage and replicas configuration in the KAfka CR are ignored. When KRaft is used in addition to Node Pools, the ZooKeeper section is not used either. This PR adds warning conditions when these ignored sections are set in the custom resource to get the users to remove them.

I originally considered setting those in the `KafkaSpecChecker` class. But that adds warning conditions based on the _model_ classes and not based on the custom resources. It would require passing additional parameters through several classes. That seemed like a lot of effort for something that will eventually go away once ZooKeeper support is dropped completely by Kafka and Strimzi. So at the end, I added them as static methods that are called in the place where the validation of these fields happens in the `KafkaAsssemblyOperator`

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally