### PR TITLE
[ST] Use real test execution instead of milis from epoch in collecting logs from CO

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -85,7 +85,12 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         // connected to https://github.com/strimzi/strimzi-kafka-operator/issues/7529 - remove this once the issue will be fixed
         RECONCILIATION_PODSET_ALREADY_EXISTS("ERROR StrimziPodSetController:[0-9]+ - Reconciliation.*[fF]ailed"
             + "(?s)(.*?)"
-            + "io.fabric8.kubernetes.client.KubernetesClientException.*already exists");
+            + "io.fabric8.kubernetes.client.KubernetesClientException.*already exists"),
+        REBALANCE_APPLY("KafkaRebalanceAssemblyOperator:.*Reconciliation.*KafkaRebalance(.*): " +
+                "Status updated to [NotReady] due to error: io.netty.channel.AbstractChannel$AnnotatedConnectException: " +
+                "Connection refused.*"),
+        LEASE_LOCK_EXISTS("LeaderElector:.*Exception occurred while acquiring lock 'LeaseLock.*" +
+                "KubernetesClientException: Failure executing: POST at.*already exists.*");
 
         final String name;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -94,7 +94,10 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         ZOOKEEPER_DNS_ERROR("Unable to resolve address:.*zookeeper.*java.net.UnknownHostException.*"),
         LOGGER_DOES_NOT_EXISTS("Logger paprika does not exist"),
         // This exception is logged on DEBUG level of the operator, however it is hit when logging is to JSON format where it is hard whitelist without this
-        ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn$EndOfStreamException");
+        ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn$EndOfStreamException"),
+        // This is expected failure in some cases, so we can whitelist it
+        REBALANCE_NON_JBOD("Status updated to [NotReady] due to error: Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config");
+
 
         final String name;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -86,11 +86,15 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         RECONCILIATION_PODSET_ALREADY_EXISTS("ERROR StrimziPodSetController:[0-9]+ - Reconciliation.*[fF]ailed"
             + "(?s)(.*?)"
             + "io.fabric8.kubernetes.client.KubernetesClientException.*already exists"),
-        REBALANCE_APPLY("KafkaRebalanceAssemblyOperator:.*Reconciliation.*KafkaRebalance(.*): " +
-                "Status updated to [NotReady] due to error: io.netty.channel.AbstractChannel$AnnotatedConnectException: " +
+        REBALANCE_APPLY("KafkaRebalanceAssemblyOperator:.*Reconciliation.*KafkaRebalance.*: " +
+                "Status updated to \\[NotReady\\] due to error: io.netty.channel.AbstractChannel\\$AnnotatedConnectException: " +
                 "Connection refused.*"),
         LEASE_LOCK_EXISTS("LeaderElector:.*Exception occurred while acquiring lock 'LeaseLock.*" +
-                "KubernetesClientException: Failure executing: POST at.*already exists.*");
+                "KubernetesClientException: Failure executing: POST at.*already exists.*"),
+        ZOOKEEPER_DNS_ERROR("Unable to resolve address:.*zookeeper.*java.net.UnknownHostException.*"),
+        LOGGER_DOES_NOT_EXISTS("Logger paprika does not exist"),
+        // This exception is logged on DEBUG level of the operator, however it is hit when logging is to JSON format where it is hard whitelist without this
+        ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn$EndOfStreamException");
 
         final String name;
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -41,7 +41,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
                 if (lineLowerCase.contains("error") || lineLowerCase.contains("exception")) {
                     boolean ignoreListResult = false;
                     for (LogIgnoreList value : LogIgnoreList.values()) {
-                        Matcher m = Pattern.compile(value.name).matcher(line);
+                        Matcher m = Pattern.compile(value.name, Pattern.MULTILINE | Pattern.DOTALL).matcher(line);
                         if (m.find()) {
                             ignoreListResult = true;
                             break;

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -257,7 +257,7 @@ final public class TestStorage {
     }
 
     public long getTestExecutionTimeInSeconds() {
-        return Duration.ofMillis(getTestExecutionStartTime() - System.currentTimeMillis()).getSeconds();
+        return Duration.ofMillis(System.currentTimeMillis() - getTestExecutionStartTime()).getSeconds();
     }
 
     public KafkaTracingClients getTracingClients() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -19,6 +19,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.time.Duration;
 import java.util.Random;
 
 import static io.strimzi.operator.common.Util.hashStub;
@@ -253,6 +254,10 @@ final public class TestStorage {
 
     public long getTestExecutionStartTime() {
         return (long) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(TestConstants.TEST_EXECUTION_START_TIME_KEY);
+    }
+
+    public long getTestExecutionTimeInSeconds() {
+        return Duration.ofMillis(getTestExecutionStartTime() - System.currentTimeMillis()).getSeconds();
     }
 
     public KafkaTracingClients getTracingClients() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -594,7 +594,7 @@ public abstract class AbstractST implements TestSeparator {
         // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
         // it will always execute the second method.
         try {
-            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionStartTime());
+            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
             afterEachMayOverride(extensionContext);
         } finally {
             afterEachMustExecute(extensionContext);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`assertNoCoErrorsLogged()` got miliseconds since eponch instead of real test execution time in seconds. This resulted in something like that:

```
2024-02-01 08:06:05 INFO  [AbstractST:437] Search in strimzi-cluster-operator log for errors in last 1706774095840 second(s)
2024-02-01 08:07:46 DEBUG [Exec:418] Failed to exec command: 'bash -c kubectl --namespace co-namespace logs Deployment/strimzi-cluster-operator --since=1706774095840s | grep  -e Exception -e Error -e Throwable -e OOM -B 1' (return code: 1)
2024-02-01 08:07:46 DEBUG [Exec:418] ======STDERR START=======
2024-02-01 08:07:46 DEBUG [Exec:418] error: invalid argument "1706774095840s" for "--since" flag: time: invalid duration "1706774095840s"
See 'kubectl logs --help' for usage.
2024-02-01 08:07:46 DEBUG [Exec:418] ======STDERR END======
2024-02-01 08:07:46 INFO  [BaseCmdKubeClient:501] Exception not found
```

which is obviously wrong. This PR resolves that.

### Checklist

- [ ] Make sure all tests pass

