### PR TITLE
Set STRIMZI_USE_KRAFT_IN_TESTS=true also for x86 on TF

### DIFF
--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -11,11 +11,11 @@ environment:
   CLUSTER_OPERATOR_INSTALL_TYPE: bundle
   PARALLEL_TEST_COUNT: 2
   RERUN_FAILED_TEST_COUNT: 2
+  # All tests on TF will use KRaft mode because ZK is not working reliably on it's infra
+  STRIMZI_USE_KRAFT_IN_TESTS: "true"
 adjust:
   - environment+:
       EXCLUDED_TEST_GROUPS: "loadbalancer,arm64unsupported"
-      # All tests on TF will use KRaft mode because ZK is not working reliably on it's infra
-      STRIMZI_USE_KRAFT_IN_TESTS: "true"
     when: arch == aarch64, arm64
 
 /smoke:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In https://github.com/strimzi/strimzi-kafka-operator/pull/9627 I set the KRaft ST env var only for arm arch. This PR solves it.

### Checklist

- [ ] Make sure all tests pass

