### PR TITLE
Update Vert.x to 4.5.2 and other related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,14 @@
         <fabric8.openshift-client.version>6.10.0</fabric8.openshift-client.version>
         <fabric8.kubernetes-model.version>6.10.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
-        <fasterxml.jackson-core.version>2.15.3</fasterxml.jackson-core.version>
-        <fasterxml.jackson-databind.version>2.15.3</fasterxml.jackson-databind.version>
-        <fasterxml.jackson-dataformat.version>2.15.3</fasterxml.jackson-dataformat.version>
-        <fasterxml.jackson-annotations.version>2.15.3</fasterxml.jackson-annotations.version>
-        <fasterxml.jackson-datatype.version>2.15.3</fasterxml.jackson-datatype.version>
-        <fasterxml.jackson-jaxrs.version>2.15.3</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.1</vertx.version>
-        <vertx-junit5.version>4.5.1</vertx-junit5.version>
+        <fasterxml.jackson-core.version>2.16.1</fasterxml.jackson-core.version>
+        <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>
+        <fasterxml.jackson-dataformat.version>2.16.1</fasterxml.jackson-dataformat.version>
+        <fasterxml.jackson-annotations.version>2.16.1</fasterxml.jackson-annotations.version>
+        <fasterxml.jackson-datatype.version>2.16.1</fasterxml.jackson-datatype.version>
+        <fasterxml.jackson-jaxrs.version>2.16.1</fasterxml.jackson-jaxrs.version>
+        <vertx.version>4.5.2</vertx.version>
+        <vertx-junit5.version>4.5.2</vertx-junit5.version>
         <kafka.version>3.6.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.3</zookeeper.version>
@@ -147,7 +147,7 @@
         <jetty.version>9.4.53.v20231009</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
-        <netty.version>4.1.103.Final</netty.version>
+        <netty.version>4.1.106.Final</netty.version>
         <micrometer.version>1.9.5</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x to 4.5.2 that among other things addresses [CVE-2024-1023](https://access.redhat.com/security/cve/cve-2024-1023). It also bumps the related dependencies: Jakcson FasterXML and Netty to the versions used by Vert.x. 

_It does not update SLF4j to 2.x as that does not seem to be fully ocmpatible with the Log4j2 version used. That change should be discussed separately for all of our projects (keeping old SLF4J 1.7.36 works fine with Vert.x 4.5.2)._

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally