### PR TITLE
Inform about reverted scale-down or role-change in `.status` section

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -630,7 +630,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         }
 
                         return new KafkaClusterCreator(vertx, reconciliation, config, supplier)
-                                .prepareKafkaCluster(kafkaAssembly, nodePools, oldStorage, currentPods, versionChange, true)
+                                .prepareKafkaCluster(kafkaAssembly, nodePools, oldStorage, currentPods, versionChange, kafkaStatus, true)
                                 .compose(kafkaCluster -> {
                                     // We store this for use with Cruise Control later. As these configurations might
                                     // not be exactly hte same as in the original custom resource (for example because

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreatorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -245,16 +247,20 @@ public class KafkaClusterCreatorTest {
     public void testNewClusterWithoutNodePools(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, null, Map.of(), Map.of(), VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA, null, Map.of(), Map.of(), VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(3));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -267,16 +273,20 @@ public class KafkaClusterCreatorTest {
     public void testExistingClusterWithoutNodePools(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_3_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_3_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(3));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -293,16 +303,24 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(0, 1, 2, 3, 4)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(5));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2, 3, 4)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions().size(), is(1));
+                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of Kafka my-cluster by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -319,16 +337,20 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(0, 1, 2)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(3));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
                     assertThat(kc.removedNodes(), is(Set.of(3, 4)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -345,14 +367,18 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(0, 1, 2, 3, 4)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(KAFKA, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.failing(ex -> context.verify(() -> {
                     // Check exception
                     assertThat(ex, instanceOf(InvalidResourceException.class));
                     assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot scale-down Kafka brokers [3, 4] because they have assigned partition-replicas.]"));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -375,16 +401,20 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(0, 1, 2, 3, 4)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(kafka, null, Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(3));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2)));
                     assertThat(kc.removedNodes(), is(Set.of(3, 4)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -401,16 +431,20 @@ public class KafkaClusterCreatorTest {
     public void testNewClusterWithNodePools(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A, POOL_B), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A, POOL_B), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(6));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2, 3, 4, 5)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -423,16 +457,20 @@ public class KafkaClusterCreatorTest {
     public void testExistingClusterWithNodePools(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(6));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -449,16 +487,28 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 1003, 2004)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(10));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 1003, 1004, 2000, 2001, 2002, 2003, 2004)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions().size(), is(2));
+                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-a by changing number of replicas to 5"));
+                    assertThat(kafkaStatus.getConditions().get(1).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(1).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(1).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(1).getMessage(), is("Reverting scale-down of KafkaNodePool pool-b by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -475,16 +525,20 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(6));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002)));
                     assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -501,14 +555,18 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 1003, 1004, 2003, 2004)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(KAFKA_WITH_POOLS, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.failing(ex -> context.verify(() -> {
                     // Check exception
                     assertThat(ex, instanceOf(InvalidResourceException.class));
                     assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot scale-down Kafka brokers [1003, 1004, 2003, 2004] because they have assigned partition-replicas.]"));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -531,16 +589,20 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 1003, 1004, 2003, 2004)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(kafka, List.of(POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(6));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002)));
                     assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -557,16 +619,20 @@ public class KafkaClusterCreatorTest {
     public void testNewClusterWithKRaft(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS, POOL_A, POOL_B), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS, POOL_A, POOL_B), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(9));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(0, 1, 2, 3, 4, 5, 6, 7, 8)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -579,16 +645,20 @@ public class KafkaClusterCreatorTest {
     public void testExistingClusterWithKRaft(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(9));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // No scale-down => scale-down check is not done
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -605,16 +675,28 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 1003, 2004)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(13));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 1003, 1004, 2000, 2001, 2002, 2003, 2004, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of(3003, 3004))); // Controllers are not affected
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions().size(), is(2));
+                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-a by changing number of replicas to 5"));
+                    assertThat(kafkaStatus.getConditions().get(1).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(1).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(1).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(1).getMessage(), is("Reverting scale-down of KafkaNodePool pool-b by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
                     verify(supplier.brokersInUseCheck, times(2)).brokersInUse(any(), any(), any(), any());
@@ -631,16 +713,24 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(3000, 3001, 3002, 3003)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(5));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(3000, 3001, 3002, 3003, 3004)));
                     assertThat(kc.removedNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions().size(), is(1));
+                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting scale-down of KafkaNodePool pool-mixed by changing number of replicas to 5"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -657,16 +747,20 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(9));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -683,14 +777,18 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1003, 1004, 2003, 2004)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.failing(ex -> context.verify(() -> {
                     // Check exception
                     assertThat(ex, instanceOf(InvalidResourceException.class));
                     assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot scale-down Kafka brokers [3003, 3004, 1003, 1004, 2003, 2004] because they have assigned partition-replicas.]"));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -709,16 +807,20 @@ public class KafkaClusterCreatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(kafka, List.of(POOL_CONTROLLERS_WITH_STATUS_5_NODES, POOL_A_WITH_STATUS_5_NODES, POOL_B_WITH_STATUS_5_NODES), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
                     assertThat(kc.nodes().size(), is(9));
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of(1003, 1004, 2003, 2004, 3003, 3004)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());
@@ -735,10 +837,11 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
@@ -746,6 +849,13 @@ public class KafkaClusterCreatorTest {
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of()));
                     assertThat(kc.usedToBeBrokerNodes(), is(Set.of()));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions().size(), is(1));
+                    assertThat(kafkaStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(kafkaStatus.getConditions().get(0).getType(), is("Warning"));
+                    assertThat(kafkaStatus.getConditions().get(0).getReason(), is("ScaleDownPreventionCheck"));
+                    assertThat(kafkaStatus.getConditions().get(0).getMessage(), is("Reverting role change of KafkaNodePool pool-mixed by adding the broker role to it"));
 
                     // Scale-down reverted => should be called twice as we still scale down controllers after the revert is done
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -762,10 +872,11 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(1000, 1001, 1002, 2000, 2001, 20022)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, true)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), CURRENT_PODS_5_NODES, VERSION_CHANGE, kafkaStatus, true)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
@@ -773,6 +884,9 @@ public class KafkaClusterCreatorTest {
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of()));
                     assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down reverted => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -789,14 +903,18 @@ public class KafkaClusterCreatorTest {
         BrokersInUseCheck brokersInUseOps = supplier.brokersInUseCheck;
         when(brokersInUseOps.brokersInUse(any(), any(), any(), any())).thenReturn(Future.succeededFuture(Set.of(3000, 3002)));
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(KAFKA_WITH_KRAFT, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.failing(ex -> context.verify(() -> {
                     // Check exception
                     assertThat(ex, instanceOf(InvalidResourceException.class));
                     assertThat(ex.getMessage(), is("Following errors were found when processing the Kafka custom resource: [Cannot remove the broker role from nodes [3000, 3001, 3002] because they have assigned partition-replicas.]"));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down failed => should be called once
                     verify(supplier.brokersInUseCheck, times(1)).brokersInUse(any(), any(), any(), any());
@@ -815,10 +933,11 @@ public class KafkaClusterCreatorTest {
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
+        KafkaStatus kafkaStatus = new KafkaStatus();
         KafkaClusterCreator creator = new KafkaClusterCreator(vertx, RECONCILIATION, CO_CONFIG, supplier);
 
         Checkpoint async = context.checkpoint();
-        creator.prepareKafkaCluster(kafka, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, false)
+        creator.prepareKafkaCluster(kafka, List.of(POOL_MIXED_NOT_MIXED_ANYMORE, POOL_A_WITH_STATUS, POOL_B_WITH_STATUS), Map.of(), null, VERSION_CHANGE, kafkaStatus, false)
                 .onComplete(context.succeeding(kc -> context.verify(() -> {
                     // Kafka cluster is created
                     assertThat(kc, is(notNullValue()));
@@ -826,6 +945,9 @@ public class KafkaClusterCreatorTest {
                     assertThat(kc.nodes().stream().map(NodeRef::nodeId).collect(Collectors.toSet()), is(Set.of(1000, 1001, 1002, 2000, 2001, 2002, 3000, 3001, 3002)));
                     assertThat(kc.removedNodes(), is(Set.of()));
                     assertThat(kc.usedToBeBrokerNodes(), is(Set.of(3000, 3001, 3002)));
+
+                    // Check the status conditions
+                    assertThat(kafkaStatus.getConditions(), is(nullValue()));
 
                     // Scale-down check skipped => should be never called
                     verify(supplier.brokersInUseCheck, never()).brokersInUse(any(), any(), any(), any());


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, when we revert a scale-down or role change because the brokers are not empty, we just log warning in the log. This PR adds this also as a warning condition to the custom resource to make it easier to see from there as well.

```yaml
  conditions:
  - lastTransitionTime: "2024-02-11T19:55:53.565162526Z"
    message: Reverting scale-down of KafkaNodePool aston by changing number of replicas
      to 2
    reason: ScaleDownPreventionCheck
    status: "True"
    type: Warning
  - lastTransitionTime: "2024-02-11T19:55:53.605476276Z"
    message: Reverting role change of KafkaNodePool controllers by adding the broker
      role to it
    reason: ScaleDownPreventionCheck
    status: "True"
    type: Warning
  - lastTransitionTime: "2024-02-11T19:55:55.428272506Z"
    status: "True"
    type: Ready
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally