### PR TITLE
Changed access modifier as package private for testing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1011,7 +1011,7 @@ public class KafkaReconciler {
     }
 
     // Adds Kafka version to the Kafka Status instance
-    protected Future<Void> updateKafkaVersion(KafkaStatus kafkaStatus) {
+    /* test */ Future<Void> updateKafkaVersion(KafkaStatus kafkaStatus) {
         kafkaStatus.setKafkaVersion(kafka.getKafkaVersion().version());
         return Future.succeededFuture();
     }


### PR DESCRIPTION
This trivial PR changes the access modifier to be package-private for testing on `KafkaReconciler.updateKafkaVersion` as we already have for other methods.