### PR TITLE
Reflect the current roles when rolling Kafka nodes in KafkaRoller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove support for Apache Kafka 3.5.0 and 3.5.1
 * The `UseKRaft` feature gate moves to beta stage and is enabled by default.
   If needed, `UseKRaft` can be disabled in the feature gates configuration in the Cluster Operator.
+* Add support for moving from dedicated controller-only KRaft nodes to mixed KRaft nodes
 * Fix NullPointerException from missing listenerConfig when using custom auth
 * Added support for Kafka Exporter `offset.show-all` parameter
 * Prevent removal of the `broker` process role from KRaft mixed-nodes that have assigned partition-replicas

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.resource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -24,6 +25,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.VertxUtil;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.Future;
@@ -458,8 +460,13 @@ public class KafkaRoller {
 
         restartContext.restartReasons = podNeedsRestart.apply(pod);
 
+        // We try to detect the current roles. If we fail to do so, we optimistically assume the roles did not
+        // change and the desired roles still apply.
+        boolean isBroker = isAlreadyBroker(pod).orElse(nodeRef.broker());
+        boolean isController = isAlreadyController(pod).orElse(nodeRef.controller());
+
         try {
-            checkIfRestartOrReconfigureRequired(nodeRef, restartContext);
+            checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext);
             if (restartContext.forceRestart) {
                 LOGGER.debugCr(reconciliation, "Pod {} can be rolled now", nodeRef);
                 restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS, restartContext);
@@ -467,7 +474,7 @@ public class KafkaRoller {
                 if (deferController(nodeRef, restartContext)) {
                     LOGGER.debugCr(reconciliation, "Pod {} is the active controller and there are other pods to verify first.", nodeRef);
                     throw new ForceableProblem("Pod " + nodeRef.podName() + " is the active controller and there are other pods to verify first");
-                } else if (!canRoll(nodeRef, 60, TimeUnit.SECONDS, false, restartContext)) {
+                } else if (!canRoll(nodeRef.nodeId(), isController, isBroker, 60, TimeUnit.SECONDS, false, restartContext)) {
                     LOGGER.debugCr(reconciliation, "Pod {} cannot be updated right now", nodeRef);
                     throw new UnforceableProblem("Pod " + nodeRef.podName() + " cannot be updated right now.");
                 } else {
@@ -491,7 +498,7 @@ public class KafkaRoller {
         } catch (ForceableProblem e) {
             if (restartContext.podStuck || restartContext.backOff.done() || e.forceNow) {
 
-                if (canRoll(nodeRef, 60_000, TimeUnit.MILLISECONDS, true, restartContext)) {
+                if (canRoll(nodeRef.nodeId(), isController, isBroker, 60_000, TimeUnit.MILLISECONDS, true, restartContext)) {
                     String errorMsg = e.getMessage();
 
                     if (e.getCause() != null) {
@@ -589,7 +596,7 @@ public class KafkaRoller {
      * Determine whether the pod should be restarted, or the broker reconfigured.
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
-    private void checkIfRestartOrReconfigureRequired(NodeRef nodeRef, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem, UnforceableProblem {
+    private void checkIfRestartOrReconfigureRequired(NodeRef nodeRef, boolean isController, boolean isBroker, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem, UnforceableProblem {
         RestartReasons reasonToRestartPod = restartContext.restartReasons;
         if (restartContext.podStuck && !reasonToRestartPod.contains(RestartReason.POD_HAS_OLD_REVISION)) {
             // If the pod is unschedulable then deleting it, or trying to open an Admin client to it will make no difference
@@ -609,8 +616,8 @@ public class KafkaRoller {
         KafkaBrokerConfigurationDiff brokerConfigDiff = null;
         KafkaBrokerLoggingConfigurationDiff brokerLoggingDiff = null;
         boolean needsReconfig = false;
-        if (nodeRef.controller()) {
 
+        if (isController) {
             if (maybeInitControllerAdminClient()) {
                 String controllerQuorumFetchTimeout = CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT;
                 String desiredConfig = kafkaConfigProvider.apply(nodeRef.nodeId());
@@ -624,7 +631,7 @@ public class KafkaRoller {
             } else {
                 //TODO When https://github.com/strimzi/strimzi-kafka-operator/issues/8593 is complete
                 // we should change this logic to immediately restart this pod because we cannot connect to it.
-                if (nodeRef.broker()) {
+                if (isBroker) {
                     // If it is a combined node (controller and broker) and the admin client cannot be initialised,
                     // restart this pod. There is no reason to continue as we won't be able to
                     // connect an admin client to this pod for other checks later.
@@ -641,8 +648,7 @@ public class KafkaRoller {
             }
         }
 
-        if (nodeRef.broker()) {
-
+        if (isBroker) {
             if (!maybeInitBrokerAdminClient()) {
                 LOGGER.infoCr(reconciliation, "Pod {} needs to be restarted, because it does not seem to responding to connection attempts", nodeRef);
                 reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
@@ -700,7 +706,7 @@ public class KafkaRoller {
      * @param nodeRef The reference of the broker.
      * @return a Future which completes with the config of the given broker.
      */
-    protected Config brokerConfig(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
+    /* test */ Config brokerConfig(NodeRef nodeRef) throws ForceableProblem, InterruptedException {
         ConfigResource resource = new ConfigResource(ConfigResource.Type.BROKER, String.valueOf(nodeRef.nodeId()));
         return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerAdminClient.describeConfigs(singletonList(resource)).values().get(resource)),
             30, TimeUnit.SECONDS,
@@ -713,7 +719,7 @@ public class KafkaRoller {
      * @param brokerId The id of the broker.
      * @return a Future which completes with the logging of the given broker.
      */
-    protected Config brokerLogging(int brokerId) throws ForceableProblem, InterruptedException {
+    /* test */ Config brokerLogging(int brokerId) throws ForceableProblem, InterruptedException {
         ConfigResource resource = Util.getBrokersLogging(brokerId);
         return await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerAdminClient.describeConfigs(singletonList(resource)).values().get(resource)),
                 30, TimeUnit.SECONDS,
@@ -721,7 +727,7 @@ public class KafkaRoller {
         );
     }
 
-    protected void dynamicUpdateBrokerConfig(NodeRef nodeRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff)
+    /* test */ void dynamicUpdateBrokerConfig(NodeRef nodeRef, Admin ac, KafkaBrokerConfigurationDiff configurationDiff, KafkaBrokerLoggingConfigurationDiff logDiff)
             throws ForceableProblem, InterruptedException {
         Map<ConfigResource, Collection<AlterConfigOp>> updatedConfig = new HashMap<>(2);
         var podId = nodeRef.nodeId();
@@ -804,20 +810,20 @@ public class KafkaRoller {
         }
     }
 
-    private boolean canRoll(NodeRef nodeRef, long timeout, TimeUnit unit, boolean ignoreSslError, RestartContext restartContext)
+    private boolean canRoll(int nodeId, boolean isController, boolean isBroker, long timeout, TimeUnit unit, boolean ignoreSslError, RestartContext restartContext)
             throws ForceableProblem, InterruptedException, UnforceableProblem {
         try {
-            if (nodeRef.broker() && nodeRef.controller()) {
-                boolean canRollController = await(restartContext.quorumCheck.canRollController(nodeRef.nodeId()), timeout, unit,
+            if (isBroker && isController) {
+                boolean canRollController = await(restartContext.quorumCheck.canRollController(nodeId), timeout, unit,
                         t -> new UnforceableProblem("An error while trying to determine the possibility of updating Kafka controller pods", t));
-                boolean canRollBroker = await(availability(brokerAdminClient).canRoll(nodeRef.nodeId()), timeout, unit,
+                boolean canRollBroker = await(availability(brokerAdminClient).canRoll(nodeId), timeout, unit,
                         t -> new ForceableProblem("An error while trying to determine the possibility of updating Kafka broker pods", t));
                 return canRollController && canRollBroker;
-            } else if (nodeRef.controller()) {
-                return await(restartContext.quorumCheck.canRollController(nodeRef.nodeId()), timeout, unit,
+            } else if (isController) {
+                return await(restartContext.quorumCheck.canRollController(nodeId), timeout, unit,
                         t -> new UnforceableProblem("An error while trying to determine the possibility of updating Kafka controller pods", t));
             } else {
-                return await(availability(brokerAdminClient).canRoll(nodeRef.nodeId()), timeout, unit,
+                return await(availability(brokerAdminClient).canRoll(nodeId), timeout, unit,
                         t -> new ForceableProblem("An error while trying to determine the possibility of updating Kafka broker pods", t));
             }
         } catch (ForceableProblem | UnforceableProblem e) {
@@ -909,7 +915,7 @@ public class KafkaRoller {
      * Returns an AdminClient instance bootstrapped from the given nodes. If nodes is an
      * empty set, use the brokers service to bootstrap the client.
      */
-    protected Admin adminClient(Set<NodeRef> nodes, boolean ceShouldBeFatal) throws ForceableProblem, FatalProblem {
+    /* test */ Admin adminClient(Set<NodeRef> nodes, boolean ceShouldBeFatal) throws ForceableProblem, FatalProblem {
         // If no nodes are passed initialize the admin client using the brokers service
         // TODO when https://github.com/strimzi/strimzi-kafka-operator/issues/8593 is completed review whether
         //      this function can be reverted to expect nodes to be non empty
@@ -935,11 +941,11 @@ public class KafkaRoller {
         }
     }
 
-    protected KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
+    /* test */ KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
         return new KafkaQuorumCheck(reconciliation, ac, vertx, controllerQuorumFetchTimeoutMs);
     }
 
-    protected KafkaAvailability availability(Admin ac) {
+    /* test */ KafkaAvailability availability(Admin ac) {
         return new KafkaAvailability(reconciliation, ac);
     }
     
@@ -1046,6 +1052,50 @@ public class KafkaRoller {
                 LOGGER.warnCr(reconciliation, "Error waiting for pod {}/{} to become ready: {}", namespace, podName, error);
                 return Future.failedFuture(error);
             });
+    }
+
+    /**
+     * Checks from the Pod labels if the Kafka node is already a broker or not.
+     *
+     * @param pod   Current Pod
+     *
+     * @return  Optional with true if the pod is already a broker, false if it is not broker or empty optional
+     * if the label is not present.
+     */
+    /* test */ static Optional<Boolean> isAlreadyBroker(Pod pod)    {
+        return checkBooleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL);
+    }
+
+    /**
+     * Checks from the Pod labels if the Kafka node is already a controller or not.
+     *
+     * @param pod   Current Pod
+     *
+     * @return  Optional with true if the pod is already a controller, false if it is not controller or empty optional
+     * if the label is not present.
+     */
+    /* test */ static Optional<Boolean> isAlreadyController(Pod pod)    {
+        return checkBooleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL);
+    }
+
+    /**
+     * Generic method to extract a boolean value from Kubernetes resource labels
+     *
+     * @param pod           Kube resource with metadata
+     * @param annotation    Name of the label for which we want to extract the boolean value
+     *
+     * @return  Optional with true if the label is present and is set to `true`, false if it is present and not set to
+     * `true` or empty optional if the label is not present.
+     */
+    private static Optional<Boolean> checkBooleanLabel(HasMetadata pod, String annotation)    {
+        if (pod != null
+                && pod.getMetadata() != null
+                && pod.getMetadata().getLabels() != null
+                && pod.getMetadata().getLabels().containsKey(annotation))  {
+            return Optional.of("true".equalsIgnoreCase(pod.getMetadata().getLabels().get(annotation)));
+        } else {
+            return Optional.empty();
+        }
     }
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -462,8 +462,8 @@ public class KafkaRoller {
 
         // We try to detect the current roles. If we fail to do so, we optimistically assume the roles did not
         // change and the desired roles still apply.
-        boolean isBroker = isAlreadyBroker(pod).orElse(nodeRef.broker());
-        boolean isController = isAlreadyController(pod).orElse(nodeRef.controller());
+        boolean isBroker = isCurrentlyBroker(pod).orElse(nodeRef.broker());
+        boolean isController = isCurrentlyController(pod).orElse(nodeRef.controller());
 
         try {
             checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext);
@@ -1055,44 +1055,44 @@ public class KafkaRoller {
     }
 
     /**
-     * Checks from the Pod labels if the Kafka node is already a broker or not.
+     * Checks from the Pod labels if the Kafka node is currently a broker or not.
      *
      * @param pod   Current Pod
      *
-     * @return  Optional with true if the pod is already a broker, false if it is not broker or empty optional
+     * @return  Optional with true if the pod is currently a broker, false if it is not broker or empty optional
      * if the label is not present.
      */
-    /* test */ static Optional<Boolean> isAlreadyBroker(Pod pod)    {
+    /* test */ static Optional<Boolean> isCurrentlyBroker(Pod pod)    {
         return checkBooleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL);
     }
 
     /**
-     * Checks from the Pod labels if the Kafka node is already a controller or not.
+     * Checks from the Pod labels if the Kafka node is currently a controller or not.
      *
      * @param pod   Current Pod
      *
-     * @return  Optional with true if the pod is already a controller, false if it is not controller or empty optional
+     * @return  Optional with true if the pod is currently a controller, false if it is not controller or empty optional
      * if the label is not present.
      */
-    /* test */ static Optional<Boolean> isAlreadyController(Pod pod)    {
+    /* test */ static Optional<Boolean> isCurrentlyController(Pod pod)    {
         return checkBooleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL);
     }
 
     /**
      * Generic method to extract a boolean value from Kubernetes resource labels
      *
-     * @param pod           Kube resource with metadata
-     * @param annotation    Name of the label for which we want to extract the boolean value
+     * @param pod       Kube resource with metadata
+     * @param label     Name of the label for which we want to extract the boolean value
      *
      * @return  Optional with true if the label is present and is set to `true`, false if it is present and not set to
      * `true` or empty optional if the label is not present.
      */
-    private static Optional<Boolean> checkBooleanLabel(HasMetadata pod, String annotation)    {
+    private static Optional<Boolean> checkBooleanLabel(HasMetadata pod, String label)    {
         if (pod != null
                 && pod.getMetadata() != null
                 && pod.getMetadata().getLabels() != null
-                && pod.getMetadata().getLabels().containsKey(annotation))  {
-            return Optional.of("true".equalsIgnoreCase(pod.getMetadata().getLabels().get(annotation)));
+                && pod.getMetadata().getLabels().containsKey(label))  {
+            return Optional.of("true".equalsIgnoreCase(pod.getMetadata().getLabels().get(label)));
         } else {
             return Optional.empty();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -709,28 +709,28 @@ public class KafkaRollerTest {
     @Test
     public void testExistingRoles() {
         // No pod
-        assertThat(KafkaRoller.isAlreadyBroker(null), is(Optional.empty()));
-        assertThat(KafkaRoller.isAlreadyController(null), is(Optional.empty()));
+        assertThat(KafkaRoller.isCurrentlyBroker(null), is(Optional.empty()));
+        assertThat(KafkaRoller.isCurrentlyController(null), is(Optional.empty()));
 
         // No annotation
         Pod pod = new PodBuilder().withNewMetadata().withName("my-pod").endMetadata().build();
-        assertThat(KafkaRoller.isAlreadyBroker(pod), is(Optional.empty()));
-        assertThat(KafkaRoller.isAlreadyController(pod), is(Optional.empty()));
-
-        // Annotation set to false
-        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "grr", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "meh")).endMetadata().build();
-        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(false));
-        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isCurrentlyBroker(pod), is(Optional.empty()));
+        assertThat(KafkaRoller.isCurrentlyController(pod), is(Optional.empty()));
 
         // Annotation set to wrong value
+        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "grr", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "meh")).endMetadata().build();
+        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(false));
+
+        // Annotation set to false
         pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "false", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "false")).endMetadata().build();
-        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(false));
-        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(false));
 
         // Annotation set to true
         pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "true", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true")).endMetadata().build();
-        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(true));
-        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(true));
+        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(true));
+        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(true));
     }
 
     private TestingKafkaRoller rollerWithControllers(PodOperator podOps, int... controllers) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.common.AdminClientProvider;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.PodOperator;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -52,6 +53,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -702,6 +704,33 @@ public class KafkaRollerTest {
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8), // brokers, combined, controllers
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
+    }
+
+    @Test
+    public void testExistingRoles() {
+        // No pod
+        assertThat(KafkaRoller.isAlreadyBroker(null), is(Optional.empty()));
+        assertThat(KafkaRoller.isAlreadyController(null), is(Optional.empty()));
+
+        // No annotation
+        Pod pod = new PodBuilder().withNewMetadata().withName("my-pod").endMetadata().build();
+        assertThat(KafkaRoller.isAlreadyBroker(pod), is(Optional.empty()));
+        assertThat(KafkaRoller.isAlreadyController(pod), is(Optional.empty()));
+
+        // Annotation set to false
+        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "grr", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "meh")).endMetadata().build();
+        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(false));
+
+        // Annotation set to wrong value
+        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "false", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "false")).endMetadata().build();
+        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(false));
+        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(false));
+
+        // Annotation set to true
+        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "true", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true")).endMetadata().build();
+        assertThat(KafkaRoller.isAlreadyBroker(pod).orElseThrow(), is(true));
+        assertThat(KafkaRoller.isAlreadyController(pod).orElseThrow(), is(true));
     }
 
     private TestingKafkaRoller rollerWithControllers(PodOperator podOps, int... controllers) {

--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -67,6 +67,7 @@ include::../../modules/configuring/proc-scaling-down-node-pools.adoc[leveloffset
 include::../../modules/configuring/proc-moving-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/con-config-node-pool-roles.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-splitting-node-pool-roles.adoc[leveloffset=+2]
+include::../../modules/configuring/proc-joining-node-pool-roles.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-managing-storage-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-managing-storage-affinity-node-pools.adoc[leveloffset=+2]
 include::../../modules/configuring/proc-migrating-clusters-node-pools.adoc[leveloffset=+2]

--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -15,7 +15,8 @@ For example, you may have a node pool that contains nodes that perform dual brok
 In this case, you create a new node pool with nodes that act only as brokers, and then reassign partitions from the dual-role nodes to the new brokers.
 You can then switch the old node pool to a controller-only role.
 
-WARNING: Although it is possible to split node pool roles in this way, it is not currently possible to transition a dedicated node pool containing only controller or broker nodes to a combined node pool where nodes operate as brokers and controllers.
+Or the other way around, when you want to move from node pools with controller-only and broker-only roles to a node pool that contains nodes that perform dual broker and controller roles.
+In this case, you can add the `broker` role to the existing controller-only node pool, reassign partitions from the broker-only nodes to the dual-role nodes, and then delete the broker-only node pool.
 
 When removing `broker` roles in the node pool configuration, keep in mind that Kafka does not automatically reassign partitions.
 Before removing the broker role, ensure that nodes changing to controller-only roles do not have any assigned partitions. 

--- a/documentation/modules/configuring/con-config-node-pool-roles.adoc
+++ b/documentation/modules/configuring/con-config-node-pool-roles.adoc
@@ -15,8 +15,8 @@ For example, you may have a node pool that contains nodes that perform dual brok
 In this case, you create a new node pool with nodes that act only as brokers, and then reassign partitions from the dual-role nodes to the new brokers.
 You can then switch the old node pool to a controller-only role.
 
-Or the other way around, when you want to move from node pools with controller-only and broker-only roles to a node pool that contains nodes that perform dual broker and controller roles.
-In this case, you can add the `broker` role to the existing controller-only node pool, reassign partitions from the broker-only nodes to the dual-role nodes, and then delete the broker-only node pool.
+You can also perform the reverse operation by moving from node pools with controller-only and broker-only roles to a node pool that contains nodes that perform dual broker and controller roles.
+In this case, you add the `broker` role to the existing controller-only node pool, reassign partitions from the broker-only nodes to the dual-role nodes, and then delete the broker-only node pool.
 
 When removing `broker` roles in the node pool configuration, keep in mind that Kafka does not automatically reassign partitions.
 Before removing the broker role, ensure that nodes changing to controller-only roles do not have any assigned partitions. 

--- a/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
@@ -12,7 +12,7 @@ To do this, add the `broker` role to the controller-only node pool, rebalance th
 
 In this procedure, we start with two node pools `pool-a`, which has only the `controller` role and `pool-b` which has only the `broker` role:
 
-.Dual-role node pool
+.Single role node pools
 [source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaNodePoolApiVersion}
@@ -105,8 +105,6 @@ spec:
         deleteClaim: false
   # ...
 ----
-
-. Apply the new `KafkaNodePool` resource to add the `broker` role to the `pool-a` nodes.
 
 . Check the status and wait for the pods in the node pool to be restarted and ready (`1/1`).
 +

--- a/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
@@ -2,15 +2,15 @@
 //
 // assembly-config.adoc
 
-[id='proc-splitting-node-pools-roles-{context}']
-= Transitioning to separate broker and controller roles
+[id='proc-joining-node-pools-roles-{context}']
+= Transitioning to dual-role nodes
 
 [role="_abstract"]
-This procedure describes how to transition to using node pools with separate roles.
-If your Kafka cluster is using a node pool with combined controller and broker roles, you can transition to using two node pools with separate roles.
-To do this, rebalance the cluster to move partition replicas to a node pool with a broker-only role, and then switch the old node pool to a controller-only role.
+This procedure describes how to transition from separate node pools with broker-only and controller-only roles to using a node pool with dual-roles.
+If your Kafka cluster is using node pools with dedicated controller and broker nodes, you can transition to using a single node pool with both roles.
+To do this, add the `broker` role to the controller-only node pool, rebalance the cluster to move partition replicas to the dual-role node pool, and then delete the old broker-only node pool.
 
-In this procedure, we start with node pool `pool-a`, which has `controller` and `broker` roles:
+In this procedure, we start with two node pools `pool-a`, which has only the `controller` role and `pool-b` which has only the `broker` role:
 
 .Dual-role node pool
 [source,yaml,subs="+attributes"]
@@ -25,7 +25,6 @@ spec:
   replicas: 3
   roles:
     - controller
-    - broker
   storage:
     type: jbod
     volumes:
@@ -34,36 +33,7 @@ spec:
         size: 20Gi
         deleteClaim: false
   # ...
-----
-
-The node pool has three nodes:
-
-.Kafka nodes in the node pool
-[source,shell]
-----
-NAME                 READY  STATUS   RESTARTS
-my-cluster-pool-a-0  1/1    Running  0
-my-cluster-pool-a-1  1/1    Running  0
-my-cluster-pool-a-2  1/1    Running  0
-----
-
-Each node performs a combined role of broker and controller.
-We create a second node pool called `pool-b`, with three nodes that act as brokers only.
-
-NOTE: During this process, the ID of the node that holds the partition replicas changes. Consider any dependencies that reference the node ID.
-
-.Prerequisites
-
-* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
-
-.Procedure
-
-. Create a node pool with a `broker` role.
-+
-.Example node pool configuration
-[source,yaml,subs="+attributes"]
-----
+---
 apiVersion: {KafkaNodePoolApiVersion}
 kind: KafkaNodePool
 metadata:
@@ -79,17 +49,66 @@ spec:
     volumes:
       - id: 0
         type: persistent-claim
+        size: 20Gi
+        deleteClaim: false
+  # ...
+----
+
+The Kafka cluster has six nodes:
+
+.Kafka nodes in the node pools
+[source,shell]
+----
+NAME                 READY  STATUS   RESTARTS
+my-cluster-pool-a-0  1/1    Running  0
+my-cluster-pool-a-1  1/1    Running  0
+my-cluster-pool-a-2  1/1    Running  0
+my-cluster-pool-b-3  1/1    Running  0
+my-cluster-pool-b-4  1/1    Running  0
+my-cluster-pool-b-5  1/1    Running  0
+----
+
+The `pool-a` nodes perform the role of controller.
+The `pool-b` nodes perform the role of broker.
+
+NOTE: During this process, the ID of the node that holds the partition replicas changes. Consider any dependencies that reference the node ID.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
+
+.Procedure
+
+. Edit the node pool `pool-a` and add the `broker` role to it.
++
+.Example node pool configuration
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-b
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
         size: 100Gi
         deleteClaim: false
   # ...
 ----
-+
-The new node pool also has three nodes.
-If you already have a broker-only node pool, you can skip this step.
 
-. Apply the new `KafkaNodePool` resource to create the brokers.
+. Apply the new `KafkaNodePool` resource to add the `broker` role to the `pool-a` nodes.
 
-. Check the status of the deployment and wait for the pods in the node pool to be created and ready (`1/1`).
+. Check the status and wait for the pods in the node pool to be restarted and ready (`1/1`).
 +
 [source,shell]
 ----
@@ -110,7 +129,7 @@ my-cluster-pool-b-5  1/1    Running  0
 +
 Node IDs are appended to the name of the node on creation.
 
-. Use the Cruise Control `remove-brokers` mode to reassign partition replicas from the dual-role nodes to the newly added brokers.
+. Use the Cruise Control `remove-brokers` mode to reassign partition replicas from the broker-only nodes to the dual-role nodes.
 +
 .Using Cruise Control to reassign partition replicas
 [source,shell,subs="+attributes"]
@@ -121,37 +140,14 @@ metadata:
   # ...
 spec:
   mode: remove-brokers
-  brokers: [0, 1, 2]
+  brokers: [3, 4, 5]
 ---- 
 +
 The reassignment can take some time depending on the number of topics and partitions in the cluster.
-+
-NOTE: If nodes changing to controller-only roles have any assigned partitions, the change is prevented.
-The `status.conditions` of the `Kafka` resource provide details of events preventing the change.
 
-. Remove the `broker` role from the node pool that originally had a combined role.
+. Remove the `pool-b` node pool that has the old broker-only nodes.
 +
-.Dual-role nodes switched to controllers
-[source,yaml,subs="+attributes"]
+[source,shell]
 ----
-apiVersion: {KafkaNodePoolApiVersion}
-kind: KafkaNodePool
-metadata:
-  name: pool-a
-  labels:
-    strimzi.io/cluster: my-cluster
-spec:
-  replicas: 3
-  roles:
-    - controller
-  storage:
-    type: jbod
-    volumes:
-      - id: 0
-        type: persistent-claim
-        size: 20Gi
-        deleteClaim: false
-  # ...
+kubectl delete kafkanodepool pool-b -n <my_cluster_operator_namespace>
 ----
-
-. Apply the configuration change so that the node pool switches to a controller-only role.

--- a/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
+++ b/documentation/modules/configuring/proc-joining-node-pool-roles.adoc
@@ -6,7 +6,7 @@
 = Transitioning to dual-role nodes
 
 [role="_abstract"]
-This procedure describes how to transition from separate node pools with broker-only and controller-only roles to using a node pool with dual-roles.
+This procedure describes how to transition from separate node pools with broker-only and controller-only roles to using a dual-role node pool.
 If your Kafka cluster is using node pools with dedicated controller and broker nodes, you can transition to using a single node pool with both roles.
 To do this, add the `broker` role to the controller-only node pool, rebalance the cluster to move partition replicas to the dual-role node pool, and then delete the old broker-only node pool.
 
@@ -30,7 +30,7 @@ spec:
     volumes:
       - id: 0
         type: persistent-claim
-        size: 20Gi
+        size: 100Gi
         deleteClaim: false
   # ...
 ---
@@ -49,7 +49,7 @@ spec:
     volumes:
       - id: 0
         type: persistent-claim
-        size: 20Gi
+        size: 100Gi
         deleteClaim: false
   # ...
 ----
@@ -88,7 +88,7 @@ NOTE: During this process, the ID of the node that holds the partition replicas 
 apiVersion: {KafkaNodePoolApiVersion}
 kind: KafkaNodePool
 metadata:
-  name: pool-b
+  name: pool-a
   labels:
     strimzi.io/cluster: my-cluster
 spec:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR updates the KafkaRoller to roll the Kafka nodes based on their current roles and not based on the desired roles. The current roles are taken from the Pod labels. If the pod or the annotation is missing, we assume that the role did not change and use the desired roles (this is what is done today all the time). This fix improves the transitions between architectures and enables moving from dedicated controller nodes to mixed nodes by adding the broker role to the controller nodes. Additional testing will be done in system tests in a separate PR.

This should resolve #9434.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md