### PR TITLE
Fix flaky Cruise Control test and fix error when RF is not configured

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -90,8 +90,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             Map.entry(CruiseControlConfigurationParameters.WEBSERVER_SSL_ENABLE.getValue(), Boolean.toString(CruiseControlConfigurationParameters.DEFAULT_WEBSERVER_SSL_ENABLED)),
             Map.entry(CruiseControlConfigurationParameters.PARTITION_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_PARTITION_METRIC_TOPIC_NAME),
             Map.entry(CruiseControlConfigurationParameters.BROKER_METRIC_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_BROKER_METRIC_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME),
-            Map.entry(CruiseControlConfigurationParameters.CAPACITY_CONFIG_FILE.getValue(), CruiseControl.CONFIG_VOLUME_MOUNT + CruiseControl.CAPACITY_CONFIG_FILENAME)
+            Map.entry(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)
     )));
 
     private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
@@ -103,9 +102,10 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
      *
      * @param reconciliation  The reconciliation
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     * @param defaults        Default configuration values
      */
-    public CruiseControlConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
+    public CruiseControlConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, Map<String, String> defaults) {
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, defaults);
     }
 
     protected static Map<String, String> getCruiseControlDefaultPropertiesMap() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1235,7 +1235,7 @@ public class KafkaRebalanceAssemblyOperator
                                     return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccApiSecretName));
                                 }
 
-                                CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet());
+                                CruiseControlConfiguration ccConfig = new CruiseControlConfiguration(reconciliation, kafka.getSpec().getCruiseControl().getConfig().entrySet(), Map.of());
                                 boolean apiAuthEnabled = ccConfig.isApiAuthEnabled();
                                 boolean apiSslEnabled = ccConfig.isApiSslEnabled();
                                 CruiseControlApi apiClient = cruiseControlClientProvider(ccSecret, ccApiSecret, apiAuthEnabled, apiSslEnabled);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -154,7 +154,7 @@ public class CruiseControlReconcilerTest {
                     // Verify deployment
                     assertThat(deployCaptor.getAllValues().size(), is(1));
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("fc0ad847"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("096591fb"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_AUTH_HASH), is("27ada64b"));
 

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -26,5 +26,6 @@ ssl.truststore.type=PKCS12
 ssl.truststore.location=/tmp/cruise-control/replication.truststore.p12
 ssl.truststore.password=$CERTS_STORE_PASSWORD
 kafka.broker.failure.detection.enable=true
+capacity.config.file=/opt/cruise-control/custom-config/capacity.json
 ${CRUISE_CONTROL_CONFIGURATION}
 EOF


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#9471 introduced a flaky test caused by inconsistent ordering of the Cruise Control configuration. There is also a bug when the default replication factor is not configured in the Kafka CR:

```
java.lang.NullPointerException: Cannot invoke "String.length()" because "v" is null
	at io.strimzi.operator.common.model.OrderedProperties$PropertiesWriter.escapeValue(OrderedProperties.java:509) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.common.model.OrderedProperties$PropertiesWriter.write(OrderedProperties.java:461) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.common.model.OrderedProperties$PropertiesWriter.write(OrderedProperties.java:443) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.common.model.OrderedProperties$PropertiesWriter.writeString(OrderedProperties.java:429) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.common.model.OrderedProperties.asPairsWithComment(OrderedProperties.java:143) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.common.model.OrderedProperties.asPairs(OrderedProperties.java:130) ~[io.strimzi.operator-common-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.cluster.model.CruiseControl.generateConfigMap(CruiseControl.java:544) ~[io.strimzi.cluster-operator-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.strimzi.operator.cluster.operator.assembly.CruiseControlReconciler.lambda$configMap$7(CruiseControlReconciler.java:189) ~[io.strimzi.cluster-operator-0.40.0-SNAPSHOT.jar:0.40.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:246) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.Mapping.onSuccess(Mapping.java:40) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:246) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.CompositeFutureImpl.complete(CompositeFutureImpl.java:172) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.CompositeFutureImpl.lambda$join$3(CompositeFutureImpl.java:109) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.3.jar:4.5.3]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.106.Final.jar:4.1.106.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

It also moves the handling of the default options to the `AbstractConfiguration` class and the `capacity.config.file` to the shell script as that is a forbidden option.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally