### PR TITLE
[ST] fixing unnecessary error logs when cleaning resources

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -346,6 +346,10 @@ public class ResourceManager {
                 type.delete(resource);
                 assertTrue(waitResourceCondition(resource, ResourceCondition.deletion()),
                         String.format("Timed out deleting %s %s/%s", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()));
+            } catch (NullPointerException e) {
+                // some of the resources may be actually deleted during the test causing extra error logs when trying to delete resource which is no longer present
+                LOGGER.info("Unable to find resource {}/{}, seems to be already deleted ", resource.getKind(), resource.getMetadata().getName());
+                LOGGER.trace(e);
             } catch (Exception e)   {
                 if (resource.getMetadata().getNamespace() == null) {
                     LOGGER.error("Failed to delete {} {}", resource.getKind(), resource.getMetadata().getName(), e);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -346,10 +346,6 @@ public class ResourceManager {
                 type.delete(resource);
                 assertTrue(waitResourceCondition(resource, ResourceCondition.deletion()),
                         String.format("Timed out deleting %s %s/%s", resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName()));
-            } catch (NullPointerException e) {
-                // some of the resources may be actually deleted during the test causing extra error logs when trying to delete resource which is no longer present
-                LOGGER.info("Unable to find resource {}/{}, seems to be already deleted ", resource.getKind(), resource.getMetadata().getName());
-                LOGGER.trace(e);
             } catch (Exception e)   {
                 if (resource.getMetadata().getNamespace() == null) {
                     LOGGER.error("Failed to delete {} {}", resource.getKind(), resource.getMetadata().getName(), e);

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -101,7 +101,8 @@ public class SetupClusterOperator {
     private int replicas = 1;
 
     private String testClassName;
-    private String testMethodName;
+    // by default, we expect at least empty method name in order to collect logs correctly
+    private String testMethodName = "";
     private List<RoleBinding> roleBindings;
     private List<Role> roles;
     private List<ClusterRole> clusterRoles;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2085,8 +2085,6 @@ public class ListenersST extends AbstractST {
         }
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(testStorage.getClusterName(), testStorage.getNamespaceName(), ".*Secret " + nonExistingCertName + " with custom TLS certificate does not exist.*");
-
-        KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).delete();
     }
 
     @ParallelNamespaceTest
@@ -2123,8 +2121,6 @@ public class ListenersST extends AbstractST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(testStorage.getClusterName(), testStorage.getNamespaceName(),
                 ".*Secret " + clusterCustomCertServer1 + " does not contain certificate under the key " + nonExistingCertName + ".*");
-
-        KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).delete();
     }
 
     @ParallelNamespaceTest
@@ -2161,8 +2157,6 @@ public class ListenersST extends AbstractST {
 
         KafkaUtils.waitUntilKafkaStatusConditionContainsMessage(testStorage.getClusterName(), testStorage.getNamespaceName(),
                 ".*Secret " + clusterCustomCertServer1 + " does not contain custom certificate private key under the key " + nonExistingCertKey + ".*");
-
-        KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).delete();
     }
 
     @ParallelNamespaceTest

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.rollingupdate;
 
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirement;
@@ -321,8 +320,6 @@ public class KafkaRollerST extends AbstractST {
 
         // kafka should get back ready in some reasonable time frame
         KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
-        KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
-        KafkaUtils.waitForKafkaDeletion(testStorage.getNamespaceName(), testStorage.getClusterName());
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description
all changes made in order to avoid error logs (mostly null pointers) when removing Kafka resources and namespaces. 

- added one check to make sure kafka is present when cleaning Kafka resource. (solve problems with "Kafka" null pointers)
- added default value for "testMethodName" when setting up cluster Operator namespaces and Logs Collecting, this is expected by the way we are creating them e.g. causing unexpected behaviour when trying to remove namespace.

additionally removal of several explicit kafka deletions in the end of the test as they are not necessary there (and are commonly no longer used as we have cleaning set up).


