### PR TITLE
Store secrets and configmaps in folders during log collecting

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -271,15 +271,19 @@ public class LogCollector {
     }
 
     private void collectConfigMaps(String namespace) {
+        Path configMapPath = namespacePath.resolve("configmaps");
+        configMapPath.toFile().mkdirs();
         LOGGER.info("Collecting ConfigMaps in Namespace: {}", namespace);
         kubeClient.listConfigMaps(namespace).forEach(configMap ->
-                writeFile(namespacePath.resolve(configMap.getMetadata().getName() + "-configmap.log"), configMap.toString()));
+                writeFile(configMapPath.resolve(configMap.getMetadata().getName() + ".log"), configMap.toString()));
     }
 
     private void collectSecrets(String namespace) {
+        Path secretPath = namespacePath.resolve("secrets");
+        secretPath.toFile().mkdirs();
         LOGGER.info("Collecting Secrets in Namespace: {}", namespace);
         kubeClient.listSecrets(namespace).forEach(secret ->
-                writeFile(namespacePath.resolve(secret.getMetadata().getName() + "-secret.log"), secret.toString()));
+                writeFile(secretPath.resolve(secret.getMetadata().getName() + ".log"), secret.toString()));
     }
 
     private void collectAllResourcesFromNamespace(String namespace) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -272,18 +272,20 @@ public class LogCollector {
 
     private void collectConfigMaps(String namespace) {
         Path configMapPath = namespacePath.resolve("configmaps");
-        configMapPath.toFile().mkdirs();
-        LOGGER.info("Collecting ConfigMaps in Namespace: {}", namespace);
-        kubeClient.listConfigMaps(namespace).forEach(configMap ->
-                writeFile(configMapPath.resolve(configMap.getMetadata().getName() + ".log"), configMap.toString()));
+        if (configMapPath.toFile().exists() || configMapPath.toFile().mkdirs()) {
+            LOGGER.info("Collecting ConfigMaps in Namespace: {}", namespace);
+            kubeClient.listConfigMaps(namespace).forEach(configMap ->
+                    writeFile(configMapPath.resolve(configMap.getMetadata().getName() + ".log"), configMap.toString()));
+        }
     }
 
     private void collectSecrets(String namespace) {
         Path secretPath = namespacePath.resolve("secrets");
-        secretPath.toFile().mkdirs();
-        LOGGER.info("Collecting Secrets in Namespace: {}", namespace);
-        kubeClient.listSecrets(namespace).forEach(secret ->
-                writeFile(secretPath.resolve(secret.getMetadata().getName() + ".log"), secret.toString()));
+        if (secretPath.toFile().exists() || secretPath.toFile().mkdirs()) {
+            LOGGER.info("Collecting Secrets in Namespace: {}", namespace);
+            kubeClient.listSecrets(namespace).forEach(secret ->
+                    writeFile(secretPath.resolve(secret.getMetadata().getName() + ".log"), secret.toString()));
+        }
     }
 
     private void collectAllResourcesFromNamespace(String namespace) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Due to mess in collected logs this PR gets configmaps and secrets into a sub-folders to keep log folder for failed tests cleaner 

