### PR TITLE
[DOC] Make it clear what happens when `brokerCertChainAndKey` certificate is updated

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
@@ -25,6 +25,8 @@ listeners:
 # ...
 ----
 
+When the certificate or key in the `brokerCertChainAndKey` secret is updated, the operator will automatically detect it in the next reconciliation and trigger a rolling update of the Kafka brokers to reload the certificate.
+
 [id='property-listener-config-traffic-policy-{context}']
 = `externalTrafficPolicy`
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

When using the `brokerCertChainAndKey` option to configure a custom listener certificate, the operator will automatically detect changes and roll the brokers when it is updated. This is not clear from the docs, but it should be so that:
* Users know to expect a rolling update when they change it (and e.g. not update the secret in the peak time of their business day)
* Users know that they should not need to do anything more after updating the secret -> especially important when integrating with other tooling and certificate providers with shorter lifespans such as Let's Encrypt.

### Checklist

- [x] Update documentation