### PR TITLE
Remove the Entity Operator TLS sidecar alert from our sample alerts

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -149,14 +149,6 @@ spec:
       annotations:
         summary: 'Container user-operator in Entity Operator pod down or in CrashLookBackOff status'
         description: 'Container user-operator in Entity Operator pod have been down or in CrashLookBackOff status for 3 minutes'
-    - alert: EntityOperatorTlsSidecarContainerDown
-      expr: absent(container_last_seen{container="tls-sidecar",pod=~".+-entity-operator-.+"})
-      for: 3m
-      labels:
-        severity: major
-      annotations:
-        summary: 'Container tls-sidecar Entity Operator pod down or in CrashLookBackOff status'
-        description: 'Container tls-sidecar in Entity Operator pod have been down or in CrashLookBackOff status for 3 minutes'
   - name: connect
     rules:
     - alert: ConnectContainersDown


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like our sample alerts contain an alert for the Entity Operator TLS sidecar. As the Unidirectional Topic Operator doesn't use the sidecar anymore, this alert is now firing for many users. This PR removes it from the samples.