### PR TITLE
Added unit tests for State machine of `KafkaMetadataStateManager` class 

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -52,16 +52,16 @@ public class KafkaMetadataStateManagerTest {
             .build();
 
     /**
-     *  Checks the expected transition between two states of the KafkaMetadataStateManager class.
+     *  Computes the next state to which the previous state has transitioned
      *
      * @param kafka The Kafka instance.
      * @param status Status of the Kafka custom resource where warnings about any issues with metadata state will be added
-     * @param useBooleanKraftFeatureEnabled if the UseKRaft feature gate is enabled on the operator
+     * @param isKRaftFeatureGateEnabled if the UseKRaft feature gate is enabled on the operator
      *
      * @return the state to which the previous state has transitioned
      */
-    private KafkaMetadataState checkTransition(Kafka kafka, KafkaStatus status, boolean useBooleanKraftFeatureEnabled) {
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, useBooleanKraftFeatureEnabled);
+    private KafkaMetadataState checkTransition(Kafka kafka, KafkaStatus status, boolean isKRaftFeatureGateEnabled) {
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, isKRaftFeatureGateEnabled);
         return kafkaMetadataStateManager.computeNextMetadataState(status);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -25,6 +25,9 @@ import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.ZooKeeper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * Tests the state transitions which happens in the KafkaMetadataStateManager class.
+ */
 public class KafkaMetadataStateManagerTest {
 
     private static final String CLUSTER_NAMESPACE = "my-namespace";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -76,7 +76,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("ZooKeeper")
+                    .withKafkaMetadataState(ZooKeeper.name())
                 .endStatus()
                 .build();
 
@@ -91,7 +91,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("ZooKeeper")
+                    .withKafkaMetadataState(ZooKeeper.name())
                 .endStatus()
                 .build();
 
@@ -110,7 +110,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("KRaftDualWriting")
+                    .withKafkaMetadataState(KRaftDualWriting.name())
                 .endStatus()
                 .build();
 
@@ -125,7 +125,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("KRaftPostMigration")
+                    .withKafkaMetadataState(KRaftPostMigration.name())
                 .endStatus()
                 .build();
 
@@ -140,7 +140,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "rollback")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("KRaftPostMigration")
+                    .withKafkaMetadataState(KRaftPostMigration.name())
                 .endStatus()
                 .build();
 
@@ -155,7 +155,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("PreKRaft")
+                    .withKafkaMetadataState(PreKRaft.name())
                 .endStatus()
                 .build();
 
@@ -170,7 +170,7 @@ public class KafkaMetadataStateManagerTest {
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled")
                 .endMetadata()
                 .withNewStatus()
-                    .withKafkaMetadataState("KRaftMigration")
+                    .withKafkaMetadataState(KRaftMigration.name())
                 .endStatus()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -63,7 +63,7 @@ public class KafkaMetadataStateManagerTest {
      *
      * @return the state to which the previous state has transitioned
      */
-    private KafkaMetadataState checkTransition(Kafka kafka, KafkaStatus status, boolean isKRaftFeatureGateEnabled) {
+    private KafkaMetadataState computeNextTransition(Kafka kafka, KafkaStatus status, boolean isKRaftFeatureGateEnabled) {
         KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, isKRaftFeatureGateEnabled);
         return kafkaMetadataStateManager.computeNextMetadataState(status);
     }
@@ -80,7 +80,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftMigration);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), KRaftMigration);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class KafkaMetadataStateManagerTest {
                 .build();
 
         var exception = assertThrows(IllegalArgumentException.class, () ->
-                checkTransition(kafka, kafka.getStatus(), false));
+                computeNextTransition(kafka, kafka.getStatus(), false));
 
         assertEquals("Failed to reconcile a KRaft enabled cluster or migration to KRaft because useKRaft feature gate is disabled",
                 exception.getMessage());
@@ -114,7 +114,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftPostMigration);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), KRaftPostMigration);
     }
 
     @Test
@@ -129,7 +129,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), PreKRaft);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), PreKRaft);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftDualWriting);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), KRaftDualWriting);
     }
 
     @Test
@@ -159,7 +159,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaft);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), KRaft);
     }
 
     @Test
@@ -174,6 +174,6 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        assertEquals(checkTransition(kafka, kafka.getStatus(), true), ZooKeeper);
+        assertEquals(computeNextTransition(kafka, kafka.getStatus(), true), ZooKeeper);
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -12,7 +12,7 @@ import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaMetadataStateManagerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource;
+
+import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
+import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.Reconciliation;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.KRaft;
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.KRaftDualWriting;
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.KRaftMigration;
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.KRaftPostMigration;
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.PreKRaft;
+import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.ZooKeeper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KafkaMetadataStateManagerTest {
+
+    private static final String CLUSTER_NAMESPACE = "my-namespace";
+
+    private static final String CLUSTER_NAME = "kafka-test-cluster";
+
+    private static final Reconciliation RECONCILIATION = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, CLUSTER_NAMESPACE, CLUSTER_NAME);
+
+    private static final Kafka KAFKA = new KafkaBuilder()
+            .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withAnnotations(Map.of(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled"))
+                .withNamespace(CLUSTER_NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withNewKafka()
+                    .withListeners(new GenericKafkaListenerBuilder()
+                        .withName("plain")
+                        .withPort(9092)
+                        .withType(KafkaListenerType.INTERNAL)
+                        .withTls(false)
+                    .build())
+                .endKafka()
+            .endSpec()
+            .build();
+
+    /**
+     *  Checks the expected transition between two states of the KafkaMetadataStateManager class.
+     *
+     * @param kafka The Kafka instance.
+     * @param status Status of the Kafka custom resource where warnings about any issues with metadata state will be added
+     * @param useBooleanKraftFeatureEnabled if the UseKRaft feature gate is enabled on the operator
+     *
+     * @return the state to which the previous state has transitioned
+     */
+    private KafkaMetadataState checkTransition(Kafka kafka, KafkaStatus status, boolean useBooleanKraftFeatureEnabled) {
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, useBooleanKraftFeatureEnabled);
+        return kafkaMetadataStateManager.computeNextMetadataState(status);
+    }
+
+    @Test
+    public void testMoveFromZookeeperToKRaftMigrationWhenMigrationAnnotationEnabled() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("ZooKeeper")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftMigration);
+    }
+
+    @Test
+    public void testMoveFromZookeeperToKRaftMigrationFailsWhenMigrationEnabledButKRaftDisabled() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("ZooKeeper")
+                .endStatus()
+                .build();
+
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+                checkTransition(kafka, kafka.getStatus(), false));
+
+        assertEquals("Failed to reconcile a KRaft enabled cluster or migration to KRaft because useKRaft feature gate is disabled",
+                exception.getMessage());
+    }
+
+    @Test
+    public void testMoveFromKRaftMigrationToKRaftDualWriteWhenMigrationEnabled() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("KRaftDualWriting")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftPostMigration);
+    }
+
+    @Test
+    public void testMoveFromKRaftPostMigrationToPreKRaftWhenEnabledAnnotationApplied() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("KRaftPostMigration")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), PreKRaft);
+    }
+
+    @Test
+    public void testMoveFromKRaftPostMigrationToKraftDualWritingWhenRollbackAnnotationApplied() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "rollback")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("KRaftPostMigration")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaftDualWriting);
+    }
+
+    @Test
+    public void testMoveFromPreKRafttoKRaftMigrationWhenEnabledAnnotationApplied() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("PreKRaft")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), KRaft);
+    }
+
+    @Test
+    public void testMoveFromKRaftMigrationToZookeeperWhenDisabledAnnotationApplied() {
+
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled")
+                .endMetadata()
+                .withNewStatus()
+                    .withKafkaMetadataState("KRaftMigration")
+                .endStatus()
+                .build();
+
+        assertEquals(checkTransition(kafka, kafka.getStatus(), true), ZooKeeper);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds unit tests for `KafkaMetadataStateManager` class. These tests basically cover the transition between the states which can be tested without mocking.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

