### PR TITLE
[ST] Remove unused methods from the KafkaNodePoolResource class

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/KafkaNodePoolResource.java
@@ -118,9 +118,8 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
 
     public static LabelSelector getLabelSelector(String clusterName, String poolName, ProcessRoles processRole) {
         Map<String, String> matchLabels = new HashMap<>();
-        if (clusterName != null) {
-            matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
-        }
+
+        matchLabels.put(Labels.STRIMZI_CLUSTER_LABEL, clusterName);
         matchLabels.put(Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND);
         matchLabels.put(Labels.STRIMZI_POOL_NAME_LABEL, poolName);
 
@@ -134,13 +133,4 @@ public class KafkaNodePoolResource implements ResourceType<KafkaNodePool> {
             .withMatchLabels(matchLabels)
             .build();
     }
-
-    public static LabelSelector getLabelSelector(final String poolName, final ProcessRoles processRoles) {
-        return getLabelSelector(null, poolName, processRoles);
-    }
-
-    public static String getStrimziPodSetName(String kafkaClusterName, String kafkaNodePoolName) {
-        return kafkaClusterName + "-" + kafkaNodePoolName;
-    }
-
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Inside `KafkaNodePoolResource` are methods that are not used anywhere in STs. Plus, in case of `getLabelSelector(final String poolName, final ProcessRoles processRoles)` it's usage little bit confuse anyone when watching rolling update of the Pods, as we can see something similar to this in the log of the test execution:

```
2024-02-06 12:29:39 [main] INFO  [RollingUpdateUtils:79] Waiting for component matching LabelSelector(matchExpressions=[], matchLabels={strimzi.io/pool-name=kafka, strimzi.io/kind=Kafka, strimzi.io/broker-role=true}, additionalProperties={}) -> co-namespace/null-kafka rolling update
2024-02-06 12:30:58 [main] INFO  [RollingUpdateUtils:90] Component matching LabelSelector(matchExpressions=[], matchLabels={strimzi.io/pool-name=kafka, strimzi.io/kind=Kafka, strimzi.io/broker-role=true}, additionalProperties={}) -> co-namespace/null-kafka has been successfully rolled
2024-02-06 12:30:59 [main] INFO  [RollingUpdateUtils:102] Waiting for 3 Pod(s) of co-namespace/null-kafka to be ready
```

### Checklist

- [ ] Make sure all tests pass
