### PR TITLE
Refactor connector preparation our of `KafkaMirrorMaker2AssemblyOperator`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -5,7 +5,6 @@
 package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
@@ -61,8 +60,6 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     protected static final String MIRRORMAKER_2_TLS_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/mm2-certs/";
     protected static final String MIRRORMAKER_2_PASSWORD_VOLUME_MOUNT = "/opt/kafka/mm2-password/";
 
-    private List<KafkaMirrorMaker2ClusterSpec> clusters;
-
     private static final Map<String, String> DEFAULT_POD_LABELS = new HashMap<>();
     static {
         String value = System.getenv(CO_ENV_VAR_CUSTOM_MIRROR_MAKER2_POD_LABELS);
@@ -71,6 +68,10 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         }
     }
 
+    private final KafkaMirrorMaker2Connectors connectors;
+
+    private List<KafkaMirrorMaker2ClusterSpec> clusters;
+
     /**
      * Constructor
      *
@@ -78,9 +79,10 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
      * @param resource Kubernetes resource with metadata containing the namespace and cluster name
      * @param sharedEnvironmentProvider Shared environment provider
      */
-    private KafkaMirrorMaker2Cluster(Reconciliation reconciliation, HasMetadata resource, SharedEnvironmentProvider sharedEnvironmentProvider) {
+    private KafkaMirrorMaker2Cluster(Reconciliation reconciliation, KafkaMirrorMaker2 resource, SharedEnvironmentProvider sharedEnvironmentProvider) {
         super(reconciliation, resource, KafkaMirrorMaker2Resources.componentName(resource.getMetadata().getName()), COMPONENT_TYPE, sharedEnvironmentProvider);
 
+        this.connectors = KafkaMirrorMaker2Connectors.fromCrd(reconciliation, resource);
         this.serviceName = KafkaMirrorMaker2Resources.serviceName(cluster);
         this.loggingAndMetricsConfigMapName = KafkaMirrorMaker2Resources.metricsAndLogConfigMapName(cluster);
     }
@@ -375,5 +377,12 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     @Override
     protected Map<String, String> defaultPodLabels() {
         return DEFAULT_POD_LABELS;
+    }
+
+    /**
+     * @return  Returns the Mirror Maker 2 Connectors model
+     */
+    public KafkaMirrorMaker2Connectors connectors() {
+        return connectors;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlain;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha256;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
+import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
+import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
+import io.strimzi.api.kafka.model.common.tracing.Tracing;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ConnectorSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.InvalidResourceException;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Kafka Mirror Maker 2 Connectors model
+ */
+public class KafkaMirrorMaker2Connectors {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaMirrorMaker2Connectors.class.getName());
+
+    private static final String CONNECTOR_JAVA_PACKAGE = "org.apache.kafka.connect.mirror";
+    private static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
+    private static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
+    private static final String STORE_LOCATION_ROOT = "/tmp/kafka/clusters/";
+    private static final String TRUSTSTORE_SUFFIX = ".truststore.p12";
+    private static final String KEYSTORE_SUFFIX = ".keystore.p12";
+    private static final String CONNECT_CONFIG_FILE = "/tmp/strimzi-connect.properties";
+    private static final String CONNECTORS_CONFIG_FILE = "/tmp/strimzi-mirrormaker2-connector.properties";
+    private static final String SOURCE_CONNECTOR_SUFFIX = ".MirrorSourceConnector";
+    private static final String CHECKPOINT_CONNECTOR_SUFFIX = ".MirrorCheckpointConnector";
+    private static final String HEARTBEAT_CONNECTOR_SUFFIX = ".MirrorHeartbeatConnector";
+    private static final Map<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> CONNECTORS = Map.of(
+            SOURCE_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getSourceConnector,
+            CHECKPOINT_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getCheckpointConnector,
+            HEARTBEAT_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getHeartbeatConnector
+    );
+
+    private final Reconciliation reconciliation;
+    private final Map<String, KafkaMirrorMaker2ClusterSpec> clusters;
+    private final List<KafkaMirrorMaker2MirrorSpec> mirrors;
+    private final Tracing tracing;
+    private final boolean rackAwarenessEnabled;
+
+    /**
+     * Constructor
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param kafkaMirrorMaker2     KafkaMirrorMaker2 custom resource
+     */
+    private KafkaMirrorMaker2Connectors(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2) {
+        this.reconciliation = reconciliation;
+        this.clusters = kafkaMirrorMaker2.getSpec().getClusters().stream().collect(Collectors.toMap(KafkaMirrorMaker2ClusterSpec::getAlias, Function.identity()));
+        this.mirrors = kafkaMirrorMaker2.getSpec().getMirrors();
+        this.tracing = kafkaMirrorMaker2.getSpec().getTracing();
+        this.rackAwarenessEnabled = kafkaMirrorMaker2.getSpec().getRack() != null;
+    }
+
+    /**
+     * Creates and returns a Mirror Maker 2 Connectors instance
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param kafkaMirrorMaker2     KafkaMirrorMaker2 custom resource
+     *
+     * @return  Newly created KafkaMirrorMaker2Connectors instance
+     */
+    public static KafkaMirrorMaker2Connectors fromCrd(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2)    {
+        validateConnectors(kafkaMirrorMaker2);
+        return new KafkaMirrorMaker2Connectors(reconciliation, kafkaMirrorMaker2);
+    }
+
+    /* test */ static void validateConnectors(KafkaMirrorMaker2 kafkaMirrorMaker2)    {
+        if (kafkaMirrorMaker2.getSpec() == null)    {
+            throw new InvalidResourceException(".spec section is required for KafkaMirrorMaker2 resource");
+        } else {
+            if (kafkaMirrorMaker2.getSpec().getClusters() == null || kafkaMirrorMaker2.getSpec().getMirrors() == null)  {
+                throw new InvalidResourceException(".spec.clusters and .spec.mirrors sections are required in KafkaMirrorMaker2 resource");
+            } else {
+                Set<String> existingClusterAliases = kafkaMirrorMaker2.getSpec().getClusters().stream().map(KafkaMirrorMaker2ClusterSpec::getAlias).collect(Collectors.toSet());
+                Set<String> errorMessages = new HashSet<>();
+
+                for (KafkaMirrorMaker2MirrorSpec mirror : kafkaMirrorMaker2.getSpec().getMirrors())  {
+                    if (mirror.getSourceCluster() == null)  {
+                        errorMessages.add("Each MirrorMaker 2 mirror definition has to specify the source cluster alias");
+                    } else if (!existingClusterAliases.contains(mirror.getSourceCluster())) {
+                        errorMessages.add("Source cluster alias " + mirror.getSourceCluster() + " is used in a mirror definition, but cluster with this alias does not exist in cluster definitions");
+                    }
+
+                    if (mirror.getTargetCluster() == null)  {
+                        errorMessages.add("Each MirrorMaker 2 mirror definition has to specify the target cluster alias");
+                    } else if (!existingClusterAliases.contains(mirror.getTargetCluster())) {
+                        errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but cluster with this alias does not exist in cluster definitions");
+                    }
+                }
+
+                if (!errorMessages.isEmpty())   {
+                    throw new InvalidResourceException("KafkaMirrorMaker2 resource validation failed: " + errorMessages);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return  List with connector definitions for this Mirror Maker 2 cluster
+     */
+    public List<KafkaConnector> generateConnectorDefinitions()    {
+        List<KafkaConnector> connectors = new ArrayList<>();
+
+        for (KafkaMirrorMaker2MirrorSpec mirror : mirrors)    {
+            for (Entry<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> connectorType : CONNECTORS.entrySet())   {
+                // Get the connector spec from the MM2 CR definitions
+                KafkaMirrorMaker2ConnectorSpec mm2ConnectorSpec = connectorType.getValue().apply(mirror);
+
+                if (mm2ConnectorSpec != null) {
+                    @SuppressWarnings("deprecation") // getPause() is deprecated
+                    KafkaConnector connector = new KafkaConnectorBuilder()
+                            .withNewMetadata()
+                                .withName(mirror.getSourceCluster() + "->" + mirror.getTargetCluster() + connectorType.getKey())
+                            .endMetadata()
+                            .withNewSpec()
+                                .withClassName(CONNECTOR_JAVA_PACKAGE + connectorType.getKey())
+                                .withConfig(prepareMirrorMaker2ConnectorConfig(mirror, mm2ConnectorSpec, clusters.get(mirror.getSourceCluster()), clusters.get(mirror.getTargetCluster())))
+                                .withPause(mm2ConnectorSpec.getPause())
+                                .withState(mm2ConnectorSpec.getState())
+                                .withTasksMax(mm2ConnectorSpec.getTasksMax())
+                            .endSpec()
+                            .build();
+
+                    connectors.add(connector);
+                }
+            }
+        }
+
+        return connectors;
+    }
+
+    /* test */ Map<String, Object> prepareMirrorMaker2ConnectorConfig(KafkaMirrorMaker2MirrorSpec mirror, KafkaMirrorMaker2ConnectorSpec connector, KafkaMirrorMaker2ClusterSpec sourceCluster, KafkaMirrorMaker2ClusterSpec targetCluster) {
+        Map<String, Object> config = new HashMap<>(connector.getConfig());
+
+        // Source and target cluster configurations
+        addClusterToMirrorMaker2ConnectorConfig(config, targetCluster, TARGET_CLUSTER_PREFIX);
+        addClusterToMirrorMaker2ConnectorConfig(config, sourceCluster, SOURCE_CLUSTER_PREFIX);
+
+        // Topics pattern
+        if (mirror.getTopicsPattern() != null) {
+            config.put("topics", mirror.getTopicsPattern());
+        }
+
+        // Topics exclusion pattern
+        String topicsExcludePattern = mirror.getTopicsExcludePattern();
+        @SuppressWarnings("deprecation") // getTopicsBlacklistPattern() is deprecated
+        String topicsBlacklistPattern = mirror.getTopicsBlacklistPattern();
+        if (topicsExcludePattern != null && topicsBlacklistPattern != null) {
+            LOGGER.warnCr(reconciliation, "Both topicsExcludePattern and topicsBlacklistPattern mirror properties are present, ignoring topicsBlacklistPattern as it is deprecated");
+        }
+        String topicsExclude = topicsExcludePattern != null ? topicsExcludePattern : topicsBlacklistPattern;
+        if (topicsExclude != null) {
+            config.put("topics.exclude", topicsExclude);
+        }
+
+        // Groups pattern
+        if (mirror.getGroupsPattern() != null) {
+            config.put("groups", mirror.getGroupsPattern());
+        }
+
+        // Groups exclusion pattern
+        String groupsExcludePattern = mirror.getGroupsExcludePattern();
+        @SuppressWarnings("deprecation") // getGroupsBlacklistPattern() is deprecated
+        String groupsBlacklistPattern = mirror.getGroupsBlacklistPattern();
+        if (groupsExcludePattern != null && groupsBlacklistPattern != null) {
+            LOGGER.warnCr(reconciliation, "Both groupsExcludePattern and groupsBlacklistPattern mirror properties are present, ignoring groupsBlacklistPattern as it is deprecated");
+        }
+        String groupsExclude = groupsExcludePattern != null ? groupsExcludePattern :  groupsBlacklistPattern;
+        if (groupsExclude != null) {
+            config.put("groups.exclude", groupsExclude);
+        }
+
+        // Tracing
+        if (tracing != null)   {
+            @SuppressWarnings("deprecation") // JaegerTracing is deprecated
+            String jaegerType = JaegerTracing.TYPE_JAEGER;
+
+            if (jaegerType.equals(tracing.getType())) {
+                LOGGER.warnCr(reconciliation, "Tracing type \"{}\" is not supported anymore and will be ignored", jaegerType);
+            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(tracing.getType())) {
+                config.put("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
+                config.put("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
+            }
+        }
+
+        // Rack awareness (client.rack has to be configured in the connector because the consumer is created by the connector)
+        if (rackAwarenessEnabled) {
+            String clientRackKey = "consumer.client.rack";
+            config.put(clientRackKey, "${file:" + CONNECT_CONFIG_FILE + ":" + clientRackKey + "}");
+        }
+
+        return config;
+    }
+
+    /* test */ static void addClusterToMirrorMaker2ConnectorConfig(Map<String, Object> config, KafkaMirrorMaker2ClusterSpec cluster, String configPrefix) {
+        config.put(configPrefix + "alias", cluster.getAlias());
+        config.put(configPrefix + AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers());
+
+        String securityProtocol = addTLSConfigToMirrorMaker2ConnectorConfig(config, cluster, configPrefix);
+
+        if (cluster.getAuthentication() != null) {
+            if (cluster.getAuthentication() instanceof KafkaClientAuthenticationTls) {
+                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
+                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, STORE_LOCATION_ROOT + cluster.getAlias() + KEYSTORE_SUFFIX);
+                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "${file:" + CONNECTORS_CONFIG_FILE + ":" + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG + "}");
+            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationPlain plainAuthentication) {
+                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
+                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, "PLAIN");
+                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
+                        AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.plain.PlainLoginModule",
+                                Map.of("username", plainAuthentication.getUsername(),
+                                        "password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}")));
+            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationScram scramAuthentication) {
+                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
+                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, scramAuthentication instanceof KafkaClientAuthenticationScramSha256 ? "SCRAM-SHA-256" : "SCRAM-SHA-512");
+                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
+                        AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.scram.ScramLoginModule",
+                                Map.of("username", scramAuthentication.getUsername(),
+                                        "password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}")));
+            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth oauthAuthentication) {
+                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
+                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
+                        oauthJaasConfig(cluster, oauthAuthentication));
+                config.put(configPrefix + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+            }
+        }
+
+        // Security protocol
+        config.put(configPrefix + AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol);
+
+        config.putAll(cluster.getConfig().entrySet().stream()
+                .collect(Collectors.toMap(entry -> configPrefix + entry.getKey(), Map.Entry::getValue)));
+        config.putAll(cluster.getAdditionalProperties());
+    }
+
+    private static String oauthJaasConfig(KafkaMirrorMaker2ClusterSpec cluster, KafkaClientAuthenticationOAuth oauth) {
+        Map<String, String> jaasOptions = cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth ? AuthenticationUtils.oauthJaasOptions((KafkaClientAuthenticationOAuth) cluster.getAuthentication()) : new LinkedHashMap<>();
+
+        if (oauth.getClientSecret() != null) {
+            jaasOptions.put("oauth.client.secret", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.client.secret}");
+        }
+
+        if (oauth.getAccessToken() != null) {
+            jaasOptions.put("oauth.access.token", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.access.token}");
+        }
+
+        if (oauth.getRefreshToken() != null) {
+            jaasOptions.put("oauth.refresh.token", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.refresh.token}");
+        }
+
+        if (oauth.getPasswordSecret() != null) {
+            jaasOptions.put("oauth.password.grant.password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.password.grant.password}");
+        }
+
+        if (oauth.getTlsTrustedCertificates() != null && !oauth.getTlsTrustedCertificates().isEmpty()) {
+            jaasOptions.put("oauth.ssl.truststore.location", "/tmp/kafka/clusters/\"" + cluster.getAlias() + "\"-oauth.truststore.p12");
+            jaasOptions.put("oauth.ssl.truststore.password", "\"${file:" + CONNECTORS_CONFIG_FILE + ":oauth.ssl.truststore.password}\"");
+            jaasOptions.put("oauth.ssl.truststore.type", "PKCS12");
+        }
+
+        return AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", jaasOptions);
+    }
+
+    /**
+     * Adds configuration for the TLS encryption to the map if TLS is configured and returns the security protocol
+     * (SSL or PLAINTEXT). The returned security protocol is later modified for SASL if needed, but this is done in the
+     * parent method.
+     *
+     * @param config        Map with the configuration
+     * @param cluster       Cluster configuration (.spec.clusters property from the MM2 custom resource)
+     * @param configPrefix  Prefix string for the added configuration options
+     *
+     * @return  String indicating whether the security protocol should be SSL or PLAINTEXT based
+     */
+    private static String addTLSConfigToMirrorMaker2ConnectorConfig(Map<String, Object> config, KafkaMirrorMaker2ClusterSpec cluster, String configPrefix) {
+        if (cluster.getTls() != null) {
+            if (cluster.getTls().getTrustedCertificates() != null && !cluster.getTls().getTrustedCertificates().isEmpty()) {
+                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, STORE_LOCATION_ROOT + cluster.getAlias() + TRUSTSTORE_SUFFIX);
+                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "${file:" + CONNECTORS_CONFIG_FILE + ":" + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG + "}");
+            }
+
+            return "SSL";
+        } else {
+            return "PLAINTEXT";
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -10,32 +10,20 @@ import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Condition;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlain;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha256;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
-import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
-import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.connector.AutoRestartStatus;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorSpec;
-import io.strimzi.api.kafka.model.connector.KafkaConnectorSpecBuilder;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
-import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
-import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ConnectorSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2List;
-import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Resources;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Spec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Status;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
-import io.strimzi.operator.cluster.model.AuthenticationUtils;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
 import io.strimzi.operator.cluster.model.KafkaMirrorMaker2Cluster;
-import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Annotations;
@@ -44,14 +32,10 @@ import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.VertxUtil;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.StatusUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.SslConfigs;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -64,7 +48,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_RESTART_CONNECTOR;
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK;
@@ -82,27 +65,6 @@ import static java.util.Collections.emptyMap;
  */
 public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaMirrorMaker2, KafkaMirrorMaker2List, KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaMirrorMaker2AssemblyOperator.class.getName());
-
-    private static final String MIRRORMAKER2_CONNECTOR_PACKAGE = "org.apache.kafka.connect.mirror";
-    private static final String MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX = ".MirrorSourceConnector";
-    private static final String MIRRORMAKER2_CHECKPOINT_CONNECTOR_SUFFIX = ".MirrorCheckpointConnector";
-    private static final String MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX = ".MirrorHeartbeatConnector";
-    private static final Map<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> MIRRORMAKER2_CONNECTORS = new HashMap<>(3);
-
-    static {
-        MIRRORMAKER2_CONNECTORS.put(MIRRORMAKER2_SOURCE_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getSourceConnector);
-        MIRRORMAKER2_CONNECTORS.put(MIRRORMAKER2_CHECKPOINT_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getCheckpointConnector);
-        MIRRORMAKER2_CONNECTORS.put(MIRRORMAKER2_HEARTBEAT_CONNECTOR_SUFFIX, KafkaMirrorMaker2MirrorSpec::getHeartbeatConnector);
-    }
-
-    private static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
-    private static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
-
-    private static final String STORE_LOCATION_ROOT = "/tmp/kafka/clusters/";
-    private static final String TRUSTSTORE_SUFFIX = ".truststore.p12";
-    private static final String KEYSTORE_SUFFIX = ".keystore.p12";
-    private static final String CONNECT_CONFIG_FILE = "/tmp/strimzi-connect.properties";
-    private static final String CONNECTORS_CONFIG_FILE = "/tmp/strimzi-mirrormaker2-connector.properties";
 
     /**
      * Constructor
@@ -289,223 +251,53 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * @return A future, failed if any of the connectors could not be reconciled.
      */
     protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
