### PR TITLE
[ST] default builders for plain/tls internal clients

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -456,7 +456,7 @@ public interface TestConstants {
 
     // Count of test messages that needs to be sent during the test
     int MESSAGE_COUNT = 100;
-    int CONTINUOUS_MESSAGE_COUNT = 300;
+    int CONTINUOUS_MESSAGE_COUNT = 200;
 
     /**
      * Auxiliary variable for cluster operator deployment

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -456,6 +456,7 @@ public interface TestConstants {
 
     // Count of test messages that needs to be sent during the test
     int MESSAGE_COUNT = 100;
+    int CONTINUOUS_MESSAGE_COUNT = 300;
 
     /**
      * Auxiliary variable for cluster operator deployment
@@ -474,12 +475,15 @@ public interface TestConstants {
     String TARGET_BROKER_POOL_KEY = "TARGET_BROKER_POOL";
     String TARGET_CONTROLLER_POOL_KEY = "TARGET_CONTROLLER_POOL";
     String TOPIC_KEY = "TOPIC_NAME";
+    String CONTINUOUS_TOPIC_KEY = "CONTINUOUS_TOPIC_NAME";
     String TARGET_TOPIC_KEY = "TARGET_TOPIC_NAME";
     String MIRRORED_SOURCE_TOPIC_KEY = "MIRRORED_SOURCE_TOPIC_NAME";
     String STREAM_TOPIC_KEY = "STREAM_TOPIC_NAME";
     String SCRAPER_KEY = "SCRAPER_NAME";
     String PRODUCER_KEY = "PRODUCER_NAME";
+    String CONTINUOUS_PRODUCER_KEY = "CONTINUOUS_PRODUCER_NAME";
     String CONSUMER_KEY = "CONSUMER_NAME";
+    String CONTINUOUS_CONSUMER_KEY = "CONTINUOUS_CONSUMER_NAME";
     String ADMIN_KEY = "ADMIN_NAME";
     String USER_NAME_KEY = "USER_NAME";
     String SOURCE_USER_NAME_KEY = "SOURCE_USER_NAME";
@@ -500,6 +504,7 @@ public interface TestConstants {
     String KAFKA_CONNECT_SELECTOR_KEY = "KAFKA_CONNECT_SELECTOR";
     String MM2_SELECTOR_KEY = "MM2_SELECTOR";
     String MESSAGE_COUNT_KEY = "MESSAGE_COUNT";
+    String CONTINUOUS_MESSAGE_COUNT_KEY = "CONTINUOUS_MESSAGE_COUNT";
     String TEST_EXECUTION_START_TIME_KEY = "TEST_EXECUTION_START_TIME";
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -92,10 +92,6 @@ public class KafkaClients extends BaseClients {
         this.setConsumerGroup(newConsumerGroup);
     }
 
-
-
-
-
     public void setConsumerGroup(String consumerGroup) {
         if (consumerGroup == null || consumerGroup.isEmpty()) {
             LOGGER.info("Consumer group were not specified going to create the random one");

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -86,6 +86,16 @@ public class KafkaClients extends BaseClients {
         return consumerGroup;
     }
 
+    public void generateNewConsumerGroup() {
+        final String newConsumerGroup = ClientUtils.generateRandomConsumerGroup();
+        LOGGER.info("Regenerating new consumer group {} for clients {} {}", newConsumerGroup, this.getProducerName(), this.getConsumerGroup());
+        this.setConsumerGroup(newConsumerGroup);
+    }
+
+
+
+
+
     public void setConsumerGroup(String consumerGroup) {
         if (consumerGroup == null || consumerGroup.isEmpty()) {
             LOGGER.info("Consumer group were not specified going to create the random one");

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -88,7 +88,7 @@ public class KafkaClients extends BaseClients {
 
     public void generateNewConsumerGroup() {
         final String newConsumerGroup = ClientUtils.generateRandomConsumerGroup();
-        LOGGER.info("Regenerating new consumer group {} for clients {} {}", newConsumerGroup, this.getProducerName(), this.getConsumerGroup());
+        LOGGER.info("Regenerating new consumer group {} for clients {} {}", newConsumerGroup, this.getProducerName(), this.getConsumerName());
         this.setConsumerGroup(newConsumerGroup);
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTopicTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTopicTemplates.java
@@ -19,6 +19,10 @@ public class KafkaTopicTemplates {
         return defaultTopic(testStorage.getClusterName(), testStorage.getTopicName(), 1, 1, 1, testStorage.getNamespaceName());
     }
 
+    public static KafkaTopicBuilder continuousTopic(TestStorage testStorage) {
+        return defaultTopic(testStorage.getClusterName(), testStorage.getContinuousTopicName(), 1, 1, 1, testStorage.getNamespaceName());
+    }
+
     public static KafkaTopicBuilder topic(String clusterName, String topicName, String topicNamespace) {
         return defaultTopic(clusterName, topicName, 1, 1, 1, topicNamespace);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.utils;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
@@ -323,15 +322,6 @@ public class ClientUtils {
         int salt = rng.nextInt(Integer.MAX_VALUE);
 
         return CONSUMER_GROUP_NAME + salt;
-    }
-
-    public static KafkaClients generateNewConsumerGroup(KafkaClients clients) {
-        final String newConsumerGroup = ClientUtils.generateRandomConsumerGroup();
-        LOGGER.info("Regenerating new consumer group {} for clients {} {}", newConsumerGroup, clients.getProducerName(), clients.getConsumerGroup());
-
-        return new KafkaClientsBuilder(clients)
-            .withConsumerGroup(newConsumerGroup)
-            .build();
     }
 
     // instant client builders

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -253,17 +253,6 @@ public class ClientUtils {
             .build();
     }
 
-    public static KafkaClientsBuilder getDefaultClientBuilder(TestStorage testStorage) {
-        return new KafkaClientsBuilder()
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withUsername(testStorage.getUsername())
-            .withTopicName(testStorage.getTopicName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName());
-    }
-
     // instant client builders
 
     private static KafkaClientsBuilder instantClientBuilderBase(TestStorage testStorage) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -35,18 +35,49 @@ public class ClientUtils {
     // ensuring that object can not be created outside of class
     private ClientUtils() {}
 
-    // Both clients success
+    /**
+     * Waits for both the instant producer and consumer clients to succeed, automatically deleting the associated jobs afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and {@link TestStorage#getConsumerName()}
+     * for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the clients' names.
+     */
     public static void waitForInstantClientSuccess(TestStorage testStorage) {
         waitForInstantClientSuccess(testStorage, true);
     }
 
+    /**
+     * Waits for both the instant producer and consumer clients to succeed, optionally deleting jobs afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getConsumerName()} for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the clients' names.
+     * @param deleteAfterSuccess Indicates whether jobs should be deleted after successful completion.
+     */
     public static void waitForInstantClientSuccess(TestStorage testStorage, boolean deleteAfterSuccess) {
         waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount(), deleteAfterSuccess);
     }
 
+    /**
+     * Waits for both the continuous producer and consumer clients to succeed, automatically deleting the associated jobs afterward.
+     * {@link TestStorage#getContinuousProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getContinuousConsumerName()} for identifying consumer Job. The timeout while waiting is directly proportional
+     * to the number of messages.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the clients' names.
+     * @param messageCount The expected number of messages to be transmitted.
+     */
     public static void waitForContinuousClientSuccess(TestStorage testStorage, int messageCount) {
         waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), messageCount, true);
     }
+
+    /**
+     * Waits for both the continuous producer and consumer clients to succeed, with default number of messages expected to be transmitted.
+     * {@link TestStorage#getContinuousProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getContinuousConsumerName()} for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the clients' names.
+     */
     public static void waitForContinuousClientSuccess(TestStorage testStorage) {
         waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), testStorage.getContinuousMessageCount(), true);
     }
@@ -71,10 +102,25 @@ public class ClientUtils {
     }
 
     // Client success
+
+    /**
+     * Waits for the instant consumer client to succeed, automatically deleting the associated job afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getConsumerName()} for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the client's name.
+     */
     public static void waitForInstantConsumerClientSuccess(TestStorage testStorage) {
         waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 
+    /**
+     * Waits for the instant producer client to succeed, automatically deleting the associated job afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getConsumerName()} for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the client's name.
+     */
     public static void waitForInstantProducerClientSuccess(TestStorage testStorage) {
         waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
@@ -98,18 +144,45 @@ public class ClientUtils {
     }
 
     // Client timeouts
+
+    /**
+     * Waits only for instant producer to timeout, automatically deleting the associated job afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance containing details about the client's name.
+     */
     public static void waitForInstantProducerClientTimeout(TestStorage testStorage) {
         waitForInstantProducerClientTimeout(testStorage, true);
     }
 
+    /**
+     * Waits only for instant producer to timeout, optionally deleting jobs afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and
+     *
+     * @param testStorage The {@link TestStorage} instance contains details about client's name.
+     * @param deleteAfterSuccess Indicates whether producer job should be deleted after timeout.
+     */
     public static void waitForInstantProducerClientTimeout(TestStorage testStorage, boolean deleteAfterSuccess) {
         waitForClientTimeout(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount(), deleteAfterSuccess);
     }
 
+    /**
+     * Waits only for instant consumer to timeout, automatically deleting the associated job afterward.
+     * {@link TestStorage#getConsumerName()} is used for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance contains details about client's name.
+     */
     public static void waitForInstantConsumerClientTimeout(TestStorage testStorage) {
         waitForInstantConsumerClientTimeout(testStorage, true);
     }
 
+    /**
+     * Waits only for instant consumer to timeout, automatically deleting the associated job afterward.
+     * {@link TestStorage#getConsumerName()} is used for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance contains details about client's name.
+     * @param deleteAfterSuccess Indicates whether consumer job should be deleted after timeout.
+     */
     public static void waitForInstantConsumerClientTimeout(TestStorage testStorage, boolean deleteAfterSuccess) {
         waitForClientTimeout(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount(), deleteAfterSuccess);
     }
@@ -142,6 +215,14 @@ public class ClientUtils {
     }
 
     // Both clients timeouts
+
+    /**
+     * Waits only for instant consumer and producer to timeout, automatically deleting the associated jobs afterward.
+     * {@link TestStorage#getProducerName()} is used for identifying producer Job and
+     * {@link TestStorage#getConsumerName()} for identifying consumer Job.
+     *
+     * @param testStorage The {@link TestStorage} instance contains details about client's name.
+     */
     public static void waitForInstantClientsTimeout(TestStorage testStorage) {
         waitForClientsTimeout(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
@@ -255,6 +336,19 @@ public class ClientUtils {
 
     // instant client builders
 
+    /**
+     * Creates and configures a {@link KafkaClientsBuilder} instance for instant Kafka clients based on test storage settings.
+     * This base configuration sets up the namespace, message count, delay, topic name, producer name, and consumer name
+     * for Kafka clients. {@link TestStorage#getProducerName()} is used for naming producer Job and
+     * {@link TestStorage#getConsumerName()} for naming consumer Job. Finally, {@link TestStorage#getTopicName()}
+     * is used as Topic target by attempted message transition. The default message count is set to 100, and the delay in milliseconds
+     * is set to 0, indicating messages will be sent practically instantly. Returned builder can be modified as desired.
+     *
+     * @param testStorage The {@link TestStorage} instance containing configuration details
+     *
+     * @return A configured {@link KafkaClientsBuilder} instance ready for further customization or immediate use
+     *         for creating Kafka producer and consumer clients.
+     */
     private static KafkaClientsBuilder instantClientBuilderBase(TestStorage testStorage) {
         return new KafkaClientsBuilder()
             .withNamespaceName(testStorage.getNamespaceName())
@@ -265,11 +359,31 @@ public class ClientUtils {
             .withConsumerName(testStorage.getConsumerName());
     }
 
+    /**
+     * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using plain communication (non-TLS),
+     * extending the base configuration with the Kafka cluster's plain bootstrap address.
+     * {@link TestStorage#getProducerName()} is used for naming producer Job and
+     * {@link TestStorage#getConsumerName()} for naming consumer Job. Finally,
+     * {@link TestStorage#getTopicName()} is used as Topic target by attempted message transition.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return A configured {@link KafkaClientsBuilder} instance for instant clients with plain communication setup.
+     */
     public static KafkaClientsBuilder getInstantPlainClientBuilder(TestStorage testStorage) {
         return instantClientBuilderBase(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()));
     }
 
+    /**
+     * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using TLS communication,
+     * extending the base configuration with the Kafka cluster's TLS bootstrap address.
+     * {@link TestStorage#getProducerName()} is used for naming producer Job and
+     * {@link TestStorage#getConsumerName()} for naming consumer Job. Finally,
+     * {@link TestStorage#getTopicName()} is used as Topic target by attempted message transition.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return A configured {@link KafkaClientsBuilder} instance for instant clients with TLS communication setup.
+     */
     public static KafkaClientsBuilder getInstantTlsClientBuilder(TestStorage testStorage) {
         return instantClientBuilderBase(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
@@ -277,8 +391,21 @@ public class ClientUtils {
 
     // continuous client builders
 
-    private static KafkaClientsBuilder continuousClientBuilderBase(TestStorage testStorage) {
+    /**
+     * Creates a {@link KafkaClientsBuilder} for continuous Kafka clients using plain (non-TLS) communication,
+     * configuring it with properties specific to continuous operation scenarios. This includes setting up
+     * (default 300 messages), a delay between messages (1000 ms) making ideal transition last by default for around 5 minutes.
+     * {@link TestStorage#getContinuousProducerName()}  is used for naming producer Job and
+     * {@link TestStorage#getContinuousConsumerName()}  for naming consumer Job. Finally,
+     * {@link TestStorage#getContinuousTopicName()}  is used as Topic target by attempted message transition.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return A configured {@link KafkaClientsBuilder} instance ready for creating Kafka clients for continuous
+     * operations with plain communication, ready for further customization.
+     */
+    public static KafkaClientsBuilder getContinuousPlainClientBuilder(TestStorage testStorage) {
         return new KafkaClientsBuilder()
+            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withNamespaceName(testStorage.getNamespaceName())
             .withMessageCount(testStorage.getContinuousMessageCount()) // default 300
             .withDelayMs(1000)
@@ -286,17 +413,6 @@ public class ClientUtils {
             .withProducerName(testStorage.getContinuousProducerName())
             .withConsumerName(testStorage.getContinuousConsumerName());
     }
-
-    public static KafkaClientsBuilder getContinuousPlainClientBuilder(TestStorage testStorage) {
-        return continuousClientBuilderBase(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()));
-    }
-
-    public static KafkaClientsBuilder getContinuousTlsClientBuilder(TestStorage testStorage) {
-        return continuousClientBuilderBase(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
-    }
-
 
 }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -376,6 +376,7 @@ public class ClientUtils {
      */
     public static KafkaClientsBuilder getInstantTlsClientBuilder(TestStorage testStorage) {
         return instantClientBuilderBase(testStorage)
+            .withUsername(testStorage.getUsername())
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -518,7 +518,7 @@ public class ClientUtils {
      * @return build {@link KafkaClients}.
      */
     public static KafkaClients getInstantTlsClients(TestStorage testStorage) {
-        return getInstantTlsClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(testStorage.getClusterName())).build();
+        return getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(testStorage.getClusterName())).build();
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -325,7 +325,9 @@ public class ClientUtils {
         return CONSUMER_GROUP_NAME + salt;
     }
 
-    // instant client builders
+    //////////////////////////////////
+    // instant Plain client builders (ScramSha, TLS, plain)
+    /////////////////////////////////
 
     /**
      * Creates and configures a {@link KafkaClientsBuilder} instance for instant Kafka clients based on test storage settings.
@@ -349,6 +351,44 @@ public class ClientUtils {
             .withProducerName(testStorage.getProducerName())
             .withConsumerName(testStorage.getConsumerName());
     }
+
+    // Instant ScramSha client builders
+
+    /**
+     * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using scram_sha over plain communication.
+     * {@link TestStorage#getClusterName()} is with port 9092 is used to generate kafka bootstrap address.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return A configured {@link KafkaClientsBuilder} instance for instant clients with plain communication setup.
+     */
+    public static KafkaClientsBuilder getInstantScramShaOverPlainClientBuilder(TestStorage testStorage) {
+        return getInstantScramShaClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(testStorage.getClusterName()));
+    }
+
+    /**
+     * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using scram_sha over tls communication.
+     * {@link TestStorage#getClusterName()} is with port 9093 is used to generate kafka bootstrap address.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return A configured {@link KafkaClientsBuilder} instance for instant clients with tls communication setup.
+     */
+    public static KafkaClientsBuilder getInstantScramShaOverTlsClientBuilder(TestStorage testStorage) {
+        return getInstantScramShaClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
+    }
+
+    /**
+     * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using specified bootstrap (plain or TLS).
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @param bootstrapServer is the exact address including port (e.g., source-cluster-kafka-bootstrap:9095)
+     * @return A configured {@link KafkaClientsBuilder} instance for instant clients with plain communication setup.
+     */
+    public static KafkaClientsBuilder getInstantScramShaClientBuilder(TestStorage testStorage, String bootstrapServer) {
+        return getInstantPlainClientBuilder(testStorage, bootstrapServer)
+            .withUsername(testStorage.getUsername());
+    }
+
+    // instant Plain client builders
 
     /**
      * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using plain communication (non-TLS).
@@ -376,6 +416,8 @@ public class ClientUtils {
         return instantClientBuilderBase(testStorage)
             .withBootstrapAddress(bootstrapServer);
     }
+
+    // Instant TLS client builders
 
     /**
      * Generates a {@link KafkaClientsBuilder} for instant Kafka clients using TLS communication.
@@ -405,28 +447,100 @@ public class ClientUtils {
             .withBootstrapAddress(bootstrapServer);
     }
 
+    ////////////////////////////////////////////////////////////
+    // (already build) instant clients (utilizing builders above)
+    /////////////////////////////////////////////////////////////
+
+    /**
+     * Retrieves an instance of {@link KafkaClients} for plain communication with scramsha activated.
+     * Targeting bootstrap address on port 9093 and leveraging the {@code getInstantPlainClientBuilder}
+     * method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return build {@link KafkaClients}.
+     */
+    public static KafkaClients getInstantScramShaOverPlainClients(TestStorage testStorage) {
+        return getInstantScramShaOverPlainClientBuilder(testStorage).build();
+    }
+
+    /**
+     * Retrieves an instance of {@link KafkaClients} for plain communication with scramsha activated.
+     * Targeting bootstrap address on port 9093 and leveraging the {@code getInstantTlsClientBuilder}
+     * method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return build {@link KafkaClients}.
+     */
+    public static KafkaClients getInstantScramShaOverTlsClients(TestStorage testStorage) {
+        return getInstantScramShaOverTlsClientBuilder(testStorage).build();
+    }
+
+    /**
+     * Retrieves an instance of {@link KafkaClients} for plain communication with scramsha activated.
+     * Leveraging the {@code getInstantPlainClientBuilder} method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @param bootstrapServer is the exact address including port (e.g., source-cluster-kafka-bootstrap:9096)
+     * @return build {@link KafkaClients}.
+     */
+    public static KafkaClients getInstantScramShaClients(TestStorage testStorage, String bootstrapServer) {
+        return getInstantScramShaClientBuilder(testStorage, bootstrapServer).build();
+    }
+
+    /**
+     * Retrieves an instance of {@link KafkaClients} for plain communication with Kafka brokers targeting port 9092 and,
+     * leveraging the {@code getInstantPlainClientBuilder} method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return build {@link KafkaClients}.
+     */
     public static KafkaClients getInstantPlainClients(TestStorage testStorage) {
         return getInstantPlainClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(testStorage.getClusterName())).build();
     }
 
+    /**
+     * Retrieves an instance of {@link KafkaClients} for plain communication with Kafka brokers,
+     * leveraging the {@code getInstantPlainClientBuilder} method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @param bootstrapServer is the exact address including port (e.g., source-cluster-kafka-bootstrap:9092)
+     * @return build {@link KafkaClients}.
+     */
     public static KafkaClients getInstantPlainClients(TestStorage testStorage, String bootstrapServer) {
         return getInstantPlainClientBuilder(testStorage, bootstrapServer).build();
     }
 
+    /**
+     * Retrieves an instance of {@link KafkaClients} for tls communication with Kafka brokers, targeting port 9093 and
+     * leveraging the {@code getInstantTlsClientBuilder} method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @return build {@link KafkaClients}.
+     */
     public static KafkaClients getInstantTlsClients(TestStorage testStorage) {
         return getInstantTlsClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(testStorage.getClusterName())).build();
     }
 
+    /**
+     * Retrieves an instance of {@link KafkaClients} for tls communication with Kafka brokers,
+     * leveraging the {@code getInstantTlsClientBuilder} method for initial configuration.
+     *
+     * @param testStorage The {@link TestStorage} instance providing necessary configurations.
+     * @param bootstrapServer is the exact address including port (e.g., source-cluster-kafka-bootstrap:9093)
+     * @return build {@link KafkaClients}.
+     */
     public static KafkaClients getInstantTlsClients(TestStorage testStorage, String bootstrapServer) {
         return getInstantTlsClientBuilder(testStorage, bootstrapServer).build();
     }
 
+    //////////////////////////////////
     // continuous client builders
+    /////////////////////////////////
 
     /**
      * Creates a {@link KafkaClientsBuilder} for continuous Kafka clients using plain (non-TLS) communication,
      * configuring it with properties specific to continuous operation scenarios. This includes setting up
-     * (default 300 messages), a delay between messages (1000 ms) making ideal transition last by default for around 5 minutes.
+     * (default 200 messages), a delay between messages (1000 ms) making ideal transition last by default for around 3-4 minutes.
      * {@link TestStorage#getContinuousProducerName()}  is used for naming producer Job and
      * {@link TestStorage#getContinuousConsumerName()}  for naming consumer Job. Finally,
      * {@link TestStorage#getContinuousTopicName()}  is used as Topic target by attempted message transition.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectUtils.java
@@ -62,10 +62,11 @@ public class KafkaConnectUtils {
         LOGGER.info("KafkaConnect API is available");
     }
 
-    public static void waitForMessagesInKafkaConnectFileSink(String namespaceName, String kafkaConnectPodName, String sinkFileName, String message) {
+    public static void waitForMessagesInKafkaConnectFileSink(String namespaceName, String kafkaConnectPodName, String sinkFileName, int sinkReceivedMsgCount) {
+        final String lastReceivedMessageIndex = Integer.toString(sinkReceivedMsgCount - 1);
         LOGGER.info("Waiting for messages to be present in file sink on {}/{}", namespaceName, kafkaConnectPodName);
         TestUtils.waitFor("messages to be present in file sink", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.TIMEOUT_FOR_SEND_RECEIVE_MSG,
-            () -> cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(message),
+            () -> cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out().contains(lastReceivedMessageIndex),
             () -> LOGGER.warn(cmdKubeClient(namespaceName).execInPod(Level.TRACE, kafkaConnectPodName, "/bin/bash", "-c", "cat " + sinkFileName).out()));
         LOGGER.info("Expected messages are in file sink on {}/{}", namespaceName, kafkaConnectPodName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -88,15 +88,10 @@ class HttpBridgeST extends AbstractST {
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(suiteTestStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build());
 
         resourceManager.createResourceWithWait(kafkaBridgeClientJob.producerStrimziBridge());
-
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()))
-            .build();
-
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()));
         resourceManager.createResourceWithWait(kafkaClients.consumerStrimzi());
-
         ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
         // Checking labels for KafkaBridge
@@ -122,13 +117,11 @@ class HttpBridgeST extends AbstractST {
             .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
+        // Start receiving messages with bridge
         resourceManager.createResourceWithWait(kafkaBridgeClientJob.consumerStrimziBridge());
 
         // Send messages to Kafka
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()))
-            .build();
-
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()));
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi());
 
         ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -60,8 +60,7 @@ class HttpBridgeScramShaST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaBridgeClientJb.producerStrimziBridge());
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
             .withUsername(suiteTestStorage.getUsername())
             .build();
 
@@ -82,8 +81,7 @@ class HttpBridgeScramShaST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaBridgeClientJb.consumerStrimziBridge());
 
         // Send messages to Kafka
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
             .withUsername(suiteTestStorage.getUsername())
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -81,7 +81,7 @@ class HttpBridgeScramShaST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaBridgeClientJb.consumerStrimziBridge());
 
         // Send messages to Kafka
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
+        KafkaClients kafkaClients = ClientUtils.getInstantScramShaClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
             .withUsername(suiteTestStorage.getUsername())
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -60,8 +60,7 @@ class HttpBridgeTlsST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaBridgeClientJobProduce.producerStrimziBridge());
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
             .withUsername(suiteTestStorage.getUsername())
             .build();
 
@@ -83,8 +82,7 @@ class HttpBridgeTlsST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaBridgeClientJobConsume.consumerStrimziBridge());
 
         // Send messages to Kafka
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(suiteTestStorage.getClusterName()))
             .withUsername(suiteTestStorage.getUsername())
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -256,9 +256,7 @@ class ConnectBuilderST extends AbstractST {
         KafkaConnector kafkaConnector = KafkaConnectorResource.kafkaConnectorClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get();
         assertThat(kafkaConnector.getSpec().getClassName(), is(TestConstants.ECHO_SINK_CLASS_NAME));
 
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()))
-            .build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()));
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi());
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
@@ -506,9 +504,7 @@ class ConnectBuilderST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients kafkaClient = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()))
-            .build();
+        final KafkaClients kafkaClient = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(suiteTestStorage.getClusterName()));
         resourceManager.createResourceWithWait(kafkaClient.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -511,7 +511,6 @@ class ConnectST extends AbstractST {
 
         // Kafka Sink Connect expect 100 messages to read
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
             .withMessageCount(100)
             .build();
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
@@ -586,7 +585,6 @@ class ConnectST extends AbstractST {
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
             .withMessageCount(100)
             .build();
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -303,15 +303,11 @@ class ConnectST extends AbstractST {
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
-        // TODO REFACTOR scramsha !
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
-
-        resourceManager.createResourceWithWait(kafkaClients.producerScramShaPlainStrimzi(),
-            kafkaClients.consumerScramShaPlainStrimzi());
+        final KafkaClients plainScramShaClients = ClientUtils.getInstantScramShaOverPlainClients(testStorage);
+        resourceManager.createResourceWithWait(
+            plainScramShaClients.producerScramShaPlainStrimzi(),
+            plainScramShaClients.consumerScramShaPlainStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
-
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
     }
 
@@ -580,7 +576,7 @@ class ConnectST extends AbstractST {
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
-        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
+        final KafkaClients kafkaClients = ClientUtils.getInstantScramShaOverTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -303,6 +303,7 @@ class ConnectST extends AbstractST {
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
+        // TODO REFACTOR scramsha !
         KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .build();
@@ -353,7 +354,7 @@ class ConnectST extends AbstractST {
 
         final String scraperPodName = kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(testStorage.getScraperName()).get(0).getMetadata().getName();
 
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -507,7 +508,7 @@ class ConnectST extends AbstractST {
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -579,7 +580,7 @@ class ConnectST extends AbstractST {
         KafkaConnectorUtils.createFileSinkConnector(testStorage.getNamespaceName(), scraperPodName, testStorage.getTopicName(),
             TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), testStorage.getNamespaceName(), 8083));
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -822,8 +823,6 @@ class ConnectST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
-
         String execConnectPod =  kubeClient(testStorage.getNamespaceName()).listPodsByPrefixInName(
             KafkaConnectResources.componentName(testStorage.getClusterName())).get(0).getMetadata().getName();
         JsonObject connectStatus = new JsonObject(cmdKubeClient(testStorage.getNamespaceName()).execInPod(
@@ -834,6 +833,7 @@ class ConnectST extends AbstractST {
         String workerNode = connectStatus.getJsonObject("connector").getString("worker_id").split(":")[0];
         String connectorPodName = workerNode.substring(0, workerNode.indexOf("."));
 
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -1452,7 +1452,7 @@ class ConnectST extends AbstractST {
 
         // messages need to be produced for each run (although there are more messages in topic eventually, sink will not copy messages it copied previously (before clearing them)
         LOGGER.info("Producing new messages which are to be watched KafkaConnector once it is resumed");
-        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -148,11 +148,10 @@ public class ConfigProviderST extends AbstractST {
             .build());
 
         KafkaClients kafkaBasicClientJob = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
-
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());
 
         String kafkaConnectPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, customFileSinkPath, "Hello-world - 99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, customFileSinkPath, testStorage.getMessageCount());
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -147,7 +147,7 @@ public class ConfigProviderST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients kafkaBasicClientJob = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients kafkaBasicClientJob = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());
 
         String kafkaConnectPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/ConfigProviderST.java
@@ -12,13 +12,11 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -47,7 +45,6 @@ public class ConfigProviderST extends AbstractST {
     @ParallelNamespaceTest
     void testConnectWithConnectorUsingConfigAndEnvProvider() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        final String producerName = "producer-" + ClientUtils.generateRandomConsumerGroup();
         final String customFileSinkPath = "/tmp/my-own-path.txt";
 
         resourceManager.createResourceWithWait(
@@ -150,14 +147,7 @@ public class ConfigProviderST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-            .withProducerName(producerName)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withDelayMs(0)
-            .withNamespaceName(testStorage.getNamespaceName())
-            .build();
+        KafkaClients kafkaBasicClientJob = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -318,16 +318,13 @@ public class KafkaNodePoolST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaTopic);
 
         LOGGER.info("Transmit messages with Kafka {}/{} using topic {}", testStorage.getNamespaceName(), testStorage.getClusterName(), topicName);
-        KafkaClients kafkaClients = ClientUtils.getDefaultClientBuilder(testStorage)
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withTopicName(topicName)
             .build();
+        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
-        resourceManager.createResourceWithWait(
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
-        ClientUtils.waitForClientsSuccess(testStorage);
-
+        // clean topic
         resourceManager.deleteResource(kafkaTopic);
         KafkaTopicUtils.waitForKafkaTopicDeletion(testStorage.getNamespaceName(), topicName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -41,7 +41,6 @@ import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
@@ -578,7 +577,6 @@ class KafkaST extends AbstractST {
     @Tag(INTERNAL_CLIENTS_USED)
     void testLabelsExistenceAndManipulation() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        final int kafkaReplicas = 3;
 
         // label key and values to be used as part of kafka CR
         final String firstKafkaLabelKey = "first-kafka-label-key";
@@ -666,14 +664,7 @@ class KafkaST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
 
         LOGGER.info("--> Test Strimzi related expected labels of managed kubernetes resources <--");
 
@@ -771,7 +762,7 @@ class KafkaST extends AbstractST {
             kafkaClients.producerStrimzi(),
             kafkaClients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("--> Test Customer specific labels manipulation (add, update) of Kafka CR and (update) PVC <--");
 
@@ -876,7 +867,7 @@ class KafkaST extends AbstractST {
             kafkaClients.producerStrimzi(),
             kafkaClients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     /**
@@ -927,14 +918,7 @@ class KafkaST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 1, 1, testStorage.getNamespaceName()).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
 
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
 
@@ -959,7 +943,7 @@ class KafkaST extends AbstractST {
             kafkaClients.producerStrimzi(),
             kafkaClients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Verifying presence of files created to store offsets Topic");
         String commandToGetFiles = "cd /var/lib/kafka/data/kafka-log0/; ls -l | grep __consumer_offsets | wc -l";
@@ -1094,20 +1078,13 @@ class KafkaST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerStrimzi(),
             kafkaClients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -664,8 +664,6 @@ class KafkaST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
-
         LOGGER.info("--> Test Strimzi related expected labels of managed kubernetes resources <--");
 
         LOGGER.info("---> PODS <---");
@@ -758,10 +756,8 @@ class KafkaST extends AbstractST {
             assertThat(pvc.getMetadata().getAnnotations().get(pvcLabelOrAnnotationKey), is(pvcLabelOrAnnotationValue));
         }
 
-        resourceManager.createResourceWithWait(
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
+        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("--> Test Customer specific labels manipulation (add, update) of Kafka CR and (update) PVC <--");
@@ -863,10 +859,7 @@ class KafkaST extends AbstractST {
         }
 
         LOGGER.info("Produce and Consume messages to make sure Kafka cluster is not broken by labels and annotations manipulation");
-        resourceManager.createResourceWithWait(
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
+        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
@@ -918,8 +911,6 @@ class KafkaST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), 1, 1, testStorage.getNamespaceName()).build());
 
-        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
-
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
 
         TestUtils.waitFor("KafkaTopic creation inside Kafka Pod", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT,
@@ -939,10 +930,8 @@ class KafkaST extends AbstractST {
         LOGGER.info("Topic: {} is present in Kafka Broker: {} with no data", testStorage.getTopicName(), brokerPodName);
         assertThat("Topic contains data", topicData, emptyOrNullString());
 
-        resourceManager.createResourceWithWait(
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
+        final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
+        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Verifying presence of files created to store offsets Topic");
@@ -1079,11 +1068,7 @@ class KafkaST extends AbstractST {
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
         final KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
-
-        resourceManager.createResourceWithWait(
-            kafkaClients.producerStrimzi(),
-            kafkaClients.consumerStrimzi()
-        );
+        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.kafka;
 
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.user.KafkaUser;
@@ -160,31 +159,24 @@ public class KafkaVersionsST extends AbstractST {
 
         LOGGER.info("Sending and receiving messages via PLAIN -> SCRAM-SHA");
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withUsername(kafkaUserWrite)
             .withConsumerGroup(readConsumerGroup)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaPlainStrimzi());
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
                 .withUsername(kafkaUserRead)
                 .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerScramShaPlainStrimzi());
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         LOGGER.info("Sending and receiving messages via TLS");
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+        kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(kafkaUserReadWriteTls)
             .build();
 
@@ -193,7 +185,7 @@ public class KafkaVersionsST extends AbstractST {
             kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())
         );
 
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -177,6 +177,7 @@ public class KafkaVersionsST extends AbstractST {
         LOGGER.info("Sending and receiving messages via TLS");
 
         kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
+            .withConsumerGroup(readConsumerGroup)
             .withUsername(kafkaUserReadWriteTls)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.kafka;
 
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.user.KafkaUser;
@@ -176,8 +177,8 @@ public class KafkaVersionsST extends AbstractST {
 
         LOGGER.info("Sending and receiving messages via TLS");
 
-        kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withConsumerGroup(readConsumerGroup)
+        kafkaClients = new KafkaClientsBuilder(kafkaClients)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
             .withUsername(kafkaUserReadWriteTls)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.kafka;
 
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.user.KafkaUser;
@@ -12,7 +11,6 @@ import io.strimzi.api.kafka.model.user.acl.AclOperation;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -159,34 +157,33 @@ public class KafkaVersionsST extends AbstractST {
         );
 
         LOGGER.info("Sending and receiving messages via PLAIN -> SCRAM-SHA");
-
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        // TODO refactor scramsha
+        final KafkaClients kafkaClientsPlainScramShaWrite = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withUsername(kafkaUserWrite)
-            .withConsumerGroup(readConsumerGroup)
             .build();
 
-        resourceManager.createResourceWithWait(kafkaClients.producerScramShaPlainStrimzi());
+        resourceManager.createResourceWithWait(kafkaClientsPlainScramShaWrite.producerScramShaPlainStrimzi());
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-                .withUsername(kafkaUserRead)
-                .build();
+        final KafkaClients kafkaClientsPlainScramShaRead = ClientUtils.getInstantPlainClientBuilder(testStorage)
+            .withConsumerGroup(readConsumerGroup)
+            .withUsername(kafkaUserRead)
+            .build();
 
-        resourceManager.createResourceWithWait(kafkaClients.consumerScramShaPlainStrimzi());
+        resourceManager.createResourceWithWait(kafkaClientsPlainScramShaRead.consumerScramShaPlainStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         LOGGER.info("Sending and receiving messages via TLS");
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+        final KafkaClients kafkaClientsTlsScramShaRead = ClientUtils.getInstantTlsClientBuilder(testStorage)
+            .withConsumerGroup(readConsumerGroup)
             .withUsername(kafkaUserReadWriteTls)
             .build();
 
         resourceManager.createResourceWithWait(
-            kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
-            kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())
+            kafkaClientsTlsScramShaRead.producerTlsStrimzi(testStorage.getClusterName()),
+            kafkaClientsTlsScramShaRead.consumerTlsStrimzi(testStorage.getClusterName())
         );
-
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaVersionsST.java
@@ -157,15 +157,14 @@ public class KafkaVersionsST extends AbstractST {
         );
 
         LOGGER.info("Sending and receiving messages via PLAIN -> SCRAM-SHA");
-        // TODO refactor scramsha
-        final KafkaClients kafkaClientsPlainScramShaWrite = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        final KafkaClients kafkaClientsPlainScramShaWrite = ClientUtils.getInstantScramShaOverPlainClientBuilder(testStorage)
             .withUsername(kafkaUserWrite)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClientsPlainScramShaWrite.producerScramShaPlainStrimzi());
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
-        final KafkaClients kafkaClientsPlainScramShaRead = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        final KafkaClients kafkaClientsPlainScramShaRead = ClientUtils.getInstantScramShaOverPlainClientBuilder(testStorage)
             .withConsumerGroup(readConsumerGroup)
             .withUsername(kafkaUserRead)
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
@@ -4,18 +4,17 @@
  */
 package io.strimzi.systemtest.kafka;
 
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.test.WaitException;
@@ -70,17 +69,10 @@ public class QuotasST extends AbstractST {
             .build());
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build());
 
-        final KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
+        final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withMessageCount(100000)
-            .withDelayMs(0)
             .withMessage(String.join("", Collections.nCopies(1000, "#")))
-            .withNamespaceName(testStorage.getNamespaceName())
             .build();
-
 
         resourceManager.createResourceWithWait(clients.producerStrimzi());
         // Kafka Quotas Plugin should stop producer in around 10-20 seconds with configured throughput

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -190,8 +190,16 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.tlsUser(testStorage).build()
         );
 
-        LOGGER.info("Transmitting messages over tls transport using mutual tls auth with bootstrap address: {}", KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
-        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
+        KafkaClients kafkaClients = new KafkaClientsBuilder()
+            .withProducerName(testStorage.getProducerName())
+            .withConsumerName(testStorage.getConsumerName())
+            .withNamespaceName(testStorage.getNamespaceName())
+            .withMessageCount(testStorage.getMessageCount())
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+            .withUsername(testStorage.getUsername())
+            .withTopicName(testStorage.getTopicName())
+            .build();
+
         resourceManager.createResourceWithWait(
             kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2316,9 +2316,7 @@ public class ListenersST extends AbstractST {
 
         LOGGER.info("Receiving messages with new password");
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
+        kafkaClients.generateNewConsumerGroup();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -136,17 +136,10 @@ public class ListenersST extends AbstractST {
         resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3).build());
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .build();
-
+        LOGGER.info("Transmitting messages over plain transport and without auth.Bootstrap address: {}", KafkaResources.plainBootstrapAddress(testStorage.getClusterName()));
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         Service kafkaService = kubeClient(testStorage.getNamespaceName()).getService(testStorage.getNamespaceName(), KafkaResources.bootstrapServiceName(testStorage.getClusterName()));
         String kafkaServiceDiscoveryAnnotation = kafkaService.getMetadata().getAnnotations().get("strimzi.io/discovery");
@@ -197,21 +190,16 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.tlsUser(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+        LOGGER.info("Transmitting messages over tls transport using mutual tls auth with bootstrap address: {}", KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
-            .withTopicName(testStorage.getTopicName())
             .build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         Service kafkaService = kubeClient(testStorage.getNamespaceName()).getService(testStorage.getNamespaceName(), KafkaResources.bootstrapServiceName(testStorage.getClusterName()));
         String kafkaServiceDiscoveryAnnotation = kafkaService.getMetadata().getAnnotations().get("strimzi.io/discovery");
@@ -270,18 +258,14 @@ public class ListenersST extends AbstractST {
             LOGGER.info("Broker Pod log:\n----\n{}\n----\n", brokerPodLog);
         }
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
+        LOGGER.info("Transmitting messages over plain transport using scram sha auth with bootstrap address: {}", KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095");
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095")
             .withUsername(testStorage.getUsername())
-            .withTopicName(testStorage.getTopicName())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaPlainStrimzi(), kafkaClients.consumerScramShaPlainStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         Service kafkaService = kubeClient(testStorage.getNamespaceName()).getService(testStorage.getNamespaceName(), KafkaResources.bootstrapServiceName(testStorage.getClusterName()));
         String kafkaServiceDiscoveryAnnotation = kafkaService.getMetadata().getAnnotations().get("strimzi.io/discovery");
@@ -337,21 +321,16 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.scramShaUser(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Checking if generated password has {} characters", passwordLength);
         String password = kubeClient().namespace(testStorage.getNamespaceName()).getSecret(testStorage.getUsername()).getData().get("password");
@@ -405,21 +384,16 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.scramShaUser(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9122")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -739,22 +713,15 @@ public class ListenersST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-                .withNamespaceName(testStorage.getNamespaceName())
-                .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaUtils.bootstrapAddressFromStatus(testStorage.getClusterName(), testStorage.getNamespaceName(), TestConstants.CLUSTER_IP_LISTENER_DEFAULT_NAME))
-                .withMessageCount(testStorage.getMessageCount())
-                .withUsername(testStorage.getUsername())
-                .withProducerName(testStorage.getProducerName())
-                .withConsumerName(testStorage.getConsumerName())
                 .build();
 
-        resourceManager.createResourceWithWait(kafkaClients.producerStrimzi());
-        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
-
-        resourceManager.createResourceWithWait(kafkaClients.consumerStrimzi());
-        ClientUtils.waitForClientSuccess(testStorage.getConsumerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
-
+        resourceManager.createResourceWithWait(
+            kafkaClients.producerStrimzi(),
+            kafkaClients.consumerStrimzi()
+        );
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -785,21 +752,16 @@ public class ListenersST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(testStorage).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-                .withNamespaceName(testStorage.getNamespaceName())
-                .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaUtils.bootstrapAddressFromStatus(testStorage.getClusterName(), testStorage.getNamespaceName(), TestConstants.CLUSTER_IP_LISTENER_DEFAULT_NAME))
-                .withMessageCount(testStorage.getMessageCount())
                 .withUsername(testStorage.getUsername())
-                .withProducerName(testStorage.getProducerName())
-                .withConsumerName(testStorage.getConsumerName())
                 .build();
 
-        resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
-
-        resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        resourceManager.createResourceWithWait(
+            kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
+            kafkaClients.consumerTlsStrimzi(testStorage.getClusterName())
+        );
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
 //    ##########################################
@@ -879,27 +841,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9104")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-1")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -991,14 +948,14 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -1070,27 +1027,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9107")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-3")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -1166,27 +1118,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9109")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-4")
             .withCaCertSecretName(clusterCustomCertChain1)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -1265,27 +1212,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9111")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-5")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -1366,27 +1308,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9112")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-6")
             .withCaCertSecretName(clusterCustomCertChain1)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(2 * testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
 
@@ -1518,20 +1455,15 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9113")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withConsumerGroup("consumer-group-certs-6")
             .withCaCertSecretName(clusterCustomCertServer2)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(3 * testStorage.getMessageCount())
@@ -1571,7 +1503,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(testStorage.getMessageCount() * 5)
@@ -1798,7 +1730,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         int expectedMessageCountForExternalClient = testStorage.getMessageCount();
 
@@ -1837,7 +1769,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         expectedMessageCountForNewGroup += testStorage.getMessageCount();
 
@@ -1846,7 +1778,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getSpec().getKafka().setListeners(asList(
@@ -1902,7 +1834,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -2049,27 +1981,22 @@ public class ListenersST extends AbstractST {
             externalKafkaClient.receiveMessagesTls()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9117")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .withCaCertSecretName(clusterCustomCertServer2)
             .withConsumerGroup("consumer-group-certs-91")
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(testStorage.getMessageCount() * 3)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // Delete already existing secrets
         SecretUtils.deleteSecretWithWait(clusterCustomCertServer1, testStorage.getNamespaceName());
@@ -2107,14 +2034,14 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withMessageCount(testStorage.getMessageCount() * 5)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getSpec().getKafka().setListeners(asList(
@@ -2182,7 +2109,7 @@ public class ListenersST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -2367,21 +2294,16 @@ public class ListenersST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getUsername(), testStorage.getNamespaceName()).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096")
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getUsername())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
             .build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Changing password in Secret: {}/{}, we should be able to send/receive messages", testStorage.getNamespaceName(), secretName);
 
@@ -2402,7 +2324,7 @@ public class ListenersST extends AbstractST {
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @Tag(NODEPORT_SUPPORTED)

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -255,12 +255,9 @@ public class ListenersST extends AbstractST {
             LOGGER.info("Broker Pod log:\n----\n{}\n----\n", brokerPodLog);
         }
 
-        // TODO refactor scramsha
-        LOGGER.info("Transmitting messages over plain transport using scram sha auth with bootstrap address: {}", KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095");
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095")
-            .withUsername(testStorage.getUsername())
-            .build();
+        final String boostrapAddress = KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095";
+        LOGGER.info("Transmitting messages over plain transport using scram sha auth with bootstrap address: {}", boostrapAddress);
+        final KafkaClients kafkaClients = ClientUtils.getInstantScramShaClients(testStorage, boostrapAddress);
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaPlainStrimzi(), kafkaClients.consumerScramShaPlainStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -318,11 +315,9 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.scramShaUser(testStorage).build()
         );
 
-        // TODO refactor scramsha
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096")
-            .withUsername(testStorage.getUsername())
-            .build();
+        final String boostrapAddress = KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096";
+        LOGGER.info("Transmitting messages over tls using scram sha auth with bootstrap address: {}", boostrapAddress);
+        KafkaClients kafkaClients = ClientUtils.getInstantScramShaClients(testStorage, boostrapAddress);
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
@@ -381,11 +376,10 @@ public class ListenersST extends AbstractST {
             KafkaUserTemplates.scramShaUser(testStorage).build()
         );
 
-        // TODO refactor scramsha
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9122")
-            .withUsername(testStorage.getUsername())
-            .build();
+
+        final String boostrapAddress = KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9122";
+        LOGGER.info("Transmitting messages over tls using scram sha auth with bootstrap address: {}", boostrapAddress);
+        final KafkaClients kafkaClients = ClientUtils.getInstantScramShaClients(testStorage, boostrapAddress);
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())
@@ -2256,11 +2250,9 @@ public class ListenersST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getUsername(), testStorage.getNamespaceName()).build()
         );
 
-        // TODO refactor scramsha
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096")
-            .withUsername(testStorage.getUsername())
-            .build();
+        final String boostrapAddress = KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9096";
+        LOGGER.info("Transmitting messages over tls using scram sha auth with bootstrap address: {} with predefined password", boostrapAddress);
+        KafkaClients kafkaClients = ClientUtils.getInstantScramShaClients(testStorage, boostrapAddress);
         resourceManager.createResourceWithWait(
             kafkaClients.producerScramShaTlsStrimzi(testStorage.getClusterName()),
             kafkaClients.consumerScramShaTlsStrimzi(testStorage.getClusterName())

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -191,9 +191,7 @@ public class ListenersST extends AbstractST {
         );
 
         LOGGER.info("Transmitting messages over tls transport using mutual tls auth with bootstrap address: {}", KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()));
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
 
         resourceManager.createResourceWithWait(
             kafkaClients.producerTlsStrimzi(testStorage.getClusterName()),
@@ -754,7 +752,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaUtils.bootstrapAddressFromStatus(testStorage.getClusterName(), testStorage.getNamespaceName(), TestConstants.CLUSTER_IP_LISTENER_DEFAULT_NAME))
-                .withUsername(testStorage.getUsername())
                 .build();
 
         resourceManager.createResourceWithWait(
@@ -843,7 +840,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9104")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-1")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
@@ -1029,7 +1025,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9107")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-3")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
@@ -1120,7 +1115,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9109")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-4")
             .withCaCertSecretName(clusterCustomCertChain1)
             .build();
@@ -1214,7 +1208,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9111")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-5")
             .withCaCertSecretName(clusterCustomCertServer1)
             .build();
@@ -1310,7 +1303,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9112")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-6")
             .withCaCertSecretName(clusterCustomCertChain1)
             .build();
@@ -1457,7 +1449,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9113")
-            .withUsername(testStorage.getUsername())
             .withConsumerGroup("consumer-group-certs-6")
             .withCaCertSecretName(clusterCustomCertServer2)
             .build();
@@ -1983,7 +1974,6 @@ public class ListenersST extends AbstractST {
 
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9117")
-            .withUsername(testStorage.getUsername())
             .withCaCertSecretName(clusterCustomCertServer2)
             .withConsumerGroup("consumer-group-certs-91")
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -1198,12 +1198,13 @@ class MirrorMaker2ST extends AbstractST {
         brokerTargetPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controlTargetSelector, 1, brokerTargetPods);
         mmSnapshot = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getMM2Selector(), 1, mmSnapshot);
 
-        LOGGER.info("Producing messages to source cluster: {} and consuming from target cluster: {} after clients certs removal", testStorage.getSourceClusterName(), testStorage.getTargetClusterName());
-        resourceManager.createResourceWithWait(
-            sourceClients.producerTlsStrimzi(testStorage.getSourceClusterName()),
-            targetClients.consumerTlsStrimzi(testStorage.getTargetClusterName())
-        );
+        LOGGER.info("Producing messages in source cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getSourceClusterName());
+        resourceManager.createResourceWithWait(sourceClients.producerTlsStrimzi(testStorage.getSourceClusterName()), sourceClients.consumerTlsStrimzi(testStorage.getSourceClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
+
+        LOGGER.info("Consuming messages in target cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getTargetClusterName());
+        resourceManager.createResourceWithWait(targetClients.consumerTlsStrimzi(testStorage.getTargetClusterName()));
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         LOGGER.info("Renew Cluster CA secret for Source clusters via annotation");
         String sourceClusterCaSecretName = KafkaResources.clusterCaCertificateSecretName(testStorage.getSourceClusterName());
@@ -1227,12 +1228,14 @@ class MirrorMaker2ST extends AbstractST {
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(testStorage.getTargetClusterName()), 1, eoTargetPods);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getMM2Selector(), 1, mmSnapshot);
 
-        LOGGER.info("Producing messages to source cluster: {} and consuming from target cluster: {} after clients certs removal", testStorage.getSourceClusterName(), testStorage.getTargetClusterName());
-        resourceManager.createResourceWithWait(
-            sourceClients.producerTlsStrimzi(testStorage.getSourceClusterName()),
-            targetClients.consumerTlsStrimzi(testStorage.getTargetClusterName())
-        );
+        LOGGER.info("Producing messages in source cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getSourceClusterName());
+        resourceManager.createResourceWithWait(sourceClients.producerTlsStrimzi(testStorage.getSourceClusterName()), sourceClients.consumerTlsStrimzi(testStorage.getSourceClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
+
+        LOGGER.info("Consuming messages in target cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getTargetClusterName());
+        resourceManager.createResourceWithWait(targetClients.consumerTlsStrimzi(testStorage.getTargetClusterName()));
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
+
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -97,17 +97,12 @@ public class MirrorMakerST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getSourceClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build());
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getSourceClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Deploy MirrorMaker
         resourceManager.createResourceWithWait(KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), testStorage.getSourceClusterName(), testStorage.getTargetClusterName(), ClientUtils.generateRandomConsumerGroup(), 1, false)
@@ -150,7 +145,7 @@ public class MirrorMakerST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     /**
@@ -222,18 +217,14 @@ public class MirrorMakerST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(testStorage.getTargetClusterName()));
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getSourceClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
             .withUsername(testStorage.getSourceUsername())
             .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(testStorage.getSourceClusterName()), clients.consumerTlsStrimzi(testStorage.getSourceClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Deploy MirrorMaker with tls listener and mutual tls auth
         resourceManager.createResourceWithWait(KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), testStorage.getSourceClusterName(), testStorage.getTargetClusterName(), ClientUtils.generateRandomConsumerGroup(), 1, true)
@@ -271,7 +262,7 @@ public class MirrorMakerST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(clients.consumerTlsStrimzi(testStorage.getTargetClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     /**
@@ -353,18 +344,14 @@ public class MirrorMakerST extends AbstractST {
         certSecretTarget.setCertificate("ca.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(testStorage.getTargetClusterName()));
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getSourceClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
             .withUsername(testStorage.getSourceUsername())
             .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(clients.producerScramShaTlsStrimzi(testStorage.getSourceClusterName()), clients.consumerScramShaTlsStrimzi(testStorage.getSourceClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Deploy MirrorMaker with TLS and ScramSha512
         resourceManager.createResourceWithWait(KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), testStorage.getSourceClusterName(), testStorage.getTargetClusterName(), ClientUtils.generateRandomConsumerGroup(), 1, true)
@@ -396,7 +383,7 @@ public class MirrorMakerST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(clients.consumerScramShaTlsStrimzi(testStorage.getTargetClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -428,24 +415,20 @@ public class MirrorMakerST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getSourceClusterName(), topicNotIncluded, testStorage.getNamespaceName()).build()
         );
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients clients = ClientUtils.getDefaultClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getSourceClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
             .withTopicName(topicName)
-            .withMessageCount(testStorage.getMessageCount())
             .build();
 
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         clients = new KafkaClientsBuilder(clients)
             .withTopicName(topicNotIncluded)
             .build();
 
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         resourceManager.createResourceWithWait(KafkaMirrorMakerTemplates.kafkaMirrorMaker(testStorage.getClusterName(), testStorage.getSourceClusterName(), testStorage.getTargetClusterName(), ClientUtils.generateRandomConsumerGroup(), 1, false)
             .editMetadata()
@@ -462,7 +445,7 @@ public class MirrorMakerST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         clients = new KafkaClientsBuilder(clients)
             .withTopicName(topicNotIncluded)
@@ -471,7 +454,7 @@ public class MirrorMakerST extends AbstractST {
         LOGGER.info("Becuase {} is not included, we should not receive any message", topicNotIncluded);
 
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
-        ClientUtils.waitForConsumerClientTimeout(testStorage);
+        ClientUtils.waitForInstantConsumerClientTimeout(testStorage);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -415,7 +415,7 @@ public class MirrorMakerST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getSourceClusterName(), topicNotIncluded, testStorage.getNamespaceName()).build()
         );
 
-        KafkaClients clients = ClientUtils.getDefaultClientBuilder(testStorage)
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getSourceClusterName()))
             .withTopicName(topicName)
             .build();

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -172,7 +172,7 @@ public class FeatureGatesST extends AbstractST {
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
         LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
-        final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients clients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(
             clients.producerStrimzi(),
             clients.consumerStrimzi()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -201,13 +201,11 @@ public class MultipleClusterOperatorsST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients basicClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withMessageCount(100)
-            .build();
+        KafkaClients basicClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(basicClients.producerStrimzi());
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "Hello-world - 99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         LOGGER.info("Verifying that all operands in Namespace: {} are managed by Cluster Operator: {}", testStorage.getNamespaceName(), FIRST_CO_NAME);
         MetricsUtils.assertMetricResourcesHigherThanOrEqualTo(firstCoMetricsCollector, Kafka.RESOURCE_KIND, 1);

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -201,7 +201,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients basicClients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients basicClients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(basicClients.producerStrimzi());
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.api.kafka.model.rebalance.KafkaRebalance;
 import io.strimzi.operator.common.Annotations;
@@ -21,7 +20,6 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
@@ -203,15 +201,9 @@ public class MultipleClusterOperatorsST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients basicClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients basicClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
+            .withMessageCount(100)
             .build();
-
         resourceManager.createResourceWithWait(basicClients.producerStrimzi());
         ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -278,7 +278,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients clients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -288,7 +288,7 @@ class NamespaceDeletionRecoveryST extends AbstractST {
     }
 
     private void verifyStabilityBySendingAndReceivingMessages(TestStorage testStorage) {
-        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients clients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/NamespaceDeletionRecoveryST.java
@@ -18,7 +18,6 @@ import io.strimzi.systemtest.annotations.KRaftWithoutUTONotSupported;
 import io.strimzi.systemtest.annotations.UTONotSupported;
 import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -279,17 +278,9 @@ class NamespaceDeletionRecoveryST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage).build());
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
-
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("##################################################");
         LOGGER.info("Environment for recovery was successfully created");
@@ -297,17 +288,9 @@ class NamespaceDeletionRecoveryST extends AbstractST {
     }
 
     private void verifyStabilityBySendingAndReceivingMessages(TestStorage testStorage) {
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
-
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     private void recreatePvcAndUpdatePv(List<PersistentVolumeClaim> persistentVolumeClaimList, String namespace) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/PodSetST.java
@@ -52,13 +52,6 @@ public class PodSetST extends AbstractST {
         final int replicas = 3;
         final int probeTimeoutSeconds = 6;
 
-        // setup clients configured to produce/consume data for next 3-4 minutes and configured for resilience against one broker being down.
-        String producerAdditionConfiguration = "acks=all\n";
-        KafkaClients clients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
-            .withMessageCount(200)
-            .withAdditionalConfig(producerAdditionConfiguration)
-            .build();
-
         EnvVar reconciliationEnv = new EnvVar(Environment.STRIMZI_POD_SET_RECONCILIATION_ONLY_ENV, "true", null);
         List<EnvVar> envVars = kubeClient().getDeployment(clusterOperator.getDeploymentNamespace(), clusterOperator.getClusterOperatorName()).getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
         envVars.add(reconciliationEnv);
@@ -89,6 +82,8 @@ public class PodSetST extends AbstractST {
                 .endSpec()
                 .build()
         );
+
+        final KafkaClients clients = ClientUtils.getContinuousPlainClientBuilder(testStorage).build();
 
         LOGGER.info("Producing and Consuming messages with clients: {}, {} in Namespace {}", testStorage.getProducerName(), testStorage.getConsumerName(), testStorage.getNamespaceName());
         resourceManager.createResourceWithWait(

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -203,10 +203,7 @@ class RecoveryST extends AbstractST {
     }
 
     private void verifyStabilityBySendingAndReceivingMessages(TestStorage testStorage) {
-        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(sharedClusterName))
-            .withUsername(testStorage.getUsername())
-            .build();
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(sharedClusterName));
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/RecoveryST.java
@@ -16,7 +16,6 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
@@ -204,18 +203,12 @@ class RecoveryST extends AbstractST {
     }
 
     private void verifyStabilityBySendingAndReceivingMessages(TestStorage testStorage) {
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(sharedClusterName))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
             .withUsername(testStorage.getUsername())
             .build();
-
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @IsolatedTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicReplicasChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicReplicasChangeST.java
@@ -424,7 +424,7 @@ public class TopicReplicasChangeST extends AbstractST {
                 kafkaClients.producerStrimzi(),
                 kafkaClients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -157,16 +157,12 @@ public class TopicST extends AbstractST {
     void testSendingMessagesToNonExistingTopic() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
-        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(sharedTestStorage.getClusterName()))
-            .build();
-
         LOGGER.info("Checking if {} is on Topic list", testStorage.getTopicName());
         assertFalse(KafkaTopicUtils.hasTopicInKafka(testStorage.getTopicName(), sharedTestStorage.getClusterName(), scraperPodName));
         LOGGER.info("Topic with name {} is not created yet", testStorage.getTopicName());
 
         LOGGER.info("Trying to send messages to non-existing Topic: {}", testStorage.getTopicName());
-
+        final KafkaClients clients = ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(sharedTestStorage.getClusterName()));
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -211,7 +207,7 @@ public class TopicST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
+        final KafkaClients clients = ClientUtils.getInstantPlainClients(testStorage);
         resourceManager.createResourceWithWait(clients.producerStrimzi());
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -22,7 +22,6 @@ import io.strimzi.systemtest.cli.KafkaCmdClient;
 import io.strimzi.systemtest.enums.ConditionStatus;
 import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.kafkaclients.internalClients.admin.AdminClient;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.resources.ComponentType;
@@ -158,13 +157,8 @@ public class TopicST extends AbstractST {
     void testSendingMessagesToNonExistingTopic() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(sharedTestStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .build();
 
         LOGGER.info("Checking if {} is on Topic list", testStorage.getTopicName());
@@ -174,7 +168,7 @@ public class TopicST extends AbstractST {
         LOGGER.info("Trying to send messages to non-existing Topic: {}", testStorage.getTopicName());
 
         resourceManager.createResourceWithWait(clients.producerStrimzi(), clients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Checking if {} is on Topic list", testStorage.getTopicName());
         assertTrue(KafkaTopicUtils.hasTopicInKafka(testStorage.getTopicName(), sharedTestStorage.getClusterName(), scraperPodName));
@@ -217,17 +211,9 @@ public class TopicST extends AbstractST {
             .endSpec()
             .build());
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .build();
-
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(clients.producerStrimzi());
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         String topicUid = KafkaTopicUtils.topicSnapshot(Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName());
         LOGGER.info("Deleting KafkaTopic: {}/{}", Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName());
@@ -241,7 +227,7 @@ public class TopicST extends AbstractST {
         LOGGER.info("KafkaTopic: {}/{} recreated", Environment.TEST_SUITE_NAMESPACE, testStorage.getTopicName());
 
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @ParallelTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -122,8 +122,7 @@ class UserST extends AbstractST {
         final long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getKafkaUsername()).get().getStatus().getObservedGeneration();
 
         // Send and receive messages
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
             .withUsername(testStorage.getKafkaUsername())
             .build();
 
@@ -203,8 +202,8 @@ class UserST extends AbstractST {
                     result.contains("controller_mutation_rate=" + mutRate);
             });
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
+        // TODO refactor scramsha
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
             .withUsername(userName)
             .build();
 
@@ -307,6 +306,7 @@ class UserST extends AbstractST {
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
+        // TODO refactor scramsha
         clients = new KafkaClientsBuilder(clients)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withUsername(secretPrefix + scramShaUserName)

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -122,18 +122,13 @@ class UserST extends AbstractST {
         final long observedGeneration = KafkaUserResource.kafkaUserClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getKafkaUsername()).get().getStatus().getObservedGeneration();
 
         // Send and receive messages
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(testStorage.getKafkaUsername())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(sharedTestStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         KafkaUserResource.replaceUserResourceInSpecificNamespace(testStorage.getKafkaUsername(), ku -> {
             ku.getSpec().setAuthentication(new KafkaUserScramSha512ClientAuthentication());
@@ -157,7 +152,7 @@ class UserST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerScramShaTlsStrimzi(sharedTestStorage.getClusterName()), kafkaClients.consumerScramShaTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelTest
@@ -208,13 +203,8 @@ class UserST extends AbstractST {
                     result.contains("controller_mutation_rate=" + mutRate);
             });
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
             .withUsername(userName)
             .build();
 
@@ -235,7 +225,7 @@ class UserST extends AbstractST {
                                                                      kafkaClients.consumerTlsStrimzi(sharedTestStorage.getClusterName()));
         }
 
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // delete user
         KafkaUserResource.kafkaUserClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(userName).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
@@ -309,19 +299,13 @@ class UserST extends AbstractST {
         assertNotNull(tlsSecret);
         assertNotNull(scramShaSecret);
 
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(secretPrefix + tlsUserName)
             .build();
 
         LOGGER.info("Checking if TLS user is able to send messages");
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         clients = new KafkaClientsBuilder(clients)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
@@ -330,7 +314,7 @@ class UserST extends AbstractST {
 
         LOGGER.info("Checking if SCRAM-SHA user is able to send messages");
         resourceManager.createResourceWithWait(clients.producerScramShaPlainStrimzi(), clients.consumerScramShaPlainStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Checking owner reference - if the Secret will be deleted when we delete KafkaUser");
 
@@ -407,19 +391,13 @@ class UserST extends AbstractST {
 
         SecretUtils.createExternalTlsUserSecret(testStorage.getNamespaceName(), testStorage.getKafkaUsername(), testStorage.getClusterName());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getKafkaUsername())
             .withConsumerGroup(consumerGroupName)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         KafkaUserResource.replaceUserResourceInSpecificNamespace(testStorage.getKafkaUsername(),
             user -> {
@@ -439,7 +417,7 @@ class UserST extends AbstractST {
         PodUtils.waitUntilMessageIsInPodLogs(testStorage.getNamespaceName(),
             PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), testStorage.getProducerName()), "authorization failed");
 
-        ClientUtils.waitForProducerClientTimeout(testStorage);
+        ClientUtils.waitForInstantProducerClientTimeout(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -202,8 +202,7 @@ class UserST extends AbstractST {
                     result.contains("controller_mutation_rate=" + mutRate);
             });
 
-        // TODO refactor scramsha
-        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
+        final KafkaClients kafkaClients = ClientUtils.getInstantScramShaClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
             .withUsername(userName)
             .build();
 
@@ -306,9 +305,8 @@ class UserST extends AbstractST {
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(testStorage.getClusterName()), clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
-        // TODO refactor scramsha
-        clients = new KafkaClientsBuilder(clients)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+
+        clients = ClientUtils.getInstantScramShaOverPlainClientBuilder(testStorage)
             .withUsername(secretPrefix + scramShaUserName)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -123,10 +123,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(testStorage).build());
 
-        KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
-
+        KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -449,7 +449,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         LOGGER.debug("Obtained Volumes total '{}' claimed by claims Belonging to Kafka {}", kafkaPvcs.size(), testStorage.getClusterName());
         assertThat("There are not 3 volumes used by Kafka Cluster", kafkaPvcs.size() == 3);
 
-        resourceManager.createResourceWithWait(clients.consumerTlsStrimzi(testStorage.getClusterName()));
+        resourceManager.createResourceWithWait(clients.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // ##############################

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -169,7 +169,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
                             || !StrimziPodSetUtils.getAnnotationsOfStrimziPodSet(testStorage.getNamespaceName(), testStorage.getControllerComponentName()).containsKey(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE));
         }
 
-        clients = ClientUtils.generateNewConsumerGroup(clients);
+        clients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -19,7 +19,6 @@ import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterTemplateBuilder;
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolSpecBuilder;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
@@ -112,13 +111,8 @@ public class KafkaRollerST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaTopicWith3Replicas);
 
         // setup clients
-        KafkaClients clients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withTopicName(topicNameWith3Replicas)
-            .withMessageCount(testStorage.getMessageCount())
-            .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
         // producing and consuming data when there are 3 brokers ensures that 'consumer_offests' topic will have all of its replicas only across first 3 brokers
@@ -127,7 +121,7 @@ public class KafkaRollerST extends AbstractST {
             clients.producerStrimzi(),
             clients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Scale Kafka up from 3 to 4 brokers");
         if (Environment.isKafkaNodePoolsEnabled()) {
@@ -155,7 +149,7 @@ public class KafkaRollerST extends AbstractST {
             clients.producerStrimzi(),
             clients.consumerStrimzi()
         );
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Scaling down to {}", initialBrokerReplicaCount);
         if (Environment.isKafkaNodePoolsEnabled()) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -164,7 +164,7 @@ class RollingUpdateST extends AbstractST {
         RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getControllerSelector(), 3);
 
         // consume messages with newly generated consumer group
-        clients = ClientUtils.generateNewConsumerGroup(clients);
+        clients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -192,7 +192,7 @@ class RollingUpdateST extends AbstractST {
         PodUtils.waitForPendingPod(testStorage.getNamespaceName(), testStorage.getBrokerComponentName());
 
         // consume messages with newly generated consumer group
-        clients = ClientUtils.generateNewConsumerGroup(clients);
+        clients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -277,7 +277,7 @@ class RollingUpdateST extends AbstractST {
         // change broker knp to unreasonable CPU request causing trigger of Rolling update
         modifyNodePoolToUnscheduledAndRecover(testStorage.getBrokerPoolName(), testStorage.getBrokerSelector(), testStorage);
 
-        clients = ClientUtils.generateNewConsumerGroup(clients);
+        clients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(clients.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
@@ -381,9 +381,7 @@ class RollingUpdateST extends AbstractST {
         // consuming data from original topic after scaling up
 
         LOGGER.info("Consume data produced before scaling up");
-        clients = new KafkaClientsBuilder(clients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
+        clients.generateNewConsumerGroup();
 
         resourceManager.createResourceWithWait(clients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
@@ -563,9 +561,7 @@ class RollingUpdateST extends AbstractST {
 
         RollingUpdateUtils.waitForComponentAndPodsReady(testStorage.getNamespaceName(), testStorage.getControllerSelector(), initialZkReplicas);
 
-        clients = new KafkaClientsBuilder(clients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
+        clients.generateNewConsumerGroup();
 
         // Wait for one zk pods will became leader and others follower state
         KafkaUtils.waitForZkMntr(testStorage.getNamespaceName(), testStorage.getClusterName(), ZK_SERVER_STATE, 0, 1, 2);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -176,28 +176,25 @@ public class NetworkPoliciesST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getClusterName(), topicNameDeniedTls, testStorage.getNamespaceName()).build()
         );
 
-        // TODO refactor scramsha sha sha sha
         LOGGER.info("Initialize producers and consumers with access to the Kafka using plain and tls listeners");
-        final KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
+        final KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getInstantScramShaOverPlainClientBuilder(testStorage)
             .withProducerName(producerNameAccessedPlain)
             .withConsumerName(consumerNameAccessedPlain)
             .withTopicName(topicNameAccessedPlain)
             .build();
-        final KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantScramShaOverTlsClientBuilder(testStorage)
             .withProducerName(producerNameAccessedTls)
             .withConsumerName(consumerNameAccessedTls)
             .withTopicName(topicNameAccessedTls)
             .build();
 
         LOGGER.info("Initialize producers and consumers without access (denied) to the Kafka using plain and tls listeners");
-        final KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
+        final KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getInstantScramShaOverPlainClientBuilder(testStorage)
             .withProducerName(producerNameDeniedPlain)
             .withConsumerName(consumerNameDeniedPlain)
             .withTopicName(topicNameDeniedPlain)
             .build();
-        final KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantScramShaOverTlsClientBuilder(testStorage)
             .withProducerName(producerNameDeniedTls)
             .withConsumerName(consumerNameDeniedTls)
             .withTopicName(topicNameDeniedTls)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -176,27 +176,28 @@ public class NetworkPoliciesST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage.getClusterName(), topicNameDeniedTls, testStorage.getNamespaceName()).build()
         );
 
+        // TODO refactor scramsha sha sha sha
         LOGGER.info("Initialize producers and consumers with access to the Kafka using plain and tls listeners");
-        KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .withProducerName(producerNameAccessedPlain)
             .withConsumerName(consumerNameAccessedPlain)
             .withTopicName(topicNameAccessedPlain)
             .build();
-        KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withProducerName(producerNameAccessedTls)
             .withConsumerName(consumerNameAccessedTls)
             .withTopicName(topicNameAccessedTls)
             .build();
 
         LOGGER.info("Initialize producers and consumers without access (denied) to the Kafka using plain and tls listeners");
-        KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .withProducerName(producerNameDeniedPlain)
             .withConsumerName(consumerNameDeniedPlain)
             .withTopicName(topicNameDeniedPlain)
             .build();
-        KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+        final KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withProducerName(producerNameDeniedTls)
             .withConsumerName(consumerNameDeniedTls)
             .withTopicName(topicNameDeniedTls)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -184,7 +184,6 @@ public class NetworkPoliciesST extends AbstractST {
             .withTopicName(topicNameAccessedPlain)
             .build();
         KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameAccessedTls)
             .withConsumerName(consumerNameAccessedTls)
             .withTopicName(topicNameAccessedTls)
@@ -198,7 +197,6 @@ public class NetworkPoliciesST extends AbstractST {
             .withTopicName(topicNameDeniedPlain)
             .build();
         KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameDeniedTls)
             .withConsumerName(consumerNameDeniedTls)
             .withTopicName(topicNameDeniedTls)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -177,26 +177,28 @@ public class NetworkPoliciesST extends AbstractST {
         );
 
         LOGGER.info("Initialize producers and consumers with access to the Kafka using plain and tls listeners");
-        KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getDefaultClientBuilder(testStorage)
+        KafkaClients kafkaClientsWithAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
+            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameAccessedPlain)
             .withConsumerName(consumerNameAccessedPlain)
             .withTopicName(topicNameAccessedPlain)
             .build();
-        KafkaClients kafkaClientsWithAccessTls = ClientUtils.getDefaultClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+        KafkaClients kafkaClientsWithAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameAccessedTls)
             .withConsumerName(consumerNameAccessedTls)
             .withTopicName(topicNameAccessedTls)
             .build();
 
         LOGGER.info("Initialize producers and consumers without access (denied) to the Kafka using plain and tls listeners");
-        KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getDefaultClientBuilder(testStorage)
+        KafkaClients kafkaClientsWithoutAccessPlain = ClientUtils.getInstantPlainClientBuilder(testStorage)
+            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameDeniedPlain)
             .withConsumerName(consumerNameDeniedPlain)
             .withTopicName(topicNameDeniedPlain)
             .build();
-        KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getDefaultClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
+        KafkaClients kafkaClientsWithoutAccessTls = ClientUtils.getInstantTlsClientBuilder(testStorage)
+            .withUsername(testStorage.getUsername())
             .withProducerName(producerNameDeniedTls)
             .withConsumerName(consumerNameDeniedTls)
             .withTopicName(topicNameDeniedTls)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -59,8 +59,7 @@ public class OpaIntegrationST extends AbstractST {
 
         LOGGER.info("Checking KafkaUser: {}/{} that is able to send and receive messages to/from Topic: {}/{}", testStorage.getNamespaceName(), OPA_GOOD_USER, testStorage.getNamespaceName(), testStorage.getTopicName());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
             .withUsername(OPA_GOOD_USER)
             .build();
 
@@ -88,8 +87,7 @@ public class OpaIntegrationST extends AbstractST {
 
         LOGGER.info("Checking KafkaUser: {}/{} that is able to send and receive messages to/from Topic: {}/{}", testStorage.getNamespaceName(), OPA_GOOD_USER, testStorage.getNamespaceName(), testStorage.getTopicName());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
             .withUsername(OPA_SUPERUSER)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/OpaIntegrationST.java
@@ -59,18 +59,13 @@ public class OpaIntegrationST extends AbstractST {
 
         LOGGER.info("Checking KafkaUser: {}/{} that is able to send and receive messages to/from Topic: {}/{}", testStorage.getNamespaceName(), OPA_GOOD_USER, testStorage.getNamespaceName(), testStorage.getTopicName());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
-            .withTopicName(testStorage.getTopicName())
             .withUsername(OPA_GOOD_USER)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(CLUSTER_NAME), kafkaClients.consumerTlsStrimzi(CLUSTER_NAME));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         LOGGER.info("Checking KafkaUser: {}/{} that is not able to send or receive messages to/from Topic: {}/{}", testStorage.getNamespaceName(), OPA_BAD_USER, testStorage.getNamespaceName(), testStorage.getTopicName());
 
@@ -79,7 +74,7 @@ public class OpaIntegrationST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(CLUSTER_NAME), kafkaClients.consumerTlsStrimzi(CLUSTER_NAME));
-        ClientUtils.waitForClientsTimeout(testStorage);
+        ClientUtils.waitForInstantClientsTimeout(testStorage);
     }
 
     @ParallelTest
@@ -93,18 +88,13 @@ public class OpaIntegrationST extends AbstractST {
 
         LOGGER.info("Checking KafkaUser: {}/{} that is able to send and receive messages to/from Topic: {}/{}", testStorage.getNamespaceName(), OPA_GOOD_USER, testStorage.getNamespaceName(), testStorage.getTopicName());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(CLUSTER_NAME))
-            .withTopicName(testStorage.getTopicName())
             .withUsername(OPA_SUPERUSER)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(CLUSTER_NAME), kafkaClients.consumerTlsStrimzi(CLUSTER_NAME));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
@@ -203,7 +203,7 @@ public class PodSecurityProfilesST extends AbstractST {
 
         // verify KafkaConnect
         final String kafkaConnectPodName = kubeClient(testStorage.getNamespaceName()).listPods(testStorage.getNamespaceName(), testStorage.getClusterName(), Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND).get(0).getMetadata().getName();
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // verify MM1, as topic name does not change, only bootstrap server is changed.
         final KafkaClients mm1Client = new KafkaClientsBuilder(kafkaClients)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
@@ -190,14 +190,9 @@ public class PodSecurityProfilesST extends AbstractST {
 
         LOGGER.info("Verify that Kafka cluster is usable and everything (MM1, MM2, and Connector) is working");
 
-        // kafka cluster itself
-        final KafkaClients clusterClient = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withPodSecurityPolicy(PodSecurityProfile.RESTRICTED)
-            .build();
-
         resourceManager.createResourceWithWait(
-            clusterClient.producerStrimzi(),
-            clusterClient.consumerStrimzi()
+            kafkaClients.producerStrimzi(),
+            kafkaClients.consumerStrimzi()
         );
         ClientUtils.waitForInstantClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
@@ -196,13 +196,16 @@ public class PodSecurityProfilesST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // verify MM1, as topic name does not change, only bootstrap server is changed.
-        final KafkaClients mm1Client =  ClientUtils.getInstantPlainClients(testStorage, KafkaResources.plainBootstrapAddress(mm1TargetClusterName));
+        final KafkaClients mm1Client =  ClientUtils.getInstantPlainClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(mm1TargetClusterName))
+            .withPodSecurityPolicy(PodSecurityProfile.RESTRICTED)
+            .build();
         resourceManager.createResourceWithWait(mm1Client.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // verify MM2
         final KafkaClients mm2Client = ClientUtils.getInstantPlainClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(mm2TargetClusterName))
             .withTopicName(mm2SourceMirroredTopicName)
+            .withPodSecurityPolicy(PodSecurityProfile.RESTRICTED)
             .build();
         resourceManager.createResourceWithWait(mm2Client.consumerStrimzi());
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -316,7 +316,7 @@ class SecurityST extends AbstractST {
                 value, is(not(initialCaCerts.get(secretName))));
         }
 
-        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
+        kafkaClients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -506,7 +506,7 @@ class SecurityST extends AbstractST {
                     value, is(not(initialCaKeys.get(secretName))));
         }
 
-        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
+        kafkaClients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -1206,7 +1206,7 @@ class SecurityST extends AbstractST {
             }
         );
 
-        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
+        kafkaClients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
@@ -1235,7 +1235,7 @@ class SecurityST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), 3, brokerPods);
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), testStorage.getEoDeploymentName(), 1, eoPods);
 
-        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
+        kafkaClients.generateNewConsumerGroup();
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -379,6 +379,7 @@ class SecurityST extends AbstractST {
                 false);
     }
 
+    // TODO flaky fail from time to time on client timeouts
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -377,7 +377,6 @@ class SecurityST extends AbstractST {
                 false);
     }
 
-    // TODO flaky fail from time to time on client timeouts
     @ParallelNamespaceTest
     @Tag(INTERNAL_CLIENTS_USED)
     @Tag(ROLLING_UPDATE)
@@ -1146,7 +1145,6 @@ class SecurityST extends AbstractST {
                 .build()
         );
 
-        // (implicit) Configuration `acks=all` paired with Kafka's `min.insync.replicas=2` enforces there are at least 2 replicas with all produced data before test continues.
         KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -256,8 +256,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
-
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -325,7 +324,6 @@ class SecurityST extends AbstractST {
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
             .withUsername(bobUserName)
             .build();
 
@@ -420,7 +418,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -511,7 +509,6 @@ class SecurityST extends AbstractST {
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
             .withUsername(bobUserName)
             .build();
 
@@ -624,7 +621,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -691,8 +688,6 @@ class SecurityST extends AbstractST {
 
         Secret kafkaUserSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getUsername());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
-
         Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
 
         CertificateAuthority newCAValidity = new CertificateAuthority();
@@ -739,6 +734,7 @@ class SecurityST extends AbstractST {
         assertThat("KafkaUser certificate has not been renewed within maintenanceTimeWindows",
                 kafkaUserSecret, not(sameInstance(kafkaUserSecretRolled)));
 
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }
@@ -762,8 +758,6 @@ class SecurityST extends AbstractST {
             KafkaUserTemplates.tlsUser(testStorage).build(),
             KafkaTopicTemplates.topic(testStorage).build()
         );
-
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
 
         List<Secret> secrets = kubeClient().listSecrets(testStorage.getNamespaceName()).stream()
             .filter(secret ->
@@ -796,6 +790,7 @@ class SecurityST extends AbstractST {
             assertThat("Certificates has different cert UIDs", !secrets.get(i).getData().get("ca.crt").equals(regeneratedSecrets.get(i).getData().get("ca.crt")));
         }
 
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
     }
@@ -1145,7 +1140,7 @@ class SecurityST extends AbstractST {
                 .build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -256,9 +256,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
@@ -423,11 +421,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withUsername(testStorage.getUsername())
-            .build();
-
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -631,10 +625,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
-
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
@@ -701,9 +692,7 @@ class SecurityST extends AbstractST {
 
         Secret kafkaUserSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getUsername());
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
 
         Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
 
@@ -775,9 +764,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
 
         List<Secret> secrets = kubeClient().listSecrets(testStorage.getNamespaceName()).stream()
             .filter(secret ->
@@ -1160,10 +1147,7 @@ class SecurityST extends AbstractST {
         );
 
         // (implicit) Configuration `acks=all` paired with Kafka's `min.insync.replicas=2` enforces there are at least 2 replicas with all produced data before test continues.
-        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withUsername(testStorage.getUsername())
-            .build();
-
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage).build();
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
         ClientUtils.waitForInstantClientSuccess(testStorage);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -256,18 +256,12 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Get all pods, and their resource versions
         Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector());
@@ -322,12 +316,9 @@ class SecurityST extends AbstractST {
                 value, is(not(initialCaCerts.get(secretName))));
         }
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
-
+        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // Check a new client (signed by new client key) can consume
         String bobUserName = "bob-" + testStorage.getUsername();
@@ -341,7 +332,7 @@ class SecurityST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         if (!Environment.isKRaftModeEnabled()) {
             if (!zkShouldRoll) {
@@ -431,18 +422,13 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
             .withUsername(testStorage.getUsername())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Get all pods, and their resource versions
         Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector());
@@ -519,12 +505,9 @@ class SecurityST extends AbstractST {
                     value, is(not(initialCaKeys.get(secretName))));
         }
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
-
+        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // Finally check a new client (signed by new client key) can consume
 
@@ -539,7 +522,7 @@ class SecurityST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         if (!Environment.isKRaftModeEnabled()) {
             if (!zkShouldRoll) {
@@ -647,18 +630,12 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         // Wait until the certificates have been replaced
         SecretUtils.waitForCertToChange(testStorage.getNamespaceName(), clusterCaCert, clusterCaCertificateSecretName(testStorage.getClusterName()));
@@ -667,7 +644,7 @@ class SecurityST extends AbstractST {
         KafkaUtils.waitForClusterStability(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -723,13 +700,7 @@ class SecurityST extends AbstractST {
 
         Secret kafkaUserSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getUsername());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .build();
 
@@ -780,7 +751,7 @@ class SecurityST extends AbstractST {
                 kafkaUserSecret, not(sameInstance(kafkaUserSecretRolled)));
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -803,13 +774,7 @@ class SecurityST extends AbstractST {
             KafkaTopicTemplates.topic(testStorage).build()
         );
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
             .build();
 
@@ -845,7 +810,7 @@ class SecurityST extends AbstractST {
         }
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest
@@ -1193,21 +1158,13 @@ class SecurityST extends AbstractST {
                 .build()
         );
 
-        // Configuration `acks=all` paired with Kafka's `min.insync.replicas=2` enforces there are at least 2 replicas with all produced data before test continues.
-        String producerAdditionConfiguration = "acks=all\n";
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
+        // (implicit) Configuration `acks=all` paired with Kafka's `min.insync.replicas=2` enforces there are at least 2 replicas with all produced data before test continues.
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withUsername(testStorage.getUsername())
-            .withAdditionalConfig(producerAdditionConfiguration)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getControllerSelector());
         Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
@@ -1248,12 +1205,9 @@ class SecurityST extends AbstractST {
             }
         );
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
-
+        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         final ResourceRequirements correctRequirements = new ResourceRequirementsBuilder()
             .addToRequests("cpu", new Quantity("200m"))
@@ -1280,12 +1234,9 @@ class SecurityST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), 3, brokerPods);
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), testStorage.getEoDeploymentName(), 1, eoPods);
 
-        kafkaClients = new KafkaClientsBuilder(kafkaClients)
-            .withConsumerGroup(ClientUtils.generateRandomConsumerGroup())
-            .build();
-
+        kafkaClients = ClientUtils.generateNewConsumerGroup(kafkaClients);
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         // Try to send and receive messages with new certificates
         String topicName = KafkaTopicUtils.generateRandomNameOfTopic();
@@ -1298,7 +1249,7 @@ class SecurityST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
@@ -118,22 +118,22 @@ public class CustomAuthorizerST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientTimeout(testStorage);
+        ClientUtils.waitForInstantConsumerClientTimeout(testStorage);
 
         kafkaClients = new KafkaClientsBuilder(kafkaClients)
             .withUsername(kafkaUserRead)
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.consumerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForConsumerClientSuccess(testStorage);
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
 
         LOGGER.info("Checking KafkaUser: {}/{} that is not able to send messages to Topic: {}", testStorage.getNamespaceName(), kafkaUserRead, testStorage.getTopicName());
 
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForProducerClientTimeout(testStorage);
+        ClientUtils.waitForInstantProducerClientTimeout(testStorage);
     }
 
     /**
@@ -172,7 +172,7 @@ public class CustomAuthorizerST extends AbstractST {
 
         LOGGER.info("Checking Kafka Super User: {}/{} is able to produce/consume despite having no explicit rights in KafkaUser", Environment.TEST_SUITE_NAMESPACE, ADMIN);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(sharedTestStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(sharedTestStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomAuthorizerST.java
@@ -106,13 +106,7 @@ public class CustomAuthorizerST extends AbstractST {
 
         LOGGER.info("Checking KafkaUser {} that is able to send messages to Topic: {}", kafkaUserWrite, testStorage.getTopicName());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
+        KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
             .withUsername(kafkaUserWrite)
             .withConsumerGroup(consumerGroupName)
             .build();
@@ -160,13 +154,7 @@ public class CustomAuthorizerST extends AbstractST {
         resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(sharedTestStorage.getClusterName(), testStorage.getTopicName(), Environment.TEST_SUITE_NAMESPACE).build());
         resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(Environment.TEST_SUITE_NAMESPACE, sharedTestStorage.getClusterName(), ADMIN).build());
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(sharedTestStorage.getClusterName()))
             .withUsername(ADMIN)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -14,7 +14,6 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -125,7 +124,10 @@ public class CustomCaST extends AbstractST {
 
         LOGGER.info("All rounds of rolling update have been finished");
         // Try to produce messages
-        producerMessages(testStorage);
+        final KafkaClients kafkaBasicClientJob = ClientUtils.getInstantTlsClients(testStorage);
+        resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(testStorage).build());
+        resourceManager.createResourceWithWait(kafkaBasicClientJob.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
 
         // Get new certificate secret and assert old value is still present
         clusterCaCertificateSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()));
@@ -195,7 +197,10 @@ public class CustomCaST extends AbstractST {
         DeploymentUtils.waitForNoRollingUpdate(testStorage.getNamespaceName(), testStorage.getEoDeploymentName(), eoPod);
 
         // Try to produce messages
-        producerMessages(testStorage);
+        final KafkaClients kafkaBasicClientJob = ClientUtils.getInstantTlsClients(testStorage);
+        resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(testStorage).build());
+        resourceManager.createResourceWithWait(kafkaBasicClientJob.producerTlsStrimzi(testStorage.getClusterName()));
+        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 
     /** This tests focuses on verifying the functionality of custom cluster and clients CAs.
@@ -273,20 +278,9 @@ public class CustomCaST extends AbstractST {
                 SystemTestCertManager.containsAllDN(userCert.getIssuerX500Principal().getName(), clientsCa.getSubjectDn()));
 
         LOGGER.info("Send and receive messages over TLS");
-
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withMessageCount(testStorage.getMessageCount())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withUsername(testStorage.getUsername())
-            .build();
-
-        LOGGER.info("Checking produced and consumed messages via TLS");
+        final KafkaClients kafkaClients = ClientUtils.getInstantTlsClients(testStorage);
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForInstantClientSuccess(testStorage, false);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
     }
 
     /** This tests focuses on invoking certificate renewal without renewing the ClusterCA.
@@ -611,29 +605,6 @@ public class CustomCaST extends AbstractST {
                 .endClusterCa()
             .endSpec()
             .build());
-    }
-
-    /**
-     * This method is a helping tool for producing and consuming messages based on context and testStorage variables.
-     * @param testStorage is required for containing client variables used to build a client job.
-     */
-    private void producerMessages(final TestStorage testStorage) {
-
-        final KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-            .withNamespaceName(testStorage.getNamespaceName())
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getClusterName())
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))
-            .withTopicName(testStorage.getTopicName())
-            .withUsername(testStorage.getUsername())
-            .withMessageCount(testStorage.getMessageCount())
-            .withDelayMs(10)
-            .build();
-
-        resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(testStorage).build());
-        resourceManager.createResourceWithWait(kafkaBasicClientJob.producerTlsStrimzi(testStorage.getClusterName()));
-
-        ClientUtils.waitForClientSuccess(testStorage.getProducerName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -286,7 +286,7 @@ public class CustomCaST extends AbstractST {
 
         LOGGER.info("Checking produced and consumed messages via TLS");
         resourceManager.createResourceWithWait(kafkaClients.producerTlsStrimzi(testStorage.getClusterName()), kafkaClients.consumerTlsStrimzi(testStorage.getClusterName()));
-        ClientUtils.waitForClientsSuccess(testStorage, false);
+        ClientUtils.waitForInstantClientSuccess(testStorage, false);
     }
 
     /** This tests focuses on invoking certificate renewal without renewing the ClusterCA.

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPasswordGrantsST.java
@@ -426,7 +426,7 @@ public class OauthPasswordGrantsST extends OauthAbstractST {
 
         KafkaConnectorUtils.createFileSinkConnector(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, testStorage.getTopicName(), TestConstants.DEFAULT_SINK_FILE_PATH, "http://localhost:8083");
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         final String kafkaConnectLogs = KubeClusterResource.cmdKubeClient(Environment.TEST_SUITE_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaConnectPodName).out();
         verifyOauthConfiguration(kafkaConnectLogs);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -367,7 +367,7 @@ public class OauthPlainST extends OauthAbstractST {
 
         KafkaConnectorUtils.createFileSinkConnector(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, testStorage.getTopicName(), TestConstants.DEFAULT_SINK_FILE_PATH, "http://localhost:8083");
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         final String kafkaConnectLogs = KubeClusterResource.cmdKubeClient(Environment.TEST_SUITE_NAMESPACE).execInCurrentNamespace(Level.DEBUG, "logs", kafkaConnectPodName).out();
         verifyOauthConfiguration(kafkaConnectLogs);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -188,7 +188,7 @@ public class OauthTlsST extends OauthAbstractST {
 
         KafkaConnectorUtils.createFileSinkConnector(Environment.TEST_SUITE_NAMESPACE, scraperPodName, testStorage.getTopicName(), TestConstants.DEFAULT_SINK_FILE_PATH, KafkaConnectResources.url(testStorage.getClusterName(), Environment.TEST_SUITE_NAMESPACE, 8083));
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "\"Hello-world - 99\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
     }
 
     @Description("As a OAuth bridge, i am able to send messages to bridge endpoint using encrypted communication")

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerST.java
@@ -68,8 +68,7 @@ public class DrainCleanerST extends AbstractST {
         // allow NetworkPolicies for the webhook in case that we have "default to deny all" mode enabled
         NetworkPolicyResource.allowNetworkPolicySettingsForWebhook(TestConstants.DRAIN_CLEANER_NAMESPACE, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME, Map.of(TestConstants.APP_POD_LABEL, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME));
 
-        KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
-            .withMessageCount(200)
+        final KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withNamespaceName(TestConstants.DRAIN_CLEANER_NAMESPACE)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/DrainCleanerST.java
@@ -12,7 +12,6 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.draincleaner.SetupDrainCleaner;
@@ -69,19 +68,14 @@ public class DrainCleanerST extends AbstractST {
         // allow NetworkPolicies for the webhook in case that we have "default to deny all" mode enabled
         NetworkPolicyResource.allowNetworkPolicySettingsForWebhook(TestConstants.DRAIN_CLEANER_NAMESPACE, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME, Map.of(TestConstants.APP_POD_LABEL, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME));
 
-        KafkaClients kafkaBasicExampleClients = new KafkaClientsBuilder()
+        KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(200)
-            .withTopicName(testStorage.getTopicName())
             .withNamespaceName(TestConstants.DRAIN_CLEANER_NAMESPACE)
-            .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withDelayMs(1000)
             .build();
 
         resourceManager.createResourceWithWait(
-            kafkaBasicExampleClients.producerStrimzi(),
-            kafkaBasicExampleClients.consumerStrimzi());
+            continuousClients.producerStrimzi(),
+            continuousClients.consumerStrimzi());
 
         List<String> brokerPods = kubeClient().listPodNames(TestConstants.DRAIN_CLEANER_NAMESPACE, testStorage.getBrokerSelector());
 
@@ -103,7 +97,7 @@ public class DrainCleanerST extends AbstractST {
         evictPodWithName(kafkaPodName);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.DRAIN_CLEANER_NAMESPACE, testStorage.getBrokerSelector(), replicas, kafkaPod);
 
-        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.DRAIN_CLEANER_NAMESPACE, 300);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.DRAIN_CLEANER_NAMESPACE, 200);
     }
 
     private void evictPodWithName(String podName) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -216,7 +216,7 @@ class RackAwarenessST extends AbstractST {
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
-        consumeDataWithNewSinkConnector(testStorage.getClusterName(), testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName());
+        consumeDataWithNewSinkConnector(testStorage.getClusterName(), testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName(), testStorage.getMessageCount());
     }
 
     /**
@@ -311,7 +311,7 @@ class RackAwarenessST extends AbstractST {
         ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
-    private void consumeDataWithNewSinkConnector(String newConnectorName, String connectClusterName, String topicName, String namespace) {
+    private void consumeDataWithNewSinkConnector(String newConnectorName, String connectClusterName, String topicName, String namespace, int msgCount) {
 
         LOGGER.info("Deploying Sink KafkaConnector in KafkaConnect Cluster: {}/{}", namespace, newConnectorName);
         Map<String, Object> connectorConfig = new HashMap<>();
@@ -334,7 +334,7 @@ class RackAwarenessST extends AbstractST {
         LOGGER.info("KafkaConnect Pod: {}/{}", namespace, kafkaConnectPodName);
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(namespace, kafkaConnectPodName);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(namespace, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(namespace, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, msgCount);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -378,7 +378,7 @@ public class AbstractUpgradeST extends AbstractST {
                 ResourceManager.waitForResourceReadiness(getResourceApiVersion(KafkaTopic.RESOURCE_PLURAL), testStorage.getTopicName());
             }
 
-            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -599,8 +599,7 @@ public class AbstractUpgradeST extends AbstractST {
         this.deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(bundleDowngradeDataWithFeatureGates, upgradeKafkaVersion, testStorage);
         this.deployKafkaUserWithWaitForReadiness(bundleDowngradeDataWithFeatureGates, testStorage.getNamespaceName());
 
-        final KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
-            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(clusterName))
+        final KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(clusterName))
             .withUsername(userName)
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -378,7 +378,7 @@ public class AbstractUpgradeST extends AbstractST {
                 ResourceManager.waitForResourceReadiness(getResourceApiVersion(KafkaTopic.RESOURCE_PLURAL), testStorage.getTopicName());
             }
 
-            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -601,7 +601,6 @@ public class AbstractUpgradeST extends AbstractST {
 
         final KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(clusterName))
-            .withMessageCount(500)
             .withUsername(userName)
             .build();
 
@@ -614,7 +613,7 @@ public class AbstractUpgradeST extends AbstractST {
 
         // Verify FileSink KafkaConnector before upgrade
         String connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // Upgrade CO to HEAD and wait for readiness of ClusterOperator
         changeClusterOperator(bundleDowngradeDataWithFeatureGates, testStorage.getNamespaceName());
@@ -631,7 +630,7 @@ public class AbstractUpgradeST extends AbstractST {
         ClientUtils.waitForInstantProducerClientSuccess(testStorage);
         // Verify FileSink KafkaConnector
         connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // Verify that pods are stable
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -24,7 +24,6 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -381,19 +380,17 @@ public class AbstractUpgradeST extends AbstractST {
 
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
-            KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-                .withProducerName(testStorage.getProducerName())
-                .withConsumerName(testStorage.getConsumerName())
+            KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
-                .withTopicName(testStorage.getTopicName())
                 .withMessageCount(upgradeData.getContinuousClientsMessages())
                 .withAdditionalConfig(producerAdditionConfiguration)
                 .withNamespaceName(namespace)
-                .withDelayMs(1000)
                 .build();
 
-            resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());
-            resourceManager.createResourceWithWait(kafkaBasicClientJob.consumerStrimzi());
+            resourceManager.createResourceWithWait(
+                kafkaBasicClientJob.producerStrimzi(),
+                kafkaBasicClientJob.consumerStrimzi()
+            );
             // ##############################
         }
 
@@ -602,19 +599,15 @@ public class AbstractUpgradeST extends AbstractST {
         this.deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(bundleDowngradeDataWithFeatureGates, upgradeKafkaVersion, testStorage);
         this.deployKafkaUserWithWaitForReadiness(bundleDowngradeDataWithFeatureGates, testStorage.getNamespaceName());
 
-        final KafkaClients clients = new KafkaClientsBuilder()
-                .withProducerName(testStorage.getProducerName())
-                .withConsumerName(testStorage.getConsumerName())
-                .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(clusterName))
-                .withTopicName(testStorage.getTopicName())
-                .withUsername(userName)
-                .withMessageCount(500)
-                .withNamespaceName(testStorage.getNamespaceName())
-                .build();
+        final KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage)
+            .withBootstrapAddress(KafkaResources.tlsBootstrapAddress(clusterName))
+            .withMessageCount(500)
+            .withUsername(userName)
+            .build();
 
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(clusterName));
         // Verify that Producer finish successfully
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
 
         makeSnapshots();
         logPodImagesWithConnect(TestConstants.CO_NAMESPACE);
@@ -635,7 +628,7 @@ public class AbstractUpgradeST extends AbstractST {
         // send again new messages
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(clusterName));
         // Verify that Producer finish successfully
-        ClientUtils.waitForProducerClientSuccess(testStorage);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
         // Verify FileSink KafkaConnector
         connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, "\"Hello-world - 499\"");

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -13,7 +13,6 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -47,16 +46,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Tag(KRAFT_UPGRADE)
 public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftKafkaUpgradeDowngradeST.class);
-
-    private final String continuousTopicName = "continuous-topic";
-    private final int continuousClientsMessageCount = 500;
+    private final int continuousClientsMessageCount = 1000;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
-
-        String producerName = clusterName + "-producer";
-        String consumerName = clusterName + "-consumer";
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
@@ -65,19 +60,19 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // If it is an upgrade test we keep the metadata version as the lower version number
             String metadataVersion = initialVersion.metadataVersion();
 
-            runVersionChange(initialVersion, newVersion, producerName, consumerName, metadataVersion, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, metadataVersion, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testKafkaClusterDowngrade() {
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = sortedVersions.size() - 1; x > 0; x--) {
@@ -86,34 +81,32 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
             // If it is a downgrade then we make sure that we are using the lowest metadataVersion from the whole list
             String metadataVersion = sortedVersions.get(0).metadataVersion();
-            runVersionChange(initialVersion, newVersion, testStorage.getProducerName(), testStorage.getConsumerName(), metadataVersion, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, metadataVersion, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testUpgradeWithNoMetadataVersionSet() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
-
-        String producerName = clusterName + "-producer";
-        String consumerName = clusterName + "-consumer";
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(initialVersion, newVersion, producerName, consumerName, null, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, null, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -131,7 +124,7 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String producerName, String consumerName, String initMetadataVersion, int controllerReplicas, int brokerReplicas) {
+    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initMetadataVersion, int controllerReplicas, int brokerReplicas) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> controllerPods;
         Map<String, String> brokerPods;
@@ -173,17 +166,13 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, continuousTopicName, 3, 3, 2, TestConstants.CO_NAMESPACE).build());
+            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
-            KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-                .withProducerName(producerName)
-                .withConsumerName(consumerName)
+            KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
-                .withTopicName(continuousTopicName)
                 .withMessageCount(continuousClientsMessageCount)
                 .withAdditionalConfig(producerAdditionConfiguration)
-                .withDelayMs(1000)
                 .build();
 
             resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Tag(KRAFT_UPGRADE)
 public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftKafkaUpgradeDowngradeST.class);
-    private final int continuousClientsMessageCount = 1000;
+    private final int continuousClientsMessageCount = 500;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -167,7 +167,7 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
-            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -167,7 +167,7 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
-            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -92,7 +92,7 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
         checkAllImages(downgradeData, TestConstants.CO_NAMESPACE);
 
         // Verify upgrade
-        verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(downgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -95,7 +95,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
 
         String controllerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
         String brokerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
@@ -136,7 +136,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
 
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @IsolatedTest
@@ -171,7 +171,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
 
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @IsolatedTest
@@ -216,7 +216,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
 
         // Verify upgrade
-        verifyProcedure(upgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(upgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -203,7 +203,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
-            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
-    private final int continuousClientsMessageCount = 1000;
+    private final int continuousClientsMessageCount = 500;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {
@@ -111,7 +111,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -203,7 +203,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
             resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
-            String producerAdditionConfiguration = "delivery.timeout.ms=35000\nrequest.timeout.ms=35000";
+            String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -11,7 +11,6 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
-import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -48,16 +47,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
-
-    private final String continuousTopicName = "continuous-topic";
-    private final int continuousClientsMessageCount = 500;
+    private final int continuousClientsMessageCount = 1000;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
-
-        String producerName = clusterName + "-producer";
-        String consumerName = clusterName + "-consumer";
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
@@ -66,19 +61,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is an upgrade test we keep the message format as the lower version number
             String logMsgFormat = initialVersion.messageVersion();
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, producerName, consumerName, logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testKafkaClusterDowngrade() {
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = sortedVersions.size() - 1; x > 0; x--) {
@@ -88,19 +83,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is a downgrade then we make sure to use the lower version number for the message format
             String logMsgFormat = newVersion.messageVersion();
             String interBrokerProtocol = newVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, testStorage.getProducerName(), testStorage.getConsumerName(), logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testKafkaClusterDowngradeToOlderMessageFormat() {
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String initLogMsgFormat = sortedVersions.get(0).messageVersion();
@@ -110,7 +105,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x - 1);
 
-            runVersionChange(initialVersion, newVersion, testStorage.getProducerName(), testStorage.getConsumerName(), initLogMsgFormat, initInterBrokerProtocol, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, initLogMsgFormat, initInterBrokerProtocol, 3, 3);
         }
 
         // ##############################
@@ -122,31 +117,27 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     @IsolatedTest
     void testUpgradeWithNoMessageAndProtocolVersionsSet() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
-
-        String producerName = clusterName + "-producer";
-        String consumerName = clusterName + "-consumer";
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(initialVersion, newVersion, producerName, consumerName, null, null, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, null, null, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousProducerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testUpgradeWithoutLogMessageFormatVersionSet() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
-
-        String producerName = clusterName + "-producer";
-        String consumerName = clusterName + "-consumer";
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
@@ -154,13 +145,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
             // If it is an upgrade test we keep the message format as the lower version number
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, producerName, consumerName, null, interBrokerProtocol, 3, 3);
+            runVersionChange(initialVersion, newVersion, testStorage, null, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(producerName, consumerName, TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -170,7 +161,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String producerName, String consumerName, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
+    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> brokerPods;
 
@@ -211,17 +202,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, continuousTopicName, 3, 3, 2, TestConstants.CO_NAMESPACE).build());
+            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(clusterName, testStorage.getContinuousTopicName(), 3, 3, 2, TestConstants.CO_NAMESPACE).build());
             String producerAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000";
 
-            KafkaClients kafkaBasicClientJob = new KafkaClientsBuilder()
-                .withProducerName(producerName)
-                .withConsumerName(consumerName)
+            KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
-                .withTopicName(continuousTopicName)
                 .withMessageCount(continuousClientsMessageCount)
                 .withAdditionalConfig(producerAdditionConfiguration)
-                .withDelayMs(1000)
                 .build();
 
             resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -91,7 +91,7 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         checkAllImages(downgradeData, TestConstants.CO_NAMESPACE);
         // Verify upgrade
-        verifyProcedure(downgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(downgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -98,7 +98,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
         assertThat(KafkaUtils.getVersionFromKafkaPodLibs(KafkaResources.kafkaPodName(clusterName, 0)), containsString(acrossUpgradeData.getProcedures().getVersion()));
     }
 
@@ -126,7 +126,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @Test
@@ -194,7 +194,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(upgradeData, testStorage.getProducerName(), testStorage.getConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(upgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
@@ -334,7 +334,7 @@ public abstract class AbstractNamespaceST extends AbstractST {
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
-        ClientUtils.waitForClientsSuccess(testStorage);
+        ClientUtils.waitForInstantClientSuccess(testStorage);
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "99");
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/watcher/AbstractNamespaceST.java
@@ -324,19 +324,14 @@ public abstract class AbstractNamespaceST extends AbstractST {
         LOGGER.info("KafkaConnect Pod: {}/{}", testStorage.getNamespaceName(), kafkaConnectPodName);
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(testStorage.getNamespaceName(), kafkaConnectPodName);
 
-        KafkaClients kafkaClients = new KafkaClientsBuilder()
-            .withTopicName(testStorage.getTopicName())
-            .withMessageCount(testStorage.getMessageCount())
+        KafkaClients kafkaClients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(PRIMARY_KAFKA_NAME))
-            .withProducerName(testStorage.getProducerName())
-            .withConsumerName(testStorage.getConsumerName())
-            .withNamespaceName(testStorage.getNamespaceName())
             .build();
 
         resourceManager.createResourceWithWait(kafkaClients.producerStrimzi(), kafkaClients.consumerStrimzi());
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
-        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, "99");
+        KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description
Changes described by files: 

####  `TestConstants` and `TestStorage`

Concerned mainly with new fields (added for smooth work with continuous clients)

- `continuousProducerName` (All 3 same as their basic counterparts but with extra suffix)
- `continuousConsumerName`
- `continuousTopicName`          
- `continuousMessageCount`   (300 in comparison to 100)

#### `ClientUtils`

Primarily following methods added: 

- `getInstantPlainClientBuilder`
- `getInstantTlsClientBuilder`
- `getContinuousPlainClientBuilder`
- `getContinuousTlsClientBuilder`

Continuous methods are waiting for continuous, clients with respective `teststorage.fields`.  

as these clients are basically hello world (used to be called that way).
there is additionaly namespace and default user which are there for completness.

Any of them can be changed and as can be seen in specific tests they sometimes are which makes it visible what is actually important about given producer/consumer. 

additional helper method `waitForContinuousClientSuccess ` which waits specifically for continuous clients. 

#### `<specific>ST` classes 
changes include: 
- replacing `Environment.TEST_SUITE_NAMESPACE` with testStorage atlernative. 
- removal of unncessary names for producer and consumers espcially with prefixes `continuous` or `<random>` if not needed 
- some continuous client time and message shortening due to very long waiting just for message sending
- slight refactors and removals of unnecessary methods. 


