### PR TITLE
ST: Add missing escape characters for log errors whitelist

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -88,8 +88,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
             + "(?s)(.*?)"
             + "io.fabric8.kubernetes.client.KubernetesClientException.*already exists"),
         REBALANCE_APPLY("KafkaRebalanceAssemblyOperator:.*Reconciliation.*KafkaRebalance.*: " +
-                "Status updated to \\[NotReady\\] due to error: io.netty.channel.AbstractChannel\\$AnnotatedConnectException: " +
-                "Connection refused.*"),
+                "Status updated to \\[NotReady\\] due to error"),
         LEASE_LOCK_EXISTS("LeaderElector:.*Exception occurred while acquiring lock 'LeaseLock.*" +
                 "KubernetesClientException: Failure executing: POST at.*already exists.*"),
         ZOOKEEPER_DNS_ERROR("Unable to resolve address:.*zookeeper.*java.net.UnknownHostException.*"),

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.matchers;
 
+import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.BaseMatcher;
@@ -27,7 +28,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
             if (actualValue.toString().contains("Unhandled Exception")) {
                 return false;
             }
-            // This pattern is used for split each log ine with stack trace if it's there from some reasons
+            // This pattern is used for split each log line with stack trace if it's there from some reasons
             // It's match start of the line which contains date in format yyyy-mm-dd hh:mm:ss
             String logLineSplitPattern = "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}";
             for (String line : ((String) actualValue).split(logLineSplitPattern)) {
@@ -48,7 +49,7 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
                         }
                     }
                     if (!ignoreListResult) {
-                        LOGGER.error(line);
+                        LOGGER.error(Exec.cutExecutorLog(line));
                         return false;
                     }
                 }
@@ -96,7 +97,8 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         // This exception is logged on DEBUG level of the operator, however it is hit when logging is to JSON format where it is hard whitelist without this
         ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn\\$EndOfStreamException"),
         // This is expected failure in some cases, so we can whitelist it
-        REBALANCE_NON_JBOD("Status updated to \\[NotReady\\] due to error: Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config");
+        REBALANCE_NON_JBOD("Status updated to \\[NotReady\\] due to error: Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config"),
+        RECONCILIATION_UPDATE_BROKER_ERROR("Reconciliation.*Error updating broker configuration");
 
 
         final String name;

--- a/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/matchers/LogHasNoUnexpectedErrors.java
@@ -94,9 +94,9 @@ public class LogHasNoUnexpectedErrors extends BaseMatcher<String> {
         ZOOKEEPER_DNS_ERROR("Unable to resolve address:.*zookeeper.*java.net.UnknownHostException.*"),
         LOGGER_DOES_NOT_EXISTS("Logger paprika does not exist"),
         // This exception is logged on DEBUG level of the operator, however it is hit when logging is to JSON format where it is hard whitelist without this
-        ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn$EndOfStreamException"),
+        ZOOKEEPER_END_OF_STREAM("org.apache.zookeeper.ClientCnxn\\$EndOfStreamException"),
         // This is expected failure in some cases, so we can whitelist it
-        REBALANCE_NON_JBOD("Status updated to [NotReady] due to error: Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config");
+        REBALANCE_NON_JBOD("Status updated to \\[NotReady\\] due to error: Cannot set rebalanceDisk=true for Kafka clusters with a non-JBOD storage config");
 
 
         final String name;

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -594,9 +594,7 @@ public abstract class AbstractST implements TestSeparator {
         // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
         // it will always execute the second method.
         try {
-            // TODO: currently this asserts makes a lot of tests failing, we should investigate all the failures and fix/whitelist them before enabling
-            // this check again - https://github.com/strimzi/strimzi-kafka-operator/issues/9648
-            // assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
+             assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
             afterEachMayOverride(extensionContext);
         } finally {
             afterEachMustExecute(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -594,7 +594,7 @@ public abstract class AbstractST implements TestSeparator {
         // does not proceed with the next method (i.e., afterEachMustExecute()). This ensures that if such problem happen
         // it will always execute the second method.
         try {
-             assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
+            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
             afterEachMayOverride(extensionContext);
         } finally {
             afterEachMustExecute(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -595,8 +595,8 @@ public abstract class AbstractST implements TestSeparator {
         // it will always execute the second method.
         try {
             assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
-            afterEachMayOverride(extensionContext);
         } finally {
+            afterEachMayOverride(extensionContext);
             afterEachMustExecute(extensionContext);
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -291,13 +291,9 @@ class ConnectST extends AbstractST {
         NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.componentName(testStorage.getClusterName()));
 
         final String kafkaConnectPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(KafkaConnectResources.componentName(testStorage.getClusterName())).get(0).getMetadata().getName();
-        final String kafkaConnectLogs = kubeClient(testStorage.getNamespaceName()).logs(kafkaConnectPodName);
         final String scraperPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getScraperName()).get(0).getMetadata().getName();
 
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(testStorage.getNamespaceName(), kafkaConnectPodName);
-
-        LOGGER.info("Verifying that KafkaConnect Pod logs don't contain ERRORs");
-        assertThat(kafkaConnectLogs, not(containsString("ERROR")));
 
         LOGGER.info("Creating FileStreamSink KafkaConnector via Pod: {}/{} with Topic: {}", testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName());
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
@@ -488,13 +484,9 @@ class ConnectST extends AbstractST {
         NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.componentName(testStorage.getClusterName()));
 
         final String kafkaConnectPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(KafkaConnectResources.componentName(testStorage.getClusterName())).get(0).getMetadata().getName();
-        final String kafkaConnectLogs = kubeClient(testStorage.getNamespaceName()).logs(kafkaConnectPodName);
         final String scraperPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getScraperName()).get(0).getMetadata().getName();
 
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(testStorage.getNamespaceName(), kafkaConnectPodName);
-
-        LOGGER.info("Verifying that KafkaConnect Pod logs don't contain ERRORs");
-        assertThat(kafkaConnectLogs, not(containsString("ERROR")));
 
         LOGGER.info("Creating FileStreamSink KafkaConnector via Pod: {}/{} with Topic: {}", testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName());
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
@@ -569,11 +561,7 @@ class ConnectST extends AbstractST {
         NetworkPolicyResource.deployNetworkPolicyForResource(extensionContext, connect, KafkaConnectResources.componentName(testStorage.getClusterName()));
 
         final String kafkaConnectPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(KafkaConnectResources.componentName(testStorage.getClusterName())).get(0).getMetadata().getName();
-        final String kafkaConnectLogs = kubeClient(testStorage.getNamespaceName()).logs(kafkaConnectPodName);
         final String scraperPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getScraperName()).get(0).getMetadata().getName();
-
-        LOGGER.info("Verifying that KafkaConnect Pod logs don't contain ERRORs");
-        assertThat(kafkaConnectLogs, not(containsString("ERROR")));
 
         LOGGER.info("Creating FileStreamSink KafkaConnector via Pod: {}/{} with Topic: {}", testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName());
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
-@Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/strimzi-kafka-operator/issues/9648
+@Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/test-clients/issues/75
 public class ThrottlingQuotaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ThrottlingQuotaST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/ThrottlingQuotaST.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import static io.strimzi.systemtest.TestConstants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -40,6 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
+@Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/strimzi-kafka-operator/issues/9648
 public class ThrottlingQuotaST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(ThrottlingQuotaST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -141,7 +141,7 @@ public class TopicST extends AbstractST {
         verifyTopicViaKafka(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), topicPartitions, KAFKA_CLUSTER_NAME);
     }
 
-    @Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/strimzi-kafka-operator/issues/9648
+    @Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/test-clients/issues/75
     @ParallelTest
     void testCreateDeleteCreate(ExtensionContext extensionContext) throws InterruptedException {
         final TestStorage testStorage = new TestStorage(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.List;
 
+import static io.strimzi.systemtest.TestConstants.ARM64_UNSUPPORTED;
 import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.systemtest.enums.ConditionStatus.False;
@@ -140,6 +141,7 @@ public class TopicST extends AbstractST {
         verifyTopicViaKafka(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName(), topicPartitions, KAFKA_CLUSTER_NAME);
     }
 
+    @Tag(ARM64_UNSUPPORTED) // Due to https://github.com/strimzi/strimzi-kafka-operator/issues/9648
     @ParallelTest
     void testCreateDeleteCreate(ExtensionContext extensionContext) throws InterruptedException {
         final TestStorage testStorage = new TestStorage(extensionContext);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTerm;
@@ -28,6 +29,7 @@ import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Annotations;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
@@ -397,11 +399,11 @@ public class KafkaRollerST extends AbstractST {
         // 2nd Rolling update triggered by PodAffinity
 
         // Modify pod affinity settings for the controller node pool
+        // Pod Affinity is expecting a running pod on a node with topologyKey with labels specify by LabelSelector
         PodAffinity podAffinity = new PodAffinityBuilder()
             .addNewRequiredDuringSchedulingIgnoredDuringExecution()
-                .withLabelSelector(controllerPoolSelector)
+                .withLabelSelector(new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND).build())
                 .withTopologyKey("kubernetes.io/hostname")
-                .withNamespaces(testStorage.getNamespaceName())
             .endRequiredDuringSchedulingIgnoredDuringExecution()
             .build();
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There were missing escape characters for two of the whitelisted errors that caused unexpected failures due to not-matching the whitelisted error. This PR should solve it.

### Checklist

- [ ] Make sure all tests pass

