### PR TITLE
Configure OAuth principal.builder.class also for controllers

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -313,9 +313,10 @@ public class KafkaBrokerConfigurationBuilder {
 
                 writer.println();
             }
-
-            configureOAuthPrincipalBuilderIfNeeded(writer, kafkaListeners);
         }
+
+        // configure OAuth principal builder for all the nodes - brokers, controllers, and mixed
+        configureOAuthPrincipalBuilderIfNeeded(writer, kafkaListeners);
 
         printSectionHeader("Common listener configuration");
         writer.println("listener.security.protocol.map=" + String.join(",", securityProtocol));


### PR DESCRIPTION
### Type of change

- Fixup

### Description

Currently when we are using OAuth authentication with Keycloak authorization, it works fine for ZK mode and KRaft mode with Kafka nodes that have mixed roles (cotroller and broker). But in case that we switch to KRaft mode with separate roles set for the nodes (so separate NodePool for controllers and for brokers), the controller Pods are not starting because of this exception:

```
2024-02-13 15:15:50,159 ERROR Encountered fatal fault: caught exception (org.apache.kafka.server.fault.ProcessTerminatingFaultHandler) [main]
io.strimzi.kafka.oauth.common.ConfigException: This authorizer requires io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder as 'principal.builder.class'
        at io.strimzi.kafka.oauth.server.authorizer.Configuration.<init>(Configuration.java:113)
        at io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer.configure(KeycloakAuthorizer.java:73)
        at kafka.server.ControllerServer.$anonfun$startup$11(ControllerServer.scala:157)
        at kafka.server.ControllerServer.$anonfun$startup$11$adapted(ControllerServer.scala:157)
        at scala.Option.foreach(Option.scala:437)
        at kafka.server.ControllerServer.startup(ControllerServer.scala:157)
        at kafka.server.KafkaRaftServer.$anonfun$startup$1(KafkaRaftServer.scala:95)
        at kafka.server.KafkaRaftServer.$anonfun$startup$1$adapted(KafkaRaftServer.scala:95)
        at scala.Option.foreach(Option.scala:437)
        at kafka.server.KafkaRaftServer.startup(KafkaRaftServer.scala:95)
        at kafka.Kafka$.main(Kafka.scala:113)
        at kafka.Kafka.main(Kafka.scala)
```

That's happening because we are not setting the `principal.builder.class` for controller nodes.

This PR moves the `configureOAuthPrincipalBuilderIfNeeded` method outside of the `if` block that contains operations for non-controllers nodes.

### Checklist

- [ ] Make sure all tests pass


