### PR TITLE
Do not use SLF4J loggers in Topic Operator classes

### DIFF
--- a/topic-operator/pom.xml
+++ b/topic-operator/pom.xml
@@ -91,10 +91,6 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.101tec</groupId>
             <artifactId>zkclient</artifactId>
         </dependency>

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreService.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaStreamsTopicStoreService.java
@@ -18,8 +18,8 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,7 +36,7 @@ import static java.lang.Integer.parseInt;
  * A service to configure and start/stop KafkaStreamsTopicStore.
  */
 public class KafkaStreamsTopicStoreService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaStreamsTopicStoreService.class);
+    private static final Logger LOGGER = LogManager.getLogger(KafkaStreamsTopicStoreService.class);
 
     private final List<AutoCloseable> closeables = new ArrayList<>();
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/Zk2KafkaStreams.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/Zk2KafkaStreams.java
@@ -7,8 +7,8 @@ package io.strimzi.operator.topic;
 import io.strimzi.operator.topic.zk.Zk;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionStage;
  * Migration tool to move ZkTopicStore to KafkaStreamsTopicStore.
  */
 public class Zk2KafkaStreams {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Zk2KafkaStreams.class);
+    private static final Logger LOGGER = LogManager.getLogger(Zk2KafkaStreams.class);
 
     protected static CompletionStage<KafkaStreamsTopicStoreService> upgrade(
             Zk zk,
@@ -38,7 +38,6 @@ public class Zk2KafkaStreams {
         return service.start(config, kafkaProperties)
                 .thenCompose(ksTopicStore -> {
                     LOGGER.info("Starting upgrade ...");
-                    @SuppressWarnings("rawtypes")
                     List<Future<Void>> results = new ArrayList<>();
                     List<String> list = zk.getChildren(topicsPath);
                     LOGGER.info("Topics to upgrade: {}", list);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like 2 classes in the Topic Operator use SLF4J loggers without any obvious reasons. This is likely just by mistake because of a wrong import? This PR changes these loggers to use Log4j2 as the other classes in TO. It also removes SLF4J as a direct dependency to avoid this happening again in the future.

(It also deletes one unnecessary warning suppression)

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally