### PR TITLE
docs(readme): adds a readme to the documentation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To get up and running quickly, check our [Quick Start for Minikube, OKD (OpenShi
 
 ## Documentation
 
-Documentation to the current _main_ branch as well as all releases can be found on our [website][strimzi].
+Documentation for the current _main_ branch as well as all releases can be found on our [website][strimzi].
 
 ## Roadmap
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,71 @@
+[strimziDoc]: https://strimzi.io/documentation/ "Strimzi documentation"
+[strimziContrib]: https://strimzi.io/contributing/guide/ "Strimzi documentation contributor guide"
+
+<!-- omit from toc -->
+# Strimzi documentation
+
+Welcome to the Strimzi documentation! This repository contains the source files for managing the Strimzi documentation. The documentation is written in AsciiDoc, and it covers guides to help you understand, deploy, and configure Strimzi.
+
+<!-- omit from toc -->
+## Table of Contents
+- [Strimzi guides](#strimzi-guides)
+- [Documentation folder structure](#documentation-folder-structure)
+- [Contributing to the documentation](#contributing-to-the-documentation)
+
+## Strimzi guides
+
+The Strimzi documentation is organized into the following guides:
+
+- **Overview guide**
+  - Files: [/documentation/overview/](overview)
+  - This guide provides an overview of Strimzi, explaining its key concepts and features.
+
+- **Deploying and Managing Strimzi guide**
+  - Files: [/documentation/deploying/](deploying)
+  - This guide provides instructions and best practices for deploying and managing Strimzi.
+
+- **API Reference**
+  - Files: [/documentation/configuring/](configuring)
+  - This guide provides detailed information on configuring Strimzi through the API.
+
+## Documentation folder structure
+
+The content for each Strimzi guide is encapsulated in a main source file:
+
+* `overview/overview.adoc` - Overview guide
+* `deploying/deploying.adoc` - Deploying and Managing Strimzi guide
+* `configuring/configuring.adoc` - API Reference
+
+The main source files are used to build the documentation and are contained in separate folders.
+Other documentation folders contain the content that's incorporated into the main source files.
+
+**Documentation folders**
+| Folder                   | Description                                          |
+| --------------           | -------------------------------------------------    |
+| `api/`                   | Property descriptions for the API Reference guide    |
+| `contributing/`          | Documentation Contributor Guide                      |
+| `deploying/`             | Deploying and Managing Strimzi guide (main)                       |
+| `overview/`              | Strimzi Overview guide (main)                               |
+| `configuring/`           | API Reference (main)                 |
+| `assemblies/`            | Assemblies (chapters) provide content for all guides |
+| `modules/`               | Modules provide content for assemblies               |
+| `shared/`                | Shared include files                                 |
+| `shared/attributes.adoc` | Global book attributes                               |
+| `shared/images/`         | Shared image files                                   |
+
+## Contributing to the documentation
+
+If there's something that you want to add or change in the documentation, do the following:
+
+1. Set up a local Git repository
+2. Create a branch for your changes
+3. Add the changes through a pull request
+
+The pull request will be reviewed and the changes merged when the review is complete.
+The guide is then rebuilt and the updated content is published on the Strimzi website.
+Published documentation for the current _main_ branch as well as all releases can be found on our [website][strimziDoc].
+
+For more information on setting up and contributing to the documentation, see the [Strimzi documentation contributor guide][strimziContrib].
+
+
+

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -6,7 +6,7 @@
 
 Welcome to the Strimzi documentation! 
 
-This repository contains the source files for managing the Strimzi documentation. The documentation is written in AsciiDoc, and it covers guides to help you understand, deploy, and configure Strimzi.
+This folder contains the source files for managing the Strimzi documentation. The documentation is written in AsciiDoc, and it covers guides to help you understand, deploy, and configure Strimzi.
 
 <!-- omit from toc -->
 ## Table of Contents

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -4,7 +4,9 @@
 <!-- omit from toc -->
 # Strimzi documentation
 
-Welcome to the Strimzi documentation! This repository contains the source files for managing the Strimzi documentation. The documentation is written in AsciiDoc, and it covers guides to help you understand, deploy, and configure Strimzi.
+Welcome to the Strimzi documentation! 
+
+This repository contains the source files for managing the Strimzi documentation. The documentation is written in AsciiDoc, and it covers guides to help you understand, deploy, and configure Strimzi.
 
 <!-- omit from toc -->
 ## Table of Contents
@@ -26,7 +28,7 @@ The Strimzi documentation is organized into the following guides:
 
 - **API Reference**
   - Files: [/documentation/configuring/](configuring)
-  - This guide provides detailed information on configuring Strimzi through the API.
+  - This guide provides detailed information on configuring Strimzi through its API.
 
 ## Documentation folder structure
 
@@ -44,9 +46,9 @@ Other documentation folders contain the content that's incorporated into the mai
 | --------------           | -------------------------------------------------    |
 | `api/`                   | Property descriptions for the API Reference guide    |
 | `contributing/`          | Documentation Contributor Guide                      |
-| `deploying/`             | Deploying and Managing Strimzi guide (main)                       |
-| `overview/`              | Strimzi Overview guide (main)                               |
-| `configuring/`           | API Reference (main)                 |
+| `deploying/`             | Deploying and Managing Strimzi guide (main)          |
+| `overview/`              | Strimzi Overview guide (main)                        |
+| `configuring/`           | API Reference (main)                                 |
 | `assemblies/`            | Assemblies (chapters) provide content for all guides |
 | `modules/`               | Modules provide content for assemblies               |
 | `shared/`                | Shared include files                                 |

--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -43,28 +43,6 @@ Assemblies, which usually encapsulate a feature or process, bring the related co
 An assembly is like a sub-section or chapter in a book.
 A module contain a procedure, concepts or reference content.
 
-.Documentation folder descriptions
-[source,options="nowrap",subs="+quotes"]
-----
-api/                          # Property descriptions for the Custom Resource API Reference guide
-contributing/                 # Documentation contributor guide (this book)
-deploying/                    # Deploying and Managing Strimzi
-overview/                     # Strimzi Overview guide
-configuring/                  # Custom Resource API Reference guide
-assemblies/                   # Assemblies provide content for all guides
-modules/                      # Modules provide the content for assemblies
-shared/                       # Shared include files
-shared/attributes.adoc        # Global book attributes
-shared/images/                # Shared image files
-----
-
-The content for each Strimzi guide is encapsulated in a source file, which is used to build the documentation:
-
-* `overview/overview.adoc` (Strimzi Overview guide)
-* `deploying/deploying.adoc` (Deploying and Managing Strimzi)
-* `configuring/configuring.adoc` (Custom Resource API Reference)
-
-
 === Strimzi Overview guide
 
 The intention of the _Strimzi Overview guide_ is for developing an understanding of Strimzi and Apache Kafka.


### PR DESCRIPTION
**Documentation**

As we now have an "Edit this page" link from the documentation pages of the Strimzi website that goes to the `/documentation` folder, this readme gives some context around the files and how to make an update . 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

