### PR TITLE
Update Vert.x to 4.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         <fasterxml.jackson-annotations.version>2.16.1</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.1</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.1</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.2</vertx.version>
-        <vertx-junit5.version>4.5.2</vertx-junit5.version>
+        <vertx.version>4.5.3</vertx.version>
+        <vertx-junit5.version>4.5.3</vertx-junit5.version>
         <kafka.version>3.6.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.3</zookeeper.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x to 4.5.3 to address [CVE-2024-1300](https://access.redhat.com/security/cve/CVE-2024-1300).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally