### PR TITLE
[ST] ZK to KRaft migration - rollback process

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -594,6 +594,6 @@ public class KafkaUtils {
 
     public static String getKafkaLogFolderNameInPod(String namespaceName, String kafkaPodName) {
         return ResourceManager.cmdKubeClient().namespace(namespaceName)
-            .execInPod(kafkaPodName, "/bin/bash", "-c", "ls /var/lib/kafka/data | grep \"kafka-log[0-9]\" -o").out().trim();
+            .execInPod(kafkaPodName, "/bin/bash", "-c", "ls /var/lib/kafka/data | grep \"kafka-log[0-9]\\+\" -o").out().trim();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -591,4 +591,9 @@ public class KafkaUtils {
             return k.getStatus().getKafkaMetadataState().equals(desiredKafkaMetadataState);
         });
     }
+
+    public static String getKafkaLogFolderNameInPod(String namespaceName, String kafkaPodName) {
+        return ResourceManager.cmdKubeClient().namespace(namespaceName)
+            .execInPod(kafkaPodName, "/bin/bash", "-c", "ls /var/lib/kafka/data | grep \"kafka-log[0-9]\" -o").out().trim();
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -369,7 +369,7 @@ public class MigrationST extends AbstractST {
 
     private void assertThatTopicIsPresentInKRaftMetadata(String namespaceName, LabelSelector controllerSelector, String topicName) {
         String controllerPodName = kubeClient().namespace(namespaceName).listPods(controllerSelector).get(0).getMetadata().getName();
-        String kafkaLogDirName = cmdKubeClient().namespace(namespaceName).execInPod(controllerPodName, "/bin/bash", "-c", "ls /var/lib/kafka/data | grep \"kafka-log[0-9]\\+\" -o").out().trim();
+        String kafkaLogDirName = KafkaUtils.getKafkaLogFolderNameInPod(namespaceName, controllerPodName);
         String commandOutput = cmdKubeClient().namespace(namespaceName).execInPod(controllerPodName, "/bin/bash", "-c", "./bin/kafka-dump-log.sh --cluster-metadata-decoder --skip-record-metadata" +
             " --files /var/lib/kafka/data/" + kafkaLogDirName + "/__cluster_metadata-0/00000000000000000000.log | grep " + topicName).out().trim();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -59,9 +59,6 @@ public class MigrationST extends AbstractST {
     private Map<String, String> brokerPodsSnapshot;
     private Map<String, String> controllerPodsSnapshot;
 
-    // for logging purposes - to log the current step number
-    private int stepNum;
-
     /**
      * @description This testcase is focused on migration process from ZK to KRaft.
      * It goes through whole process, together with checking that message transmission throughout the test will not be

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.migration;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
@@ -46,6 +47,15 @@ public class MigrationST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(MigrationST.class);
     private static final String CONTINUOUS_SUFFIX = "-continuous";
+
+    private KafkaClients immediateClients;
+    private KafkaClients continuousClients;
+    private String postMigrationTopicName;
+    private String kraftTopicName;
+    private LabelSelector brokerSelector;
+    private LabelSelector controllerSelector;
+    private Map<String, String> brokerPodsSnapshot;
+    private Map<String, String> controllerPodsSnapshot;
 
     /**
      * @description This testcase is focused on migration process from ZK to KRaft.
@@ -261,6 +271,232 @@ public class MigrationST extends AbstractST {
 
         LOGGER.info("14. migration is completed, waiting for continuous clients to finish");
         ClientUtils.waitForClientsSuccess(continuousProducerName, continuousConsumerName, testStorage.getNamespaceName(), continuousMessageCount);
+    }
+
+    @IsolatedTest
+    void testRollbackDuringMigration(ExtensionContext extensionContext) {
+        TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
+
+        setupMigrationTestCase(extensionContext, testStorage);
+        doFirstPartOfMigration(extensionContext, testStorage);
+        doRollback(testStorage);
+    }
+
+    void setupMigrationTestCase(ExtensionContext extensionContext, TestStorage testStorage) {
+        postMigrationTopicName = testStorage.getTopicName() + "-midstep";
+        kraftTopicName = testStorage.getTopicName() + "-kraft";
+
+        String continuousTopicName = testStorage.getTopicName() + CONTINUOUS_SUFFIX;
+        String continuousProducerName = testStorage.getProducerName() + CONTINUOUS_SUFFIX;
+        String continuousConsumerName = testStorage.getConsumerName() + CONTINUOUS_SUFFIX;
+        int continuousMessageCount = 500;
+
+        brokerSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getBrokerPoolName(), ProcessRoles.BROKER);
+        controllerSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getControllerPoolName(), ProcessRoles.CONTROLLER);
+
+        String clientsAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000\nacks=all";
+
+        immediateClients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(testStorage.getTopicName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withUsername(testStorage.getUsername())
+            .build();
+
+        continuousClients = new KafkaClientsBuilder()
+            .withProducerName(continuousProducerName)
+            .withConsumerName(continuousConsumerName)
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+            .withTopicName(continuousTopicName)
+            .withMessageCount(continuousMessageCount)
+            .withDelayMs(1000)
+            .withAdditionalConfig(clientsAdditionConfiguration)
+            .build();
+
+        LOGGER.info("Deploying Kafka resource with Broker NodePool");
+
+        // create Kafka resource with ZK and Broker NodePool
+        resourceManager.createResourceWithWait(extensionContext,
+            KafkaNodePoolTemplates.kafkaNodePoolWithBrokerRoleAndPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3).build(),
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled")
+                .endMetadata()
+                .editSpec()
+                    .editOrNewKafka()
+                        .addToConfig("default.replication.factor", 3)
+                        .addToConfig("min.insync.replicas", 2)
+                    .endKafka()
+                .endSpec()
+                .build());
+
+        brokerPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), brokerSelector);
+
+        // the controller pods will not be up and running, because we are using the ZK nodes as controllers, they will be created once the migration starts
+        // creating it here (before KafkaTopics) to correctly delete KafkaTopics and prevent stuck because UTO cannot connect to controllers
+        resourceManager.createResourceWithoutWait(extensionContext,
+            KafkaNodePoolTemplates.kafkaNodePoolWithControllerRoleAndPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build());
+
+        // at this moment, everything should be ready, so we should ideally create some topics and send + receive the messages (to have some data present in Kafka + metadata about topics in ZK)
+        LOGGER.info("Creating two topics for immediate and continuous message transmission and KafkaUser for the TLS");
+        resourceManager.createResourceWithWait(extensionContext,
+            KafkaTopicTemplates.topic(testStorage).build(),
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), continuousTopicName, 3, 3, 2, testStorage.getNamespaceName()).build(),
+            KafkaUserTemplates.tlsUser(testStorage).build()
+        );
+
+        // sanity check that kafkaMetadataState shows ZooKeeper
+        String currentKafkaMetadataState = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus().getKafkaMetadataState();
+        assertThat(currentKafkaMetadataState, is(KafkaMetadataState.ZooKeeper.name()));
+
+        // start continuous clients and do the immediate message transmission
+        resourceManager.createResourceWithWait(extensionContext,
+            continuousClients.producerStrimzi(),
+            continuousClients.consumerStrimzi(),
+            immediateClients.producerTlsStrimzi(testStorage.getClusterName()),
+            immediateClients.consumerTlsStrimzi(testStorage.getClusterName())
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
+    }
+
+    void doFirstPartOfMigration(ExtensionContext extensionContext, TestStorage testStorage) {
+        // starting the migration
+        LOGGER.info("Starting the migration process");
+
+        LOGGER.info("1. applying the {} annotation with value: {}", Annotations.ANNO_STRIMZI_IO_KRAFT, "migration");
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration"), testStorage.getNamespaceName());
+
+        LOGGER.info("2. waiting for controller Pods to be up and running");
+        PodUtils.waitForPodsReady(testStorage.getNamespaceName(), controllerSelector, 3, true);
+        controllerPodsSnapshot = PodUtils.podSnapshot(testStorage.getNamespaceName(), controllerSelector);
+
+        LOGGER.info("3. waiting until .status.kafkaMetadataState in Kafka will contain KRaftMigration state");
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.KRaftMigration.name());
+
+        LOGGER.info("4. waiting for first rolling update of broker Pods - bringing to DualWrite mode");
+        brokerPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerPodsSnapshot);
+
+        LOGGER.info("5. waiting until .status.kafkaMetadataState in Kafka will contain KRaftDualWriting state");
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.KRaftDualWriting.name());
+
+        LOGGER.info("6. waiting for second rolling update of broker Pods - removing dependency on ZK");
+        brokerPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, brokerPodsSnapshot);
+
+        LOGGER.info("7. waiting until .status.kafkaMetadataState in Kafka will contain KRaftPostMigration state");
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.KRaftPostMigration.name());
+
+        createKafkaTopicAndCheckMetadataWithMessageTransmission(extensionContext, testStorage, postMigrationTopicName);
+    }
+
+    void doSecondPartOfMigration(ExtensionContext extensionContext, TestStorage testStorage) {
+        LOGGER.info("9. finishing migration - applying the {} annotation with value: {}, controllers should be rolled", Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled");
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled"), testStorage.getNamespaceName());
+
+        controllerPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controllerSelector, 3, controllerPodsSnapshot);
+
+        LOGGER.info("10. ZK related resources should be removed now, so waiting for all resources to be deleted");
+
+        waitForZooKeeperResourcesDeletion(testStorage);
+
+        LOGGER.info("11. Everything related to ZK is deleted, waiting until .status.kafkaMetadataState in Kafka will contain KRaft state");
+
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.KRaft.name());
+
+        // the configuration of LMFV and IBPV is done (encapsulated) inside the KafkaTemplates.kafkaPersistent() method
+        LOGGER.info("12. removing LMFV and IBPV from Kafka config -> brokers and controllers should be rolled");
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
+            kafka.getSpec().getKafka().getConfig().remove("log.message.format.version");
+            kafka.getSpec().getKafka().getConfig().remove("inter.broker.protocol.version");
+        }, testStorage.getNamespaceName());
+
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, brokerPodsSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controllerSelector, 3, controllerPodsSnapshot);
+
+        LOGGER.info("13. creating KafkaTopic: {} and checking if the metadata are only in KRaft", kraftTopicName);
+        resourceManager.createResourceWithWait(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), kraftTopicName, testStorage.getNamespaceName()).build());
+
+        LOGGER.info("13a. checking if metadata about KafkaTopic: {} are in KRaft controller", kraftTopicName);
+
+        assertThatTopicIsPresentInKRaftMetadata(controllerSelector, kraftTopicName);
+
+        LOGGER.info("13b. checking if we are able to do a message transmission on KafkaTopic: {}", kraftTopicName);
+
+        immediateClients = new KafkaClientsBuilder(immediateClients)
+            .withTopicName(kraftTopicName)
+            .build();
+
+        resourceManager.createResourceWithWait(extensionContext,
+            immediateClients.producerTlsStrimzi(testStorage.getClusterName()),
+            immediateClients.consumerTlsStrimzi(testStorage.getClusterName())
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
+
+        LOGGER.info("14. migration is completed, waiting for continuous clients to finish");
+        ClientUtils.waitForClientsSuccess(continuousClients.getProducerName(), continuousClients.getConsumerName(), testStorage.getNamespaceName(), continuousClients.getMessageCount());
+    }
+
+    void doRollback(TestStorage testStorage) {
+        LOGGER.info("From {} state we are going to roll back to ZK", KafkaMetadataState.KRaftPostMigration.name());
+
+        LOGGER.info("6. rolling migration back - applying {}: rollback annotation", Annotations.ANNO_STRIMZI_IO_KRAFT);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_KRAFT, "rollback"), testStorage.getNamespaceName());
+
+        LOGGER.info("7. waiting for Broker Pods to be rolled");
+        brokerPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, brokerPodsSnapshot);
+
+        LOGGER.info("8. waiting until .status.kafkaMetadataState contains {} state", KafkaMetadataState.KRaftDualWriting.name());
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.KRaftDualWriting.name());
+
+        LOGGER.info("9. deleting Controller's NodePool");
+        KafkaNodePool controllerPool = KafkaNodePoolResource.kafkaNodePoolClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getControllerPoolName()).get();
+        resourceManager.deleteResource(controllerPool);
+
+        LOGGER.info("10. applying {}: disabled annotation", Annotations.ANNO_STRIMZI_IO_KRAFT);
+        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(),
+            kafka -> kafka.getMetadata().getAnnotations().put(Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled"), testStorage.getNamespaceName());
+
+        LOGGER.info("11. waiting for Broker Pods to be rolled");
+        brokerPodsSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, brokerPodsSnapshot);
+
+        LOGGER.info("12. waiting until .status.kafkaMetadataState contains {} state", KafkaMetadataState.ZooKeeper.name());
+        KafkaUtils.waitUntilKafkaStatusContainsKafkaMetadataState(testStorage.getNamespaceName(), testStorage.getClusterName(), KafkaMetadataState.ZooKeeper.name());
+
+        LOGGER.info("Rollback completed, waiting until continuous messages transmission is finished");
+        ClientUtils.waitForClientsSuccess(continuousClients.getProducerName(), continuousClients.getConsumerName(), testStorage.getNamespaceName(), continuousClients.getMessageCount());
+    }
+
+    void createKafkaTopicAndCheckMetadataWithMessageTransmission(ExtensionContext extensionContext, TestStorage testStorage, String newTopicName) {
+        LOGGER.info("5. creating KafkaTopic: {} and checking if the metadata are in both ZK and KRaft", newTopicName);
+        resourceManager.createResourceWithWait(extensionContext, KafkaTopicTemplates.topic(testStorage.getClusterName(), newTopicName, testStorage.getNamespaceName()).build());
+
+        LOGGER.info("5a. checking if metadata about KafkaTopic: {} are in KRaft controller", newTopicName);
+
+        assertThatTopicIsPresentInKRaftMetadata(controllerSelector, newTopicName);
+
+        LOGGER.info("5b. checking if metadata about KafkaTopic: {} are in ZK", newTopicName);
+
+        assertThatTopicIsPresentInZKMetadata(testStorage.getZookeeperSelector(), newTopicName);
+
+        LOGGER.info("5c. checking if we are able to do a message transmission on KafkaTopic: {}", newTopicName);
+
+        immediateClients = new KafkaClientsBuilder(immediateClients)
+            .withTopicName(newTopicName)
+            .build();
+
+        resourceManager.createResourceWithWait(extensionContext,
+            immediateClients.producerTlsStrimzi(testStorage.getClusterName()),
+            immediateClients.consumerTlsStrimzi(testStorage.getClusterName())
+        );
+
+        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 
     void waitForZooKeeperResourcesDeletion(TestStorage testStorage) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -149,7 +149,7 @@ public class MigrationST extends AbstractST {
     }
 
     private void setupMigrationTestCase(ExtensionContext extensionContext, TestStorage testStorage) {
-        postMigrationTopicName = testStorage.getTopicName() + "-midstep";
+        postMigrationTopicName = testStorage.getTopicName() + "-post-migration";
         kraftTopicName = testStorage.getTopicName() + "-kraft";
 
         String continuousTopicName = testStorage.getTopicName() + CONTINUOUS_SUFFIX;
@@ -336,7 +336,6 @@ public class MigrationST extends AbstractST {
 
         if (checkZk) {
             LOGGER.info("Checking if metadata about KafkaTopic: {} are in ZK", newTopicName);
-
             assertThatTopicIsPresentInZKMetadata(testStorage.getNamespaceName(), testStorage.getZookeeperSelector(), newTopicName);
         }
 


### PR DESCRIPTION
### Type of change

- New ST

### Description

This PR adds ST for second part of the migration - rollback process. After first part of the migration is finished (we are in the KRaftPostMigration state), we annotate the Kafka resource with `strimzi.io/kraft:rollback` to roll-back to the ZK mode.
The changes are mostly about splitting the parts of the first test into multiple methods, so they can be reusable by other tests (also for those that will come in next PR). The main change is the `doRollback()` method, which executes the whole roll-back process.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
