### PR TITLE
[ST] Add AZP for migration and few fixups to the migration tests

### DIFF
--- a/.azure/migration-pipeline.yaml
+++ b/.azure/migration-pipeline.yaml
@@ -1,0 +1,28 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then images will be built as part of the pipeline
+    default: "latest"
+  - name: kafkaVersion
+    displayName: Kafka Version
+    type: string
+    # If kafkaVersion == latest, the latest supported version of Kafka is used
+    default: "latest"
+
+jobs:
+  - template: 'templates/jobs/system-tests/migration_jobs.yaml'
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+
+

--- a/.azure/templates/jobs/system-tests/migration_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/migration_jobs.yaml
@@ -6,6 +6,6 @@ jobs:
       profile: 'all'
       groups: 'migration'
       cluster_operator_install_type: 'bundle'
-      timeout: 240
+      timeout: 120
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/migration_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/migration_jobs.yaml
@@ -1,0 +1,11 @@
+jobs:
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'migration'
+      display_name: 'migration-bundle'
+      profile: 'all'
+      groups: 'migration'
+      cluster_operator_install_type: 'bundle'
+      timeout: 240
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -3,6 +3,7 @@ parameters:
   name: ''
   display_name: ''
   profile: ''
+  groups: ''
   excludedGroups: ''
   cluster_operator_install_type: ''
   timeout: ''
@@ -122,6 +123,7 @@ jobs:
         goals: 'verify'
         options: >-
           -P${{ parameters.profile }} 
+          -Dgroups=${{ parameters.groups }} 
           -DexcludedGroups=flaky,loadbalancer,networkpolicies,${{ parameters.excludedGroups }} 
           -Dmaven.javadoc.skip=true 
           -B 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -277,7 +277,11 @@ public class Environment {
      * @return true if KRaft mode is enabled, otherwise false
      */
     public static boolean isKRaftModeEnabled() {
-        return !STRIMZI_FEATURE_GATES.contains(TestConstants.DONT_USE_KRAFT_MODE) && STRIMZI_USE_KRAFT_IN_TESTS;
+        return isKRaftForCOEnabled() && STRIMZI_USE_KRAFT_IN_TESTS;
+    }
+
+    public static boolean isKRaftForCOEnabled() {
+        return !STRIMZI_FEATURE_GATES.contains(TestConstants.DONT_USE_KRAFT_MODE);
     }
 
     public static boolean isKafkaNodePoolsEnabled() {


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds AZP for migration testgroup, which will allow us testing the migration inside the Azure. First idea was to add it to the `regression`, but the execution time is ~30 minutes for those two test cases - so it would make the current execution time of the regression pipelines too long and we could possibly hit the timeout.
Also, it's not maybe something we should run for every regression execution, so we can save some execution time by running just migration test cases.

Finally, this PR adds some fixes to the current STs:

- instead of short names of the resources in the `waitForZooKeeperResourcesDeletion` I'm using the whole names - to remove issues with "No such resource" exceptions
- in two checks for existence of KafkaTopic in ZK/KRaft metadata - instead of direct `assert` I added `waitFor`s that will wait until the KafkaTopic is in metadata, otherwise it fails the test -> that's because of issue in ZK, where we sometimes get "Connection refused" exception

Finally I added assumption to the `beforeAll` to check, so the tests will be skipped in case we are disabling KafkaNodePools or KRaft feature gates (comment from previous PR that I forgot to add).

### Checklist

- [ ] Make sure all tests pass