-        String mirrorMaker2Name = kafkaMirrorMaker2.getMetadata().getName();
-        if (kafkaMirrorMaker2.getSpec() == null) {
-            return maybeUpdateMirrorMaker2Status(reconciliation, kafkaMirrorMaker2,
-                    new InvalidResourceException("spec property is required"));
-        }
-        List<KafkaMirrorMaker2MirrorSpec> mirrors = ModelUtils.asListOrEmptyList(kafkaMirrorMaker2.getSpec().getMirrors());
-        String host = KafkaMirrorMaker2Resources.qualifiedServiceName(mirrorMaker2Name, reconciliation.namespace());
+        String host = KafkaMirrorMaker2Resources.qualifiedServiceName(mirrorMaker2Cluster.getCluster(), reconciliation.namespace());
         KafkaConnectApi apiClient = getKafkaConnectApi();
-        return apiClient.list(reconciliation, host, KafkaConnectCluster.REST_API_PORT).compose(deleteMirrorMaker2ConnectorNames -> {
+        List<KafkaConnector> desiredConnectors = mirrorMaker2Cluster.connectors().generateConnectorDefinitions();
 
-            for (Map.Entry<String, Function<KafkaMirrorMaker2MirrorSpec, KafkaMirrorMaker2ConnectorSpec>> connectorEntry : MIRRORMAKER2_CONNECTORS.entrySet()) {
-                deleteMirrorMaker2ConnectorNames.removeAll(mirrors.stream()
-                        .filter(mirror -> connectorEntry.getValue().apply(mirror) != null) // filter out non-existent connectors
-                        .map(mirror -> mirror.getSourceCluster() + "->" + mirror.getTargetCluster() + connectorEntry.getKey())
-                        .collect(Collectors.toSet()));
-            }
-            LOGGER.debugCr(reconciliation, "delete MirrorMaker 2 connectors: {}", deleteMirrorMaker2ConnectorNames);
-            Stream<Future<Void>> deletionFutures = deleteMirrorMaker2ConnectorNames.stream()
-                    .map(connectorName -> apiClient.delete(reconciliation, host, KafkaConnectCluster.REST_API_PORT, connectorName));
-            Stream<Future<Void>> createUpdateFutures = mirrors.stream()
-                    .map(mirror -> reconcileMirrorMaker2Connectors(reconciliation, host, apiClient, kafkaMirrorMaker2, mirror, mirrorMaker2Cluster, mirrorMaker2Status, desiredLogging));
-            return Future.join(Stream.concat(deletionFutures, createUpdateFutures).collect(Collectors.toList())).map((Void) null);
+        return apiClient.list(reconciliation, host, KafkaConnectCluster.REST_API_PORT).compose(currentConnectors -> {
+            currentConnectors.removeAll(desiredConnectors.stream().map(c -> c.getMetadata().getName()).collect(Collectors.toSet()));
+
+            Future<Void> deletionFuture = deleteConnectors(reconciliation, host, apiClient, currentConnectors);
+            Future<Void> createOrUpdateFuture = reconcileConnectors(reconciliation, host, apiClient, kafkaMirrorMaker2, mirrorMaker2Cluster, desiredConnectors, mirrorMaker2Status, desiredLogging);
+
+            return Future.join(deletionFuture, createOrUpdateFuture).map((Void) null);
         });
     }
 
-    private Future<Void> reconcileMirrorMaker2Connectors(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, KafkaMirrorMaker2 mirrorMaker2, KafkaMirrorMaker2MirrorSpec mirror, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
-        String targetClusterAlias = mirror.getTargetCluster();
-        String sourceClusterAlias = mirror.getSourceCluster();
-        if (targetClusterAlias == null) {
-            return maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2,
-                    new InvalidResourceException("targetCluster property is required"));
-        } else if (sourceClusterAlias == null) {
-            return maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2,
-                    new InvalidResourceException("sourceCluster property is required"));
-        }
-        List<KafkaMirrorMaker2ClusterSpec> clusters = ModelUtils.asListOrEmptyList(mirrorMaker2.getSpec().getClusters());
-        Map<String, KafkaMirrorMaker2ClusterSpec> clusterMap = clusters.stream()
-            .filter(cluster -> targetClusterAlias.equals(cluster.getAlias()) || sourceClusterAlias.equals(cluster.getAlias()))
-            .collect(Collectors.toMap(KafkaMirrorMaker2ClusterSpec::getAlias, Function.identity()));
-
-        if (!clusterMap.containsKey(targetClusterAlias)) {
-            return maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2,
-                    new InvalidResourceException("targetCluster with alias " + mirror.getTargetCluster() + " cannot be found in the list of clusters at spec.clusters"));
-        } else if (!clusterMap.containsKey(sourceClusterAlias)) {
-            return maybeUpdateMirrorMaker2Status(reconciliation, mirrorMaker2,
-                    new InvalidResourceException("sourceCluster with alias " + mirror.getSourceCluster() + " cannot be found in the list of clusters at spec.clusters"));
-        }
-
-        return Future.join(MIRRORMAKER2_CONNECTORS.entrySet().stream()
-                    .filter(entry -> entry.getValue().apply(mirror) != null) // filter out non-existent connectors
-                    .map(entry -> {
-                        String connectorName = sourceClusterAlias + "->" + targetClusterAlias + entry.getKey();
-                        String className = MIRRORMAKER2_CONNECTOR_PACKAGE + entry.getKey();
-
-                        KafkaMirrorMaker2ConnectorSpec mm2ConnectorSpec = entry.getValue().apply(mirror);
-                        @SuppressWarnings("deprecation")
-                        KafkaConnectorSpec connectorSpec = new KafkaConnectorSpecBuilder()
-                                .withClassName(className)
-                                .withConfig(mm2ConnectorSpec.getConfig())
-                                .withPause(mm2ConnectorSpec.getPause())
-                                .withState(mm2ConnectorSpec.getState())
-                                .withTasksMax(mm2ConnectorSpec.getTasksMax())
-                                .build();
-
-                        prepareMirrorMaker2ConnectorConfig(reconciliation, mirror, clusterMap.get(sourceClusterAlias), clusterMap.get(targetClusterAlias), connectorSpec, mirrorMaker2Cluster);
-                        LOGGER.debugCr(reconciliation, "creating/updating connector {} config: {}", connectorName, connectorSpec.getConfig());
-                        return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connectorName, connectorSpec, mirrorMaker2Status);
-                    })
-                    .collect(Collectors.toList()))
-                    .map((Void) null)
-                    .compose(i -> apiClient.updateConnectLoggers(reconciliation, host, KafkaConnectCluster.REST_API_PORT, desiredLogging, mirrorMaker2Cluster.defaultLogConfig()))
-                    .compose(i -> {
-                        boolean failedConnector = mirrorMaker2Status.getConnectors().stream()
-                                .anyMatch(connector -> {
-                                    @SuppressWarnings({ "rawtypes" })
-                                    Object state = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
-                                    return "FAILED".equalsIgnoreCase(state.toString());
-                                });
-                        if (failedConnector) {
-                            return Future.failedFuture("One or more connectors are in FAILED state");
-                        } else {
-                            return Future.succeededFuture();
-                        }
-                    })
-                    .map((Void) null);
+    private Future<Void> deleteConnectors(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, List<String> connectorsForDeletion) {
+        return Future.join(connectorsForDeletion.stream()
+                        .map(connectorName -> {
+                            LOGGER.debugCr(reconciliation, "Deleting connector {}", connectorName);
+                            return apiClient.delete(reconciliation, host, KafkaConnectCluster.REST_API_PORT, connectorName);
+                        })
+                        .collect(Collectors.toList()))
+                .map((Void) null);
     }
 
-    @SuppressWarnings("deprecation")
-    private static void prepareMirrorMaker2ConnectorConfig(Reconciliation reconciliation, KafkaMirrorMaker2MirrorSpec mirror, KafkaMirrorMaker2ClusterSpec sourceCluster, KafkaMirrorMaker2ClusterSpec targetCluster, KafkaConnectorSpec connectorSpec, KafkaMirrorMaker2Cluster mirrorMaker2Cluster) {
-        Map<String, Object> config = connectorSpec.getConfig();
-        addClusterToMirrorMaker2ConnectorConfig(config, targetCluster, TARGET_CLUSTER_PREFIX);
-        addClusterToMirrorMaker2ConnectorConfig(config, sourceCluster, SOURCE_CLUSTER_PREFIX);
-
-        if (mirror.getTopicsPattern() != null) {
-            config.put("topics", mirror.getTopicsPattern());
-        }
-
-        String topicsExcludePattern = mirror.getTopicsExcludePattern();
-        String topicsBlacklistPattern = mirror.getTopicsBlacklistPattern();
-        if (topicsExcludePattern != null && topicsBlacklistPattern != null) {
-            LOGGER.warnCr(reconciliation, "Both topicsExcludePattern and topicsBlacklistPattern mirror properties are present, ignoring topicsBlacklistPattern as it is deprecated");
-        }
-        String topicsExclude = topicsExcludePattern != null ? topicsExcludePattern : topicsBlacklistPattern;
-        if (topicsExclude != null) {
-            config.put("topics.exclude", topicsExclude);
-        }
-
-        if (mirror.getGroupsPattern() != null) {
-            config.put("groups", mirror.getGroupsPattern());
-        }
-
-        String groupsExcludePattern = mirror.getGroupsExcludePattern();
-        String groupsBlacklistPattern = mirror.getGroupsBlacklistPattern();
-        if (groupsExcludePattern != null && groupsBlacklistPattern != null) {
-            LOGGER.warnCr(reconciliation, "Both groupsExcludePattern and groupsBlacklistPattern mirror properties are present, ignoring groupsBlacklistPattern as it is deprecated");
-        }
-        String groupsExclude = groupsExcludePattern != null ? groupsExcludePattern :  groupsBlacklistPattern;
-        if (groupsExclude != null) {
-            config.put("groups.exclude", groupsExclude);
-        }
-
-        if (mirrorMaker2Cluster.getTracing() != null)   {
-            if (JaegerTracing.TYPE_JAEGER.equals(mirrorMaker2Cluster.getTracing().getType())) {
-                LOGGER.warnCr(reconciliation, "Tracing type \"{}\" is not supported anymore and will be ignored", JaegerTracing.TYPE_JAEGER);
-            } else if (OpenTelemetryTracing.TYPE_OPENTELEMETRY.equals(mirrorMaker2Cluster.getTracing().getType())) {
-                config.put("consumer.interceptor.classes", OpenTelemetryTracing.CONSUMER_INTERCEPTOR_CLASS_NAME);
-                config.put("producer.interceptor.classes", OpenTelemetryTracing.PRODUCER_INTERCEPTOR_CLASS_NAME);
-            }
-        }
-
-        // setting client.rack here because the consumer is created by the connector
-        String clientRackKey = "consumer.client.rack";
-        config.put(clientRackKey, "${file:" + CONNECT_CONFIG_FILE + ":" + clientRackKey + "}");
-
-        config.putAll(mirror.getAdditionalProperties());
-    }
-
-    /* test */ static void addClusterToMirrorMaker2ConnectorConfig(Map<String, Object> config, KafkaMirrorMaker2ClusterSpec cluster, String configPrefix) {
-        config.put(configPrefix + "alias", cluster.getAlias());
-        config.put(configPrefix + AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.getBootstrapServers());
-
-        String securityProtocol = addTLSConfigToMirrorMaker2ConnectorConfig(config, cluster, configPrefix);
-
-        if (cluster.getAuthentication() != null) {
-            if (cluster.getAuthentication() instanceof KafkaClientAuthenticationTls) {
-                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
-                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, STORE_LOCATION_ROOT + cluster.getAlias() + KEYSTORE_SUFFIX);
-                config.put(configPrefix + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "${file:" + CONNECTORS_CONFIG_FILE + ":" + SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG + "}");
-            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationPlain plainAuthentication) {
-                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
-                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, "PLAIN");
-                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
-                        AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.plain.PlainLoginModule",
-                                Map.of("username", plainAuthentication.getUsername(),
-                                        "password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}")));
-            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationScram scramAuthentication) {
-                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
-                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, scramAuthentication instanceof KafkaClientAuthenticationScramSha256 ? "SCRAM-SHA-256" : "SCRAM-SHA-512");
-                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
-                        AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.scram.ScramLoginModule",
-                                Map.of("username", scramAuthentication.getUsername(),
-                                        "password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}")));
-            } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth oauthAuthentication) {
-                securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
-                config.put(configPrefix + SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
-                config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,
-                        oauthJaasConfig(cluster, oauthAuthentication));
-                config.put(configPrefix + SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
-            }
-        }
-
-        if (securityProtocol != null) {
-            config.put(configPrefix + AdminClientConfig.SECURITY_PROTOCOL_CONFIG, securityProtocol);
-        }
-
-        config.putAll(cluster.getConfig().entrySet().stream()
-                .collect(Collectors.toMap(entry -> configPrefix + entry.getKey(), Map.Entry::getValue)));
-        config.putAll(cluster.getAdditionalProperties());
-    }
-
-    private static String oauthJaasConfig(KafkaMirrorMaker2ClusterSpec cluster,
-                                          KafkaClientAuthenticationOAuth oauth) {
-
-        var oauthConfig = cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth ? AuthenticationUtils.oauthJaasOptions((KafkaClientAuthenticationOAuth) cluster.getAuthentication()) : Map.<String, String>of();
-        Map<String, String> jaasOptions = new HashMap<>(oauthConfig);
-        if (oauth.getClientSecret() != null) {
-            jaasOptions.put("oauth.client.secret", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.client.secret}");
-        }
-        if (oauth.getAccessToken() != null) {
-            jaasOptions.put("oauth.access.token", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.access.token}");
-        }
-        if (oauth.getRefreshToken() != null) {
-            jaasOptions.put("oauth.refresh.token", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.refresh.token}");
-        }
-        if (oauth.getPasswordSecret() != null) {
-            jaasOptions.put("oauth.password.grant.password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".oauth.password.grant.password}");
-        }
-        if (oauth.getTlsTrustedCertificates() != null && !oauth.getTlsTrustedCertificates().isEmpty()) {
-            jaasOptions.put("oauth.ssl.truststore.location", "/tmp/kafka/clusters/\"" + cluster.getAlias() + "\"-oauth.truststore.p12");
-            jaasOptions.put("oauth.ssl.truststore.password", "\"${file:" + CONNECTORS_CONFIG_FILE + ":oauth.ssl.truststore.password}\"");
-            jaasOptions.put("oauth.ssl.truststore.type", "PKCS12");
-        }
-        return AuthenticationUtils.jaasConfig("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule", jaasOptions);
-    }
-
-
-    private static String addTLSConfigToMirrorMaker2ConnectorConfig(Map<String, Object> config, KafkaMirrorMaker2ClusterSpec cluster, String configPrefix) {
-        String securityProtocol = null;
-        if (cluster.getTls() != null) {
-            securityProtocol = "SSL";
-            if (cluster.getTls().getTrustedCertificates() != null && !cluster.getTls().getTrustedCertificates().isEmpty()) {
-                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
-                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, STORE_LOCATION_ROOT + cluster.getAlias() + TRUSTSTORE_SUFFIX);
-                config.put(configPrefix + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "${file:" + CONNECTORS_CONFIG_FILE + ":" + SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG + "}");
-            }
-        }
-        return securityProtocol;
+    private Future<Void> reconcileConnectors(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, KafkaMirrorMaker2 mirrorMaker2, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, List<KafkaConnector> connectors, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
+        return Future.join(connectors.stream()
+                        .map(connector -> {
+                            LOGGER.debugCr(reconciliation, "Creating / updating connector {}", connector.getMetadata().getName());
+                            return reconcileMirrorMaker2Connector(reconciliation, mirrorMaker2, apiClient, host, connector.getMetadata().getName(), connector.getSpec(), mirrorMaker2Status);
+                        })
+                        .collect(Collectors.toList()))
+                .map((Void) null)
+                .compose(i -> apiClient.updateConnectLoggers(reconciliation, host, KafkaConnectCluster.REST_API_PORT, desiredLogging, mirrorMaker2Cluster.defaultLogConfig()))
+                .compose(i -> {
+                    boolean failedConnector = mirrorMaker2Status.getConnectors().stream()
+                            .anyMatch(connector -> {
+                                @SuppressWarnings({ "rawtypes" })
+                                Object state = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
+                                return "FAILED".equalsIgnoreCase(state.toString());
+                            });
+                    if (failedConnector) {
+                        return Future.failedFuture("One or more connectors are in FAILED state");
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                })
+                .map((Void) null);
     }
 
     private Future<Void> reconcileMirrorMaker2Connector(Reconciliation reconciliation, KafkaMirrorMaker2 mirrorMaker2, KafkaConnectApi apiClient, String host, String connectorName, KafkaConnectorSpec connectorSpec, KafkaMirrorMaker2Status mirrorMaker2Status) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -432,7 +432,10 @@ public class ResourceUtils {
                         .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
-                .withNewSpec().endSpec();
+                .withNewSpec()
+                    .withClusters(List.of())
+                    .withMirrors(List.of())
+                .endSpec();
 
         if (replicas != null) {
             kafkaMirrorMaker2Builder

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -137,6 +137,7 @@ public class KafkaMirrorMaker2ClusterTest {
                 .withLivenessProbe(new Probe(healthDelay, healthTimeout))
                 .withConnectCluster(targetClusterAlias)
                 .withClusters(targetCluster)
+                .withMirrors(List.of())
             .endSpec()
             .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -1,0 +1,675 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.api.kafka.model.common.CertAndKeySecretSourceBuilder;
+import io.strimzi.api.kafka.model.common.ConnectorState;
+import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpecBuilder;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpecBuilder;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.InvalidResourceException;
+import org.junit.jupiter.api.Test;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("deprecation") // Uses deprecated getPause() field in tests
+public class KafkaMirrorMaker2ConnectorsTest {
+    private static final String PREFIX = "prefix.";
+
+    private final static KafkaMirrorMaker2 KMM2 = new KafkaMirrorMaker2Builder()
+            .withNewMetadata()
+                .withName("my-mm2")
+                .withNamespace("my-namespace")
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(3)
+            .withConnectCluster("target")
+            .withClusters(new KafkaMirrorMaker2ClusterSpecBuilder()
+                    .withAlias("source")
+                    .withBootstrapServers("source:9092")
+                    .build(),
+                    new KafkaMirrorMaker2ClusterSpecBuilder()
+                            .withAlias("target")
+                            .withBootstrapServers("target:9092")
+                            .build())
+            .withMirrors(new KafkaMirrorMaker2MirrorSpecBuilder()
+                    .withSourceCluster("source")
+                    .withTargetCluster("target")
+                    .withNewSourceConnector()
+                        .withTasksMax(5)
+                        .withConfig(Map.of("sync.topic.acls.enabled", "false"))
+                    .endSourceConnector()
+                    .withNewCheckpointConnector()
+                        .withTasksMax(3)
+                        .withConfig(Map.of("sync.group.offsets.enabled", "true"))
+                    .endCheckpointConnector()
+                    .withNewHeartbeatConnector()
+                        .withTasksMax(1)
+                    .endHeartbeatConnector()
+                    .withTopicsPattern("my-topic-.*")
+                    .withTopicsExcludePattern("exclude-topic-.*")
+                    .withGroupsPattern("my-group-.*")
+                    .withGroupsExcludePattern("exclude-group-.*")
+                    .build())
+            .endSpec()
+            .build();
+
+    @Test
+    public void testValidation()    {
+        assertDoesNotThrow(() -> KafkaMirrorMaker2Connectors.validateConnectors(KMM2));
+    }
+
+    @Test
+    public void testFailingValidation()    {
+        // Missing spec
+        KafkaMirrorMaker2 kmm2WithoutSpec = new KafkaMirrorMaker2Builder(KMM2)
+                .withSpec(null)
+                .build();
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2WithoutSpec));
+        assertThat(ex.getMessage(), is(".spec section is required for KafkaMirrorMaker2 resource"));
+
+        // Missing clusters
+        KafkaMirrorMaker2 kmm2WithoutClusters = new KafkaMirrorMaker2Builder(KMM2)
+                .withNewSpec()
+                    .withMirrors(List.of())
+                .endSpec()
+                .build();
+        ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2WithoutClusters));
+        assertThat(ex.getMessage(), is(".spec.clusters and .spec.mirrors sections are required in KafkaMirrorMaker2 resource"));
+
+        // Missing mirrors
+        KafkaMirrorMaker2 kmm2WithoutMirrors = new KafkaMirrorMaker2Builder(KMM2)
+                .withNewSpec()
+                    .withClusters(List.of())
+                .endSpec()
+                .build();
+        ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2WithoutMirrors));
+        assertThat(ex.getMessage(), is(".spec.clusters and .spec.mirrors sections are required in KafkaMirrorMaker2 resource"));
+
+        // Missing alias
+        KafkaMirrorMaker2 kmm2WrongAlias = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                    .editMirror(0)
+                        .withSourceCluster(null)
+                        .withTargetCluster("wrong-target")
+                    .endMirror()
+                .endSpec()
+                .build();
+        ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2WrongAlias));
+        assertThat(ex.getMessage(), is("KafkaMirrorMaker2 resource validation failed: " +
+                "[Each MirrorMaker 2 mirror definition has to specify the source cluster alias, " +
+                "Target cluster alias wrong-target is used in a mirror definition, but cluster with this alias does not exist in cluster definitions]"));
+    }
+
+    @Test
+    public void testConnectors() {
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KMM2);
+        List<KafkaConnector> kcs = connectors.generateConnectorDefinitions();
+
+        Map<String, Object> expectedAll = new TreeMap<>();
+        expectedAll.put("source.cluster.alias", "source");
+        expectedAll.put("source.cluster.bootstrap.servers", "source:9092");
+        expectedAll.put("source.cluster.security.protocol", "PLAINTEXT");
+        expectedAll.put("target.cluster.alias", "target");
+        expectedAll.put("target.cluster.bootstrap.servers", "target:9092");
+        expectedAll.put("target.cluster.security.protocol", "PLAINTEXT");
+        expectedAll.put("topics", "my-topic-.*");
+        expectedAll.put("topics.exclude", "exclude-topic-.*");
+        expectedAll.put("groups", "my-group-.*");
+        expectedAll.put("groups.exclude", "exclude-group-.*");
+
+        Map<String, Object> expectedSource = new TreeMap<>(expectedAll);
+        expectedSource.put("sync.topic.acls.enabled", "false");
+
+        Map<String, Object> expectedCheckpoint = new TreeMap<>(expectedAll);
+        expectedCheckpoint.put("sync.group.offsets.enabled", "true");
+
+        assertThat(kcs.size(), is(3));
+
+        KafkaConnector kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorSourceConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(5));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedSource));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorCheckpointConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(3));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedCheckpoint));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorHeartbeatConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(1));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedAll));
+    }
+
+    @Test
+    public void testConnectorsWithMultipleSources() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                    .addToClusters(new KafkaMirrorMaker2ClusterSpecBuilder()
+                            .withAlias("other-source")
+                            .withBootstrapServers("other-source:9092")
+                            .build())
+                    .addToMirrors(new KafkaMirrorMaker2MirrorSpecBuilder()
+                            .withSourceCluster("other-source")
+                            .withTargetCluster("target")
+                            .withNewSourceConnector()
+                                .withTasksMax(15)
+                                .withConfig(Map.of("sync.topic.acls.enabled", "true"))
+                            .endSourceConnector()
+                            .withNewCheckpointConnector()
+                                .withTasksMax(13)
+                                .withConfig(Map.of("sync.group.offsets.enabled", "false"))
+                            .endCheckpointConnector()
+                            .withNewHeartbeatConnector()
+                                .withTasksMax(11)
+                            .endHeartbeatConnector()
+                            .build())
+                .endSpec()
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2);
+        List<KafkaConnector> kcs = connectors.generateConnectorDefinitions();
+
+        Map<String, Object> expectedAll = new TreeMap<>();
+        expectedAll.put("source.cluster.alias", "source");
+        expectedAll.put("source.cluster.bootstrap.servers", "source:9092");
+        expectedAll.put("source.cluster.security.protocol", "PLAINTEXT");
+        expectedAll.put("target.cluster.alias", "target");
+        expectedAll.put("target.cluster.bootstrap.servers", "target:9092");
+        expectedAll.put("target.cluster.security.protocol", "PLAINTEXT");
+        expectedAll.put("topics", "my-topic-.*");
+        expectedAll.put("topics.exclude", "exclude-topic-.*");
+        expectedAll.put("groups", "my-group-.*");
+        expectedAll.put("groups.exclude", "exclude-group-.*");
+
+        Map<String, Object> expectedSource = new TreeMap<>(expectedAll);
+        expectedSource.put("sync.topic.acls.enabled", "false");
+
+        Map<String, Object> expectedCheckpoint = new TreeMap<>(expectedAll);
+        expectedCheckpoint.put("sync.group.offsets.enabled", "true");
+
+        Map<String, Object> expectedAll2 = new TreeMap<>();
+        expectedAll2.put("source.cluster.alias", "other-source");
+        expectedAll2.put("source.cluster.bootstrap.servers", "other-source:9092");
+        expectedAll2.put("source.cluster.security.protocol", "PLAINTEXT");
+        expectedAll2.put("target.cluster.alias", "target");
+        expectedAll2.put("target.cluster.bootstrap.servers", "target:9092");
+        expectedAll2.put("target.cluster.security.protocol", "PLAINTEXT");
+
+        Map<String, Object> expectedSource2 = new TreeMap<>(expectedAll2);
+        expectedSource2.put("sync.topic.acls.enabled", "true");
+
+        Map<String, Object> expectedCheckpoint2 = new TreeMap<>(expectedAll2);
+        expectedCheckpoint2.put("sync.group.offsets.enabled", "false");
+
+        assertThat(kcs.size(), is(6));
+
+        KafkaConnector kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorSourceConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(5));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedSource));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorCheckpointConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(3));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedCheckpoint));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorHeartbeatConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(1));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedAll));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("other-source->target.MirrorSourceConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("other-source->target.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(15));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedSource2));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("other-source->target.MirrorCheckpointConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("other-source->target.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(13));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedCheckpoint2));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("other-source->target.MirrorHeartbeatConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("other-source->target.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getTasksMax(), is(11));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+        assertThat(kc.getSpec().getConfig(), is(expectedAll2));
+    }
+
+    @Test
+    public void testConnectorsOnlySome() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                    .editMirror(0)
+                        .withCheckpointConnector(null)
+                    .endMirror()
+                .endSpec()
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2);
+        List<KafkaConnector> kcs = connectors.generateConnectorDefinitions();
+
+        assertThat(kcs.size(), is(2));
+
+        KafkaConnector kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorSourceConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorSourceConnector"));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorHeartbeatConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"));
+    }
+
+    @Test
+    public void testConnectorsPauseState() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                    .editMirror(0)
+                        .editSourceConnector()
+                            .withState(ConnectorState.PAUSED)
+                        .endSourceConnector()
+                        .editCheckpointConnector()
+                            .withPause(true)
+                        .endCheckpointConnector()
+                        .editHeartbeatConnector()
+                            .withState(ConnectorState.STOPPED)
+                            .withPause(true)
+                        .endHeartbeatConnector()
+                    .endMirror()
+                .endSpec()
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2);
+        List<KafkaConnector> kcs = connectors.generateConnectorDefinitions();
+
+        assertThat(kcs.size(), is(3));
+
+        KafkaConnector kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorSourceConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorSourceConnector"));
+        assertThat(kc.getSpec().getPause(), is(nullValue()));
+        assertThat(kc.getSpec().getState(), is(ConnectorState.PAUSED));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorCheckpointConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorCheckpointConnector"));
+        assertThat(kc.getSpec().getPause(), is(true));
+        assertThat(kc.getSpec().getState(), is(nullValue()));
+
+        kc = kcs.stream().filter(k -> k.getMetadata().getName().contains("source->target.MirrorHeartbeatConnector")).findFirst().orElseThrow();
+        assertThat(kc.getMetadata().getName(), is("source->target.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getClassName(), is("org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"));
+        assertThat(kc.getSpec().getPause(), is(true));
+        assertThat(kc.getSpec().getState(), is(ConnectorState.STOPPED));
+    }
+
+    @Test
+    public void testConnectorConfiguration() {
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KMM2);
+        Map<String, Object> config = connectors.prepareMirrorMaker2ConnectorConfig(KMM2.getSpec().getMirrors().get(0),
+                KMM2.getSpec().getMirrors().get(0).getSourceConnector(),
+                KMM2.getSpec().getClusters().get(0),
+                KMM2.getSpec().getClusters().get(1));
+
+        Map<String, Object> expected = new TreeMap<>();
+        expected.put("source.cluster.alias", "source");
+        expected.put("source.cluster.bootstrap.servers", "source:9092");
+        expected.put("source.cluster.security.protocol", "PLAINTEXT");
+        expected.put("target.cluster.alias", "target");
+        expected.put("target.cluster.bootstrap.servers", "target:9092");
+        expected.put("target.cluster.security.protocol", "PLAINTEXT");
+        expected.put("sync.topic.acls.enabled", "false");
+        expected.put("topics", "my-topic-.*");
+        expected.put("topics.exclude", "exclude-topic-.*");
+        expected.put("groups", "my-group-.*");
+        expected.put("groups.exclude", "exclude-group-.*");
+
+        assertThat(new TreeMap<>(config), is(expected));
+    }
+
+    @Test
+    public void testConnectorConfigurationAlsoWithDeprecatedFields() {
+        KafkaMirrorMaker2MirrorSpec mirror = new KafkaMirrorMaker2MirrorSpecBuilder(KMM2.getSpec().getMirrors().get(0))
+                .withGroupsBlacklistPattern("other-group-.*")
+                .withTopicsBlacklistPattern("other-topic-.*")
+
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KMM2);
+        Map<String, Object> config = connectors.prepareMirrorMaker2ConnectorConfig(mirror,
+                KMM2.getSpec().getMirrors().get(0).getSourceConnector(),
+                KMM2.getSpec().getClusters().get(0),
+                KMM2.getSpec().getClusters().get(1));
+
+        Map<String, Object> expected = new TreeMap<>();
+        expected.put("source.cluster.alias", "source");
+        expected.put("source.cluster.bootstrap.servers", "source:9092");
+        expected.put("source.cluster.security.protocol", "PLAINTEXT");
+        expected.put("target.cluster.alias", "target");
+        expected.put("target.cluster.bootstrap.servers", "target:9092");
+        expected.put("target.cluster.security.protocol", "PLAINTEXT");
+        expected.put("sync.topic.acls.enabled", "false");
+        expected.put("topics", "my-topic-.*");
+        expected.put("topics.exclude", "exclude-topic-.*");
+        expected.put("groups", "my-group-.*");
+        expected.put("groups.exclude", "exclude-group-.*");
+
+        assertThat(new TreeMap<>(config), is(expected));
+    }
+
+    @Test
+    public void testConnectorConfigurationOnlyWithDeprecatedFields() {
+        KafkaMirrorMaker2MirrorSpec mirror = new KafkaMirrorMaker2MirrorSpecBuilder(KMM2.getSpec().getMirrors().get(0))
+                .withGroupsBlacklistPattern("other-group-.*")
+                .withTopicsBlacklistPattern("other-topic-.*")
+                .withTopicsExcludePattern(null)
+                .withGroupsExcludePattern(null)
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KMM2);
+        Map<String, Object> config = connectors.prepareMirrorMaker2ConnectorConfig(mirror,
+                KMM2.getSpec().getMirrors().get(0).getSourceConnector(),
+                KMM2.getSpec().getClusters().get(0),
+                KMM2.getSpec().getClusters().get(1));
+
+        Map<String, Object> expected = new TreeMap<>();
+        expected.put("source.cluster.alias", "source");
+        expected.put("source.cluster.bootstrap.servers", "source:9092");
+        expected.put("source.cluster.security.protocol", "PLAINTEXT");
+        expected.put("target.cluster.alias", "target");
+        expected.put("target.cluster.bootstrap.servers", "target:9092");
+        expected.put("target.cluster.security.protocol", "PLAINTEXT");
+        expected.put("sync.topic.acls.enabled", "false");
+        expected.put("topics", "my-topic-.*");
+        expected.put("topics.exclude", "other-topic-.*");
+        expected.put("groups", "my-group-.*");
+        expected.put("groups.exclude", "other-group-.*");
+
+        assertThat(new TreeMap<>(config), is(expected));
+    }
+
+    @Test
+    public void testConnectorConfigurationOnlyWithRackAndTracing() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                .withNewRack()
+                    .withTopologyKey("my-topology-key")
+                .endRack()
+                .withNewOpenTelemetryTracing()
+                .endOpenTelemetryTracing()
+                .endSpec()
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2);
+        Map<String, Object> config = connectors.prepareMirrorMaker2ConnectorConfig(KMM2.getSpec().getMirrors().get(0),
+                KMM2.getSpec().getMirrors().get(0).getSourceConnector(),
+                KMM2.getSpec().getClusters().get(0),
+                KMM2.getSpec().getClusters().get(1));
+
+        Map<String, Object> expected = new TreeMap<>();
+        expected.put("source.cluster.alias", "source");
+        expected.put("source.cluster.bootstrap.servers", "source:9092");
+        expected.put("source.cluster.security.protocol", "PLAINTEXT");
+        expected.put("target.cluster.alias", "target");
+        expected.put("target.cluster.bootstrap.servers", "target:9092");
+        expected.put("target.cluster.security.protocol", "PLAINTEXT");
+        expected.put("sync.topic.acls.enabled", "false");
+        expected.put("topics", "my-topic-.*");
+        expected.put("topics.exclude", "exclude-topic-.*");
+        expected.put("groups", "my-group-.*");
+        expected.put("groups.exclude", "exclude-group-.*");
+        expected.put("consumer.client.rack", "${file:/tmp/strimzi-connect.properties:consumer.client.rack}");
+        expected.put("consumer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.TracingConsumerInterceptor");
+        expected.put("producer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.TracingProducerInterceptor");
+
+        assertThat(new TreeMap<>(config), is(expected));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithoutAuth() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                                "prefix.security.protocol", "PLAINTEXT",
+                                "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithoutAuthWithClusterConfig() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withConfig(Map.of("config.storage.replication.factor", "-1"))
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                                "prefix.security.protocol", "PLAINTEXT",
+                                "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092",
+                                "prefix.config.storage.replication.factor", "-1"))));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithTlsAuth() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withNewKafkaClientAuthenticationTls()
+                    .withNewCertificateAndKey()
+                        .withSecretName("my-secret")
+                        .withCertificate("my.crt")
+                        .withKey("my.key")
+                    .endCertificateAndKey()
+                .endKafkaClientAuthenticationTls()
+                .withNewTls()
+                .endTls()
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        assertThat(config.containsKey("prefix.sasl.jaas.config"), is(false));
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                                "prefix.security.protocol", "SSL",
+                                "prefix.ssl.keystore.location", "/tmp/kafka/clusters/sourceClusterAlias.keystore.p12",
+                                "prefix.ssl.keystore.password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:ssl.keystore.password}",
+                                "prefix.ssl.keystore.type", "PKCS12",
+                                "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithPlain() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withNewKafkaClientAuthenticationPlain()
+                    .withUsername("shaza")
+                    .withNewPasswordSecret()
+                        .withPassword("pa55word")
+                    .endPasswordSecret()
+                    .endKafkaClientAuthenticationPlain()
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        String jaasConfig = (String) config.remove("prefix.sasl.jaas.config");
+        AppConfigurationEntry configEntry = AuthenticationUtilsTest.parseJaasConfig(jaasConfig);
+        assertThat(configEntry.getLoginModuleName(), is("org.apache.kafka.common.security.plain.PlainLoginModule"));
+        assertThat(configEntry.getOptions(),
+                is(Map.of("username", "shaza",
+                        "password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.sasl.password}")));
+
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                        "prefix.security.protocol", "SASL_PLAINTEXT",
+                        "prefix.sasl.mechanism", "PLAIN",
+                        "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithScram() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withNewKafkaClientAuthenticationScramSha512()
+                    .withUsername("shaza")
+                    .withNewPasswordSecret()
+                        .withPassword("pa55word")
+                    .endPasswordSecret()
+                .endKafkaClientAuthenticationScramSha512()
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        String jaasConfig = (String) config.remove("prefix.sasl.jaas.config");
+        AppConfigurationEntry configEntry = AuthenticationUtilsTest.parseJaasConfig(jaasConfig);
+        assertThat(configEntry.getLoginModuleName(), is("org.apache.kafka.common.security.scram.ScramLoginModule"));
+        assertThat(configEntry.getOptions(),
+                is(Map.of("username", "shaza",
+                        "password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.sasl.password}")));
+
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                        "prefix.security.protocol", "SASL_PLAINTEXT",
+                        "prefix.sasl.mechanism", "SCRAM-SHA-512",
+                        "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithOauth() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withNewKafkaClientAuthenticationOAuth()
+                    .withNewAccessToken()
+                        .withKey("accessTokenKey")
+                        .withSecretName("accessTokenSecretName")
+                    .endAccessToken()
+                    .withNewClientSecret()
+                        .withKey("clientSecretKey")
+                        .withSecretName("clientSecretSecretName")
+                    .endClientSecret()
+                    .withNewPasswordSecret()
+                        .withPassword("passwordSecretPassword")
+                        .withSecretName("passwordSecretSecretName")
+                    .endPasswordSecret()
+                    .withNewRefreshToken()
+                        .withKey("refreshTokenKey")
+                        .withSecretName("refreshTokenSecretName")
+                    .endRefreshToken()
+                .endKafkaClientAuthenticationOAuth()
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        String jaasConfig = (String) config.remove("prefix.sasl.jaas.config");
+        AppConfigurationEntry configEntry = AuthenticationUtilsTest.parseJaasConfig(jaasConfig);
+        assertThat(configEntry.getLoginModuleName(), is("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"));
+        assertThat(configEntry.getOptions(),
+                is(Map.of("oauth.client.secret", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.oauth.client.secret}",
+                        "oauth.access.token", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.oauth.access.token}",
+                        "oauth.refresh.token", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.oauth.refresh.token}",
+                        "oauth.password.grant.password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.oauth.password.grant.password}")));
+
+        assertThat(config,
+                is(Map.of("prefix.alias", "sourceClusterAlias",
+                        "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092",
+                        "prefix.sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler",
+                        "prefix.sasl.mechanism", "OAUTHBEARER",
+                        "prefix.security.protocol", "SASL_PLAINTEXT")));
+    }
+
+    @Test
+    public void testAddClusterToMirrorMaker2ConnectorConfigWithScramAndTlsEncryption() {
+        Map<String, Object> config = new HashMap<>();
+        KafkaMirrorMaker2ClusterSpec cluster = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("sourceClusterAlias")
+                .withBootstrapServers("sourceClusterAlias.sourceNamespace.svc:9092")
+                .withNewKafkaClientAuthenticationScramSha512()
+                    .withUsername("shaza")
+                    .withNewPasswordSecret()
+                        .withPassword("pa55word")
+                    .endPasswordSecret()
+                .endKafkaClientAuthenticationScramSha512()
+                .withNewTls()
+                    .withTrustedCertificates(new CertAndKeySecretSourceBuilder().withSecretName("my-tls").withCertificate("ca.crt").build())
+                .endTls()
+                .build();
+
+        KafkaMirrorMaker2Connectors.addClusterToMirrorMaker2ConnectorConfig(config, cluster, PREFIX);
+
+        String jaasConfig = (String) config.remove("prefix.sasl.jaas.config");
+        AppConfigurationEntry configEntry = AuthenticationUtilsTest.parseJaasConfig(jaasConfig);
+        assertThat("org.apache.kafka.common.security.scram.ScramLoginModule", is(configEntry.getLoginModuleName()));
+        assertThat(configEntry.getOptions(),
+                is(Map.of("username", "shaza",
+                        "password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:sourceClusterAlias.sasl.password}")));
+
+        assertThat(new TreeMap<>(config),
+                is(new TreeMap<>(Map.of("prefix.alias", "sourceClusterAlias",
+                        "prefix.security.protocol", "SASL_SSL",
+                       "prefix.ssl.truststore.location", "/tmp/kafka/clusters/sourceClusterAlias.truststore.p12",
+                       "prefix.ssl.truststore.password", "${file:/tmp/strimzi-mirrormaker2-connector.properties:ssl.truststore.password}",
+                        "prefix.ssl.truststore.type", "PKCS12",
+                        "prefix.sasl.mechanism", "SCRAM-SHA-512",
+                        "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -162,7 +162,9 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                         .withLabels(TestUtils.map("foo", "bar"))
                         .build())
                 .withNewSpec()
-                .withReplicas(REPLICAS)
+                    .withReplicas(REPLICAS)
+                    .withClusters(List.of())
+                    .withMirrors(List.of())
                 .endSpec()
             .build()).create();
 
@@ -190,7 +192,9 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                         .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", "true"))
                         .build())
                 .withNewSpec()
-                .withReplicas(REPLICAS)
+                    .withReplicas(REPLICAS)
+                    .withClusters(List.of())
+                    .withMirrors(List.of())
                 .endSpec()
                 .build()).create();
 

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.withAffinity-KafkaMirrorMaker2.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.withAffinity-KafkaMirrorMaker2.yaml
@@ -3,6 +3,8 @@ kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster
 spec:
+  clusters: []
+  mirrors: []
   template:
     pod:
       affinity:

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.withTolerations-KafkaMirrorMaker2.yaml
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.withTolerations-KafkaMirrorMaker2.yaml
@@ -3,6 +3,8 @@ kind: KafkaMirrorMaker2
 metadata:
   name: my-mm2-cluster
 spec:
+  clusters: []
+  mirrors: []
   template:
     pod:
       tolerations:


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors how the Kafka Mirror Maker 2 connectors are managed in `KafkaMirrorMaker2AssemblyOperator`. It factors the preparation of the connectors into a separate class `KafkaMirrorMaker2Connectors` linked from `KafkaMirrorMaker2Cluster`. This class doesn't do any reconciliation, it only prepares the connector specifications. 

The reconciliation is still handled by `KafkaMirrorMaker2AssemblyOperator`. The code there was only slightly simplified to use the new class.

This refactoring allowed to easily add more unit tests for the various connector configurations that should hopefully help us to allow issues such as #9418 in the future.

This should resolve #9419.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging