### PR TITLE
docs(node pools): adds a procedure to describe role transitions

### DIFF
--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -61,11 +61,12 @@ include::../../modules/configuring/con-zookeeper-default-config.adoc[leveloffset
 
 //configuring node pools
 include::../../modules/configuring/con-config-node-pools.adoc[leveloffset=+1]
-include::../../modules/configuring/con-config-node-pool-roles.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-managing-node-pools-ids.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-scaling-up-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-scaling-down-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-moving-node-pools.adoc[leveloffset=+2]
+include::../../modules/configuring/con-config-node-pool-roles.adoc[leveloffset=+2]
+include::../../modules/configuring/proc-splitting-node-pool-roles.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-managing-storage-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-managing-storage-affinity-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-migrating-clusters-node-pools.adoc[leveloffset=+2]

--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -15,7 +15,7 @@ For example, you may have a node pool that contains nodes that perform dual brok
 In this case, you create a new node pool with nodes that act only as brokers, and then reassign partitions from the dual-role nodes to the new brokers.
 You can then switch the old node pool to a controller-only role.
 
-WARNING: Although it is possible to split node pool roles in this way, it not currently possible to transition a dedicated node pool containing only controller or broker nodes to a combined node pool where nodes operate as brokers and controllers.
+WARNING: Although it is possible to split node pool roles in this way, it is not currently possible to transition a dedicated node pool containing only controller or broker nodes to a combined node pool where nodes operate as brokers and controllers.
 
 When removing `broker` roles in the node pool configuration, keep in mind that Kafka does not automatically reassign partitions.
 Before removing the broker role, ensure that nodes changing to controller-only roles do not have any assigned partitions. 

--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -15,6 +15,8 @@ For example, you may have a node pool that contains nodes that perform dual brok
 In this case, you create a new node pool with nodes that act only as brokers, and then reassign partitions from the dual-role nodes to the new brokers.
 You can then switch the old node pool to a controller-only role.
 
+WARNING: Although it is possible to split node pool roles in this way, it not currently possible to transition a dedicated node pool containing only controller or broker nodes to a combined node pool where nodes operate as brokers and controllers.
+
 When removing `broker` roles in the node pool configuration, keep in mind that Kafka does not automatically reassign partitions.
 Before removing the broker role, ensure that nodes changing to controller-only roles do not have any assigned partitions. 
 If partitions are assigned, the change is prevented.

--- a/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
@@ -109,7 +109,7 @@ spec:
 ----
 
 . Apply the node pool configuration.
-. Check the status of the deployment and wait for the pods in the node pools to be created and have a status of `Running`.
+. Check the status of the deployment and wait for the pods in the node pools to be created and ready (`1/1`).
 +
 [source,shell]
 ----

--- a/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-affinity-node-pools.adoc
@@ -109,17 +109,17 @@ spec:
 ----
 
 . Apply the node pool configuration.
-. Check the status of the deployment and wait for the pods in the node pools to be created and have a status of `READY`.
+. Check the status of the deployment and wait for the pods in the node pools to be created and have a status of `Running`.
 +
 [source,shell]
 ----
 kubectl get pods -n <my_cluster_operator_namespace>
 ----
 +
-.Output shows 3 Kafka nodes in `pool-zone-1` and 4 Kafka nodes in `pool-zone-2`:
+.Output shows 3 Kafka nodes in `pool-zone-1` and 4 Kafka nodes in `pool-zone-2`
 [source,shell]
 ----
-NAME                       READY  STATUS   RESTARTS
+NAME                            READY  STATUS   RESTARTS
 my-cluster-pool-zone-1-kafka-0  1/1    Running  0
 my-cluster-pool-zone-1-kafka-1  1/1    Running  0
 my-cluster-pool-zone-1-kafka-2  1/1    Running  0

--- a/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
@@ -50,7 +50,7 @@ spec:
 Nodes in `pool-a` are configured to use Amazon EBS (Elastic Block Store) GP2 volumes.
 
 . Apply the node pool configuration for `pool-a`.
-. Check the status of the deployment and wait for the pods in `pool-a` to be created and `Running`.
+. Check the status of the deployment and wait for the pods in `pool-a` to be created and ready (`1/1`).
 +
 [source,shell]
 ----
@@ -93,10 +93,25 @@ spec:
 Nodes in `pool-b` are configured to use Amazon EBS (Elastic Block Store) GP3 volumes.
 
 . Apply the node pool configuration for `pool-b`.
-. Check the status of the deployment and wait for the pods in `pool-b` to be created and have a status of `Running`.
+. Check the status of the deployment and wait for the pods in `pool-b` to be created and ready.
 . Reassign the partitions from `pool-a` to `pool-b`.
 +
-When migrating to a new storage configuration, you can use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
+When migrating to a new storage configuration, use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
++
+.Using Cruise Control to reassign partition replicas
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  # ...
+spec:
+  mode: remove-brokers
+  brokers: [0, 1, 2]
+----
++
+We are reassigning partitions from `pool-a`. 
+The reassignment can take some time depending on the number of topics and partitions in the cluster.
 
 . After the reassignment process is complete, delete the old node pool:
 +

--- a/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
+++ b/documentation/modules/configuring/proc-managing-storage-node-pools.adoc
@@ -50,7 +50,7 @@ spec:
 Nodes in `pool-a` are configured to use Amazon EBS (Elastic Block Store) GP2 volumes.
 
 . Apply the node pool configuration for `pool-a`.
-. Check the status of the deployment and wait for the pods in `pool-a` to be created and have a status of `READY`.
+. Check the status of the deployment and wait for the pods in `pool-a` to be created and `Running`.
 +
 [source,shell]
 ----
@@ -93,7 +93,7 @@ spec:
 Nodes in `pool-b` are configured to use Amazon EBS (Elastic Block Store) GP3 volumes.
 
 . Apply the node pool configuration for `pool-b`.
-. Check the status of the deployment and wait for the pods in `pool-b` to be created and have a status of `READY`.
+. Check the status of the deployment and wait for the pods in `pool-b` to be created and have a status of `Running`.
 . Reassign the partitions from `pool-a` to `pool-b`.
 +
 When migrating to a new storage configuration, you can use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -42,29 +42,48 @@ For example, node pool `pool-a` has three replicas. We add a node by increasing 
 kubectl scale kafkanodepool pool-a --replicas=4
 ----
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
+. Check the status of the deployment and wait for the pods in the node pool to be created and ready (`1/1`).
 +
 [source,shell]
 ----
 kubectl get pods -n <my_cluster_operator_namespace>
 ----
 +
-.Output shows four Kafka nodes in the target node pool
+.Output shows four Kafka nodes in the source and target node pools
 [source,shell]
 ----
 NAME                 READY  STATUS   RESTARTS
 my-cluster-pool-a-0  1/1    Running  0
 my-cluster-pool-a-1  1/1    Running  0
 my-cluster-pool-a-4  1/1    Running  0
-my-cluster-pool-a-5  1/1    Running  0
+my-cluster-pool-a-7  1/1    Running  0
+my-cluster-pool-b-2  1/1    Running  0
+my-cluster-pool-b-3  1/1    Running  0
+my-cluster-pool-b-5  1/1    Running  0
+my-cluster-pool-b-6  1/1    Running  0
 ----
 +
 Node IDs are appended to the name of the node on creation.
-We add node `my-cluster-pool-a-5`, which has a node ID of `5`.
+We add node `my-cluster-pool-a-7`, which has a node ID of `7`.
 
 . Reassign the partitions from the old node to the new node.
 +
-Before scaling down the source node pool, you can use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
+Before scaling down the source node pool, use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
++
+.Using Cruise Control to reassign partition replicas
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  # ...
+spec:
+  mode: remove-brokers
+  brokers: [6]
+----
++
+We are reassigning partitions from node `my-cluster-pool-b-6`. 
+The reassignment can take some time depending on the number of topics and partitions in the cluster.
 
 . After the reassignment process is complete, reduce the number of Kafka nodes in the source node pool.
 +
@@ -75,7 +94,7 @@ For example, node pool `pool-b` has four replicas. We remove a node by decreasin
 kubectl scale kafkanodepool pool-b --replicas=3
 ----
 +
-The node with the highest ID within a pool is removed.
+The node with the highest ID (`6`) within the pool is removed.
 +
 .Output shows three Kafka nodes in the source node pool
 [source,shell]
@@ -83,6 +102,6 @@ The node with the highest ID within a pool is removed.
 NAME                       READY  STATUS   RESTARTS
 my-cluster-pool-b-kafka-2  1/1    Running  0
 my-cluster-pool-b-kafka-3  1/1    Running  0
-my-cluster-pool-b-kafka-6  1/1    Running  0
+my-cluster-pool-b-kafka-5  1/1    Running  0
 ----
 

--- a/documentation/modules/configuring/proc-moving-node-pools.adoc
+++ b/documentation/modules/configuring/proc-moving-node-pools.adoc
@@ -42,7 +42,7 @@ For example, node pool `pool-a` has three replicas. We add a node by increasing 
 kubectl scale kafkanodepool pool-a --replicas=4
 ----
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `READY`.
+. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
 +
 [source,shell]
 ----

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -40,7 +40,22 @@ Otherwise, the node with the highest available ID in the node pool is removed.
 
 . Reassign the partitions before decreasing the number of nodes in the node pool.
 +
-Before scaling down a node pool, you can use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
+Before scaling down a node pool, use the Cruise Control `remove-brokers` mode to move partition replicas off the brokers that are going to be removed.
++
+.Using Cruise Control to reassign partition replicas
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  # ...
+spec:
+  mode: remove-brokers
+  brokers: [3]
+----
++
+We are reassigning partitions from node `my-cluster-pool-a-3`. 
+The reassignment can take some time depending on the number of topics and partitions in the cluster.
 
 . After the reassignment process is complete, and the node being removed has no live partitions, reduce the number of Kafka nodes in the node pool.
 +

--- a/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-down-node-pools.adoc
@@ -7,6 +7,7 @@
 
 [role="_abstract"]
 This procedure describes how to scale down a node pool to remove nodes.
+Currently, scale down is only possible for broker-only node pools containing nodes that run as dedicated brokers.
 
 In this procedure, we start with four nodes for node pool `pool-a`:
 

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -46,7 +46,7 @@ For example, node pool `pool-a` has three replicas. We add a node by increasing 
 kubectl scale kafkanodepool pool-a --replicas=4
 ----
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
+. Check the status of the deployment and wait for the pods in the node pool to be created and ready (`1/1`).
 +
 [source,shell]
 ----
@@ -65,4 +65,19 @@ my-cluster-pool-a-3  1/1    Running  0
 
 . Reassign the partitions after increasing the number of nodes in the node pool.
 +
-After scaling up a node pool, you can use the Cruise Control `add-brokers` mode to move partition replicas from existing brokers to the newly added brokers.
+After scaling up a node pool, use the Cruise Control `add-brokers` mode to move partition replicas from existing brokers to the newly added brokers.
++
+.Using Cruise Control to reassign partition replicas
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  # ...
+spec:
+  mode: add-brokers
+  brokers: [3]
+----
++
+We are reassigning partitions to node `my-cluster-pool-a-3`. 
+The reassignment can take some time depending on the number of topics and partitions in the cluster.

--- a/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
+++ b/documentation/modules/configuring/proc-scaling-up-node-pools.adoc
@@ -7,6 +7,7 @@
 
 [role="_abstract"]
 This procedure describes how to scale up a node pool to add new nodes.
+Currently, scale up is only possible for broker-only node pools containing nodes that run as dedicated brokers.
 
 In this procedure, we start with three nodes for node pool `pool-a`:
 
@@ -45,7 +46,7 @@ For example, node pool `pool-a` has three replicas. We add a node by increasing 
 kubectl scale kafkanodepool pool-a --replicas=4
 ----
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `READY`.
+. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
 +
 [source,shell]
 ----

--- a/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 This procedure describes how to transition to using node pools with separate roles.
 If your Kafka cluster is using a node pool with combined controller and broker roles, you can transition to using two node pools with separate roles.
-To do this, rebalance the cluster to move partition replicas to the node pool with a broker-only role, and then switch the old node pool to a controller-only role.
+To do this, rebalance the cluster to move partition replicas to a node pool with a broker-only role, and then switch the old node pool to a controller-only role.
 
 In this procedure, we start with node pool `pool-a`, which has `controller` and `broker` roles:
 
@@ -89,7 +89,7 @@ If you already have a broker-only node pool, you can skip this step.
 
 . Apply the new `KafkaNodePool` resource to create the brokers.
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
+. Check the status of the deployment and wait for the pods in the node pool to be created and ready (`1/1`).
 +
 [source,shell]
 ----
@@ -111,6 +111,18 @@ my-cluster-pool-b-5  1/1    Running  0
 Node IDs are appended to the name of the node on creation.
 
 . Use the Cruise Control `remove-brokers` mode to reassign partition replicas from the dual-role nodes to the newly added brokers.
++
+.Using Cruise Control to reassignin partition replicas
+[source,shell,subs="+attributes"]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  # ...
+spec:
+  mode: remove-brokers
+  brokers: [0, 1, 2]
+---- 
 +
 The reassignment can take some time depending on the number of topics and partitions in the cluster.
 +

--- a/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-splitting-node-pool-roles.adoc
@@ -1,0 +1,145 @@
+// Module included in the following assemblies:
+//
+// assembly-config.adoc
+
+[id='proc-splitting-node-pools-roles-{context}']
+= Transitioning to separate broker and controller roles
+
+[role="_abstract"]
+This procedure describes how to transition to using node pools with separate roles.
+If your Kafka cluster is using a node pool with combined controller and broker roles, you can transition to using two node pools with separate roles.
+To do this, rebalance the cluster to move partition replicas to the node pool with a broker-only role, and then switch the old node pool to a controller-only role.
+
+In this procedure, we start with node pool `pool-a`, which has `controller` and `broker` roles:
+
+.Dual-role node pool
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        deleteClaim: false
+  # ...
+----
+
+The node pool has three nodes:
+
+.Kafka nodes in the node pool
+[source,shell]
+----
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
+----
+
+Each node performs a combined role of broker and controller.
+We create a second node pool called `pool-b`, with three nodes that act as brokers only.
+
+NOTE: During this process, the ID of the node that holds the partition replicas changes. Consider any dependencies that reference the node ID.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
+
+.Procedure
+
+. Create a node pool with a `broker` role.
++
+.Example node pool configuration
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  # ...
+----
++
+The new node pool also has three nodes.
+If you already have a broker-only node pool, you can skip this step.
+
+. Apply the new `KafkaNodePool` resource to create the brokers.
+
+. Check the status of the deployment and wait for the pods in the node pool to be created and have a status of `Running`.
++
+[source,shell]
+----
+kubectl get pods -n <my_cluster_operator_namespace>
+----
++
+.Output shows pods running in two node pools
+[source,shell]
+----
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
+my-cluster-pool-b-3  1/1    Running  0
+my-cluster-pool-b-4  1/1    Running  0
+my-cluster-pool-b-5  1/1    Running  0
+---- 
++
+Node IDs are appended to the name of the node on creation.
+
+. Use the Cruise Control `remove-brokers` mode to reassign partition replicas from the dual-role nodes to the newly added brokers.
++
+The reassignment can take some time depending on the number of topics and partitions in the cluster.
++
+NOTE: If nodes changing to controller-only roles have any assigned partitions, the change is prevented.
+The `status.conditions` of the `Kafka` resource provide details of events preventing the change.
+
+. Remove the `broker` role from the node pool that originally had a combined role.
++
+.Dual-role nodes switched to controllers
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        deleteClaim: false
+  # ...
+----
+
+. Apply the configuration change so that the node pool switches to a controller-only role.


### PR DESCRIPTION
**Documentation**

Updates to the node pool content, to include:

- New procedure for _Transitioning to separate broker and controller roles_
- Limitations on managing node pools with controller role
- Minor consistency changes

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

