### PR TITLE
Precreate the plugins directory to avoid errors in Mirror Maker 2 pods

### DIFF
--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -25,6 +25,7 @@ ENV STRIMZI_VERSION=${strimzi_version}
 
 COPY $KAFKA_DIST_DIR $KAFKA_HOME
 COPY ./scripts/ $KAFKA_HOME
+RUN mkdir $KAFKA_HOME/plugins
 
 #####
 # Add Kafka Exporter


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In Connect and MM2, we preconfigure the `plugin.path` option to `/opt/kafka/plugins`. But out of the box, this directory does not exist. And that causes the following error:

```
2024-01-27 15:48:27,103 ERROR Could not get listing for plugin path: /opt/kafka/plugins. Ignoring. (org.apache.kafka.connect.runtime.isolation.PluginUtils) [main]
java.io.FileNotFoundException: /opt/kafka/plugins
	at org.apache.kafka.connect.runtime.isolation.PluginUtils.pluginLocations(PluginUtils.java:214)
	at org.apache.kafka.connect.runtime.isolation.Plugins.<init>(Plugins.java:71)
	at org.apache.kafka.connect.runtime.isolation.Plugins.<init>(Plugins.java:64)
	at org.apache.kafka.connect.cli.AbstractConnectCli.startConnect(AbstractConnectCli.java:121)
	at org.apache.kafka.connect.cli.AbstractConnectCli.run(AbstractConnectCli.java:94)
	at org.apache.kafka.connect.cli.ConnectDistributed.main(ConnectDistributed.java:116)
```

It is just a log message without causing any crash-looping, but it is not great if it can be avoided. With Connect, the general expectation is that users will add connectors and create the plugin directory that way. But in Mirror Maker 2, users normally don't add plugins, so this directory is almost always missing. 

This PR pre-creates the directly already in the base image and leaves it empty. That helps us avoid the error even if the base image is used directly such as in MM2.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally