### PR TITLE
Fix #9270: Incorrect TO ResourceConflict message

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
@@ -191,7 +191,7 @@ class BatchingLoop {
             try {
                 synchronized (BatchingLoop.this) {
                     // remove the old batch from the inflight set and reset the batch
-                    LOGGER.debugOp("[Batch #{}] Removing batch from inflight", batchId - 1);
+                    LOGGER.traceOp("[Batch #{}] Removing batch from inflight", batchId - 1);
                     batch.toUpdate.stream().map(TopicEvent::toRef).forEach(inFlight::remove);
                     batch.toDelete.stream().map(TopicEvent::toRef).forEach(inFlight::remove);
                     batch.clear();
@@ -210,7 +210,7 @@ class BatchingLoop {
                     }
                     LOGGER.debugOp("[Batch #{}] Reconciled batch", batchId);
                 } else {
-                    LOGGER.debugOp("[Batch #{}] Empty batch", batchId);
+                    LOGGER.traceOp("[Batch #{}] Empty batch", batchId);
                 }
             } catch (InterruptedException e) {
                 LOGGER.infoOp("[Batch #{}] Interrupted", batchId);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 import java.io.InterruptedIOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -80,7 +81,7 @@ public class BatchingTopicController {
     private final KubernetesClient kubeClient;
 
     // Key: topic name, Value: The KafkaTopics known to manage that topic
-    /* test */ final Map<String, Set<KubeRef>> topics = new HashMap<>();
+    /* test */ final Map<String, List<KubeRef>> topics = new HashMap<>();
 
     private final TopicOperatorMetricsHolder metrics;
     private final String namespace;
@@ -201,9 +202,11 @@ public class BatchingTopicController {
 
     private boolean rememberTopic(ReconcilableTopic reconcilableTopic) {
         String tn = reconcilableTopic.topicName();
-        var existing = topics.computeIfAbsent(tn, k -> new HashSet<>());
+        var existing = topics.computeIfAbsent(tn, k -> new ArrayList<>(1));
         KubeRef thisRef = new KubeRef(reconcilableTopic.kt());
-        existing.add(thisRef);
+        if (!existing.contains(thisRef)) {
+            existing.add(thisRef);
+        }
         return true;
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -726,7 +727,7 @@ class TopicControllerIT {
         assertEquals(Set.of(kt.getSpec().getReplicas()), replicationFactors(topicDescription));
         assertEquals(Map.of(), topicConfigMap(expectedTopicName));
 
-        Map<String, Set<KubeRef>> topics = new HashMap<>(operator.controller.topics);
+        Map<String, List<KubeRef>> topics = new HashMap<>(operator.controller.topics);
         assertFalse(topics.containsKey("foo")
                         || topics.containsKey("FOO"),
                 "Transition to a non-selected resource should result in removal from topics map: " + topics);
@@ -1918,7 +1919,7 @@ class TopicControllerIT {
             TopicOperatorException.Reason.NOT_SUPPORTED.reason,
             "Decreasing partitions not supported"));
     }
-    @Test
+    @RepeatedTest(10)
     public void shouldDetectConflictingKafkaTopicCreations(
             @BrokerConfig(name = "auto.create.topics.enable", value = "false")
             KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -68,7 +68,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -80,6 +83,7 @@ import java.util.stream.Collectors;
 
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 import static io.strimzi.operator.topic.v2.BatchingTopicController.isPaused;
+import static io.strimzi.operator.topic.v2.TopicOperatorTestUtil.findKafkaTopicByName;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -474,6 +478,42 @@ class TopicControllerIT {
         LOGGER.info("Test created KafkaTopic {} with resourceVersion {}",
                 created.getMetadata().getName(), BatchingTopicController.resourceVersion(created));
         return waitUntil(created, condition);
+    }
+
+    private List<KafkaTopic> createTopicsConcurrently(KafkaCluster kc, KafkaTopic... kts) throws InterruptedException, ExecutionException {
+        if (kts == null || kts.length == 0) {
+            throw new IllegalArgumentException("You need pass at least one topic to be created");
+        }
+        String ns = namespace(kts[0].getMetadata().getNamespace());
+        maybeStartOperator(topicOperatorConfig(ns, kc));
+        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        CountDownLatch latch = new CountDownLatch(kts.length);
+        List<KafkaTopic> result = new ArrayList<>();
+        for (KafkaTopic kt : kts) {
+            executor.submit(() -> {
+                try {
+                    var created = Crds.topicOperation(client).resource(kt).create();
+                    LOGGER.info("Test created KafkaTopic {} with creationTimestamp {}",
+                        created.getMetadata().getName(),
+                        created.getMetadata().getCreationTimestamp());
+                    var reconciled = waitUntil(created, readyIsTrueOrFalse());
+                    result.add(reconciled);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                latch.countDown();
+            });
+        }
+        latch.await(1, TimeUnit.MINUTES);
+        try {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            if (!executor.isTerminated()) {
+                executor.shutdownNow();
+            }
+        }
+        return result;
     }
 
     private KafkaTopic pauseTopic(String namespace, String topicName) {
@@ -1834,19 +1874,14 @@ class TopicControllerIT {
 
     @Test
     public void shouldFailIfNumPartitionsDivergedWithConfigChange(@BrokerConfig(name = "auto.create.topics.enable", value = "false")
-                                                  KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException, TimeoutException {
-        // Scenario from https://github.com/strimzi/strimzi-kafka-operator/pull/8627#pullrequestreview-1477513413
-
-        // given
+                                                                  KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException, TimeoutException {
+        // scenario from https://github.com/strimzi/strimzi-kafka-operator/pull/8627#pullrequestreview-1477513413
 
         // create foo
         var topicName = randomTopicName();
         LOGGER.info("Create foo");
         var foo = kafkaTopic(NAMESPACE, "foo", null, null, 1, 1);
         var createdFoo = createTopicAndAssertSuccess(kafkaCluster, foo);
-
-        // TODO remove after fixing https://github.com/strimzi/strimzi-kafka-operator/issues/9270
-        Thread.sleep(1000);
 
         // create conflicting bar
         LOGGER.info("Create conflicting bar");
@@ -1861,29 +1896,72 @@ class TopicControllerIT {
         // increase partitions of foo
         LOGGER.info("Increase partitions of foo");
         var editedFoo = modifyTopicAndAwait(createdFoo, theKt ->
-                        new KafkaTopicBuilder(theKt).editSpec().withPartitions(3).endSpec().build(),
-                readyIsTrue());
+                new KafkaTopicBuilder(theKt).editSpec().withPartitions(3).endSpec().build(),
+            readyIsTrue());
 
         // unmanage foo
         LOGGER.info("Unmanage foo");
         var unmanagedFoo = modifyTopicAndAwait(editedFoo, theKt ->
-                        new KafkaTopicBuilder(theKt).editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
-                readyIsTrue());
+                new KafkaTopicBuilder(theKt).editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
+            readyIsTrue());
 
         // when: delete foo
         LOGGER.info("Delete foo");
         Crds.topicOperation(client).resource(unmanagedFoo).delete();
         LOGGER.info("Test deleted KafkaTopic {} with resourceVersion {}",
-                unmanagedFoo.getMetadata().getName(), BatchingTopicController.resourceVersion(unmanagedFoo));
+            unmanagedFoo.getMetadata().getName(), BatchingTopicController.resourceVersion(unmanagedFoo));
         Resource<KafkaTopic> resource = Crds.topicOperation(client).resource(unmanagedFoo);
         TopicOperatorTestUtil.waitUntilCondition(resource, Objects::isNull);
 
         // then: expect bar's unreadiness to be due to mismatching #partitions
         waitUntil(createdBar, readyIsFalseAndReasonIs(
-                TopicOperatorException.Reason.NOT_SUPPORTED.reason,
-                "Decreasing partitions not supported"));
+            TopicOperatorException.Reason.NOT_SUPPORTED.reason,
+            "Decreasing partitions not supported"));
+    }
+    @Test
+    public void shouldDetectConflictingKafkaTopicCreations(
+            @BrokerConfig(name = "auto.create.topics.enable", value = "false")
+            KafkaCluster kafkaCluster) throws ExecutionException, InterruptedException {
+        var foo = kafkaTopic("ns", "foo", null, null, 1, 1);
+        var bar = kafkaTopic("ns", "bar", SELECTOR, null, null, "foo", 1, 1,
+            Map.of(TopicConfig.COMPRESSION_TYPE_CONFIG, "snappy"));
+
+        LOGGER.info("Create conflicting topics: foo and bar");
+        var reconciledTopics = createTopicsConcurrently(kafkaCluster, foo, bar);
+        var reconciledFoo = findKafkaTopicByName(reconciledTopics, "foo");
+        var reconciledBar = findKafkaTopicByName(reconciledTopics, "bar");
+
+        // only one resource with the same topicName should be reconciled
+        var fooFailed = readyIsFalse().test(reconciledFoo);
+        var barFailed = readyIsFalse().test(reconciledBar);
+        assertTrue(fooFailed ^ barFailed);
+
+        if (fooFailed) {
+            assertKafkaTopicConflict(reconciledFoo, reconciledBar);
+        } else {
+            assertKafkaTopicConflict(reconciledBar, reconciledFoo);
+        }
     }
 
+    private void assertKafkaTopicConflict(KafkaTopic failed, KafkaTopic ready) {
+        // the error message should refer to the ready resource name
+        var condition = assertExactlyOneCondition(failed);
+        assertEquals(TopicOperatorException.Reason.RESOURCE_CONFLICT.reason, condition.getReason());
+        assertEquals(format("Managed by Ref{namespace='ns', name='%s'}", ready.getMetadata().getName()), condition.getMessage());
+
+        // the failed resource should become ready after we unmanage and delete the other
+        LOGGER.info("Unmanage {}", ready.getMetadata().getName());
+        var unmanagedBar = modifyTopicAndAwait(ready, theKt -> new KafkaTopicBuilder(theKt)
+                .editMetadata().addToAnnotations(BatchingTopicController.MANAGED, "false").endMetadata().build(),
+            readyIsTrue());
+
+        LOGGER.info("Delete {}", ready.getMetadata().getName());
+        Crds.topicOperation(client).resource(unmanagedBar).delete();
+        Resource<KafkaTopic> resource = Crds.topicOperation(client).resource(unmanagedBar);
+        TopicOperatorTestUtil.waitUntilCondition(resource, Objects::isNull);
+
+        waitUntil(failed, readyIsTrue());
+    }
     private static <T> KafkaFuture<T> failedFuture(Throwable error) {
         var future = new KafkaFutureImpl<T>();
         future.completeExceptionally(error);

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorTestUtil.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.TestInfo;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -123,5 +124,9 @@ class TopicOperatorTestUtil {
                 }
             }
         }
+    }
+
+    static KafkaTopic findKafkaTopicByName(List<KafkaTopic> topics, String name) {
+        return topics.stream().filter(kt -> kt.getMetadata().getName().equals(name)).findFirst().orElse(null);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Change `BatchingTopicController#topics` from being a `Map<String, HashSet<KubeRef>>` to `Map<String, ArrayList<KubeRef>>` so that the encounter order of KubRefs is maintained and the `byCreationTime`  at the point we validate the single managing resource has a stable ordering in the presence of `KafkaTopics` with the same `creationTimestamp`.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

