### PR TITLE
Read and store ST configuration in yaml

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -295,11 +295,16 @@ All available test groups are listed in [Constants](systemtest/src/main/java/io/
 System tests can be configured by several environment variables, which are loaded before test execution.
 
 Variables can be defined via environmental variables or a configuration file; this file can be located anywhere on the file system as long as a path is provided to this file.
-The path is defined by the environmental variable `ST_CONFIG_PATH`; if the `ST_CONFIG_PATH` environmental variable is not defined, the default config file location is used `systemtest/config.json`.
+The path is defined by the environmental variable `ST_CONFIG_PATH`; if the `ST_CONFIG_PATH` environmental variable is not defined, the default config file location is used `systemtest/config.yaml`.
 Loading of system configuration has the following priority order:
 1. Environment variable
 2. Variable defined in the configuration file
 3. Default value
+
+After every systemtest tes run all env variables is automatically stored into $TEST_LOG_DIR/test-run.../config.yaml so it test run can be easily reproduced just by running
+```commandline
+ST_CONFIG_PATH="path/to/config/file/config.yaml" mvn verify ...
+```
 
 All environment variables are defined in [Environment](systemtest/src/main/java/io/strimzi/systemtest/Environment.java) class:
 
@@ -311,6 +316,7 @@ All environment variables are defined in [Environment](systemtest/src/main/java/
 | BRIDGE_IMAGE                           | Specify the Kafka bridge image used in system tests                                                                                                   | quay.io/strimzi/kafka-bridge:latest |
 | TEST_LOG_DIR                           | Directory for storing logs collected during the tests                                                                                                 | ../systemtest/target/logs/          |
 | ST_KAFKA_VERSION                       | Kafka version used in images during the system tests                                                                                                  | 2.3.0                               |
+| ST_CONFIG_PATH                         | Path to file where environment variables are defined in yaml format                                                                                   | ../systemtest/config.yaml           |
 | STRIMZI_LOG_LEVEL                      | Log level for the cluster operator                                                                                                                    | DEBUG                               |
 | STRIMZI_COMPONENTS_LOG_LEVEL           | Log level for the components                                                                                                                          | INFO                                |
 | KUBERNETES_DOMAIN                      | Cluster domain                                                                                                                                        | .nip.io                             |

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -301,7 +301,7 @@ Loading of system configuration has the following priority order:
 2. Variable defined in the configuration file
 3. Default value
 
-After every systemtest tes run all env variables is automatically stored into $TEST_LOG_DIR/test-run.../config.yaml so it test run can be easily reproduced just by running
+After every systemtest test run all env variables are automatically stored into $TEST_LOG_DIR/test-run.../config.yaml so each test run can be easily reproduced just by running
 ```commandline
 ST_CONFIG_PATH="path/to/config/file/config.yaml" mvn verify ...
 ```

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.systemtest;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.Service;
 import io.strimzi.systemtest.enums.ClusterOperatorInstallType;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
@@ -19,8 +19,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -35,7 +39,7 @@ public class Environment {
 
     private static final Logger LOGGER = LogManager.getLogger(Environment.class);
     private static final Map<String, String> VALUES = new HashMap<>();
-    private static final JsonNode JSON_DATA = loadConfigurationFile();
+    private static final Map<String, Object> YAML_DATA = loadConfigurationFile();
 
     /**
      * Specify the system test configuration file path from an environmental variable
@@ -258,6 +262,11 @@ public class Environment {
         VALUES.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .forEach(entry -> LOGGER.info(debugFormat, entry.getKey(), entry.getValue()));
+        try {
+            saveConfigurationFile();
+        } catch (IOException e) {
+            LOGGER.warn("Yaml configuration can't be saved");
+        }
     }
 
     public static boolean isOlmInstall() {
@@ -359,8 +368,8 @@ public class Environment {
     private static <T> T getOrDefault(String var, Function<String, T> converter, T defaultValue) {
         String value = System.getenv(var) != null ?
                 System.getenv(var) :
-                (Objects.requireNonNull(JSON_DATA).get(var) != null ?
-                        JSON_DATA.get(var).asText() :
+                (Objects.requireNonNull(YAML_DATA).get(var) != null ?
+                        YAML_DATA.get(var).toString() :
                         null);
         T returnValue = defaultValue;
         if (value != null) {
@@ -370,16 +379,37 @@ public class Environment {
         return returnValue;
     }
 
-    private static JsonNode loadConfigurationFile() {
-        config = System.getenv().getOrDefault(CONFIG_FILE_PATH_ENV,
-                Paths.get(System.getProperty("user.dir"), "config.json").toAbsolutePath().toString());
-        ObjectMapper mapper = new ObjectMapper();
+    private static void saveConfigurationFile() throws IOException {
+        Path logPath = Path.of(TEST_LOG_DIR);
+        Files.createDirectories(logPath);
+
+        LinkedHashMap<String, String> toSave = new LinkedHashMap<>();
+
+        VALUES.forEach((key, value) -> {
+            if (isWriteable(key, value)) {
+                toSave.put(key, value);
+            }
+        });
+
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.writerWithDefaultPrettyPrinter().writeValue(logPath.resolve("config.yaml").toFile(), toSave);
+    }
+
+    private static Map<String, Object> loadConfigurationFile() {
+        String config = System.getenv().getOrDefault(CONFIG_FILE_PATH_ENV,
+                Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {
-            File jsonFile = new File(config).getAbsoluteFile();
-            return mapper.readTree(jsonFile);
+            return mapper.readValue(new File(config), Map.class);
         } catch (IOException ex) {
-            LOGGER.debug("JSON configuration is not provided or cannot be processed!");
-            return mapper.createObjectNode();
+            LOGGER.info("Yaml configuration not provider or not exists");
+            return Collections.emptyMap();
         }
+    }
+
+    private static boolean isWriteable(String var, String value) {
+        return !value.equals("null")
+                && !var.equals(CONFIG_FILE_PATH_ENV)
+                && !var.equals("USER");
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -410,6 +410,7 @@ public class Environment {
     private static boolean isWriteable(String var, String value) {
         return !value.equals("null")
                 && !var.equals(CONFIG_FILE_PATH_ENV)
+                && !var.equals(TEST_LOG_DIR)
                 && !var.equals("USER");
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Read and store configuration from environment variables for systemtest run in yaml format.
Configuration is automatically created for every systemtest run so test run can be easily reproduces with just passing env file and not writing all env vars.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Update documentation

