### PR TITLE
Update Micrometer Metrics to 1.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
         <netty.version>4.1.106.Final</netty.version>
-        <micrometer.version>1.9.5</micrometer.version>
+        <micrometer.version>1.12.2</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the version of Micrometer Metrics to 1.12.2 to keep it in-sync with the version used by Vert.x.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally