### PR TITLE
Use KRaft only on Testing Farm to avoid unexpected ZK failures

### DIFF
--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -142,7 +142,7 @@ finish:
   summary: Run smoke strimzi test suite with kraft
   provision:
     hardware:
-      memory: ">= 8 GiB"
+      memory: ">= 12 GiB"
       cpu:
         processors: ">= 4"
   discover+:
@@ -187,7 +187,7 @@ finish:
   summary: Run upgrade strimzi test suite with kraft
   provision:
     hardware:
-      memory: ">= 8 GiB"
+      memory: ">= 12 GiB"
       cpu:
         processors: ">= 4"
   discover+:

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -139,7 +139,7 @@ finish:
 #######################################################################
 
 /smoke:
-  summary: Run smoke strimzi test suite
+  summary: Run smoke strimzi test suite with kraft
   provision:
     hardware:
       memory: ">= 8 GiB"
@@ -150,31 +150,19 @@ finish:
       - smoke
 
 /regression-operators:
-  summary: Run regression strimzi test suite
+  summary: Run regression strimzi test suite with kraft
   discover+:
     test:
       - regression-operators
 
 /regression-components:
-  summary: Run regression strimzi test suite
+  summary: Run regression strimzi test suite with kraft
   discover+:
     test:
       - regression-components
 
-/kraft-operators:
-  summary: Run regression kraft strimzi test suite
-  discover+:
-    test:
-      - kraft-operators
-
-/kraft-components:
-  summary: Run regression kraft strimzi test suite
-  discover+:
-    test:
-      - kraft-components
-
 /acceptance:
-  summary: Run acceptance strimzi test suite
+  summary: Run acceptance strimzi test suite with kraft
   provision:
     hardware:
       memory: ">= 24 GiB"
@@ -185,7 +173,7 @@ finish:
       - acceptance
 
 /sanity:
-  summary: Run sanity strimzi test suite
+  summary: Run sanity strimzi test suite with kraft
   provision:
     hardware:
       memory: ">= 16 GiB"
@@ -196,7 +184,7 @@ finish:
       - sanity
 
 /upgrade:
-  summary: Run upgrade strimzi test suite
+  summary: Run upgrade strimzi test suite with kraft
   provision:
     hardware:
       memory: ">= 8 GiB"
@@ -204,4 +192,4 @@ finish:
         processors: ">= 4"
   discover+:
     test:
-      - upgrade
+      - kraft_upgrade

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -14,11 +14,13 @@ environment:
 adjust:
   - environment+:
       EXCLUDED_TEST_GROUPS: "loadbalancer,arm64unsupported"
+      # All tests on TF will use KRaft mode because ZK is not working reliably on it's infra
+      STRIMZI_USE_KRAFT_IN_TESTS: "true"
     when: arch == aarch64, arm64
 
 /smoke:
   summary: Run smoke strimzi test suite
-  tags: [smoke]
+  tags: [strimzi, kafka, kraft, smoke]
   duration: 40m
   tier: 1
   environment+:
@@ -26,7 +28,7 @@ adjust:
 
 /upgrade:
   summary: Run upgrade strimzi test suite
-  tags: [strimzi, kafka, upgrade]
+  tags: [strimzi, kafka, kraft, upgrade]
   duration: 5h
   tier: 2
   environment+:
@@ -34,7 +36,7 @@ adjust:
 
 /regression-operators:
   summary: Run regression strimzi test suite
-  tags: [strimzi, kafka, regression, operators]
+  tags: [strimzi, kafka, kraft, regression, operators]
   duration: 10h
   tier: 2
   environment+:
@@ -42,31 +44,15 @@ adjust:
 
 /regression-components:
   summary: Run regression strimzi test suite
-  tags: [strimzi, kafka, regression, components]
+  tags: [strimzi, kafka, kraft, regression, components]
   duration: 12h
-  tier: 2
-  environment+:
-    TEST_PROFILE: components
-
-/kraft-operators:
-  summary: Run regression kraft strimzi test suite
-  tags: [strimzi, kafka, kraft, operators]
-  duration: 8h
-  tier: 2
-  environment+:
-    TEST_PROFILE: operators
-
-/kraft-components:
-  summary: Run regression kraft strimzi test suite
-  tags: [strimzi, kafka, kraft, components]
-  duration: 8h
   tier: 2
   environment+:
     TEST_PROFILE: components
 
 /acceptance:
   summary: Run acceptance strimzi test suite
-  tags: [strimzi, kafka, acceptance]
+  tags: [strimzi, kafka, kraft, acceptance]
   duration: 5h
   tier: 2
   environment+:
@@ -74,7 +60,7 @@ adjust:
 
 /sanity:
   summary: Run sanity strimzi test suite
-  tags: [strimzi, kafka, sanity]
+  tags: [strimzi, kafka, kraft, sanity]
   duration: 5h
   tier: 2
   environment+:

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
@@ -47,7 +47,7 @@ public class Kind implements KubeCluster {
     public boolean isClusterUp() {
         List<String> cmd = Arrays.asList("kubectl", "get", "nodes", "-o", "jsonpath='{.items[*].spec.providerID}'");
         try {
-            return Exec.exec(cmd).out().contains("kind-cluster");
+            return Exec.exec(cmd).out().contains("kind://");
         } catch (KubeClusterException e) {
             LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
             LOGGER.debug(e);

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
@@ -47,7 +47,9 @@ public class Kind implements KubeCluster {
     public boolean isClusterUp() {
         List<String> cmd = Arrays.asList("kubectl", "get", "nodes", "-o", "jsonpath='{.items[*].spec.providerID}'");
         try {
-            return Exec.exec(cmd).out().startsWith("kind");
+            String cmdOut = Exec.exec(cmd).out();
+            LOGGER.debug("IsKindUp cmd output: " + cmdOut);
+            return cmdOut.contains("kind");
         } catch (KubeClusterException e) {
             LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
             LOGGER.debug(e);

--- a/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
+++ b/test/src/main/java/io/strimzi/test/k8s/cluster/Kind.java
@@ -47,9 +47,7 @@ public class Kind implements KubeCluster {
     public boolean isClusterUp() {
         List<String> cmd = Arrays.asList("kubectl", "get", "nodes", "-o", "jsonpath='{.items[*].spec.providerID}'");
         try {
-            String cmdOut = Exec.exec(cmd).out();
-            LOGGER.debug("IsKindUp cmd output: " + cmdOut);
-            return cmdOut.contains("kind");
+            return Exec.exec(cmd).out().contains("kind-cluster");
         } catch (KubeClusterException e) {
             LOGGER.debug("'" + String.join(" ", cmd) + "' failed. Please double check connectivity to your cluster!");
             LOGGER.debug(e);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Because we are closer to KRaft to be production ready, we would like to start using Testing Farm for system tests. This PR removes option to run ZK mode on TF as it was failing with unexpected dns errors caused by ZK bug and move all pipelines to use KRaft mode. 

The pipelines will still be executable only via comments on the PRs.

### Checklist

- [x] Make sure all tests pass


