### PR TITLE
Fix CC not restarted when API secret changes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -415,10 +415,11 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
     /**
      * Creates Cruise Control API auth usernames, passwords, and credentials file
      *
+     * @param passwordGenerator The password generator for API users
+     *
      * @return Map containing Cruise Control API auth credentials
      */
-    public static Map<String, String> generateCruiseControlApiCredentials() {
-        PasswordGenerator passwordGenerator = new PasswordGenerator(16);
+    public static Map<String, String> generateCruiseControlApiCredentials(PasswordGenerator passwordGenerator) {
         String apiAdminPassword = passwordGenerator.generate();
         String apiUserPassword = passwordGenerator.generate();
 
@@ -441,10 +442,13 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
     /**
      * Generate the Secret containing the Cruise Control API auth credentials.
      *
+     * @param passwordGenerator The password generator for API users
+     * 
      * @return The generated Secret.
      */
-    public Secret generateApiSecret() {
-        return ModelUtils.createSecret(CruiseControlResources.apiSecretName(cluster), namespace, labels, ownerReference, generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
+    public Secret generateApiSecret(PasswordGenerator passwordGenerator) {
+        return ModelUtils.createSecret(CruiseControlResources.apiSecretName(cluster), namespace, labels, ownerReference, 
+            generateCruiseControlApiCredentials(passwordGenerator), Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -26,6 +26,7 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ConfigMapOperator;
 import io.strimzi.operator.common.operator.resource.DeploymentOperator;
 import io.strimzi.operator.common.operator.resource.NetworkPolicyOperator;
@@ -40,7 +41,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 
 /**
  * Class used for reconciliation of Cruise Control. This class contains both the steps of the Cruise Control
@@ -64,12 +64,13 @@ public class CruiseControlReconciler {
     private final ServiceOperator serviceOperator;
     private final NetworkPolicyOperator networkPolicyOperator;
     private final ConfigMapOperator configMapOperator;
+    private final PasswordGenerator passwordGenerator;
 
     private boolean existingCertsChanged = false;
 
     private String serverConfigurationHash = "";
     private String capacityConfigurationHash = "";
-    private String apiCredentialsHash = "";
+    private String apiSecretHash = "";
     
     /**
      * Constructs the Cruise Control reconciler
@@ -83,6 +84,7 @@ public class CruiseControlReconciler {
      * @param kafkaBrokerStorage        A map with storage configuration used by the Kafka cluster and its broker pools
      * @param kafkaBrokerResources      A map with resource configuration used by the Kafka cluster and its broker pools
      * @param clusterCa                 The Cluster CA instance
+     * @param passwordGenerator         The password generator for API users
      */
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public CruiseControlReconciler(
@@ -94,7 +96,8 @@ public class CruiseControlReconciler {
             Set<NodeRef> kafkaBrokerNodes,
             Map<String, Storage> kafkaBrokerStorage,
             Map<String, ResourceRequirements> kafkaBrokerResources,
-            ClusterCa clusterCa
+            ClusterCa clusterCa,
+            PasswordGenerator passwordGenerator
     ) {
         this.reconciliation = reconciliation;
         this.cruiseControl = CruiseControl.fromCrd(reconciliation, kafkaAssembly, versions, kafkaBrokerNodes, kafkaBrokerStorage, kafkaBrokerResources, supplier.sharedEnvironmentProvider);
@@ -111,6 +114,7 @@ public class CruiseControlReconciler {
         this.serviceOperator = supplier.serviceOperations;
         this.networkPolicyOperator = supplier.networkPolicyOperator;
         this.configMapOperator = supplier.configMapOperations;
+        this.passwordGenerator = passwordGenerator;
     }
 
     /**
@@ -242,7 +246,7 @@ public class CruiseControlReconciler {
         if (cruiseControl != null) {
             return secretOperator.getAsync(reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()))
                     .compose(oldSecret -> {
-                        Secret newSecret = cruiseControl.generateApiSecret();
+                        Secret newSecret = cruiseControl.generateApiSecret(passwordGenerator);
 
                         if (oldSecret != null)  {
                             // The credentials should not change with every release
@@ -250,9 +254,9 @@ public class CruiseControlReconciler {
                             // But we use the new secret to update labels etc. if needed
                             newSecret.setData(oldSecret.getData());
                         }
-
-                        this.apiCredentialsHash = String.valueOf(newSecret.hashCode());
-
+                        
+                        this.apiSecretHash = ReconcilerUtils.hashSecretContent(newSecret, "password");
+                        
                         return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()), newSecret)
                                 .map((Void) null);
                     });
@@ -289,7 +293,7 @@ public class CruiseControlReconciler {
             podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(clusterCa.caKeyGeneration()));
             podAnnotations.put(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH, serverConfigurationHash);
             podAnnotations.put(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH, capacityConfigurationHash);
-            podAnnotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, apiCredentialsHash);
+            podAnnotations.put(Annotations.ANNO_STRIMZI_AUTH_HASH, apiSecretHash);
             
             Deployment deployment = cruiseControl.generateDeployment(podAnnotations, isOpenShift, imagePullPolicy, imagePullSecrets);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -704,7 +704,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     kafkaBrokerNodes,
                     kafkaBrokerStorage,
                     kafkaBrokerResources,
-                    clusterCa
+                    clusterCa,
+                    new PasswordGenerator(16)
             );
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -699,13 +699,13 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     reconciliation,
                     config,
                     supplier,
+                    passwordGenerator,
                     kafkaAssembly,
                     versions,
                     kafkaBrokerNodes,
                     kafkaBrokerStorage,
                     kafkaBrokerResources,
-                    clusterCa,
-                    new PasswordGenerator(16)
+                    clusterCa
             );
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -383,9 +383,9 @@ public class ReconcilerUtils {
     }
 
     /**
-     * Creates a hash from Secret's content.
+     * Creates a hash from Secret's data.
      * @param secret Secret with data.
-     * @return Hash of the values whose keys match the keyword.
+     * @return Hash of all secret values.
      */
     public static String hashSecretContent(Secret secret) {
         if (secret == null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -383,22 +383,25 @@ public class ReconcilerUtils {
     }
 
     /**
-     * Creates a hash from Secret's data.
+     * Creates a hash from Secret's content.
      * 
-     * @param secret Secret with data.
-     * @return Hash of all secret values.
+     * @param secret Secret with content.
+     * @return Hash of the secret content.
      */
     public static String hashSecretContent(Secret secret) {
         if (secret == null) {
             throw new RuntimeException("Secret not found");
         }
+        
         if (secret.getData() == null || secret.getData().isEmpty()) {
             throw new RuntimeException("Empty secret");
         }
+        
         StringBuilder sb = new StringBuilder();
-        for (String key : secret.getData().keySet()) {
-            sb.append(secret.getData().get(key));
-        }
+        secret.getData().entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> sb.append(entry.getKey()).append(entry.getValue()));
+        
         return Util.hashStub(sb.toString());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -32,11 +32,15 @@ import io.strimzi.operator.common.operator.resource.SecretOperator;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_SERVER_CERT_HASH;
 
@@ -380,5 +384,35 @@ public class ReconcilerUtils {
      */
     public static boolean kraftEnabled(Kafka kafka) {
         return KafkaCluster.ENABLED_VALUE_STRIMZI_IO_KRAFT.equals(Annotations.stringAnnotation(kafka, Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled").toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Creates a hash from Secret's content.
+     * @param secret Secret with data.
+     * @param keyword String used to find matching keys.
+     * @return Hash of the values whose keys match the keyword.
+     */
+    public static String hashSecretContent(Secret secret, String keyword) {
+        if (secret == null) {
+            return hash("Secret not found");
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String key : secret.getData().keySet()) {
+            if (Pattern.compile(keyword, Pattern.CASE_INSENSITIVE).matcher(key).find()) {
+                sb.append(secret.getData().get(key));
+            }
+        }
+        return sb.toString().length() > 0 
+            ? hash(sb.toString()) 
+            : hash("Keyword not found");
+    }
+    
+    private static String hash(String s) {
+        try {
+            byte[] hash = MessageDigest.getInstance("MD5").digest(s.getBytes());
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -384,6 +384,7 @@ public class ReconcilerUtils {
 
     /**
      * Creates a hash from Secret's data.
+     * 
      * @param secret Secret with data.
      * @return Hash of all secret values.
      */
@@ -391,12 +392,12 @@ public class ReconcilerUtils {
         if (secret == null) {
             throw new RuntimeException("Secret not found");
         }
+        if (secret.getData() == null || secret.getData().isEmpty()) {
+            throw new RuntimeException("Empty secret");
+        }
         StringBuilder sb = new StringBuilder();
         for (String key : secret.getData().keySet()) {
             sb.append(secret.getData().get(key));
-        }
-        if (sb.toString().length() == 0) {
-            throw new RuntimeException("Empty secret");
         }
         return Util.hashStub(sb.toString());
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -54,7 +54,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -80,12 +79,11 @@ public class CruiseControlReconcilerTest {
         ServiceOperator mockServiceOps = supplier.serviceOperations;
         NetworkPolicyOperator mockNetPolicyOps = supplier.networkPolicyOperator;
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
-        PasswordGenerator mockPasswordGenerator = mock(PasswordGenerator.class);
+        PasswordGenerator mockPasswordGenerator = new PasswordGenerator(10, "a", "a");
         
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceAccountName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
         
-        when(mockPasswordGenerator.generate()).thenReturn("secret");
         ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.apiSecretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
@@ -123,13 +121,13 @@ public class CruiseControlReconcilerTest {
                 Reconciliation.DUMMY_RECONCILIATION,
                 ResourceUtils.dummyClusterOperatorConfig(),
                 supplier,
+                mockPasswordGenerator,
                 kafka,
                 VERSIONS,
                 NODES,
                 Map.of("kafka", kafka.getSpec().getKafka().getStorage()),
                 Map.of(),
-                clusterCa,
-                mockPasswordGenerator
+                clusterCa
         );
 
         Checkpoint async = context.checkpoint();
@@ -156,7 +154,7 @@ public class CruiseControlReconcilerTest {
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("f6dc41c7"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("bLEULIBSrWikUZUQPf7GZQ=="));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("178b8283"));
 
                     async.flag();
                 })));
@@ -208,13 +206,13 @@ public class CruiseControlReconcilerTest {
                 Reconciliation.DUMMY_RECONCILIATION,
                 ResourceUtils.dummyClusterOperatorConfig(),
                 supplier,
+                new PasswordGenerator(16),
                 kafka,
                 VERSIONS,
                 NODES,
                 Map.of(NAME + "-kafka", kafka.getSpec().getKafka().getStorage()),
                 Map.of(),
-                clusterCa,
-                new PasswordGenerator(16)
+                clusterCa
         );
 
         Checkpoint async = context.checkpoint();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -25,6 +25,7 @@ import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -151,6 +152,7 @@ public class CruiseControlReconcilerTest {
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("f6dc41c7"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), notNullValue());
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -83,11 +83,11 @@ public class CruiseControlReconcilerTest {
         
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceAccountName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
-        
+
         ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.apiSecretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
-        
+
         ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
         when(mockServiceOps.reconcile(any(), eq(NAMESPACE), eq(CruiseControlResources.serviceName(NAME)), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -154,7 +154,7 @@ public class CruiseControlReconcilerTest {
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("f6dc41c7"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("178b8283"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("27ada64b"));
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
@@ -297,7 +297,7 @@ public class ReconcilerUtilsTest {
             .addToData(Map.of("username", "foo"))
             .addToData(Map.of("password", "changeit"))
             .build();
-        assertThat(ReconcilerUtils.hashSecretContent(secret), is("9b583ce9"));
+        assertThat(ReconcilerUtils.hashSecretContent(secret), is("756937ae"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
@@ -290,6 +290,17 @@ public class ReconcilerUtilsTest {
                     async.flag();
                 })));
     }
+    
+    @Test
+    public void testHashSecretContent() {
+        Secret secret = new SecretBuilder()
+            .addToData(Map.of("user-password", "changeit"))
+            .addToData(Map.of("userPassword", "changeit"))
+            .addToData(Map.of("PASSWORD", "changeit"))
+            .build();
+        
+        assertThat(ReconcilerUtils.hashSecretContent(secret, "password"), is("F9yAQqlPifM1mCBESPQ7hA=="));
+    }
 
     static class MockJmxCluster implements SupportsJmx {
         private final JmxModel jmx;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtilsTest.java
@@ -294,12 +294,23 @@ public class ReconcilerUtilsTest {
     @Test
     public void testHashSecretContent() {
         Secret secret = new SecretBuilder()
-            .addToData(Map.of("user-password", "changeit"))
-            .addToData(Map.of("userPassword", "changeit"))
-            .addToData(Map.of("PASSWORD", "changeit"))
+            .addToData(Map.of("username", "foo"))
+            .addToData(Map.of("password", "changeit"))
             .build();
-        
-        assertThat(ReconcilerUtils.hashSecretContent(secret, "password"), is("F9yAQqlPifM1mCBESPQ7hA=="));
+        assertThat(ReconcilerUtils.hashSecretContent(secret), is("9b583ce9"));
+    }
+
+    @Test
+    public void testHashSecretContentWithNoData() {
+        Secret secret = new SecretBuilder().build();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> ReconcilerUtils.hashSecretContent(secret));
+        assertThat(ex.getMessage(), is("Empty secret"));
+    }
+
+    @Test
+    public void testHashSecretContentWithNoSecret() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> ReconcilerUtils.hashSecretContent(null));
+        assertThat(ex.getMessage(), is("Secret not found"));
     }
 
     static class MockJmxCluster implements SupportsJmx {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -12,6 +12,7 @@ import io.strimzi.certs.Subject;
 import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 import io.strimzi.operator.common.operator.MockCertManager;
@@ -79,7 +80,7 @@ public class MockCruiseControl {
             .addToData("cruise-control.crt", MockCertManager.clusterCaCert())
             .build();
     public static final Secret CC_API_SECRET = ModelUtils.createSecret(CruiseControlResources.apiSecretName(CLUSTER), NAMESPACE, Labels.EMPTY, null,
-            CruiseControl.generateCruiseControlApiCredentials(), Collections.emptyMap(), Collections.emptyMap());
+            CruiseControl.generateCruiseControlApiCredentials(new PasswordGenerator(16)), Collections.emptyMap(), Collections.emptyMap());
 
     private static final Header AUTH_HEADER = convertToHeader(CruiseControlApiImpl.getAuthHttpHeader(true, CC_API_SECRET));
 


### PR DESCRIPTION
The user may need to create new CC API credentials because they may have been compromised. This can be done by simply deleting the secret containing CC API credentials, which is then recreated by the CO. The problem is that CC is not restarted, which leads to the following Rebalance error:

```sh
2024-01-29 17:44:08 ERROR KafkaRebalanceAssemblyOperator:483 - Reconciliation #64(kafkarebalance-watch) KafkaRebalance(test/my-rebalance): Status updated to [NotReady] due to error: Unexpected status code 401 for request to my-cluster-cruise-control.test.svc:9090/kafkacruisecontrol/rebalance?json=true&dryrun=true&verbose=true&skip_hard_goal_check=false&rebalance_disk=false
```

To fix this issue, I'm adding the API secret hash as CC annotation, so that any change will trigger a CC pod restart.
