### PR TITLE
Update CC goal documentation

### DIFF
--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -76,7 +76,7 @@ In Cruise Control, the following xref:main-goals[main optimization goals] are ha
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
-You configure which hard goals will be enforced to execute in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
+In your Cruise Control deployment configuration, you can specify which hard goals to enforce using the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
 * To enforce that all the hard goals are executed, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -78,7 +78,7 @@ RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal
 
 In your Cruise Control deployment configuration, you can specify which hard goals to enforce using the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
-* To enforce execution of all hard goals, simply omit the `hard.goals` property."
+* To enforce execution of all hard goals, simply omit the `hard.goals` property.
 
 * To change which hard goals Cruise Control enforces, specify the required goals in the `hard.goals` property using their fully-qualified domain names.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -61,7 +61,7 @@ Resource distribution goals are subject to link:{BookURLConfiguring}#property-cr
 == Hard and soft optimization goals
 
 Hard goals are goals that _must_ be satisfied in optimization proposals.
-Goals that are not hard coded as _hard goals_ in Cruise Control are known as _soft goals_.
+Goals that are not defined as _hard goals_ in the Cruise Control code are known as _soft goals_.
 You can think of soft goals as _best effort_ goals: they do _not_ need to be satisfied in optimization proposals, but are included in optimization calculations.
 An optimization proposal that violates one or more soft goals, but satisfies all hard goals, is valid.
 
@@ -71,21 +71,21 @@ An optimization proposal that does _not_ satisfy all the hard goals is rejected 
 NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal).
 Cruise Control will ignore this goal if doing so enables all the configured hard goals to be met.
 
-In Cruise Control, the following xref:main-goals[main optimization goals] are hard coded as hard goals:
+In Cruise Control, the following xref:main-goals[main optimization goals] are hard goals:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
 You configure which hard goals will be enforced to execute in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
-* To enforce that all hard coded hard goals from Cruise Control are executed, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
+* To enforce that all the hard goals are executed, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
 
 * To change which hard goals are enforced to execute by Cruise Control, specify the desired goals in the `hard.goals` property, using their fully-qualified domain names.
 
 * To prevent a hard goal from being executed, make sure the goal is not included in the `default.goals` and `hard.goals` list configurations.
 
 NOTE: We can not configure which goals are _soft goals_ or _hard goals_.
-This is hard coded by Cruise Control.
+This is defined by the Cruise Control code.
 
 .Example `Kafka` configuration for hard optimization goals
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -61,7 +61,7 @@ Resource distribution goals are subject to link:{BookURLConfiguring}#property-cr
 == Hard and soft optimization goals
 
 Hard goals are goals that _must_ be satisfied in optimization proposals.
-Goals that are not configured as hard goals are known as _soft goals_.
+Goals that are not hard coded as _hard goals_ in Cruise Control are known as _soft goals_.
 You can think of soft goals as _best effort_ goals: they do _not_ need to be satisfied in optimization proposals, but are included in optimization calculations.
 An optimization proposal that violates one or more soft goals, but satisfies all hard goals, is valid.
 
@@ -71,16 +71,21 @@ An optimization proposal that does _not_ satisfy all the hard goals is rejected 
 NOTE: For example, you might have a soft goal to distribute a topic's replicas evenly across the cluster (the topic replica distribution goal).
 Cruise Control will ignore this goal if doing so enables all the configured hard goals to be met.
 
-In Cruise Control, the following xref:main-goals[main optimization goals] are preset as hard goals:
+In Cruise Control, the following xref:main-goals[main optimization goals] are hard coded as hard goals:
 
 [source]
 RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal; NetworkOutboundCapacityGoal; CpuCapacityGoal
 
-You configure hard goals in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
+You configure which hard goals will be enforced to execute in the Cruise Control deployment configuration, by editing the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
-* To inherit the preset hard goals from Cruise Control, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
+* To enforce that all hard coded hard goals from Cruise Control are executed, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
 
-* To change the preset hard goals, specify the desired goals in the `hard.goals` property, using their fully-qualified domain names.
+* To change which hard goals are enforced to execute by Cruise Control, specify the desired goals in the `hard.goals` property, using their fully-qualified domain names.
+
+* To prevent a hard goal from being executed, make sure the goal is not included in the `default.goals` and `hard.goals` list configurations.
+
+NOTE: We can not configure which goals are _soft goals_ or _hard goals_.
+This is hard coded by Cruise Control.
 
 .Example `Kafka` configuration for hard optimization goals
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -78,7 +78,7 @@ RackAwareGoal; ReplicaCapacityGoal; DiskCapacityGoal; NetworkInboundCapacityGoal
 
 In your Cruise Control deployment configuration, you can specify which hard goals to enforce using the `hard.goals` property in `Kafka.spec.cruiseControl.config`.
 
-* To enforce that all the hard goals are executed, do not specify the `hard.goals` property in `Kafka.spec.cruiseControl.config`
+* To enforce execution of all hard goals, simply omit the `hard.goals` property."
 
 * To change which hard goals are enforced to execute by Cruise Control, specify the desired goals in the `hard.goals` property, using their fully-qualified domain names.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -80,7 +80,7 @@ In your Cruise Control deployment configuration, you can specify which hard goal
 
 * To enforce execution of all hard goals, simply omit the `hard.goals` property."
 
-* To change which hard goals are enforced to execute by Cruise Control, specify the desired goals in the `hard.goals` property, using their fully-qualified domain names.
+* To change which hard goals Cruise Control enforces, specify the required goals in the `hard.goals` property using their fully-qualified domain names.
 
 * To prevent a hard goal from being executed, make sure the goal is not included in the `default.goals` and `hard.goals` list configurations.
 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -84,8 +84,8 @@ In your Cruise Control deployment configuration, you can specify which hard goal
 
 * To prevent execution of a specific hard goal, ensure that the goal is not included in both the `default.goals` and `hard.goals` list configurations.
 
-NOTE: We can not configure which goals are _soft goals_ or _hard goals_.
-This is defined by the Cruise Control code.
+NOTE: It is not possible to configure which goals are considered soft or hard goals. 
+This distinction is determined by the Cruise Control code.
 
 .Example `Kafka` configuration for hard optimization goals
 [source,yaml,subs="attributes+"]

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -81,7 +81,6 @@ In your Cruise Control deployment configuration, you can specify which hard goal
 * To enforce execution of all hard goals, simply omit the `hard.goals` property.
 
 * To change which hard goals Cruise Control enforces, specify the required goals in the `hard.goals` property using their fully-qualified domain names.
-
 * To prevent execution of a specific hard goal, ensure that the goal is not included in both the `default.goals` and `hard.goals` list configurations.
 
 NOTE: It is not possible to configure which goals are considered soft or hard goals. 

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -82,7 +82,7 @@ In your Cruise Control deployment configuration, you can specify which hard goal
 
 * To change which hard goals Cruise Control enforces, specify the required goals in the `hard.goals` property using their fully-qualified domain names.
 
-* To prevent a hard goal from being executed, make sure the goal is not included in the `default.goals` and `hard.goals` list configurations.
+* To prevent execution of a specific hard goal, ensure that the goal is not included in both the `default.goals` and `hard.goals` list configurations.
 
 NOTE: We can not configure which goals are _soft goals_ or _hard goals_.
 This is defined by the Cruise Control code.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Following up the discussion from here [1]  and here [2] we have a misunderstanding of how the `hard.goals` configuration works in Cruise Control.  We cannot configure whether a goal is a "soft goal" or a "hard goal". The `hard.goals` configuration only allows us to specify which goals will be enforced to run by Cruise Control. 

For example, if `NetworkInboundCapacityGoal` is not specified in `default.goals` list but specified in the `hard.goals` list, Cruise Control will throw an error. In order to ensure `NetworkInboundCapacityGoal` is not run, it must be removed from `default.goals` and `hard.goals` lists. Cruise Control hard codes which goals are "hard" and which are "soft" (e.g. `NetworkInboundCapacityGoal` is hard coded as a "hard goal", we cannot configure it as a "soft goal"). Therefore, if a hard goal is listed in the `default.goals` list, it will prevent a optimization proposal from being generated if it is not satisfied.

This PR updates the documentation to reflect this information.

[1] https://github.com/orgs/strimzi/discussions/9546
[2] https://github.com/linkedin/cruise-control/issues/2111

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

