### PR TITLE
[ST] Re-enable applying of NetworkPolicies during namespace creation

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/parallel/TestSuiteNamespaceManager.java
@@ -50,7 +50,7 @@ public class TestSuiteNamespaceManager {
         if (ExecutionListener.hasSuiteParallelOrIsolatedTest(extensionContext)) {
             // if RBAC is enabled we don't run tests in parallel mode and with that said we don't create another namespaces
             if (!Environment.isNamespaceRbacScope()) {
-                NamespaceManager.getInstance().createNamespaceAndPrepare(Environment.TEST_SUITE_NAMESPACE, CollectorElement.createCollectorElement(testSuiteName));
+                NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, Environment.TEST_SUITE_NAMESPACE, CollectorElement.createCollectorElement(testSuiteName));
             } else {
                 LOGGER.info("We are not gonna create additional namespace: {}, because test suite: {} does not " +
                         "contains @ParallelTest or @IsolatedTest.", Environment.TEST_SUITE_NAMESPACE, testSuiteName);
@@ -97,7 +97,7 @@ public class TestSuiteNamespaceManager {
                 // create namespace by
                 LOGGER.info("Creating Namespace: {} for TestCase: {}", namespaceTestCase, StUtils.removePackageName(testCaseName));
 
-                NamespaceManager.getInstance().createNamespaceAndPrepare(namespaceTestCase, CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), testCaseName));
+                NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, namespaceTestCase, CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), testCaseName));
             }
         }
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.NamespaceStatus;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
@@ -16,7 +17,9 @@ import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -132,13 +135,13 @@ public class NamespaceManager {
     }
 
     /**
-     * Overloads {@link #createNamespaceAndPrepare(String, CollectorElement)} - with {@code CollectorElement} set to {@code null},
+     * Overloads {@link #createNamespaceAndPrepare(ExtensionContext, String, CollectorElement)} - with {@code CollectorElement} set to {@code null},
      * so the Namespace will not be added into the {@link #MAP_WITH_SUITE_NAMESPACES}.
      *
      * @param namespaceName name of Namespace that should be created
      */
-    public void createNamespaceAndPrepare(String namespaceName) {
-        createNamespaceAndPrepare(namespaceName, null);
+    public void createNamespaceAndPrepare(ExtensionContext extensionContext, String namespaceName) {
+        createNamespaceAndPrepare(extensionContext, namespaceName, null);
     }
 
     /**
@@ -151,8 +154,9 @@ public class NamespaceManager {
      * @param namespaceName name of the Namespace that should be created and prepared
      * @param collectorElement "key" for accessing the particular Set of Namespaces
      */
-    public void createNamespaceAndPrepare(String namespaceName, CollectorElement collectorElement) {
+    public void createNamespaceAndPrepare(ExtensionContext extensionContext, String namespaceName, CollectorElement collectorElement) {
         createNamespaceAndAddToSet(namespaceName, collectorElement);
+        NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, Collections.singletonList(namespaceName));
         StUtils.copyImagePullSecrets(namespaceName);
     }
 
@@ -164,8 +168,8 @@ public class NamespaceManager {
      * @param collectorElement "key" for accessing the particular Set of Namespaces
      * @param namespacesToBeCreated list of Namespaces that should be created
      */
-    public void createNamespaces(String useNamespace, CollectorElement collectorElement, List<String> namespacesToBeCreated) {
-        namespacesToBeCreated.forEach(namespaceToBeCreated -> createNamespaceAndPrepare(namespaceToBeCreated, collectorElement));
+    public void createNamespaces(ExtensionContext extensionContext, String useNamespace, CollectorElement collectorElement, List<String> namespacesToBeCreated) {
+        namespacesToBeCreated.forEach(namespaceToBeCreated -> createNamespaceAndPrepare(extensionContext, namespaceToBeCreated, collectorElement));
 
         KubeClusterResource.getInstance().setNamespace(useNamespace);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.NamespaceStatus;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaTopicUtils;
 import io.strimzi.test.TestUtils;
@@ -18,7 +17,6 @@ import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -155,7 +153,6 @@ public class NamespaceManager {
      */
     public void createNamespaceAndPrepare(String namespaceName, CollectorElement collectorElement) {
         createNamespaceAndAddToSet(namespaceName, collectorElement);
-        NetworkPolicyResource.applyDefaultNetworkPolicySettings(Collections.singletonList(namespaceName));
         StUtils.copyImagePullSecrets(namespaceName);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/jaeger/SetupJaeger.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/jaeger/SetupJaeger.java
@@ -77,7 +77,7 @@ public class SetupJaeger {
      */
     private static void deployCertManager(ExtensionContext extensionContext) {
         // create namespace `cert-manager` and add it to stack, to collect logs from it
-        NamespaceManager.getInstance().createNamespaceAndPrepare(CERT_MANAGER_NAMESPACE, CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()));
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, CERT_MANAGER_NAMESPACE, CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName()));
 
         LOGGER.info("Deploying CertManager from {}", CERT_MANAGER_PATH);
         // because we don't want to apply CertManager's file to specific namespace, passing the empty String will do the trick

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -551,12 +551,11 @@ public class SetupClusterOperator {
      * specific config files such as ServiceAccount, Roles and CRDs.
      * @param clientNamespace namespace which will be created and used as default by kube client
      * @param namespaces list of namespaces which will be created
-     * @param resources list of path to yaml files with resources specifications
      */
-    public void prepareEnvForOperator(ExtensionContext extensionContext, String clientNamespace, List<String> namespaces, String... resources) {
+    public void prepareEnvForOperator(ExtensionContext extensionContext, String clientNamespace, List<String> namespaces) {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
         applyClusterOperatorInstallFiles(clientNamespace);
-        NetworkPolicyResource.applyDefaultNetworkPolicySettings(namespaces);
+        NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, namespaces);
 
         if (cluster.cluster() instanceof OpenShift) {
             // This is needed in case you are using internal kubernetes registry and you want to pull images from there

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -29,7 +29,6 @@ import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.ResourceItem;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.ClusterRoleBindingResource;
-import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.resources.kubernetes.RoleBindingResource;
 import io.strimzi.systemtest.resources.kubernetes.RoleResource;
 import io.strimzi.systemtest.resources.operator.configuration.OlmConfiguration;
@@ -290,7 +289,7 @@ public class SetupClusterOperator {
         LOGGER.info("Install Cluster Operator via Yaml bundle");
         // check if namespace is already created
         createClusterOperatorNamespaceIfPossible();
-        prepareEnvForOperator(extensionContext, namespaceInstallTo, bindingsNamespaces);
+        prepareEnvForOperator(namespaceInstallTo, bindingsNamespaces);
         // if we manage directly in the individual test one of the Role, ClusterRole, RoleBindings and ClusterRoleBinding we must do it
         // everything by ourselves in scope of RBAC permissions otherwise we apply the default one
         if (this.isRolesAndBindingsManagedByAnUser()) {
@@ -406,7 +405,7 @@ public class SetupClusterOperator {
                     CollectorElement.createCollectorElement(this.testClassName) :
                     CollectorElement.createCollectorElement(this.testClassName, this.testMethodName);
 
-                NamespaceManager.getInstance().createNamespaces(namespaceInstallTo, collectorElement, bindingsNamespaces);
+                NamespaceManager.getInstance().createNamespaces(this.extensionContext, namespaceInstallTo, collectorElement, bindingsNamespaces);
 
                 this.extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).put(TestConstants.PREPARE_OPERATOR_ENV_KEY + namespaceInstallTo, true);
             }
@@ -552,10 +551,9 @@ public class SetupClusterOperator {
      * @param clientNamespace namespace which will be created and used as default by kube client
      * @param namespaces list of namespaces which will be created
      */
-    public void prepareEnvForOperator(ExtensionContext extensionContext, String clientNamespace, List<String> namespaces) {
+    public void prepareEnvForOperator(String clientNamespace, List<String> namespaces) {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
         applyClusterOperatorInstallFiles(clientNamespace);
-        NetworkPolicyResource.applyDefaultNetworkPolicySettings(extensionContext, namespaces);
 
         if (cluster.cluster() instanceof OpenShift) {
             // This is needed in case you are using internal kubernetes registry and you want to pull images from there

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/NetworkPolicyTemplates.java
@@ -34,7 +34,7 @@ public class NetworkPolicyTemplates {
                     .endSpec();
     }
 
-    public static NetworkPolicy applyDefaultNetworkPolicy(String namespace, DefaultNetworkPolicy policy) {
+    public static NetworkPolicy defaultNetworkPolicy(String namespace, DefaultNetworkPolicy policy) {
         NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
             .withApiVersion("networking.k8s.io/v1")
             .withKind(TestConstants.NETWORK_POLICY)
@@ -57,8 +57,6 @@ public class NetworkPolicyTemplates {
                 .endSpec()
                 .build();
         }
-
-        LOGGER.debug("Creating NetworkPolicy: {}", networkPolicy.toString());
 
         return networkPolicy;
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -702,7 +702,7 @@ public class MetricsST extends AbstractST {
     void setupEnvironment(ExtensionContext extensionContext) throws Exception {
         // Metrics tests are not designed to run with namespace RBAC scope.
         assumeFalse(Environment.isNamespaceRbacScope());
-        NamespaceManager.getInstance().createNamespaces(Environment.TEST_SUITE_NAMESPACE, CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(namespaceFirst, namespaceSecond));
+        NamespaceManager.getInstance().createNamespaces(extensionContext, Environment.TEST_SUITE_NAMESPACE, CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(namespaceFirst, namespaceSecond));
 
         clusterOperator = clusterOperator.defaultInstallation(extensionContext)
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -148,7 +148,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
         MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE, secondCOScraper);
 
         LOGGER.info("Deploying Namespace: {} to host all additional operands", testStorage.getNamespaceName());
-        NamespaceManager.getInstance().createNamespaceAndPrepare(testStorage.getNamespaceName());
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, testStorage.getNamespaceName());
 
         LOGGER.info("Set cluster namespace to {}, as all operands will be from now on deployd here", testStorage.getNamespaceName());
         cluster.setNamespace(testStorage.getNamespaceName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -76,7 +76,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         // Get list of topics and list of PVC needed for recovery
         List<KafkaTopic> kafkaTopicList = KafkaTopicResource.kafkaTopicClient().inNamespace(testStorage.getNamespaceName()).list().getItems();
         List<PersistentVolumeClaim> persistentVolumeClaimList = kubeClient().getClient().persistentVolumeClaims().list().getItems();
-        deleteAndRecreateNamespace(testStorage.getNamespaceName());
+        deleteAndRecreateNamespace(extensionContext, testStorage.getNamespaceName());
 
         recreatePvcAndUpdatePv(persistentVolumeClaimList, testStorage.getNamespaceName());
         recreateClusterOperator(extensionContext, testStorage.getNamespaceName());
@@ -148,7 +148,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
         }
 
         LOGGER.info("Deleting namespace and recreating for recovery");
-        deleteAndRecreateNamespace(testStorage.getNamespaceName());
+        deleteAndRecreateNamespace(extensionContext, testStorage.getNamespaceName());
 
         LOGGER.info("Recreating PVCs and updating PVs for recovery");
         recreatePvcAndUpdatePv(persistentVolumeClaimList, testStorage.getNamespaceName());
@@ -283,11 +283,11 @@ class NamespaceDeletionRecoveryST extends AbstractST {
             .runInstallation();
     }
 
-    private void deleteAndRecreateNamespace(String namespace) {
+    private void deleteAndRecreateNamespace(ExtensionContext extensionContext, String namespace) {
         NamespaceManager.getInstance().deleteNamespaceWithWait(namespace);
 
         // Recreate namespace
-        NamespaceManager.getInstance().createNamespaceAndPrepare(namespace);
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, namespace);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicScalabilityST.java
@@ -115,7 +115,7 @@ public class TopicScalabilityST extends AbstractST {
 
         LOGGER.info("Deploying shared Kafka across all test cases in Namespace: {}", Environment.TEST_SUITE_NAMESPACE);
 
-        NamespaceManager.getInstance().createNamespaceAndPrepare(Environment.TEST_SUITE_NAMESPACE);
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, Environment.TEST_SUITE_NAMESPACE);
 
         resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaEphemeral(sharedClusterName, 3, 1)
             .editMetadata()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -129,7 +129,7 @@ public class OauthAbstractST extends AbstractST {
     protected void setupCoAndKeycloak(ExtensionContext extensionContext, String keycloakNamespace) {
         clusterOperator.defaultInstallation(extensionContext).createInstallation().runInstallation();
 
-        resourceManager.createResourceWithWait(extensionContext, NetworkPolicyTemplates.applyDefaultNetworkPolicy(keycloakNamespace, DefaultNetworkPolicy.DEFAULT_TO_ALLOW));
+        resourceManager.createResourceWithWait(extensionContext, NetworkPolicyTemplates.defaultNetworkPolicy(keycloakNamespace, DefaultNetworkPolicy.DEFAULT_TO_ALLOW));
         resourceManager.createResourceWithoutWait(extensionContext, ScraperTemplates.scraperPod(Environment.TEST_SUITE_NAMESPACE, TestConstants.SCRAPER_NAME).build());
 
         LOGGER.info("Deploying keycloak");

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -13,11 +13,9 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IPv6NotSupported;
-import io.strimzi.systemtest.enums.DefaultNetworkPolicy;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.keycloak.SetupKeycloak;
-import io.strimzi.systemtest.templates.kubernetes.NetworkPolicyTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
@@ -129,7 +127,6 @@ public class OauthAbstractST extends AbstractST {
     protected void setupCoAndKeycloak(ExtensionContext extensionContext, String keycloakNamespace) {
         clusterOperator.defaultInstallation(extensionContext).createInstallation().runInstallation();
 
-        resourceManager.createResourceWithWait(extensionContext, NetworkPolicyTemplates.defaultNetworkPolicy(keycloakNamespace, DefaultNetworkPolicy.DEFAULT_TO_ALLOW));
         resourceManager.createResourceWithoutWait(extensionContext, ScraperTemplates.scraperPod(Environment.TEST_SUITE_NAMESPACE, TestConstants.SCRAPER_NAME).build());
 
         LOGGER.info("Deploying keycloak");
@@ -138,7 +135,7 @@ public class OauthAbstractST extends AbstractST {
         // Keycloak do not support cluster-wide namespace, and thus we need it to deploy in non-OLM cluster wide namespace
         // (f.e., our `infra-namespace`)
         if (kubeClient().getNamespace(Environment.TEST_SUITE_NAMESPACE) == null) {
-            NamespaceManager.getInstance().createNamespaceAndPrepare(Environment.TEST_SUITE_NAMESPACE);
+            NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, Environment.TEST_SUITE_NAMESPACE);
         }
 
         SetupKeycloak.deployKeycloakOperator(extensionContext, Environment.TEST_SUITE_NAMESPACE, keycloakNamespace);

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -96,7 +96,8 @@ public class SpecificST extends AbstractST {
         clusterOperator.unInstall();
 
         // create namespace, where we will be able to deploy Custom Resources
-        NamespaceManager.getInstance().createNamespaceAndPrepare(namespaceWhereCreationOfCustomResourcesIsApproved, CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()));
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, namespaceWhereCreationOfCustomResourcesIsApproved,
+            CollectorElement.createCollectorElement(extensionContext.getRequiredTestClass().getName(), extensionContext.getRequiredTestMethod().getName()));
 
         clusterOperator = clusterOperator.defaultInstallation(extensionContext)
             // use our pre-defined Roles

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -96,8 +96,8 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     }
 
     @BeforeEach
-    void setupEnvironment() {
-        NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+    void setupEnvironment(ExtensionContext extensionContext) {
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, CO_NAMESPACE);
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -220,8 +220,8 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
     }
 
     @BeforeEach
-    void setupEnvironment() {
-        NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+    void setupEnvironment(ExtensionContext extensionContext) {
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, CO_NAMESPACE);
     }
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -95,8 +95,8 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
     }
 
     @BeforeEach
-    void setupEnvironment() {
-        NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+    void setupEnvironment(ExtensionContext extensionContext) {
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, CO_NAMESPACE);
     }
 
     @AfterEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -199,8 +199,8 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     }
 
     @BeforeEach
-    void setupEnvironment() {
-        NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+    void setupEnvironment(ExtensionContext extensionContext) {
+        NamespaceManager.getInstance().createNamespaceAndPrepare(extensionContext, CO_NAMESPACE);
     }
 
     protected void afterEachMayOverride(ExtensionContext extensionContext) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AllNamespaceST.java
@@ -27,7 +27,8 @@ class AllNamespaceST extends AbstractNamespaceST {
     private void deployTestSpecificClusterOperator(final ExtensionContext extensionContext) {
         LOGGER.info("Creating Cluster Operator which will watch over all Namespaces");
 
-        NamespaceManager.getInstance().createNamespaces(clusterOperator.getDeploymentNamespace(), CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
+        NamespaceManager.getInstance().createNamespaces(extensionContext, clusterOperator.getDeploymentNamespace(),
+            CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
 
         clusterOperator = clusterOperator.defaultInstallation(extensionContext)
             .withWatchingNamespaces(TestConstants.WATCH_ALL_NAMESPACES)

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/MultipleNamespaceST.java
@@ -26,7 +26,8 @@ class MultipleNamespaceST extends AbstractNamespaceST {
     private void deployTestSpecificClusterOperator(final ExtensionContext extensionContext) {
         LOGGER.info("Creating Cluster Operator which will watch over multiple Namespaces");
 
-        NamespaceManager.getInstance().createNamespaces(clusterOperator.getDeploymentNamespace(), CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
+        NamespaceManager.getInstance().createNamespaces(extensionContext, clusterOperator.getDeploymentNamespace(),
+            CollectorElement.createCollectorElement(this.getClass().getName()), Arrays.asList(PRIMARY_KAFKA_WATCHED_NAMESPACE, MAIN_TEST_NAMESPACE));
 
         clusterOperator = new SetupClusterOperator.SetupClusterOperatorBuilder()
             .withExtensionContext(extensionContext)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

During work on `NamespaceManager` I found out that the NetworkPolicies, that were part of the Namespace creation, are not created at all -> the `NetworkPolicyTemplates.applyDefaultNetworkPolicy()` method, even though named as "apply", just returned the NetworkPolicy object, which was then never actually created (only in `OauthAbstractST`, where it's done by `ResourceManager` from the beginning).

This PR fixes this issue. It adds the correct deployment of NetworkPolicies to `NamespaceManager`, so it is on one place and removes it from anywhere else. Also, it removes old and not used methods after changes, that were made in last PRs.

### Checklist

- [ ] Make sure all tests pass
