### PR TITLE
Additional authentication type 'serviceaccount-oauth' that extends 'oauth'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for setting `publishNotReadyAddresses` on services for listener types other than internal.
 * Update HTTP bridge to latest 0.29.0 release
 * Uncommented and enabled (by default) KRaft-related metrics in the `kafka-metrics.yaml` example file.
+* Added 'serviceaccount-oauth' authentication type which is an extension of 'oauth' that automatically configures the necessary configuration parameters to use the local Kubernetes API server as an OAuth authorization server.
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -27,6 +27,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaClientAuthenticationScramSha512.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationPlain.TYPE_PLAIN, value = KafkaClientAuthenticationPlain.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationOAuth.TYPE_OAUTH, value = KafkaClientAuthenticationOAuth.class),
+    @JsonSubTypes.Type(name = KafkaClientAuthenticationK8sOIDC.TYPE_K8S_OIDC, value = KafkaClientAuthenticationK8sOIDC.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
@@ -35,10 +36,11 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. " +
+            "Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. " +
             "`scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. " +
             "`plain` type uses SASL PLAIN Authentication. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
+            "`k8s-oidc` type uses SASL OAUTHBEARER Authentication. " +
             "The `tls` type uses TLS Client Authentication. " +
             "The `tls` type is supported only over TLS connections.")
     public abstract String getType();

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -40,7 +40,7 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
             "`scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. " +
             "`plain` type uses SASL PLAIN Authentication. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
-            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. " +
+            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. " +
             "The `tls` type uses TLS Client Authentication. " +
             "The `tls` type is supported only over TLS connections.")
     public abstract String getType();

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -27,7 +27,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = KafkaClientAuthenticationScramSha512.TYPE_SCRAM_SHA_512, value = KafkaClientAuthenticationScramSha512.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationPlain.TYPE_PLAIN, value = KafkaClientAuthenticationPlain.class),
     @JsonSubTypes.Type(name = KafkaClientAuthenticationOAuth.TYPE_OAUTH, value = KafkaClientAuthenticationOAuth.class),
-    @JsonSubTypes.Type(name = KafkaClientAuthenticationK8sOIDC.TYPE_K8S_OIDC, value = KafkaClientAuthenticationK8sOIDC.class),
+    @JsonSubTypes.Type(name = KafkaClientAuthenticationServiceAccountOAuth.TYPE_SERVICEACCOUNT_OAUTH, value = KafkaClientAuthenticationServiceAccountOAuth.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
@@ -36,11 +36,11 @@ public abstract class KafkaClientAuthentication implements UnknownPropertyPreser
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +
-            "Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. " +
+            "Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. " +
             "`scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. " +
             "`plain` type uses SASL PLAIN Authentication. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
-            "`k8s-oidc` type uses SASL OAUTHBEARER Authentication. " +
+            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. " +
             "The `tls` type uses TLS Client Authentication. " +
             "The `tls` type is supported only over TLS connections.")
     public abstract String getType();

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.authentication;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Configures the Kafka client authentication using SASL OAUTHBEARER mechanism configured to authenticate with the Kubernetes provided token
+ */
+@DescriptionFile
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+public class KafkaClientAuthenticationK8sOIDC extends KafkaClientAuthenticationOAuth {
+
+    public static final String TYPE_K8S_OIDC = "k8s-oidc";
+
+    @Description("Must be `" + TYPE_K8S_OIDC + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Override
+    public String getType() {
+        return TYPE_K8S_OIDC;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -20,6 +21,11 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+// Make sure this is in sync with KafkaClientAuthenticationOAuth
+@JsonPropertyOrder({"type", "clientId", "username", "scope", "audience", "tokenEndpointUri", "connectTimeoutSeconds",
+    "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientSecret", "passwordSecret", "accessToken",
+    "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
+    "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader", "accessTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaClientAuthenticationK8sOIDC extends KafkaClientAuthenticationOAuth {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationK8sOIDC.java
@@ -20,8 +20,9 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class KafkaClientAuthenticationK8sOIDC extends KafkaClientAuthenticationOAuth {
+    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_K8S_OIDC = "k8s-oidc";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -48,6 +48,7 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     private GenericSecretSource clientSecret;
     private PasswordSecretSource passwordSecret;
     private GenericSecretSource accessToken;
+    private String accessTokenLocation;
     private GenericSecretSource refreshToken;
     private List<CertSecretSource> tlsTrustedCertificates;
     private boolean disableTlsHostnameVerification = false;
@@ -164,6 +165,16 @@ public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
 
     public void setAccessToken(GenericSecretSource accessToken) {
         this.accessToken = accessToken;
+    }
+
+    @Description("Path to the token file containing an access token to be used for authentication.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getAccessTokenLocation() {
+        return accessTokenLocation;
+    }
+
+    public void setAccessTokenLocation(String path) {
+        this.accessTokenLocation = path;
     }
 
     @Description("Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -27,10 +27,11 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+// Make sure this is in sync with KafkaClientAuthenticationK8sOIDC
 @JsonPropertyOrder({"type", "clientId", "username", "scope", "audience", "tokenEndpointUri", "connectTimeoutSeconds",
     "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientSecret", "passwordSecret", "accessToken",
     "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
-    "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader"})
+    "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader", "accessTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -27,7 +27,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-// Make sure this is in sync with KafkaClientAuthenticationK8sOIDC
+// Make sure this is in sync with KafkaClientAuthenticationServiceAccountOAuth
 @JsonPropertyOrder({"type", "clientId", "username", "scope", "audience", "tokenEndpointUri", "connectTimeoutSeconds",
     "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientSecret", "passwordSecret", "accessToken",
     "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationServiceAccountOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationServiceAccountOAuth.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using SASL OAUTHBEARER mechanism configured to authenticate with the Kubernetes provided token
@@ -27,6 +28,7 @@ import lombok.EqualsAndHashCode;
     "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
     "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader", "accessTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationServiceAccountOAuth extends KafkaClientAuthenticationOAuth {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationServiceAccountOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationServiceAccountOAuth.java
@@ -27,15 +27,15 @@ import lombok.EqualsAndHashCode;
     "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
     "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader", "accessTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
-public class KafkaClientAuthenticationK8sOIDC extends KafkaClientAuthenticationOAuth {
+public class KafkaClientAuthenticationServiceAccountOAuth extends KafkaClientAuthenticationOAuth {
     private static final long serialVersionUID = 1L;
 
-    public static final String TYPE_K8S_OIDC = "k8s-oidc";
+    public static final String TYPE_SERVICEACCOUNT_OAUTH = "serviceaccount-oauth";
 
-    @Description("Must be `" + TYPE_K8S_OIDC + "`")
+    @Description("Must be `" + TYPE_SERVICEACCOUNT_OAUTH + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
-        return TYPE_K8S_OIDC;
+        return TYPE_SERVICEACCOUNT_OAUTH;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -27,7 +27,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationTls.TYPE_TLS, value = KafkaListenerAuthenticationTls.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationScramSha512.SCRAM_SHA_512, value = KafkaListenerAuthenticationScramSha512.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationOAuth.TYPE_OAUTH, value = KafkaListenerAuthenticationOAuth.class),
-    @JsonSubTypes.Type(name = KafkaListenerAuthenticationK8sOIDC.TYPE_K8S_OIDC, value = KafkaListenerAuthenticationK8sOIDC.class),
+    @JsonSubTypes.Type(name = KafkaListenerAuthenticationServiceAccountOAuth.TYPE_SERVICEACCOUNT_OAUTH, value = KafkaListenerAuthenticationServiceAccountOAuth.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationCustom.TYPE_CUSTOM, value = KafkaListenerAuthenticationCustom.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -42,7 +42,7 @@ public abstract class KafkaListenerAuthentication implements UnknownPropertyPres
 
     @Description("Authentication type. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
-            "`k8s-oidc` type uses SASL OAUTHBEARER Authentication. " +
+            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
             "`tls` type is supported only on TLS listeners." +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -27,6 +27,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationTls.TYPE_TLS, value = KafkaListenerAuthenticationTls.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationScramSha512.SCRAM_SHA_512, value = KafkaListenerAuthenticationScramSha512.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationOAuth.TYPE_OAUTH, value = KafkaListenerAuthenticationOAuth.class),
+    @JsonSubTypes.Type(name = KafkaListenerAuthenticationK8sOIDC.TYPE_K8S_OIDC, value = KafkaListenerAuthenticationK8sOIDC.class),
     @JsonSubTypes.Type(name = KafkaListenerAuthenticationCustom.TYPE_CUSTOM, value = KafkaListenerAuthenticationCustom.class),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -41,6 +42,7 @@ public abstract class KafkaListenerAuthentication implements UnknownPropertyPres
 
     @Description("Authentication type. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
+            "`k8s-oidc` type uses SASL OAUTHBEARER Authentication. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
             "`tls` type is supported only on TLS listeners." +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -42,7 +42,7 @@ public abstract class KafkaListenerAuthentication implements UnknownPropertyPres
 
     @Description("Authentication type. " +
             "`oauth` type uses SASL OAUTHBEARER Authentication. " +
-            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. " +
+            "`serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication in combination with Kubernetes ServiceAccounts and pre-configured to use the Kubernetes API server's JWKS endpoint. " +
             "`scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. " +
             "`tls` type uses TLS Client Authentication. " +
             "`tls` type is supported only on TLS listeners." +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.listener;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+public class KafkaListenerAuthenticationK8sOIDC extends KafkaListenerAuthenticationOAuth {
+
+    public static final String TYPE_K8S_OIDC = "k8s-oidc";
+
+    @Description("Must be `" + TYPE_K8S_OIDC + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Override
+    public String getType() {
+        return TYPE_K8S_OIDC;
+    }
+
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -15,6 +16,15 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+// Make sure this is in sync with KafkaListenerAuthenticationOAuth
+@JsonPropertyOrder({"type", "clientId", "clientSecret", "validIssuerUri", "checkIssuer", "checkAudience",
+    "jwksEndpointUri", "jwksRefreshSeconds", "jwksMinRefreshPauseSeconds", "jwksExpirySeconds", "jwksIgnoreKeyUse",
+    "introspectionEndpointUri", "userNameClaim", "fallbackUserNameClaim", "fallbackUserNamePrefix",
+    "groupsClaim", "groupsClaimDelimiter", "userInfoEndpointUri", "checkAccessTokenType", "validTokenType",
+    "accessTokenIsJwt", "tlsTrustedCertificates", "disableTlsHostnameVerification", "enableECDSA",
+    "maxSecondsWithoutReauthentication", "enablePlain", "tokenEndpointUri", "enableOauthBearer", "customClaimCheck",
+    "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientScope", "clientAudience",
+    "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
 public class KafkaListenerAuthenticationK8sOIDC extends KafkaListenerAuthenticationOAuth {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationK8sOIDC.java
@@ -15,8 +15,9 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class KafkaListenerAuthenticationK8sOIDC extends KafkaListenerAuthenticationOAuth {
+    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_K8S_OIDC = "k8s-oidc";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -56,6 +56,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private Integer jwksExpirySeconds;
     private boolean jwksIgnoreKeyUse = false;
     private String introspectionEndpointUri;
+    private String serverBearerTokenLocation;
     private String userNameClaim;
     private String fallbackUserNameClaim;
     private String fallbackUserNamePrefix;
@@ -283,6 +284,16 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     public void setIntrospectionEndpointUri(String introspectionEndpointUri) {
         this.introspectionEndpointUri = introspectionEndpointUri;
+    }
+
+    @Description("Path to the file on the local filesystem that contains a bearer token to be used instead of client_id and secret when authenticating to authorization server")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getServerBearerTokenLocation() {
+        return serverBearerTokenLocation;
+    }
+
+    public void setServerBearerTokenLocation(String serverBearerTokenLocation) {
+        this.serverBearerTokenLocation = serverBearerTokenLocation;
     }
 
     @Description("Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -28,6 +28,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+// Make sure this is in sync with KafkaListenerAuthenticationK8sOIDC
 @JsonPropertyOrder({"type", "clientId", "clientSecret", "validIssuerUri", "checkIssuer", "checkAudience",
     "jwksEndpointUri", "jwksRefreshSeconds", "jwksMinRefreshPauseSeconds", "jwksExpirySeconds", "jwksIgnoreKeyUse",
     "introspectionEndpointUri", "userNameClaim", "fallbackUserNameClaim", "fallbackUserNamePrefix",
@@ -35,7 +36,7 @@ import java.util.List;
     "accessTokenIsJwt", "tlsTrustedCertificates", "disableTlsHostnameVerification", "enableECDSA",
     "maxSecondsWithoutReauthentication", "enablePlain", "tokenEndpointUri", "enableOauthBearer", "customClaimCheck",
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientScope", "clientAudience",
-    "enableMetrics", "failFast", "includeAcceptHeader"})
+    "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -63,7 +63,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private String groupsClaim;
     private String groupsClaimDelimiter;
     private String userInfoEndpointUri;
-    private boolean checkAccessTokenType = true;
+    private Boolean checkAccessTokenType;
     private String validTokenType;
     private boolean accessTokenIsJwt = true;
     private List<CertSecretSource> tlsTrustedCertificates;
@@ -82,7 +82,7 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     private String clientAudience = null;
     private boolean enableMetrics = false;
     private boolean failFast = true;
-    private boolean includeAcceptHeader = true;
+    private Boolean includeAcceptHeader;
 
     @Description("Must be `" + TYPE_OAUTH + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -350,11 +350,11 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
     @Description("Configure whether the access token type check is performed or not. This should be set to `false` " +
             "if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public boolean isCheckAccessTokenType() {
+    public Boolean getCheckAccessTokenType() {
         return checkAccessTokenType;
     }
 
-    public void setCheckAccessTokenType(boolean checkAccessTokenType) {
+    public void setCheckAccessTokenType(Boolean checkAccessTokenType) {
         this.checkAccessTokenType = checkAccessTokenType;
     }
 
@@ -494,11 +494,11 @@ public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthenticatio
 
     @Description("Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public boolean isIncludeAcceptHeader() {
+    public Boolean getIncludeAcceptHeader() {
         return includeAcceptHeader;
     }
 
-    public void setIncludeAcceptHeader(boolean includeAcceptHeader) {
+    public void setIncludeAcceptHeader(Boolean includeAcceptHeader) {
         this.includeAcceptHeader = includeAcceptHeader;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -28,7 +28,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-// Make sure this is in sync with KafkaListenerAuthenticationK8sOIDC
+// Make sure this is in sync with KafkaListenerAuthenticationServiceAccountOAuth
 @JsonPropertyOrder({"type", "clientId", "clientSecret", "validIssuerUri", "checkIssuer", "checkAudience",
     "jwksEndpointUri", "jwksRefreshSeconds", "jwksMinRefreshPauseSeconds", "jwksExpirySeconds", "jwksIgnoreKeyUse",
     "introspectionEndpointUri", "userNameClaim", "fallbackUserNameClaim", "fallbackUserNamePrefix",

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationServiceAccountOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationServiceAccountOAuth.java
@@ -26,16 +26,16 @@ import lombok.EqualsAndHashCode;
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientScope", "clientAudience",
     "enableMetrics", "failFast", "includeAcceptHeader", "serverBearerTokenLocation"})
 @EqualsAndHashCode(callSuper = true)
-public class KafkaListenerAuthenticationK8sOIDC extends KafkaListenerAuthenticationOAuth {
+public class KafkaListenerAuthenticationServiceAccountOAuth extends KafkaListenerAuthenticationOAuth {
     private static final long serialVersionUID = 1L;
 
-    public static final String TYPE_K8S_OIDC = "k8s-oidc";
+    public static final String TYPE_SERVICEACCOUNT_OAUTH = "serviceaccount-oauth";
 
-    @Description("Must be `" + TYPE_K8S_OIDC + "`")
+    @Description("Must be `" + TYPE_SERVICEACCOUNT_OAUTH + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override
     public String getType() {
-        return TYPE_K8S_OIDC;
+        return TYPE_SERVICEACCOUNT_OAUTH;
     }
 
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -9,10 +9,10 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDC;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlain;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.kafka.oauth.client.ClientConfig;
 import io.strimzi.kafka.oauth.server.ServerConfig;
@@ -91,7 +91,7 @@ public class AuthenticationUtils {
         boolean passwordGrantCase = auth.getTokenEndpointUri() != null && auth.getClientId() != null && auth.getUsername() != null && auth.getPasswordSecret() != null;
 
         // If not one of valid cases throw exception
-        if (!(accessTokenCase || refreshTokenCase || clientSecretCase || passwordGrantCase) && !(auth instanceof KafkaClientAuthenticationK8sOIDC)) {
+        if (!(accessTokenCase || refreshTokenCase || clientSecretCase || passwordGrantCase) && !(auth instanceof KafkaClientAuthenticationServiceAccountOAuth)) {
             throw new InvalidResourceException("OAUTH authentication selected, but some options are missing. You have to specify one of the following combinations: [accessToken], [tokenEndpointUri, clientId, refreshToken], [tokenEndpointUri, clientId, clientSecret], [tokenEndpointUri, username, password, clientId].");
         }
 
@@ -313,7 +313,7 @@ public class AuthenticationUtils {
         if (!oauth.isIncludeAcceptHeader()) {
             options.put(ServerConfig.OAUTH_INCLUDE_ACCEPT_HEADER, "false");
         }
-        if (oauth instanceof KafkaClientAuthenticationK8sOIDC) {
+        if (oauth instanceof KafkaClientAuthenticationServiceAccountOAuth) {
             String tokenPath = oauth.getAccessTokenLocation();
             addOption(options, ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, tokenPath != null ? tokenPath : "/var/run/secrets/kubernetes.io/serviceaccount/token");
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -17,9 +17,9 @@ import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthentication;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom;
-import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationK8sOIDC;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationScramSha512;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationTls;
 import io.strimzi.api.kafka.model.kafka.tieredstorage.RemoteStorageManager;
 import io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorage;
@@ -485,7 +485,7 @@ public class KafkaBrokerConfigurationBuilder {
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.location", String.format("/tmp/kafka/oauth-%s.truststore.p12", listenerNameInProperty));
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.password", PLACEHOLDER_CERT_STORE_PASSWORD);
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.type", "PKCS12");
-            } else if (auth instanceof KafkaListenerAuthenticationK8sOIDC) {
+            } else if (auth instanceof KafkaListenerAuthenticationServiceAccountOAuth) {
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.location", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.type", "PEM");
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -582,6 +582,7 @@ public class KafkaBrokerConfigurationBuilder {
         if (oauth.getJwksMinRefreshPauseSeconds() != null && oauth.getJwksMinRefreshPauseSeconds() >= 0) {
             addOptionIfNotNull(options, ServerConfig.OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS, String.valueOf(oauth.getJwksMinRefreshPauseSeconds()));
         }
+        addOptionIfNotEmpty(options, ServerConfig.OAUTH_SERVER_BEARER_TOKEN_LOCATION, oauth.getServerBearerTokenLocation());
         addBooleanOptionIfTrue(options, ServerConfig.OAUTH_JWKS_IGNORE_KEY_USE, oauth.getJwksIgnoreKeyUse());
         addOptionIfNotNull(options, ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI, oauth.getIntrospectionEndpointUri());
         addOptionIfNotNull(options, ServerConfig.OAUTH_USERINFO_ENDPOINT_URI, oauth.getUserInfoEndpointUri());
@@ -620,6 +621,12 @@ public class KafkaBrokerConfigurationBuilder {
 
     static void addOptionIfNotNull(Map<String, String> options, String option, String value) {
         if (value != null) {
+            options.put(option, value);
+        }
+    }
+
+    static void addOptionIfNotEmpty(Map<String, String> options, String option, String value) {
+        if (value != null && !value.isEmpty()) {
             options.put(option, value);
         }
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -481,13 +481,13 @@ public class KafkaBrokerConfigurationBuilder {
                 addOptionIfNotNull(jaasOptions, "oauth.client.secret", String.format(PLACEHOLDER_OAUTH_CLIENT_SECRET, listenerNameInEnvVar));
             }
 
-            if (auth instanceof KafkaListenerAuthenticationK8sOIDC) {
-                addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.location", "/var/run/secrets/kubernetes.io/serviceaccount/..data/ca.crt");
-                addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.type", "PEM");
-            } else if (oauth.getTlsTrustedCertificates() != null && oauth.getTlsTrustedCertificates().size() > 0)    {
+            if (oauth.getTlsTrustedCertificates() != null && oauth.getTlsTrustedCertificates().size() > 0)    {
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.location", String.format("/tmp/kafka/oauth-%s.truststore.p12", listenerNameInProperty));
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.password", PLACEHOLDER_CERT_STORE_PASSWORD);
                 addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.type", "PKCS12");
+            } else if (auth instanceof KafkaListenerAuthenticationK8sOIDC) {
+                addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.location", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
+                addOptionIfNotNull(jaasOptions, "oauth.ssl.truststore.type", "PEM");
             }
 
             StringBuilder enabledMechanisms = new StringBuilder();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -8,6 +8,7 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationPlain;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha256;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
@@ -252,6 +253,10 @@ public class KafkaMirrorMaker2Connectors {
                                 Map.of("username", scramAuthentication.getUsername(),
                                         "password", "${file:" + CONNECTORS_CONFIG_FILE + ":" + cluster.getAlias() + ".sasl.password}")));
             } else if (cluster.getAuthentication() instanceof KafkaClientAuthenticationOAuth oauthAuthentication) {
+                if (KafkaClientAuthenticationServiceAccountOAuth.TYPE_SERVICEACCOUNT_OAUTH.equals(oauthAuthentication.getType())) {
+                    // validate the configuration again in order to autofill any fields not yet filled (e.g. serviceaccount-oauth may need to autofill 'accessTokenLocation')
+                    AuthenticationUtils.validateClientAuthentication(oauthAuthentication, false);
+                }
                 securityProtocol = cluster.getTls() != null ? "SASL_SSL" : "SASL_PLAINTEXT";
                 config.put(configPrefix + SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
                 config.put(configPrefix + SaslConfigs.SASL_JAAS_CONFIG,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationK8sOIDC;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuth;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.kafka.listener.NodeAddressType;
@@ -45,13 +46,27 @@ public class ListenersUtils {
      *
      * @param listener  Listener to check
      *
-     * @return  True if the listener uses OAuth authentication. False otherwise.
+     * @return  True if the listener is configured to use OAuth authentication. False otherwise.
      */
     public static boolean isListenerWithOAuth(GenericKafkaListener listener) {
         if (listener.getAuth() == null || listener.getAuth().getType() == null)
             return false;
 
         return KafkaListenerAuthenticationOAuth.TYPE_OAUTH.equals(listener.getAuth().getType());
+    }
+
+    /**
+     * Checks whether the listener is using OAuth authentication with Kubernetes OIDC JWKS endpoint
+     *
+     * @param listener Listener to check
+     *
+     * @return  True if the listener is configured to use OAuth authentication with Kubernetes OIDC JWKS endpoint. False otherwise.
+     */
+    public static boolean isListenerWithK8sOIDC(GenericKafkaListener listener) {
+        if (listener.getAuth() == null || listener.getAuth().getType() == null)
+            return false;
+
+        return KafkaListenerAuthenticationK8sOIDC.TYPE_K8S_OIDC.equals(listener.getAuth().getType());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -10,8 +10,8 @@ import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom;
-import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationK8sOIDC;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationOAuth;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.kafka.listener.NodeAddressType;
 
@@ -62,11 +62,11 @@ public class ListenersUtils {
      *
      * @return  True if the listener is configured to use OAuth authentication with Kubernetes OIDC JWKS endpoint. False otherwise.
      */
-    public static boolean isListenerWithK8sOIDC(GenericKafkaListener listener) {
+    public static boolean isListenerWithServiceAccountOAuth(GenericKafkaListener listener) {
         if (listener.getAuth() == null || listener.getAuth().getType() == null)
             return false;
 
-        return KafkaListenerAuthenticationK8sOIDC.TYPE_K8S_OIDC.equals(listener.getAuth().getType());
+        return KafkaListenerAuthenticationServiceAccountOAuth.TYPE_SERVICEACCOUNT_OAUTH.equals(listener.getAuth().getType());
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithK8sOIDC;
 import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithOAuth;
+import static io.strimzi.operator.cluster.model.ListenersUtils.isListenerWithServiceAccountOAuth;
 
 /**
  * Util methods for validating Kafka listeners
@@ -559,12 +559,12 @@ public class ListenersValidator {
      */
     @SuppressWarnings({"checkstyle:BooleanExpressionComplexity", "checkstyle:NPathComplexity", "checkstyle:CyclomaticComplexity"})
     private static void validateOauth(Set<String> errors, GenericKafkaListener listener) {
-        if (isListenerWithOAuth(listener) || isListenerWithK8sOIDC(listener)) {
+        if (isListenerWithOAuth(listener) || isListenerWithServiceAccountOAuth(listener)) {
             KafkaListenerAuthenticationOAuth oAuth = (KafkaListenerAuthenticationOAuth) listener.getAuth();
             String listenerName = listener.getName();
 
-            if (isListenerWithK8sOIDC(listener)) {
-                validateAndOverrideK8sOIDC(oAuth);
+            if (isListenerWithServiceAccountOAuth(listener)) {
+                validateAndOverrideServiceAccountOAuth(oAuth);
             }
 
             if (!oAuth.isEnablePlain() && !oAuth.isEnableOauthBearer()) {
@@ -661,7 +661,7 @@ public class ListenersValidator {
         }
     }
 
-    private static void validateAndOverrideK8sOIDC(KafkaListenerAuthenticationOAuth oAuth) {
+    private static void validateAndOverrideServiceAccountOAuth(KafkaListenerAuthenticationOAuth oAuth) {
         if (oAuth.getValidIssuerUri() == null) {
             oAuth.setValidIssuerUri("https://kubernetes.default.svc.cluster.local");
         }
@@ -674,13 +674,13 @@ public class ListenersValidator {
 
         if (oAuth.getIncludeAcceptHeader() == null || oAuth.getIncludeAcceptHeader()) {
             if (oAuth.getIncludeAcceptHeader() != null && oAuth.getIncludeAcceptHeader()) {
-                LOGGER.warnOp("'includeAcceptHeader' force-set to 'false' for compatibility with 'k8s-oidc'");
+                LOGGER.warnOp("'includeAcceptHeader' force-set to 'false' for compatibility with 'serviceaccount-oauth'");
             }
             oAuth.setIncludeAcceptHeader(false);
         }
         if (oAuth.getCheckAccessTokenType() == null || oAuth.getCheckAccessTokenType()) {
             if (oAuth.getCheckAccessTokenType() != null && oAuth.getCheckAccessTokenType()) {
-                LOGGER.warnOp("'checkAccessTokenType' force-set to 'false' for compatibility with 'k8s-oidc'");
+                LOGGER.warnOp("'checkAccessTokenType' force-set to 'false' for compatibility with 'serviceaccount-oauth'");
             }
             oAuth.setCheckAccessTokenType(false);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -564,7 +564,7 @@ public class ListenersValidator {
             String listenerName = listener.getName();
 
             if (isListenerWithK8sOIDC(listener)) {
-                configureK8sOIDC(oAuth);
+                validateAndOverrideK8sOIDC(oAuth);
             }
 
             if (!oAuth.isEnablePlain() && !oAuth.isEnableOauthBearer()) {
@@ -661,7 +661,7 @@ public class ListenersValidator {
         }
     }
 
-    private static void configureK8sOIDC(KafkaListenerAuthenticationOAuth oAuth) {
+    private static void validateAndOverrideK8sOIDC(KafkaListenerAuthenticationOAuth oAuth) {
         if (oAuth.getValidIssuerUri() == null) {
             oAuth.setValidIssuerUri("https://kubernetes.default.svc.cluster.local");
         }
@@ -673,11 +673,15 @@ public class ListenersValidator {
         }
 
         if (oAuth.getIncludeAcceptHeader() == null || oAuth.getIncludeAcceptHeader()) {
-            LOGGER.warnOp("'includeAcceptHeader' force-set to 'false' for compatibility with 'k8s-oidc'");
+            if (oAuth.getIncludeAcceptHeader() != null && oAuth.getIncludeAcceptHeader()) {
+                LOGGER.warnOp("'includeAcceptHeader' force-set to 'false' for compatibility with 'k8s-oidc'");
+            }
             oAuth.setIncludeAcceptHeader(false);
         }
         if (oAuth.getCheckAccessTokenType() == null || oAuth.getCheckAccessTokenType()) {
-            LOGGER.warnOp("'checkAccessTokenType' force-set to 'false' for compatibility with 'k8s-oidc'");
+            if (oAuth.getCheckAccessTokenType() != null && oAuth.getCheckAccessTokenType()) {
+                LOGGER.warnOp("'checkAccessTokenType' force-set to 'false' for compatibility with 'k8s-oidc'");
+            }
             oAuth.setCheckAccessTokenType(false);
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -951,6 +951,7 @@ public class KafkaBridgeClusterTest {
                 .editSpec()
                 .withAuthentication(
                         new KafkaClientAuthenticationServiceAccountOAuthBuilder()
+                                .withConnectTimeoutSeconds(30)
                                 .build())
                 .endSpec()
                 .build();
@@ -961,7 +962,7 @@ public class KafkaBridgeClusterTest {
 
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
         assertThat(cont.getEnv().stream().filter(var -> KafkaBridgeCluster.ENV_VAR_KAFKA_BRIDGE_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
-                is(String.format("%s=\"%s\"", ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token")));
+                is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, "30", ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token")));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -40,8 +40,8 @@ import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.JvmOptionsBuilder;
 import io.strimzi.api.kafka.model.common.SystemPropertyBuilder;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDCBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuthBuilder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuthBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.DeploymentStrategy;
@@ -946,11 +946,11 @@ public class KafkaBridgeClusterTest {
     }
 
     @ParallelTest
-    public void testGenerateDeploymentWithK8sOIDC() {
+    public void testGenerateDeploymentWithServiceAccountOAuth() {
         KafkaBridge resource = new KafkaBridgeBuilder(this.resource)
                 .editSpec()
                 .withAuthentication(
-                        new KafkaClientAuthenticationK8sOIDCBuilder()
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
                                 .build())
                 .endSpec()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -2154,13 +2154,13 @@ public class KafkaBrokerConfigurationBuilderTest {
     }
 
     @ParallelTest
-    public void testK8sOIDCConfiguration() {
+    public void testServiceAccountOAuthConfiguration() {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
                 .withPort(9092)
                 .withType(KafkaListenerType.INTERNAL)
                 .withTls(false)
-                .withNewKafkaListenerAuthenticationK8sOIDCAuth()
+                .withNewKafkaListenerAuthenticationServiceAccountOAuth()
                 .withMaxSecondsWithoutReauthentication(3600)
                 .withJwksMinRefreshPauseSeconds(5)
                 .withEnablePlain(true)
@@ -2169,7 +2169,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withEnableMetrics(true)
                 .withIncludeAcceptHeader(true)  // should automatically get overridden to 'false' during validation
                 .withCheckAccessTokenType(true) // should automatically get overridden to 'false' during validation
-                .endKafkaListenerAuthenticationK8sOIDCAuth()
+                .endKafkaListenerAuthenticationServiceAccountOAuth()
                 .build();
 
         // It is the validation phase that sets some of the default values, and overrides some of the incompatibly set values
@@ -2213,14 +2213,14 @@ public class KafkaBrokerConfigurationBuilderTest {
     }
 
     @ParallelTest
-    public void testK8sOIDCConfigurationWithoutOptions()  {
+    public void testServiceAccountOAuthConfigurationWithoutOptions()  {
         GenericKafkaListener listener = new GenericKafkaListenerBuilder()
                 .withName("plain")
                 .withPort(9092)
                 .withType(KafkaListenerType.INTERNAL)
                 .withTls(false)
-                .withNewKafkaListenerAuthenticationK8sOIDCAuth()
-                .endKafkaListenerAuthenticationK8sOIDCAuth()
+                .withNewKafkaListenerAuthenticationServiceAccountOAuth()
+                .endKafkaListenerAuthenticationServiceAccountOAuth()
                 .build();
 
         // It is the validation phase that sets some of the default values, and overrides some of the incompatibly set values

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -2084,6 +2084,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withCheckAudience(true)
                 .withJwksEndpointUri("http://jwks-endpoint")
                 .withIntrospectionEndpointUri("http://introspection-endpoint")
+                .withServerBearerTokenLocation("/var/run/secrets/kubernetes.io/serviceaccount/token")
                 .withUserInfoEndpointUri("http://userinfo-endpoint")
                 .withJwksExpirySeconds(160)
                 .withJwksRefreshSeconds(50)
@@ -2127,6 +2128,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         expectedOptions.put(ServerConfig.OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS, "5");
         expectedOptions.put(ServerConfig.OAUTH_JWKS_IGNORE_KEY_USE, String.valueOf(true));
         expectedOptions.put(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI, "http://introspection-endpoint");
+        expectedOptions.put(ServerConfig.OAUTH_SERVER_BEARER_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token");
         expectedOptions.put(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI, "http://userinfo-endpoint");
         expectedOptions.put(ServerConfig.OAUTH_USERNAME_CLAIM, "preferred_username");
         expectedOptions.put(ServerConfig.OAUTH_FALLBACK_USERNAME_CLAIM, "client_id");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -41,7 +41,6 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -2173,7 +2172,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         // It is the validation phase that sets some of the default values, and overrides some of the incompatibly set values
-        Set<String> errors = ListenersValidator.validateAndGetErrorMessages(new HashSet(singletonList(NODE_REF)), singletonList(listener));
+
+        Set<String> errors = ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, Collections.singleton(NODE_REF), singletonList(listener));
         assertThat("No listener validation errors", errors.isEmpty());
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)
@@ -2224,7 +2224,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         // It is the validation phase that sets some of the default values, and overrides some of the incompatibly set values
-        Set<String> errors = ListenersValidator.validateAndGetErrorMessages(new HashSet(singletonList(NODE_REF)), singletonList(listener));
+        Set<String> errors = ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, Collections.singleton(NODE_REF), singletonList(listener));
         assertThat("No listener validation errors", errors.isEmpty());
 
         String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -1817,6 +1817,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .withNewKafkaListenerAuthenticationOAuth()
                     .withValidIssuerUri("http://valid-issuer")
                     .withJwksEndpointUri("http://jwks")
+                    .withServerBearerTokenLocation("/var/run/secrets/kubernetes.io/serviceaccount/token")
                     .withEnableECDSA(true)
                     .withUserNameClaim("preferred_username")
                     .withGroupsClaim("$.groups")
@@ -1861,9 +1862,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "ssl.endpoint.identification.algorithm=HTTPS",
                 "principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder",
                 "listener.name.plain-9092.oauthbearer.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler",
-                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\";",
+                "listener.name.plain-9092.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub=\"thePrincipalName\" oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\";",
                 "listener.name.plain-9092.plain.sasl.server.callback.handler.class=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler",
-                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.username.claim=\"preferred_username\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
+                "listener.name.plain-9092.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required oauth.valid.issuer.uri=\"http://valid-issuer\" oauth.jwks.endpoint.uri=\"http://jwks\" oauth.jwks.refresh.min.pause.seconds=\"5\" oauth.server.bearer.token.location=\"/var/run/secrets/kubernetes.io/serviceaccount/token\" oauth.username.claim=\"preferred_username\" oauth.groups.claim=\"$.groups\" oauth.groups.claim.delimiter=\";\" oauth.connect.timeout.seconds=\"30\" oauth.read.timeout.seconds=\"30\" oauth.enable.metrics=\"true\" oauth.include.accept.header=\"false\" oauth.config.id=\"PLAIN-9092\" oauth.token.endpoint.uri=\"http://token\";",
                 "listener.name.plain-9092.sasl.enabled.mechanisms=OAUTHBEARER,PLAIN",
                 "listener.name.plain-9092.connections.max.reauth.ms=3600000"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -2175,8 +2175,8 @@ public class KafkaBrokerConfigurationBuilderTest {
         Set<String> errors = ListenersValidator.validateAndGetErrorMessages(new HashSet(singletonList(NODE_REF)), singletonList(listener));
         assertThat("No listener validation errors", errors.isEmpty());
 
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, "2", false)
-                .withListeners("my-cluster", "my-namespace", NODE_REF, singletonList(listener), listenerId -> "dummy-advertised-address", listenerId -> "1919")
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), listenerId -> "dummy-advertised-address", listenerId -> "1919")
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",
@@ -2226,8 +2226,8 @@ public class KafkaBrokerConfigurationBuilderTest {
         Set<String> errors = ListenersValidator.validateAndGetErrorMessages(new HashSet(singletonList(NODE_REF)), singletonList(listener));
         assertThat("No listener validation errors", errors.isEmpty());
 
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, "2", false)
-                .withListeners("my-cluster", "my-namespace", NODE_REF, singletonList(listener), listenerId -> "dummy-advertised-address", listenerId -> "1919")
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)
+                .withListeners("my-cluster", "my-namespace", singletonList(listener), listenerId -> "dummy-advertised-address", listenerId -> "1919")
                 .build();
 
         assertThat(configuration, isEquivalent("broker.id=2",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -39,8 +39,8 @@ import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDCBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuthBuilder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuthBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
@@ -1543,11 +1543,11 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
-    public void testPodSetWithK8sOIDC() {
+    public void testPodSetWithServiceAccountOAuth() {
         KafkaConnect resource = new KafkaConnectBuilder(this.resource)
                 .editSpec()
                 .withAuthentication(
-                        new KafkaClientAuthenticationK8sOIDCBuilder()
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
                                 .build())
                 .endSpec()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1548,6 +1548,7 @@ public class KafkaConnectClusterTest {
                 .editSpec()
                 .withAuthentication(
                         new KafkaClientAuthenticationServiceAccountOAuthBuilder()
+                                .withReadTimeoutSeconds(30)
                                 .build())
                 .endSpec()
                 .build();
@@ -1560,7 +1561,7 @@ public class KafkaConnectClusterTest {
             Container cont = pod.getSpec().getContainers().get(0);
             assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
-                    is(String.format("%s=\"%s\"", ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token")));
+                    is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_READ_TIMEOUT_SECONDS, "30", ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token")));
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -33,8 +33,8 @@ import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Probe;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDCBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuthBuilder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuthBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptionsBuilder;
@@ -1637,15 +1637,15 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
-    public void testPodSetWithK8sOIDC() {
-        KafkaMirrorMaker2ClusterSpec targetClusterWithK8sOIDC = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
+    public void testPodSetWithServiceAccountOAuth() {
+        KafkaMirrorMaker2ClusterSpec targetClusterWithServiceAccountOAuth = new KafkaMirrorMaker2ClusterSpecBuilder(this.targetCluster)
                 .withAuthentication(
-                        new KafkaClientAuthenticationK8sOIDCBuilder()
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
                                 .build())
                 .build();
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
-                .withClusters(targetClusterWithK8sOIDC)
+                .withClusters(targetClusterWithServiceAccountOAuth)
                 .endSpec()
                 .build();
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1633,6 +1633,7 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_ACCESS_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getName(), is("my-token-secret"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_ACCESS_TOKEN.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-token-key"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().isEmpty(), is(true));
+            assertThat(cont.getVolumeMounts().stream().filter(var -> "target-my-token-secret".equals(var.getName())).count(), is(1L));
         });
     }
 
@@ -1643,9 +1644,26 @@ public class KafkaMirrorMaker2ClusterTest {
                         new KafkaClientAuthenticationServiceAccountOAuthBuilder()
                                 .build())
                 .build();
+
+        KafkaMirrorMaker2ClusterSpec sourceClusterWithServiceAccountOAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("source-cluster-1")
+                .withBootstrapServers("source-bootstrap-kafka:9092")
+                .withAuthentication(
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
+                                .build())
+                .build();
+
+        KafkaMirrorMaker2ClusterSpec sourceCluster2WithServiceAccountOAuth = new KafkaMirrorMaker2ClusterSpecBuilder()
+                .withAlias("source-cluster-2")
+                .withBootstrapServers("source2-bootstrap-kafka:9092")
+                .withAuthentication(
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
+                                .build())
+                .build();
+
         KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(this.resource)
                 .editSpec()
-                .withClusters(targetClusterWithServiceAccountOAuth)
+                .withClusters(targetClusterWithServiceAccountOAuth, sourceClusterWithServiceAccountOAuth, sourceCluster2WithServiceAccountOAuth)
                 .endSpec()
                 .build();
 
@@ -1658,6 +1676,8 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_SASL_MECHANISM.equals(var.getName())).findFirst().orElseThrow().getValue(), is("oauth"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
                     is(String.format("%s=\"%s\"", ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION, "/var/run/secrets/kubernetes.io/serviceaccount/token")));
+
+            assertThat(cont.getVolumeMounts().stream().filter(var -> var.getName().endsWith("token-secret")).count(), is(0L));
         });
     }
 
@@ -1698,6 +1718,8 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
                     is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server",
                             ClientConfig.OAUTH_CONNECT_TIMEOUT_SECONDS, "15", ClientConfig.OAUTH_READ_TIMEOUT_SECONDS, "15", ClientConfig.OAUTH_HTTP_RETRIES, "2", ClientConfig.OAUTH_HTTP_RETRY_PAUSE_MILLIS, "500", ClientConfig.OAUTH_ENABLE_METRICS, "true", ClientConfig.OAUTH_INCLUDE_ACCEPT_HEADER, "false")));
+
+            assertThat(cont.getVolumeMounts().stream().filter(var -> "target-my-token-secret".equals(var.getName())).count(), is(1L));
         });
     }
 
@@ -1731,6 +1753,8 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
                     is(String.format("%s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
+
+            assertThat(cont.getVolumeMounts().stream().filter(var -> "target-my-secret-secret".equals(var.getName())).count(), is(1L));
         });
     }
 
@@ -1771,6 +1795,9 @@ public class KafkaMirrorMaker2ClusterTest {
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CLIENT_SECRET.equals(var.getName())).findFirst().orElseThrow().getValueFrom().getSecretKeyRef().getKey(), is("my-secret-key"));
             assertThat(cont.getEnv().stream().filter(var -> KafkaMirrorMaker2Cluster.ENV_VAR_KAFKA_CONNECT_OAUTH_CONFIG.equals(var.getName())).findFirst().orElseThrow().getValue().trim(),
                     is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME, "user1", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server")));
+
+            assertThat(cont.getVolumeMounts().stream().filter(var -> "target-my-password-secret".equals(var.getName())).count(), is(1L));
+            assertThat(cont.getVolumeMounts().stream().filter(var -> "target-my-secret-secret".equals(var.getName())).count(), is(1L));
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -24,8 +24,8 @@ import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDCBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuthBuilder;
+import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuthBuilder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
 import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBuilder;
@@ -1064,12 +1064,12 @@ public class KafkaMirrorMakerClusterTest {
     }
 
     @ParallelTest
-    public void testGenerateDeploymentWithConsumerK8sOIDC() {
+    public void testGenerateDeploymentWithConsumerServiceAccountOAuth() {
         KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(this.resource)
                 .editSpec()
                 .editConsumer()
                 .withAuthentication(
-                        new KafkaClientAuthenticationK8sOIDCBuilder()
+                        new KafkaClientAuthenticationServiceAccountOAuthBuilder()
                                 .build())
                 .endConsumer()
                 .endSpec()

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDC.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationK8sOIDC.adoc
@@ -1,0 +1,27 @@
+To configure Kubernetes OIDC client authentication, set the `type` property to `k8s-oidc`.
+
+Kubernetes OIDC authentication can be configured using one of the following options:
+
+* Service account token
+
+.Service account token
+You can configure the access token as a service account token obtained from Kubernetes OIDC server.
+By default, the service account token of the pod is used, available in a file mounted by Kubernetes and accessible at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+Alternatively, `oauth` authentication can be used to set the `accessToken` property to the name of a `Secret` containing the access token.
+Another alternative is to use `oauth` with `accessTokenLocation` property, and specify a path to the token file.
+
+.An example of Kubernetes OIDC client authentication using the service account token provided to the pod by Kubernetes
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: k8s-oidc
+----
+
+This is equivalent to:
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: oauth
+  accessTokenLocation: `/var/run/secrets/kubernetes.io/serviceaccount/token`
+----
+

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
@@ -48,6 +48,7 @@ authentication:
 You can configure the access token used for authentication with the Kafka broker directly.
 In this case, you do not specify the `tokenEndpointUri`.
 In the `accessToken` property, specify a link to a `Secret` containing the access token.
+Alternatively, use `accessTokenLocation` property, and specify a path to the token file.
 
 .Example access token only configuration
 [source,yaml,subs=attributes+]
@@ -57,6 +58,14 @@ authentication:
   accessToken:
     secretName: my-access-token-secret
     key: access-token
+----
+
+.An example of OAuth client authentication using an access token provided in the form of the file on the mounted filesystem
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: oauth
+  accessTokenLocation: `/path/to/token/file`
 ----
 
 .Username and password

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth.adoc
@@ -1,13 +1,11 @@
 To configure ServiceAccount OAuth client authentication, set the `type` property to `serviceaccount-oauth`.
 
-ServiceAccount OAuth uses Kubernetes API server's JWKS endpoint to validate service account tokens.
+ServiceAccount OAuth uses service account tokens issued by the Kubernetes API server. The listener should be configured with `type: serviceaccount-oauth` as well
+in order to be able to validate these tokens using Kubernetes API server's JWKS endpoint.
 
-This kind of client authentication can be configured using one of the following options:
-
-* Service account token
 
 .Service account token
-You can configure the access token as a service account token obtained from Kubernetes OIDC server.
+You can configure a service account token obtained from Kubernetes OIDC server as the access token.
 By default, the service account token of the pod is used, available in a file mounted by Kubernetes and accessible at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 Alternatively, `oauth` authentication can be used to set the `accessToken` property to the name of a `Secret` containing the access token.
 Another alternative is to use `oauth` with `accessTokenLocation` property, and specify a path to the token file.

--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth.adoc
@@ -1,6 +1,8 @@
-To configure Kubernetes OIDC client authentication, set the `type` property to `k8s-oidc`.
+To configure ServiceAccount OAuth client authentication, set the `type` property to `serviceaccount-oauth`.
 
-Kubernetes OIDC authentication can be configured using one of the following options:
+ServiceAccount OAuth uses Kubernetes API server's JWKS endpoint to validate service account tokens.
+
+This kind of client authentication can be configured using one of the following options:
 
 * Service account token
 
@@ -10,11 +12,11 @@ By default, the service account token of the pod is used, available in a file mo
 Alternatively, `oauth` authentication can be used to set the `accessToken` property to the name of a `Secret` containing the access token.
 Another alternative is to use `oauth` with `accessTokenLocation` property, and specify a path to the token file.
 
-.An example of Kubernetes OIDC client authentication using the service account token provided to the pod by Kubernetes
+.An example of ServiceAccount OAuth client authentication using the service account token provided to the pod by Kubernetes
 [source,yaml,subs=attributes+]
 ----
 authentication:
-  type: k8s-oidc
+  type: serviceaccount-oauth
 ----
 
 This is equivalent to:

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth.adoc
@@ -29,6 +29,13 @@ authentication:
 ----
 
 Note that the `tlsTrustedCertificates` is configured to point to a manually created Secret that contains the Kubernetes API server public certificate, which is mounted to the running pods under `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+The secret can be mounted using the following command:
+[source,shell,subs=attributes+]
+----
+kubectl get cm kube-root-ca.crt -o jsonpath="{['data']['ca\.crt']}" > /tmp/ca.crt
+kubectl create secret generic oauth-server-cert --from-file=ca.crt=/tmp/ca.crt
+----
+
 When using `type: serviceaccount-oauth` the trusted certificate to connect to Kubernetes OIDC server is configured automatically.
 
 The configuration option `customClaimCheck` can be used to allow authentication on this listener to some clients only, based on the namespace where the client application is deployed or any other custom claim present in service account JWT token.

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationServiceAccountOAuth.adoc
@@ -1,0 +1,34 @@
+To configure ServiceAccount OAuth client authentication, set the `type` property to `serviceaccount-oauth`.
+
+ServiceAccount OAuth uses Kubernetes API server's JWKS endpoint to validate service account tokens.
+
+.An example of ServiceAccount OAuth authentication on the listener
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: serviceaccount-oauth
+  maxSecondsWithoutReauthentication: 3600
+  customClaimCheck: "@.['kubernetes.io'] && @.['kubernetes.io'].['namespace'] in ['example']"
+----
+
+This is equivalent to:
+[source,yaml,subs=attributes+]
+----
+authentication:
+  type: oauth
+  maxSecondsWithoutReauthentication: 3600
+  customClaimCheck: "@.['kubernetes.io'] && @.['kubernetes.io'].['namespace'] in ['example']"
+  jwksEnpointUri: https://kubernetes.default.svc.cluster.local/openid/v1/jwks
+  validIssuerUri: https://kubernetes.default.svc.cluster.local
+  serverBearerTokenLocation: /var/run/secrets/kubernetes.io/serviceaccount/token
+  checkAccessTokenType: false
+  includeAcceptHeader: false
+  tlsTrustedCertificates:
+    - secretName: oauth-server-cert
+      certificate: ca.crt
+----
+
+Note that the `tlsTrustedCertificates` is configured to point to a manually created Secret that contains the Kubernetes API server public certificate, which is mounted to the running pods under `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+When using `type: serviceaccount-oauth` the trusted certificate to connect to Kubernetes OIDC server is configured automatically.
+
+The configuration option `customClaimCheck` can be used to allow authentication on this listener to some clients only, based on the namespace where the client application is deployed or any other custom claim present in service account JWT token.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -166,7 +166,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.a
 |boolean
 |Enables TLS encryption on the listener. This is a required property.
 |authentication
-|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`]
+|xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`]
 |Authentication configuration for this listener.
 |configuration
 |xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaListenerConfiguration`]
@@ -182,7 +182,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.a
 Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationTls` type from xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
+The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationTls` type from xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
 It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 [cols="2,2,3a",options="header"]
 |====
@@ -198,7 +198,7 @@ It must have the value `tls` for the type `KafkaListenerAuthenticationTls`.
 Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationScramSha512` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
+The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationScramSha512` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
 It must have the value `scram-sha-512` for the type `KafkaListenerAuthenticationScramSha512`.
 [cols="2,2,3a",options="header"]
 |====
@@ -214,7 +214,7 @@ It must have the value `scram-sha-512` for the type `KafkaListenerAuthentication
 Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationOAuth` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
+The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationOAuth` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`].
 It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 [cols="2,2,3a",options="header"]
 |====
@@ -333,12 +333,15 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |includeAcceptHeader
 |boolean
 |Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
+|serverBearerTokenLocation
+|string
+|Path to the file on the local filesystem that contains a bearer token to be used instead of client_id and secret when authenticating to authorization server.
 |====
 
 [id='type-GenericSecretSource-{context}']
 = `GenericSecretSource` schema reference
 
-Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
+Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`]
 
 
 [cols="2,2,3a",options="header"]
@@ -355,7 +358,7 @@ Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenti
 [id='type-CertSecretSource-{context}']
 = `CertSecretSource` schema reference
 
-Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaAuthorizationOpa-{context}[`KafkaAuthorizationOpa`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
+Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizationKeycloak-{context}[`KafkaAuthorizationKeycloak`], xref:type-KafkaAuthorizationOpa-{context}[`KafkaAuthorizationOpa`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`]
 
 
 [cols="2,2,3a",options="header"]
@@ -372,6 +375,134 @@ Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizatio
 |Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used.
 |====
 
+[id='type-KafkaListenerAuthenticationServiceAccountOAuth-{context}']
+= `KafkaListenerAuthenticationServiceAccountOAuth` schema reference
+
+Used in: xref:type-GenericKafkaListener-{context}[`GenericKafkaListener`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `serviceaccount-oauth`.
+|clientId
+|string
+|OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+|clientSecret
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
+|validIssuerUri
+|string
+|URI of the token issuer used for authentication.
+|checkIssuer
+|boolean
+|Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
+|checkAudience
+|boolean
+|Enable or disable audience checking. Audience checks identify the recipients of tokens. If audience checking is enabled, the OAuth Client ID also has to be configured using the `clientId` property. The Kafka broker will reject tokens that do not have its `clientId` in their `aud` (audience) claim.Default value is `false`.
+|jwksEndpointUri
+|string
+|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
+|jwksRefreshSeconds
+|integer
+|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
+|jwksMinRefreshPauseSeconds
+|integer
+|The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.
+|jwksExpirySeconds
+|integer
+|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
+|jwksIgnoreKeyUse
+|boolean
+|Flag to ignore the 'use' attribute of `key` declarations in a JWKS endpoint response. Default value is `false`.
+|introspectionEndpointUri
+|string
+|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
+|userNameClaim
+|string
+|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
+|fallbackUserNameClaim
+|string
+|The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
+|fallbackUserNamePrefix
+|string
+|The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions.
+|groupsClaim
+|string
+|JsonPath query used to extract groups for the user during authentication. Extracted groups can be used by a custom authorizer. By default no groups are extracted.
+|groupsClaimDelimiter
+|string
+|A delimiter used to parse groups when they are extracted as a single String value rather than a JSON array. Default value is ',' (comma).
+|userInfoEndpointUri
+|string
+|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
+|checkAccessTokenType
+|boolean
+|Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
+|validTokenType
+|string
+|Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
+|accessTokenIsJwt
+|boolean
+|Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|tlsTrustedCertificates
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|Trusted certificates for TLS connection to the OAuth server.
+|disableTlsHostnameVerification
+|boolean
+|Enable or disable TLS hostname verification. Default value is `false`.
+|enableECDSA
+|boolean
+|**The `enableECDSA` property has been deprecated.** Enable or disable ECDSA support by installing BouncyCastle crypto provider. ECDSA support is always enabled. The BouncyCastle libraries are no longer packaged with Strimzi. Value is ignored.
+|maxSecondsWithoutReauthentication
+|integer
+|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
+|enablePlain
+|boolean
+|Enable or disable OAuth authentication over SASL_PLAIN. There is no re-authentication support when this mechanism is used. Default value is `false`.
+|tokenEndpointUri
+|string
+|URI of the Token Endpoint to use with SASL_PLAIN mechanism when the client authenticates with `clientId` and a `secret`. If set, the client can authenticate over SASL_PLAIN by either setting `username` to `clientId`, and setting `password` to client `secret`, or by setting `username` to account username, and `password` to access token prefixed with `$accessToken:`. If this option is not set, the `password` is always interpreted as an access token (without a prefix), and `username` as the account username (a so called 'no-client-credentials' mode).
+|enableOauthBearer
+|boolean
+|Enable or disable OAuth authentication over SASL_OAUTHBEARER. Default value is `true`.
+|customClaimCheck
+|string
+|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
+|connectTimeoutSeconds
+|integer
+|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|readTimeoutSeconds
+|integer
+|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
+|httpRetries
+|integer
+|The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.
+|httpRetryPauseMs
+|integer
+|The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.
+|clientScope
+|string
+|The scope to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|clientAudience
+|string
+|The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|enableMetrics
+|boolean
+|Enable or disable OAuth metrics. Default value is `false`.
+|failFast
+|boolean
+|Enable or disable termination of Kafka broker processes due to potentially recoverable runtime errors during startup. Default value is `true`.
+|includeAcceptHeader
+|boolean
+|Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
+|serverBearerTokenLocation
+|string
+|Path to the file on the local filesystem that contains a bearer token to be used instead of client_id and secret when authenticating to authorization server.
+|====
+
 [id='type-KafkaListenerAuthenticationCustom-{context}']
 = `KafkaListenerAuthenticationCustom` schema reference
 
@@ -385,7 +516,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthentic
 == `KafkaListenerAuthenticationCustom` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationCustom` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`].
+The `type` property is a discriminator that distinguishes use of the `KafkaListenerAuthenticationCustom` type from xref:type-KafkaListenerAuthenticationTls-{context}[`KafkaListenerAuthenticationTls`], xref:type-KafkaListenerAuthenticationScramSha512-{context}[`KafkaListenerAuthenticationScramSha512`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationServiceAccountOAuth-{context}[`KafkaListenerAuthenticationServiceAccountOAuth`].
 It must have the value `custom` for the type `KafkaListenerAuthenticationCustom`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2178,7 +2309,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |xref:type-ClientTls-{context}[`ClientTls`]
 |TLS configuration.
 |authentication
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 |Authentication configuration for Kafka Connect.
 |config
 |map
@@ -2258,7 +2389,7 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 == `KafkaClientAuthenticationTls` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationTls` type from xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationTls` type from xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`].
 It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2301,7 +2432,7 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 [id='type-PasswordSecretSource-{context}']
 = `PasswordSecretSource` schema reference
 
-Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`]
+Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 
 
 [cols="2,2,3a",options="header"]
@@ -2355,7 +2486,7 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 == `KafkaClientAuthenticationPlain` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationPlain` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationPlain` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`].
 It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2384,7 +2515,7 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 == `KafkaClientAuthenticationOAuth` schema properties
 
 
-The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationOAuth` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`].
+The `type` property is a discriminator that distinguishes use of the `KafkaClientAuthenticationOAuth` type from xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`].
 It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 [cols="2,2,3a",options="header"]
 |====
@@ -2449,6 +2580,90 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 |includeAcceptHeader
 |boolean
 |Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
+|accessTokenLocation
+|string
+|Path to the token file containing an access token to be used for authentication.
+|====
+
+[id='type-KafkaClientAuthenticationServiceAccountOAuth-{context}']
+= `KafkaClientAuthenticationServiceAccountOAuth` schema reference
+
+Used in: xref:type-KafkaBridgeSpec-{context}[`KafkaBridgeSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2ClusterSpec-{context}[`KafkaMirrorMaker2ClusterSpec`], xref:type-KafkaMirrorMakerConsumerSpec-{context}[`KafkaMirrorMakerConsumerSpec`], xref:type-KafkaMirrorMakerProducerSpec-{context}[`KafkaMirrorMakerProducerSpec`]
+
+xref:type-KafkaClientAuthenticationServiceAccountOAuth-schema-{context}[Full list of `KafkaClientAuthenticationServiceAccountOAuth` schema properties]
+
+include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationServiceAccountOAuth.adoc[leveloffset=+1]
+
+[id='type-KafkaClientAuthenticationServiceAccountOAuth-schema-{context}']
+== `KafkaClientAuthenticationServiceAccountOAuth` schema properties
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `serviceaccount-oauth`.
+|clientId
+|string
+|OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|username
+|string
+|Username used for the authentication.
+|scope
+|string
+|OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+|audience
+|string
+|OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request.
+|tokenEndpointUri
+|string
+|Authorization server token endpoint URI.
+|connectTimeoutSeconds
+|integer
+|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|readTimeoutSeconds
+|integer
+|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
+|httpRetries
+|integer
+|The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.
+|httpRetryPauseMs
+|integer
+|The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.
+|clientSecret
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|passwordSecret
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|Reference to the `Secret` which holds the password.
+|accessToken
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
+|refreshToken
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+|tlsTrustedCertificates
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|Trusted certificates for TLS connection to the OAuth server.
+|disableTlsHostnameVerification
+|boolean
+|Enable or disable TLS hostname verification. Default value is `false`.
+|maxTokenExpirySeconds
+|integer
+|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+|accessTokenIsJwt
+|boolean
+|Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|enableMetrics
+|boolean
+|Enable or disable OAuth metrics. Default value is `false`.
+|includeAcceptHeader
+|boolean
+|Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
+|accessTokenLocation
+|string
+|Path to the token file containing an access token to be used for authentication.
 |====
 
 [id='type-JaegerTracing-{context}']
@@ -3428,7 +3643,7 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerConsumerS
 |string
 |A unique string that identifies the consumer group this consumer belongs to.
 |authentication
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 |Authentication configuration for connecting to the cluster.
 |tls
 |xref:type-ClientTls-{context}[`ClientTls`]
@@ -3461,7 +3676,7 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerProducerS
 |boolean
 |Flag to set the MirrorMaker to exit on a failed send. Default value is `true`.
 |authentication
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 |Authentication configuration for connecting to the cluster.
 |config
 |map
@@ -3564,7 +3779,7 @@ include::../api/io.strimzi.api.kafka.model.bridge.KafkaBridgeSpec.adoc[leveloffs
 |xref:type-ClientTls-{context}[`ClientTls`]
 |TLS configuration for connecting Kafka Bridge to the cluster.
 |authentication
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 |Authentication configuration for connecting to the cluster.
 |http
 |xref:type-KafkaBridgeHttpConfig-{context}[`KafkaBridgeHttpConfig`]
@@ -4000,7 +4215,7 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Cluster
 |xref:type-ClientTls-{context}[`ClientTls`]
 |TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
 |authentication
-|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
+|xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaClientAuthenticationServiceAccountOAuth-{context}[`KafkaClientAuthenticationServiceAccountOAuth`]
 |Authentication configuration for connecting to the cluster.
 |config
 |map

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -236,6 +236,9 @@ spec:
                                     - key
                                     - secretName
                                 description: Secrets to be mounted to /opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_.
+                              serverBearerTokenLocation:
+                                type: string
+                                description: Path to the file on the local filesystem that contains a bearer token to be used instead of client_id and secret when authenticating to authorization server.
                               tlsTrustedCertificates:
                                 type: array
                                 items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -274,8 +274,9 @@ spec:
                                   - tls
                                   - scram-sha-512
                                   - oauth
+                                  - k8s-oidc
                                   - custom
-                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                               userInfoEndpointUri:
                                 type: string
                                 description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -274,9 +274,9 @@ spec:
                                   - tls
                                   - scram-sha-512
                                   - oauth
-                                  - k8s-oidc
+                                  - serviceaccount-oauth
                                   - custom
-                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                               userInfoEndpointUri:
                                 type: string
                                 description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -276,7 +276,7 @@ spec:
                                   - oauth
                                   - serviceaccount-oauth
                                   - custom
-                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                                description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication in combination with Kubernetes ServiceAccounts and pre-configured to use the Kubernetes API server's JWKS endpoint. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                               userInfoEndpointUri:
                                 type: string
                                 description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -115,6 +115,9 @@ spec:
                     accessTokenIsJwt:
                       type: boolean
                       description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                    accessTokenLocation:
+                      type: string
+                      description: Path to the token file containing an access token to be used for authentication.
                     audience:
                       type: string
                       description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -241,7 +244,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - k8s-oidc
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -245,7 +245,7 @@ spec:
                         - plain
                         - oauth
                         - serviceaccount-oauth
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -244,8 +244,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        - k8s-oidc
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - serviceaccount-oauth
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -238,8 +238,8 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                            - k8s-oidc
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                            - serviceaccount-oauth
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.
@@ -441,8 +441,8 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                            - k8s-oidc
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                            - serviceaccount-oauth
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -109,6 +109,9 @@ spec:
                         accessTokenIsJwt:
                           type: boolean
                           description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                        accessTokenLocation:
+                          type: string
+                          description: Path to the token file containing an access token to be used for authentication.
                         audience:
                           type: string
                           description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -235,7 +238,8 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                            - k8s-oidc
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.
@@ -308,6 +312,9 @@ spec:
                         accessTokenIsJwt:
                           type: boolean
                           description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                        accessTokenLocation:
+                          type: string
+                          description: Path to the token file containing an access token to be used for authentication.
                         audience:
                           type: string
                           description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -434,7 +441,8 @@ spec:
                             - scram-sha-512
                             - plain
                             - oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                            - k8s-oidc
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -239,7 +239,7 @@ spec:
                             - plain
                             - oauth
                             - serviceaccount-oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.
@@ -442,7 +442,7 @@ spec:
                             - plain
                             - oauth
                             - serviceaccount-oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -248,7 +248,7 @@ spec:
                         - plain
                         - oauth
                         - serviceaccount-oauth
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -247,8 +247,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        - k8s-oidc
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - serviceaccount-oauth
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -118,6 +118,9 @@ spec:
                     accessTokenIsJwt:
                       type: boolean
                       description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                    accessTokenLocation:
+                      type: string
+                      description: Path to the token file containing an access token to be used for authentication.
                     audience:
                       type: string
                       description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -244,7 +247,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - k8s-oidc
+                      description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                     username:
                       type: string
                       description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -127,6 +127,9 @@ spec:
                           accessTokenIsJwt:
                             type: boolean
                             description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                          accessTokenLocation:
+                            type: string
+                            description: Path to the token file containing an access token to be used for authentication.
                           audience:
                             type: string
                             description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -253,7 +256,8 @@ spec:
                               - scram-sha-512
                               - plain
                               - oauth
-                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                              - k8s-oidc
+                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -257,7 +257,7 @@ spec:
                               - plain
                               - oauth
                               - serviceaccount-oauth
-                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -256,8 +256,8 @@ spec:
                               - scram-sha-512
                               - plain
                               - oauth
-                              - k8s-oidc
-                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                              - serviceaccount-oauth
+                            description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                           username:
                             type: string
                             description: Username used for the authentication.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -235,6 +235,9 @@ spec:
                                 - key
                                 - secretName
                               description: Secrets to be mounted to /opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_.
+                            serverBearerTokenLocation:
+                              type: string
+                              description: Path to the file on the local filesystem that contains a bearer token to be used instead of client_id and secret when authenticating to authorization server.
                             tlsTrustedCertificates:
                               type: array
                               items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -275,7 +275,7 @@ spec:
                               - oauth
                               - serviceaccount-oauth
                               - custom
-                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication in combination with Kubernetes ServiceAccounts and pre-configured to use the Kubernetes API server's JWKS endpoint. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                             userInfoEndpointUri:
                               type: string
                               description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -273,8 +273,9 @@ spec:
                               - tls
                               - scram-sha-512
                               - oauth
+                              - k8s-oidc
                               - custom
-                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                             userInfoEndpointUri:
                               type: string
                               description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -273,9 +273,9 @@ spec:
                               - tls
                               - scram-sha-512
                               - oauth
-                              - k8s-oidc
+                              - serviceaccount-oauth
                               - custom
-                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
+                              description: Authentication type. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. `scram-sha-512` type uses SASL SCRAM-SHA-512 Authentication. `tls` type uses TLS Client Authentication. `tls` type is supported only on TLS listeners.`custom` type allows for any authentication type to be used.
                             userInfoEndpointUri:
                               type: string
                               description: 'URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. '

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -244,7 +244,7 @@ spec:
                     - plain
                     - oauth
                     - serviceaccount-oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -243,8 +243,8 @@ spec:
                     - scram-sha-512
                     - plain
                     - oauth
-                    - k8s-oidc
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    - serviceaccount-oauth
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -114,6 +114,9 @@ spec:
                   accessTokenIsJwt:
                     type: boolean
                     description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  accessTokenLocation:
+                    type: string
+                    description: Path to the token file containing an access token to be used for authentication.
                   audience:
                     type: string
                     description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -240,7 +243,8 @@ spec:
                     - scram-sha-512
                     - plain
                     - oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    - k8s-oidc
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -238,7 +238,7 @@ spec:
                         - plain
                         - oauth
                         - serviceaccount-oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.
@@ -441,7 +441,7 @@ spec:
                         - plain
                         - oauth
                         - serviceaccount-oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -108,6 +108,9 @@ spec:
                       accessTokenIsJwt:
                         type: boolean
                         description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      accessTokenLocation:
+                        type: string
+                        description: Path to the token file containing an access token to be used for authentication.
                       audience:
                         type: string
                         description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -234,7 +237,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - k8s-oidc
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.
@@ -307,6 +311,9 @@ spec:
                       accessTokenIsJwt:
                         type: boolean
                         description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      accessTokenLocation:
+                        type: string
+                        description: Path to the token file containing an access token to be used for authentication.
                       audience:
                         type: string
                         description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -433,7 +440,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - k8s-oidc
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -237,8 +237,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        - k8s-oidc
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - serviceaccount-oauth
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.
@@ -440,8 +440,8 @@ spec:
                         - scram-sha-512
                         - plain
                         - oauth
-                        - k8s-oidc
-                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                        - serviceaccount-oauth
+                        description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                       username:
                         type: string
                         description: Username used for the authentication.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -247,7 +247,7 @@ spec:
                     - plain
                     - oauth
                     - serviceaccount-oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -117,6 +117,9 @@ spec:
                   accessTokenIsJwt:
                     type: boolean
                     description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  accessTokenLocation:
+                    type: string
+                    description: Path to the token file containing an access token to be used for authentication.
                   audience:
                     type: string
                     description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -243,7 +246,8 @@ spec:
                     - scram-sha-512
                     - plain
                     - oauth
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    - k8s-oidc
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -246,8 +246,8 @@ spec:
                     - scram-sha-512
                     - plain
                     - oauth
-                    - k8s-oidc
-                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                    - serviceaccount-oauth
+                    description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                   username:
                     type: string
                     description: Username used for the authentication.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -126,6 +126,9 @@ spec:
                         accessTokenIsJwt:
                           type: boolean
                           description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                        accessTokenLocation:
+                          type: string
+                          description: Path to the token file containing an access token to be used for authentication.
                         audience:
                           type: string
                           description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
@@ -252,7 +255,8 @@ spec:
                           - scram-sha-512
                           - plain
                           - oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, and 'oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                          - k8s-oidc
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -255,8 +255,8 @@ spec:
                           - scram-sha-512
                           - plain
                           - oauth
-                          - k8s-oidc
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'k8s-oidc'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `k8s-oidc` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                          - serviceaccount-oauth
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -256,7 +256,7 @@ spec:
                           - plain
                           - oauth
                           - serviceaccount-oauth
-                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
+                          description: "Authentication type. Currently the supported types are `tls`, `scram-sha-256`, `scram-sha-512`, `plain`, 'oauth', and 'serviceaccount-oauth'. `scram-sha-256` and `scram-sha-512` types use SASL SCRAM-SHA-256 and SASL SCRAM-SHA-512 Authentication, respectively. `plain` type uses SASL PLAIN Authentication. `oauth` type uses SASL OAUTHBEARER Authentication. `serviceaccount-oauth` type uses SASL OAUTHBEARER Authentication uses SASL OAUTHBEARER Authentication pre-configured with Kubernetes ServiceAccount token file location. The `tls` type uses TLS Client Authentication. The `tls` type is supported only over TLS connections."
                         username:
                           type: string
                           description: Username used for the authentication.

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    
+
     <modules>
         <module>kafka-agent</module>
         <module>mirror-maker-agent</module>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Make it easy to configure the usage of Kubernetes internal OIDC server. The new authentication type 'serviceaccount-oauth' is an extension of 'oauth' type for listeners and various managed Kafka clients (KafkaConnector, KafkaBridge, KafkaMirrorMaker2, ...).


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [X] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

