### PR TITLE
[ST] Use correct Kafka resource for each mode (ZK without NP / ZK with NP / KRaft)

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -21,35 +21,88 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.k8s.KubeClusterResource;
 
 import java.util.Collections;
-
-import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 public class KafkaTemplates {
 
     private KafkaTemplates() {}
 
+    private static final String PATH_TO_KAFKA_EPHEMERAL_KRAFT_EXAMPLE = TestConstants.PATH_TO_PACKAGING_EXAMPLES + "/kafka/kraft/kafka-ephemeral.yaml";
+    private static final String PATH_TO_KAFKA_PERSISTENT_KRAFT_EXAMPLE = TestConstants.PATH_TO_PACKAGING_EXAMPLES + "/kafka/kraft/kafka.yaml";
+    private static final String PATH_TO_KAFKA_PERSISTENT_NODE_POOLS_EXAMPLE = TestConstants.PATH_TO_PACKAGING_EXAMPLES + "/kafka/kafka-with-node-pools.yaml";
     private static final String KAFKA_METRICS_CONFIG_REF_KEY = "kafka-metrics-config.yml";
     private static final String ZOOKEEPER_METRICS_CONFIG_REF_KEY = "zookeeper-metrics-config.yml";
+    private static final String METRICS_KAFKA_CONFIG_MAP_SUFFIX = "-kafka-metrics";
+    private static final String METRICS_CC_CONFIG_MAP_SUFFIX = "-kafka-metrics";
 
-    public static KafkaBuilder kafkaEphemeral(String name, int kafkaReplicas) {
-        return kafkaEphemeral(name, kafkaReplicas, Math.min(kafkaReplicas, 3));
+    // -------------------------------------------------------------------------------------------
+    // Kafka Ephemeral
+    // -------------------------------------------------------------------------------------------
+    public static KafkaBuilder kafkaEphemeral(String clusterName, int kafkaReplicas) {
+        return kafkaEphemeral(clusterName, kafkaReplicas, Math.min(kafkaReplicas, 3));
     }
 
-    public static KafkaBuilder kafkaEphemeral(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_EPHEMERAL_CONFIG);
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas);
+    public static KafkaBuilder kafkaEphemeral(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        if (Environment.isKafkaNodePoolsEnabled()) {
+            if (Environment.isKRaftModeEnabled()) {
+                return kafkaEphemeralKRaft(clusterName, kafkaReplicas);
+            }
+            return kafkaEphemeralNodePools(clusterName, kafkaReplicas, zookeeperReplicas);
+        } else {
+            return kafkaEphemeralWithoutNodePools(clusterName, kafkaReplicas, zookeeperReplicas);
+        }
     }
 
-    public static KafkaBuilder kafkaPersistent(String name, int kafkaReplicas) {
-        return kafkaPersistent(name, kafkaReplicas, Math.min(kafkaReplicas, 3));
+    public static KafkaBuilder kafkaEphemeralWithoutNodePools(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_EPHEMERAL_CONFIG, false);
+        return defaultKafka(kafka, clusterName, kafkaReplicas, zookeeperReplicas);
     }
 
-    public static KafkaBuilder kafkaPersistent(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_PERSISTENT_CONFIG);
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+    public static KafkaBuilder kafkaEphemeralNodePools(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_PERSISTENT_NODE_POOLS_EXAMPLE, true);
+
+        kafka.getSpec().getZookeeper().setStorage(null);
+
+        return defaultKafkaNodePools(kafka, clusterName, kafkaReplicas, zookeeperReplicas)
+            .editSpec()
+            .editZookeeper()
+                // the NodePools (in ZK mode) example contains persistent storage for ZK, so we need to specify the
+                // ephemeral storage
+                .withNewEphemeralStorage()
+                .endEphemeralStorage()
+            .endZookeeper()
+            .endSpec();
+    }
+
+    public static KafkaBuilder kafkaEphemeralKRaft(String clusterName, int kafkaReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_EPHEMERAL_KRAFT_EXAMPLE, true);
+        return defaultKafkaKRaft(kafka, clusterName, kafkaReplicas);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Kafka Persistent
+    // -------------------------------------------------------------------------------------------
+
+    public static KafkaBuilder kafkaPersistent(String clusterName, int kafkaReplicas) {
+        return kafkaPersistent(clusterName, kafkaReplicas, Math.min(kafkaReplicas, 3));
+    }
+
+    public static KafkaBuilder kafkaPersistent(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        if (Environment.isKafkaNodePoolsEnabled()) {
+            if (Environment.isKRaftModeEnabled()) {
+                return kafkaPersistentKRaft(clusterName, kafkaReplicas);
+            }
+            return kafkaPersistentNodePools(clusterName, kafkaReplicas, zookeeperReplicas);
+        } else {
+            return kafkaPersistentWithoutNodePools(clusterName, kafkaReplicas, zookeeperReplicas);
+        }
+    }
+
+    public static KafkaBuilder kafkaPersistentWithoutNodePools(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_EPHEMERAL_CONFIG, false);
+
+        return defaultKafka(kafka, clusterName, kafkaReplicas, zookeeperReplicas)
             .editSpec()
                 .editKafka()
                     .withNewPersistentClaimStorage()
@@ -66,52 +119,54 @@ public class KafkaTemplates {
             .endSpec();
     }
 
-    /**
-     * Overloads {@link #kafkaPersistent(String, int)}, but the difference is that it removes LMFV and IBPV from the Kafka
-     * config
-     * @param name of the Kafka cluster
-     * @param kafkaReplicas number of Kafka replicas
-     * @return KafkaBuilder for Kafka with persistent storage
-     */
-    public static KafkaBuilder kafkaPersistentKRaft(String name, int kafkaReplicas) {
-        return kafkaPersistent(name, kafkaReplicas)
-            .editSpec()
-                .editKafka()
-                    .removeFromConfig("log.message.format.version")
-                    .removeFromConfig("inter.broker.protocol.version")
-                .endKafka()
-            .endSpec();
-    }
+    public static KafkaBuilder kafkaPersistentNodePools(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_PERSISTENT_NODE_POOLS_EXAMPLE, true);
+        kafka.getSpec().getZookeeper().setStorage(null);
 
-    public static KafkaBuilder kafkaJBOD(String name, int kafkaReplicas, JbodStorage jbodStorage) {
-        return kafkaJBOD(name, kafkaReplicas, 3, jbodStorage);
-    }
-
-    public static KafkaBuilder kafkaJBOD(String name, int kafkaReplicas, int zookeeperReplicas, JbodStorage jbodStorage) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_PERSISTENT_CONFIG);
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+        return defaultKafkaNodePools(kafka, clusterName, kafkaReplicas, zookeeperReplicas)
             .editSpec()
-                .editKafka()
-                    .withStorage(jbodStorage)
-                .endKafka()
-                .editZookeeper().
-                    withReplicas(zookeeperReplicas)
+                .editZookeeper()
+                    .withNewPersistentClaimStorage()
+                        .withSize("1Gi")
+                        .withDeleteClaim(true)
+                    .endPersistentClaimStorage()
                 .endZookeeper()
             .endSpec();
     }
 
-    public static KafkaBuilder kafkaWithMetrics(String name, String namespace, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG);
-        String metricsConfigMapName = name + "-kafka-metrics";
-        ConfigMap metricsCm = TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        metricsCm.getMetadata().setName(metricsConfigMapName);
-        if (KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespace).withName(metricsConfigMapName).get() != null) {
-            KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespace).withName(metricsConfigMapName).delete();
+    public static KafkaBuilder kafkaPersistentKRaft(String clusterName, int kafkaReplicas) {
+        Kafka kafka = getKafkaFromYaml(PATH_TO_KAFKA_PERSISTENT_KRAFT_EXAMPLE, true);
+        return defaultKafkaKRaft(kafka, clusterName, kafkaReplicas);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Kafka JBOD
+    // -------------------------------------------------------------------------------------------
+
+    public static KafkaBuilder kafkaJBOD(String clusterName, int kafkaReplicas, int zookeeperReplicas, JbodStorage jbodStorage) {
+        if (Environment.isKafkaNodePoolsEnabled()) {
+            return kafkaPersistentNodePools(clusterName, kafkaReplicas, zookeeperReplicas);
+        } else {
+            return kafkaPersistentWithoutNodePools(clusterName, kafkaReplicas, kafkaReplicas)
+                .editSpec()
+                    .editKafka()
+                        .withStorage(jbodStorage)
+                    .endKafka()
+                .endSpec();
         }
-        KubeClusterResource.kubeClient().createConfigMapInNamespace(namespace, metricsCm);
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
-            .editOrNewMetadata()
-                .withNamespace(namespace)
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Kafka with metrics
+    // -------------------------------------------------------------------------------------------
+
+    public static KafkaBuilder kafkaWithMetrics(String namespaceName, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, false);
+        String configMapName = clusterName + METRICS_KAFKA_CONFIG_MAP_SUFFIX;
+
+        return defaultKafka(kafka, clusterName, kafkaReplicas, zookeeperReplicas)
+            .editMetadata()
+                .withNamespace(namespaceName)
             .endMetadata()
             .editSpec()
                 .withNewKafkaExporter()
@@ -119,191 +174,303 @@ public class KafkaTemplates {
                 .editKafka()
                     .withNewJmxPrometheusExporterMetricsConfig()
                         .withNewValueFrom()
-                            .withNewConfigMapKeyRef(KAFKA_METRICS_CONFIG_REF_KEY, metricsConfigMapName, false)
+                            .withNewConfigMapKeyRef(KAFKA_METRICS_CONFIG_REF_KEY, configMapName, false)
                         .endValueFrom()
                     .endJmxPrometheusExporterMetricsConfig()
                 .endKafka()
                 .editZookeeper()
                     .withNewJmxPrometheusExporterMetricsConfig()
                         .withNewValueFrom()
-                            .withNewConfigMapKeyRef(ZOOKEEPER_METRICS_CONFIG_REF_KEY, metricsConfigMapName, false)
+                            .withNewConfigMapKeyRef(ZOOKEEPER_METRICS_CONFIG_REF_KEY, configMapName, false)
                         .endValueFrom()
                     .endJmxPrometheusExporterMetricsConfig()
                 .endZookeeper()
             .endSpec();
     }
 
-    public static KafkaBuilder kafkaWithCruiseControl(String name, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG);
-
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
-                .editSpec()
-                    .editCruiseControl()
-                        // Extend active users tasks as we
-                        .addToConfig("max.active.user.tasks", 10)
-                    .endCruiseControl()
-                .endSpec();
-    }
-
-    public static KafkaBuilder kafkaWithMetricsAndCruiseControlWithMetrics(String name, String namespaceName, int kafkaReplicas, int zookeeperReplicas) {
-        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG);
-        String metricsConfigMapName = name + "-kafka-metrics";
-        String ccConfigMapName = name + "-cruise-control-metrics-test";
-        ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-        kafkaMetricsCm.getMetadata().setName(metricsConfigMapName);
-        if (KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(metricsConfigMapName).get() != null) {
-            KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(metricsConfigMapName).delete();
-        }
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(kafkaMetricsCm).create();
-
-        ConfigMap ccCm = new ConfigMapBuilder()
-                .withApiVersion("v1")
-                .withNewMetadata()
-                    .withName(ccConfigMapName)
-                    .withLabels(Collections.singletonMap("app", "strimzi"))
-                .endMetadata()
-                .withData(Collections.singletonMap("metrics-config.yml",
-                        "lowercaseOutputName: true\n" +
-                        "rules:\n" +
-                        "- pattern: kafka.cruisecontrol<name=(.+)><>(\\w+)\n" +
-                        "  name: kafka_cruisecontrol_$1_$2\n" +
-                        "  type: GAUGE"))
-                .build();
-        if (KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(ccConfigMapName).get() != null) {
-            KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).withName(ccConfigMapName).delete();
-        }
-        KubeClusterResource.kubeClient().getClient().configMaps().inNamespace(namespaceName).resource(ccCm).create();
+    public static KafkaBuilder kafkaWithMetricsAndCruiseControlWithMetrics(String namespaceName, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        String ccConfigMapName = clusterName + METRICS_CC_CONFIG_MAP_SUFFIX;
 
         ConfigMapKeySelector cmks = new ConfigMapKeySelectorBuilder()
-                .withName(ccConfigMapName)
-                .withKey("metrics-config.yml")
-                .build();
-        JmxPrometheusExporterMetrics jmxPrometheusExporterMetrics = new JmxPrometheusExporterMetricsBuilder()
-                .withNewValueFrom()
-                    .withConfigMapKeyRef(cmks)
-                .endValueFrom()
-                .build();
+            .withName(ccConfigMapName)
+            .withKey("metrics-config.yml")
+            .build();
 
-        return defaultKafka(kafka, name, kafkaReplicas, zookeeperReplicas)
+        JmxPrometheusExporterMetrics jmxPrometheusExporterMetrics = new JmxPrometheusExporterMetricsBuilder()
+            .withNewValueFrom()
+                .withConfigMapKeyRef(cmks)
+            .endValueFrom()
+            .build();
+
+        return kafkaWithMetrics(namespaceName, clusterName, kafkaReplicas, zookeeperReplicas)
             .editSpec()
-                .withNewKafkaExporter()
-                .endKafkaExporter()
                 .withNewCruiseControl()
                     .withMetricsConfig(jmxPrometheusExporterMetrics)
-                    // Extend active users tasks as we
+                    // Extend active users tasks
                     .addToConfig("max.active.user.tasks", 10)
                 .endCruiseControl()
+            .endSpec();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // ConfigMaps for Kafka with metrics
+    // -------------------------------------------------------------------------------------------
+
+    public static ConfigMap kafkaMetricsConfigMap(String namespaceName, String clusterName) {
+        String configMapName = clusterName + METRICS_KAFKA_CONFIG_MAP_SUFFIX;
+
+        ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
+
+        return new ConfigMapBuilder(kafkaMetricsCm)
+            .editMetadata()
+                .withName(configMapName)
+                .withNamespace(namespaceName)
+            .endMetadata()
+            .build();
+    }
+
+    public static ConfigMap cruiseControlMetricsConfigMap(String namespaceName, String clusterName) {
+        String configMapName = clusterName + METRICS_CC_CONFIG_MAP_SUFFIX;
+
+        return new ConfigMapBuilder()
+            .withNewMetadata()
+                .withName(configMapName)
+                .withLabels(Collections.singletonMap("app", "strimzi"))
+                .withNamespace(namespaceName)
+            .endMetadata()
+            .withData(
+                Collections.singletonMap("metrics-config.yml",
+                "lowercaseOutputName: true\n" +
+                    "rules:\n" +
+                    "- pattern: kafka.cruisecontrol<name=(.+)><>(\\w+)\n" +
+                    "  name: kafka_cruisecontrol_$1_$2\n" +
+                    "  type: GAUGE"))
+            .build();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Kafka with Cruise Control
+    // -------------------------------------------------------------------------------------------
+
+    public static KafkaBuilder kafkaWithCruiseControl(String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        Kafka kafka = getKafkaFromYaml(TestConstants.PATH_TO_KAFKA_CRUISE_CONTROL_CONFIG, false);
+
+        return defaultKafka(kafka, clusterName, kafkaReplicas, zookeeperReplicas)
+            .editSpec()
+                .editCruiseControl()
+                    // Extend active users tasks
+                    .addToConfig("max.active.user.tasks", 10)
+                .endCruiseControl()
+            .endSpec();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Kafka default templates
+    // -------------------------------------------------------------------------------------------
+
+    private static KafkaBuilder defaultKafka(Kafka kafka, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        if (Environment.isKafkaNodePoolsEnabled()) {
+            if (Environment.isKRaftModeEnabled()) {
+                return defaultKafkaKRaft(kafka, clusterName, kafkaReplicas);
+            }
+            return defaultKafkaNodePools(kafka, clusterName, kafkaReplicas, zookeeperReplicas);
+        } else {
+            return defaultKafkaWithoutNodePools(kafka, clusterName, kafkaReplicas, zookeeperReplicas);
+        }
+    }
+
+    private static KafkaBuilder defaultKafkaWithoutNodePools(Kafka kafka, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        KafkaBuilder kb = new KafkaBuilder(kafka)
+            .withNewMetadata()
+                .withName(clusterName)
+            .endMetadata()
+            .editSpec()
                 .editKafka()
-                    .withNewJmxPrometheusExporterMetricsConfig()
-                        .withNewValueFrom()
-                            .withNewConfigMapKeyRef(KAFKA_METRICS_CONFIG_REF_KEY, metricsConfigMapName, false)
-                        .endValueFrom()
-                    .endJmxPrometheusExporterMetricsConfig()
+                    .withReplicas(kafkaReplicas)
+                .endKafka()
+            .endSpec();
+
+        applyDefaultSpecOfKafka(kb, kafkaReplicas);
+        applyDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
+        applyDefaultLogging(kb, true);
+        applyMemoryRequestsAndLimitsIfNeeded(kb, true);
+        removeFieldsNotRelatedToParticularMode(kb, true);
+
+        return kb;
+    }
+
+    private static KafkaBuilder defaultKafkaNodePools(Kafka kafka, String clusterName, int kafkaReplicas, int zookeeperReplicas) {
+        KafkaBuilder kb = new KafkaBuilder(kafka)
+            .withNewMetadata()
+                .withName(clusterName)
+            .endMetadata();
+
+        applyDefaultSpecOfKafka(kb, kafkaReplicas);
+        applyDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
+        applyDefaultLogging(kb, true);
+        applyMemoryRequestsAndLimitsIfNeeded(kb, true);
+        removeFieldsNotRelatedToParticularMode(kb, true);
+
+        return kb;
+    }
+
+    private static KafkaBuilder defaultKafkaKRaft(Kafka kafka, String clusterName, int kafkaReplicas) {
+        KafkaBuilder kb = new KafkaBuilder(kafka)
+            .withNewMetadata()
+                .withName(clusterName)
+            .endMetadata()
+            .editSpec()
+                .editKafka()
+                    .withMetadataVersion(TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).metadataVersion())
+                .endKafka()
+            .endSpec();
+
+        applyDefaultSpecOfKafka(kb, kafkaReplicas);
+        applyDefaultLogging(kb, false);
+        applyMemoryRequestsAndLimitsIfNeeded(kb, false);
+        removeFieldsNotRelatedToParticularMode(kb, false);
+
+        return kb;
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Application of defaults to the builders
+    // -------------------------------------------------------------------------------------------
+
+    private static void applyDefaultConfigurationOfZookeeperKafka(KafkaBuilder kafkaBuilder, int zookeeperReplicas) {
+        kafkaBuilder
+            .editSpec()
+                .editKafka()
+                    .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).messageVersion())
+                    .addToConfig("inter.broker.protocol.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                 .endKafka()
                 .editZookeeper()
-                    .withNewJmxPrometheusExporterMetricsConfig()
-                        .withNewValueFrom()
-                            .withNewConfigMapKeyRef(ZOOKEEPER_METRICS_CONFIG_REF_KEY, metricsConfigMapName, false)
-                        .endValueFrom()
-                    .endJmxPrometheusExporterMetricsConfig()
+                    .withReplicas(zookeeperReplicas)
                 .endZookeeper()
             .endSpec();
     }
 
-    private static KafkaBuilder defaultKafka(Kafka kafka, String name, int kafkaReplicas, int zookeeperReplicas) {
-        KafkaBuilder kb = new KafkaBuilder(kafka)
-            .withNewMetadata()
-                .withName(name)
-                .withNamespace(kubeClient().getNamespace())
-            .endMetadata()
+    private static void applyDefaultLogging(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
+        kafkaBuilder
             .editSpec()
                 .editKafka()
+                    .withNewInlineLogging()
+                        .addToLoggers("kafka.root.logger.level", "DEBUG")
+                    .endInlineLogging()
+                .endKafka()
+                .editEntityOperator()
+                    .editUserOperator()
+                        .withNewInlineLogging()
+                            .addToLoggers("rootLogger.level", "DEBUG")
+                        .endInlineLogging()
+                    .endUserOperator()
+                    .editTopicOperator()
+                        .withNewInlineLogging()
+                            .addToLoggers("rootLogger.level", "DEBUG")
+                        .endInlineLogging()
+                    .endTopicOperator()
+                .endEntityOperator()
+            .endSpec();
+
+        if (withZookeeper) {
+            kafkaBuilder
+                .editSpec()
+                    .editZookeeper()
+                        .withNewInlineLogging()
+                            .addToLoggers("zookeeper.root.logger", "DEBUG")
+                        .endInlineLogging()
+                    .endZookeeper()
+                .endSpec();
+        }
+    }
+
+    private static void applyMemoryRequestsAndLimitsIfNeeded(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
+        if (!Environment.isSharedMemory()) {
+            kafkaBuilder
+                .editSpec()
+                    .editKafka()
+                        // we use such values, because on environments where it is limited to 7Gi, we are unable to deploy
+                        // Cluster Operator, two Kafka clusters and MirrorMaker/2. Such situation may result in an OOM problem.
+                        // For Kafka using 784Mi is too much and on the other hand 256Mi is causing OOM problem at the start.
+                        .withResources(new ResourceRequirementsBuilder()
+                            .addToLimits("memory", new Quantity("512Mi"))
+                            .addToRequests("memory", new Quantity("512Mi"))
+                            .build())
+                    .endKafka()
+                    .editEntityOperator()
+                        .editUserOperator()
+                            // For User Operator using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
+                            .withResources(new ResourceRequirementsBuilder()
+                                .addToLimits("memory", new Quantity("256Mi"))
+                                .addToRequests("memory", new Quantity("256Mi"))
+                                .build())
+                        .endUserOperator()
+                        .editTopicOperator()
+                            // For Topic Operator using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
+                            .withResources(new ResourceRequirementsBuilder()
+                                .addToLimits("memory", new Quantity("256Mi"))
+                                .addToRequests("memory", new Quantity("256Mi"))
+                                .build())
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec();
+
+            if (withZookeeper) {
+                kafkaBuilder
+                    .editSpec()
+                        .editZookeeper()
+                            // For ZooKeeper using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
+                            .withResources(new ResourceRequirementsBuilder()
+                                .addToLimits("memory", new Quantity("256Mi"))
+                                .addToRequests("memory", new Quantity("256Mi"))
+                                .build())
+                        .endZookeeper()
+                    .endSpec();
+            }
+        }
+    }
+
+    private static void applyDefaultSpecOfKafka(KafkaBuilder kafkaBuilder, int kafkaReplicas) {
+        kafkaBuilder
+            .editSpec()
+                .editKafka()
+                    .withListeners(
+                        new GenericKafkaListenerBuilder()
+                            .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                            .withPort(9092)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(false)
+                            .build(),
+                        new GenericKafkaListenerBuilder()
+                            .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
+                            .withPort(9093)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .withTls(true)
+                            .build())
                     .withVersion(Environment.ST_KAFKA_VERSION)
-                    .withReplicas(kafkaReplicas)
-                    .addToConfig("log.message.format.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
-                    .addToConfig("inter.broker.protocol.version", TestKafkaVersion.getKafkaVersionsInMap().get(Environment.ST_KAFKA_VERSION).protocolVersion())
                     .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                     .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("default.replication.factor", Math.min(kafkaReplicas, 3))
                     .addToConfig("min.insync.replicas", Math.min(Math.max(kafkaReplicas - 1, 1), 2))
-                    .withListeners(new GenericKafkaListenerBuilder()
-                                .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
-                                .withPort(9092)
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withTls(false)
-                                .build(),
-                            new GenericKafkaListenerBuilder()
-                                .withName(TestConstants.TLS_LISTENER_DEFAULT_NAME)
-                                .withPort(9093)
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withTls(true)
-                                .build())
-                    .withNewInlineLogging()
-                        .addToLoggers("kafka.root.logger.level", "DEBUG")
-                    .endInlineLogging()
                 .endKafka()
-                .editZookeeper()
-                    .withReplicas(zookeeperReplicas)
-                    .withNewInlineLogging()
-                        .addToLoggers("zookeeper.root.logger", "DEBUG")
-                    .endInlineLogging()
-                .endZookeeper()
-                .editEntityOperator()
-                    .editUserOperator()
-                        .withNewInlineLogging()
-                            .addToLoggers("rootLogger.level", "DEBUG")
-                        .endInlineLogging()
-                    .endUserOperator()
-                    .editTopicOperator()
-                        .withNewInlineLogging()
-                            .addToLoggers("rootLogger.level", "DEBUG")
-                        .endInlineLogging()
-                    .endTopicOperator()
-                .endEntityOperator()
             .endSpec();
-
-        if (!Environment.isSharedMemory()) {
-            kb.editSpec()
-                .editKafka()
-                    // we use such values, because on environments where it is limited to 7Gi, we are unable to deploy
-                    // Cluster Operator, two Kafka clusters and MirrorMaker/2. Such situation may result in an OOM problem.
-                    // For Kafka using 784Mi is too much and on the other hand 256Mi is causing OOM problem at the start.
-                    .withResources(new ResourceRequirementsBuilder()
-                        .addToLimits("memory", new Quantity("512Mi"))
-                        .addToRequests("memory", new Quantity("512Mi"))
-                        .build())
-                .endKafka()
-                .editZookeeper()
-                    // For ZooKeeper using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
-                    .withResources(new ResourceRequirementsBuilder()
-                        .addToLimits("memory", new Quantity("256Mi"))
-                        .addToRequests("memory", new Quantity("256Mi"))
-                        .build())
-                .endZookeeper()
-                .editEntityOperator()
-                    .editUserOperator()
-                        // For User Operator using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
-                        .withResources(new ResourceRequirementsBuilder()
-                            .addToLimits("memory", new Quantity("256Mi"))
-                            .addToRequests("memory", new Quantity("256Mi"))
-                            .build())
-                    .endUserOperator()
-                    .editTopicOperator()
-                        // For Topic Operator using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
-                        .withResources(new ResourceRequirementsBuilder()
-                            .addToLimits("memory", new Quantity("256Mi"))
-                            .addToRequests("memory", new Quantity("256Mi"))
-                            .build())
-                    .endTopicOperator()
-                .endEntityOperator()
-                .endSpec();
-        }
-
-        return kb;
     }
 
-    private static Kafka getKafkaFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, Kafka.class);
+    private static void removeFieldsNotRelatedToParticularMode(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
+        // in case that we are using file that is not customized to usage of NodePools or KRaft, we need to remove all the
+        // fields here
+        if (!withZookeeper) {
+            kafkaBuilder.getSpec().setZookeeper(null);
+        }
+
+        kafkaBuilder.getSpec().getKafka().setStorage(null);
+        // TODO: currently commented, as we are not able to set null or completely remove the .replicas field
+        // kafkaBuilder.getSpec().getKafka().setReplicas();
+    }
+
+    private static Kafka getKafkaFromYaml(String yamlPath, boolean containsNodePools) {
+        return containsNodePools ?
+            TestUtils.configFromMultiYamlFile(yamlPath, Kafka.RESOURCE_KIND, Kafka.class) : TestUtils.configFromYaml(yamlPath, Kafka.class);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -390,7 +390,7 @@ class KafkaST extends AbstractST {
 
         JbodStorage jbodStorage = new JbodStorageBuilder().withVolumes(idZeroVolumeOriginal, idOneVolumeOriginal).build();
 
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaJBOD(testStorage.getClusterName(), kafkaReplicas, jbodStorage).build());
+        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaJBOD(testStorage.getClusterName(), kafkaReplicas, 3, jbodStorage).build());
         // kafka cluster already deployed
         verifyVolumeNamesAndLabels(testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getKafkaStatefulSetName(), kafkaReplicas, 2, diskSizeGi);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -717,6 +717,8 @@ public class MetricsST extends AbstractST {
 
         // create resources without wait to deploy them simultaneously
         resourceManager.createResourceWithoutWait(extensionContext,
+            KafkaTemplates.kafkaMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
+            KafkaTemplates.cruiseControlMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
             // Kafka with CruiseControl and metrics
             KafkaTemplates.kafkaWithMetricsAndCruiseControlWithMetrics(kafkaClusterFirstName, namespaceFirst, 3, 3)
                 .editOrNewSpec()
@@ -730,7 +732,8 @@ public class MetricsST extends AbstractST {
                     .endEntityOperator()
                 .endSpec()
                 .build(),
-            KafkaTemplates.kafkaWithMetrics(kafkaClusterSecondName, namespaceSecond, 1, 1).build(),
+            KafkaTemplates.kafkaMetricsConfigMap(namespaceSecond, kafkaClusterSecondName),
+            KafkaTemplates.kafkaWithMetrics(namespaceSecond, kafkaClusterSecondName, 1, 1).build(),
             ScraperTemplates.scraperPod(TestConstants.CO_NAMESPACE, coScraperName).build(),
             ScraperTemplates.scraperPod(Environment.TEST_SUITE_NAMESPACE, testSuiteScraperName).build(),
             ScraperTemplates.scraperPod(namespaceFirst, scraperName).build(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -268,11 +268,14 @@ public class NetworkPoliciesST extends AbstractST {
 
         cluster.setNamespace(secondNamespace);
 
-        resourceManager.createResourceWithWait(extensionContext, KafkaTemplates.kafkaWithMetrics(testStorage.getClusterName(), secondNamespace, 3, 3)
-            .editMetadata()
-                .addToLabels(labels)
-            .endMetadata()
-            .build());
+        resourceManager.createResourceWithWait(extensionContext,
+            KafkaTemplates.kafkaMetricsConfigMap(secondNamespace, testStorage.getClusterName()),
+            KafkaTemplates.kafkaWithMetrics(secondNamespace, testStorage.getClusterName(), 3, 3)
+                .editMetadata()
+                    .addToLabels(labels)
+                .endMetadata()
+                .build()
+        );
 
         checkNetworkPoliciesInNamespace(testStorage.getClusterName(), secondNamespace);
 

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -336,6 +336,25 @@ public final class TestUtils {
 
     }
 
+    public static <T> T configFromMultiYamlFile(String yamlFile, String expectedKind, Class<T> kindClass) {
+        return configFromMultiYamlFile(new File(yamlFile), expectedKind, kindClass);
+    }
+
+    public static <T> T configFromMultiYamlFile(File yamlFile, String expectedKind, Class<T> kindClass) {
+        try {
+            YAMLFactory yamlFactory = new YAMLFactory();
+            ObjectMapper mapper = new ObjectMapper();
+            YAMLParser yamlParser = yamlFactory.createParser(yamlFile);
+            List<Map<String, Object>> resources = mapper.readValues(yamlParser, new TypeReference<Map<String, Object>>() { }).readAll();
+
+            return mapper.convertValue(resources.stream().filter(resource -> resource.get("kind").equals(expectedKind)).findFirst().get(), kindClass);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static <T> T configFromYaml(File yamlFile, Class<T> c) {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {


### PR DESCRIPTION
### Type of change

- Bugfix / Enhancement

### Description

This PR refactors `KafkaTemplates` class, so during STs the correct Kafka resource is used. Currently, when we are running the STs, we are getting a lot of warnings about specified fields, that are not used:

In ZK with NodePools:
- `.spec.kafka.replicas` is used
- `.spec.kafka.storage` is used

In KRaft then:
- `.spec.zookeeper` is used
- LMFV and IBPV are used in config
- `metadataVersion` is not set (IIRC that's not a warning, but for LMFV and IBPV we are setting a version here, so we should do a same thing in KRaft as well)

Also, `kafkaWithMetrics` and `kafkaWithMetricsAndCruiseControlWithMetrics` contain creation of `ConfigMap`s, which IMHO shouldn't be part of the particular methods, but the creation should be done in `ResourceManager`, thus I removed it from those two methods and created separate one just for the `ConfigMap`s. Those have to applied before applying `Kafka` resource, but that's something what would user anyway do and it's not hidden.

As part of this PR I moved out common code and I created methods that are used in particular `default*` templates.

_NOTE: `kafkaBuilder.getSpec().getKafka().setReplicas();` is currently commented, because we cannot set 0 or null to this field, which is needed to get rid of the "`.spec.kafka.replicas` used" warning - the field is `int` and minimum number of replicas user can set is 1, so Fabric8 API prevents creating such object. Once this is resolved, we should enable this set._

### Checklist

- [ ] Make sure all tests pass