### PR TITLE
Update various dependencies - Vert.x, Cruise Control, Kaniko, Json-Path, ...

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -66,8 +66,8 @@ public class ZookeeperLeaderFinder {
                 .setConnectTimeout(10_000)
                 .setSsl(true)
                 .setHostnameVerificationAlgorithm("HTTPS")
-                .setPemKeyCertOptions(keyCertOptions(coCertKeySecret))
-                .setPemTrustOptions(trustOptions(reconciliation, clusterCaCertificateSecret));
+                .setKeyCertOptions(keyCertOptions(coCertKeySecret))
+                .setTrustOptions(trustOptions(reconciliation, clusterCaCertificateSecret));
     }
 
     private CertificateFactory x509Factory() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -76,7 +76,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING)
                 .setSsl(true)
                 .setVerifyHost(true)
-                .setPemTrustOptions(
+                .setTrustOptions(
                     new PemTrustOptions(pto)
                 );
         } else {

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.5.x/pom.xml
@@ -17,7 +17,8 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.133</cruise-control.version>
+        <jayway-json-path.version>2.9.0</jayway-json-path.version>
+        <cruise-control.version>2.5.135</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
@@ -125,6 +126,23 @@
                 <exclusion>
                     <groupId>com.github.stephenc.jcip</groupId>
                     <artifactId>jcip-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Excluded because of CVE-2023-51074 and replaced with newer version-->
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Override of OAuth dependency because of CVE-2023-51074 -->
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jayway-json-path.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -17,7 +17,8 @@
 
     <properties>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <cruise-control.version>2.5.133</cruise-control.version>
+        <jayway-json-path.version>2.9.0</jayway-json-path.version>
+        <cruise-control.version>2.5.135</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
@@ -155,6 +156,23 @@
                 <exclusion>
                     <groupId>com.sun.activation</groupId>
                     <artifactId>jakarta.activation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Excluded because of CVE-2023-51074 and replaced with newer version-->
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Override of OAuth dependency because of CVE-2023-51074 -->
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jayway-json-path.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.133</cruise-control.version>
+        <cruise-control.version>2.5.135</cruise-control.version>
     </properties>
 
     <repositories>

--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.19.1
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.20.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         <fasterxml.jackson-annotations.version>2.15.3</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.15.3</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.15.3</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.0</vertx.version>
-        <vertx-junit5.version>4.5.0</vertx-junit5.version>
+        <vertx.version>4.5.1</vertx.version>
+        <vertx-junit5.version>4.5.1</vertx-junit5.version>
         <kafka.version>3.6.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.3</zookeeper.version>
@@ -147,9 +147,9 @@
         <jetty.version>9.4.53.v20231009</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.103.Final</netty.version>
         <micrometer.version>1.9.5</micrometer.version>
-        <jayway-jsonpath.version>2.8.0</jayway-jsonpath.version>
+        <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates various dependencies:
* Vert.x (and aligns Netty with the version used by Vert.x)
* Kaniko
* Cruise Control
* Jayway Json Path (to address CVE-2023-51074)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally