### PR TITLE
Cleanup test certificate temp files

### DIFF
--- a/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
+++ b/certificate-manager/src/test/java/io/strimzi/certs/OpenSslCertManagerIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.certs;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -50,26 +49,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class OpenSslCertManagerIT {
-    private static final String TEST_PREFIX = "crt-man-";
 
     private static CertificateFactory certFactory;
     private static OpenSslCertManager ssl;
 
     @BeforeAll
-    public static void beforeAll() throws CertificateException {
+    public static void before() throws CertificateException {
         Assumptions.assumeTrue(System.getProperty("os.name").contains("nux"));
         certFactory = CertificateFactory.getInstance("X.509");
         ssl = new OpenSslCertManager();
-    }
-    
-    @AfterAll
-    public static void  afterAll() {
-        // cleanup temp files
-        for (File f : new File(System.getProperty("java.io.tmpdir")).listFiles()) {
-            if (f.getName().startsWith(TEST_PREFIX)) {
-                f.delete();
-            }
-        }
     }
 
     interface Cmd {
@@ -79,9 +67,12 @@ public class OpenSslCertManagerIT {
     @Test
     public void testGenerateRootCaCertWithDays() throws Exception {
 
-        File key = Files.createTempFile(TEST_PREFIX + "key-", ".key").toFile();
-        File cert = Files.createTempFile(TEST_PREFIX + "crt-", ".crt").toFile();
-        File store = Files.createTempFile(TEST_PREFIX + "crt-", ".p12").toFile();
+        File key = Files.createTempFile("key-", ".key").toFile();
+        key.deleteOnExit();
+        File cert = Files.createTempFile("crt-", ".crt").toFile();
+        cert.deleteOnExit();
+        File store = Files.createTempFile("crt-", ".p12").toFile();
+        store.deleteOnExit();
         Subject sbj = new Subject.Builder().withCommonName("MyCommonName").withOrganizationName("MyOrganization").build();
 
         ((Cmd) () -> ssl.generateSelfSignedCert(key, cert, sbj, 365)).exec();
@@ -274,16 +265,22 @@ public class OpenSslCertManagerIT {
         Path path = Files.createTempDirectory(OpenSslCertManagerIT.class.getSimpleName());
         path.toFile().deleteOnExit();
         long fileCount = Files.list(path).count();
-        File caKey = Files.createTempFile(TEST_PREFIX + "ca-key-", ".key").toFile();
-        File caCert = Files.createTempFile(TEST_PREFIX + "ca-crt-", ".crt").toFile();
-        File store = Files.createTempFile(TEST_PREFIX + "store-", ".p12").toFile();
+        File caKey = Files.createTempFile("ca-key-", ".key").toFile();
+        caKey.deleteOnExit();
+        File caCert = Files.createTempFile("ca-crt-", ".crt").toFile();
+        caCert.deleteOnExit();
+        File store = Files.createTempFile("store-", ".p12").toFile();
+        store.deleteOnExit();
 
         Subject caSbj = new Subject.Builder().withCommonName("CACommonName").withOrganizationName("CAOrganizationName").build();
 
-        File key = Files.createTempFile(TEST_PREFIX + "key-", ".key").toFile();
-        File csr = Files.createTempFile(TEST_PREFIX + "csr-", ".csr").toFile();
+        File key = Files.createTempFile("key-", ".key").toFile();
+        key.deleteOnExit();
+        File csr = Files.createTempFile("csr-", ".csr").toFile();
+        csr.deleteOnExit();
         Subject sbj = new Subject.Builder().withCommonName("MyCommonName").withOrganizationName("MyOrganization").build();
-        File cert = Files.createTempFile(TEST_PREFIX + "crt-", ".crt").toFile();
+        File cert = Files.createTempFile("crt-", ".crt").toFile();
+        cert.deleteOnExit();
 
         ssl.generateSelfSignedCert(caKey, caCert, caSbj, 365);
         doGenerateSignedCert(caKey, caCert, caSbj, key, csr, cert, store, "123456", sbj);
@@ -301,14 +298,19 @@ public class OpenSslCertManagerIT {
     @Test
     public void testGenerateClientCertWithSubjectAndAltNames() throws Exception {
 
-        File caKey = Files.createTempFile(TEST_PREFIX + "ca-key-", ".key").toFile();
-        File caCert = Files.createTempFile(TEST_PREFIX + "ca-crt-", ".crt").toFile();
-        File store = Files.createTempFile(TEST_PREFIX + "store-", ".p12").toFile();
+        File caKey = Files.createTempFile("ca-key-", ".key").toFile();
+        caKey.deleteOnExit();
+        File caCert = Files.createTempFile("ca-crt-", ".crt").toFile();
+        caCert.deleteOnExit();
+        File store = Files.createTempFile("store-", ".p12").toFile();
+        store.deleteOnExit();
 
         Subject caSbj = new Subject.Builder().withCommonName("CACommonName").withOrganizationName("CAOrganizationName").build();
 
-        File key = Files.createTempFile(TEST_PREFIX + "key-", ".key").toFile();
-        File csr = Files.createTempFile(TEST_PREFIX + "csr-", ".csr").toFile();
+        File key = Files.createTempFile("key-", ".key").toFile();
+        key.deleteOnExit();
+        File csr = Files.createTempFile("csr-", ".csr").toFile();
+        csr.deleteOnExit();
         Subject subject = new Subject.Builder()
                 .withCommonName("MyCommonName")
                 .withOrganizationName("MyOrganization")
@@ -386,9 +388,12 @@ public class OpenSslCertManagerIT {
 
     public void doRenewSelfSignedCertWithSubject(Subject caSubject) throws Exception {
         // First generate a self-signed cert
-        File caKey = Files.createTempFile(TEST_PREFIX + "key-", ".key").toFile();
-        File originalCert = Files.createTempFile(TEST_PREFIX + "crt-", ".crt").toFile();
-        File originalStore = Files.createTempFile(TEST_PREFIX + "crt-", ".p12").toFile();
+        File caKey = Files.createTempFile("key-", ".key").toFile();
+        caKey.deleteOnExit();
+        File originalCert = Files.createTempFile("crt-", ".crt").toFile();
+        originalCert.deleteOnExit();
+        File originalStore = Files.createTempFile("crt-", ".p12").toFile();
+        originalStore.deleteOnExit();
 
         ((Cmd) () -> ssl.generateSelfSignedCert(caKey, originalCert, caSubject, 365)).exec();
         ssl.addCertToTrustStore(originalCert, "ca", originalStore, "123456");
@@ -453,9 +458,12 @@ public class OpenSslCertManagerIT {
         Subject caSubject = new Subject.Builder().withCommonName("MyRootCa").withOrganizationName("MyOrganization").build();
 
         // First generate the CA
-        File caKey = Files.createTempFile(TEST_PREFIX + "ca-", ".key").toFile();
-        File caCert = Files.createTempFile(TEST_PREFIX + "ca-", ".crt").toFile();
-        File caStore = Files.createTempFile(TEST_PREFIX + "ca-", ".p12").toFile();
+        File caKey = Files.createTempFile("ca-", ".key").toFile();
+        caKey.deleteOnExit();
+        File caCert = Files.createTempFile("ca-", ".crt").toFile();
+        caCert.deleteOnExit();
+        File caStore = Files.createTempFile("ca-", ".p12").toFile();
+        caStore.deleteOnExit();
 
         ssl.generateSelfSignedCert(caKey, caCert, caSubject, 365);
         ssl.addCertToTrustStore(caCert, "ca", caStore, "123456");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -48,7 +48,6 @@ import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -101,7 +99,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerTest {
-    private static final String TEST_PREFIX = "ca-recon-";
     public static final String NAMESPACE = "test";
     public static final String NAME = "my-kafka";
 
@@ -116,11 +113,6 @@ public class CaReconcilerTest {
     private List<Secret> secrets = new ArrayList<>();
     private WorkerExecutor sharedWorkerExecutor;
 
-    @AfterAll
-    public static void  afterAll() {
-        
-    }
-
     @BeforeEach
     public void setup(Vertx vertx) {
         secrets = new ArrayList<>();
@@ -130,12 +122,6 @@ public class CaReconcilerTest {
     @AfterEach
     public void teardown() {
         sharedWorkerExecutor.close();
-        // cleanup temp files
-        for (File f : new File(System.getProperty("java.io.tmpdir")).listFiles()) {
-            if (f.getName().startsWith(TEST_PREFIX)) {
-                f.delete();
-            }
-        }
     }
 
     private Future<ArgumentCaptor<Secret>> reconcileCa(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
@@ -210,9 +196,12 @@ public class CaReconcilerTest {
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         String clusterCaStorePassword = "123456";
 
-        Path clusterCaKeyFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-key");
-        Path clusterCaCertFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-cert");
-        Path clusterCaStoreFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-store");
+        Path clusterCaKeyFile = Files.createTempFile("tls", "cluster-ca-key");
+        clusterCaKeyFile.toFile().deleteOnExit();
+        Path clusterCaCertFile = Files.createTempFile("tls", "cluster-ca-cert");
+        clusterCaCertFile.toFile().deleteOnExit();
+        Path clusterCaStoreFile = Files.createTempFile("tls", "cluster-ca-store");
+        clusterCaStoreFile.toFile().deleteOnExit();
 
         try {
             Subject sbj = new Subject.Builder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -48,6 +48,7 @@ import io.vertx.core.WorkerExecutor;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -99,6 +101,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 @ExtendWith(VertxExtension.class)
 public class CaReconcilerTest {
+    private static final String TEST_PREFIX = "ca-recon-";
     public static final String NAMESPACE = "test";
     public static final String NAME = "my-kafka";
 
@@ -113,6 +116,11 @@ public class CaReconcilerTest {
     private List<Secret> secrets = new ArrayList<>();
     private WorkerExecutor sharedWorkerExecutor;
 
+    @AfterAll
+    public static void  afterAll() {
+        
+    }
+
     @BeforeEach
     public void setup(Vertx vertx) {
         secrets = new ArrayList<>();
@@ -122,6 +130,12 @@ public class CaReconcilerTest {
     @AfterEach
     public void teardown() {
         sharedWorkerExecutor.close();
+        // cleanup temp files
+        for (File f : new File(System.getProperty("java.io.tmpdir")).listFiles()) {
+            if (f.getName().startsWith(TEST_PREFIX)) {
+                f.delete();
+            }
+        }
     }
 
     private Future<ArgumentCaptor<Secret>> reconcileCa(Vertx vertx, CertificateAuthority clusterCa, CertificateAuthority clientsCa) {
@@ -196,9 +210,9 @@ public class CaReconcilerTest {
             throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException {
         String clusterCaStorePassword = "123456";
 
-        Path clusterCaKeyFile = Files.createTempFile("tls", "cluster-ca-key");
-        Path clusterCaCertFile = Files.createTempFile("tls", "cluster-ca-cert");
-        Path clusterCaStoreFile = Files.createTempFile("tls", "cluster-ca-store");
+        Path clusterCaKeyFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-key");
+        Path clusterCaCertFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-cert");
+        Path clusterCaStoreFile = Files.createTempFile(TEST_PREFIX, "cluster-ca-store");
 
         try {
             Subject sbj = new Subject.Builder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -58,7 +58,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -97,7 +96,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     .withBrokers(3)
                     .build();
 
-    private static ClientAndServer ccServer;
+    private static MockCruiseControl ccServer;
     // Injected by Fabric8 Mock Kubernetes Server
     @SuppressWarnings("unused")
     private KubernetesClient client;
@@ -137,8 +136,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     .build();
 
     @BeforeAll
-    public static void beforeAll() throws IOException {
-        ccServer = MockCruiseControl.server(CruiseControl.REST_API_PORT);
+    public static void beforeAll() {
+        ccServer = new MockCruiseControl(CruiseControl.REST_API_PORT);
     }
 
     @AfterAll
@@ -228,7 +227,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToProposalReady(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -263,7 +262,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     public void testKrNotReadyToProposalReadyOnSpecChange(VertxTestContext context) throws IOException, URISyntaxException {
 
         // Setup the rebalance endpoint to get error about hard goals
-        MockCruiseControl.setupCCRebalanceBadGoalsError(ccServer, CruiseControlEndpoints.REBALANCE);
+        ccServer.setupCCRebalanceBadGoalsError(CruiseControlEndpoints.REBALANCE);
 
         KafkaRebalanceSpec kafkaRebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withGoals("DiskCapacityGoal", "CpuCapacityGoal")
@@ -297,7 +296,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     ccServer.reset();
                     try {
                         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-                        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0, CruiseControlEndpoints.REBALANCE);
+                        ccServer.setupCCRebalanceResponse(0, CruiseControlEndpoints.REBALANCE);
                     } catch (IOException | URISyntaxException e) {
                         context.failNow(e);
                     }
@@ -358,7 +357,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalToProposalReady(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -428,7 +427,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalToStopped(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -510,7 +509,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalToStoppedAndRefresh(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -653,8 +652,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToProposalReadyToRebalancingToReady(VertxTestContext context, int pendingCalls, int activeCalls, int inExecutionCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -735,8 +734,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToProposalReadyToReconciliationPaused(VertxTestContext context, int pendingCalls, int activeCalls, int inExecutionCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -820,8 +819,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToProposalReadyToRebalancingToReadyThenRefresh(VertxTestContext context, int pendingCalls, int activeCalls, int inExecutionCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -923,7 +922,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewWithMissingHardGoals(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint to get error about hard goals
-        MockCruiseControl.setupCCRebalanceBadGoalsError(ccServer, endpoint);
+        ccServer.setupCCRebalanceBadGoalsError(endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -950,7 +949,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     @Test
     public void testUnknownPropertyInSpec(VertxTestContext context) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, 2, CruiseControlEndpoints.REBALANCE);
+        ccServer.setupCCRebalanceResponse(2, CruiseControlEndpoints.REBALANCE);
 
         String yaml = "apiVersion: kafka.strimzi.io/v1beta2\n" +
                 "kind: KafkaRebalance\n" +
@@ -1044,7 +1043,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToProposalReadySkipHardGoals(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -1116,7 +1115,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewWithMissingHardGoalsAndRefresh(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint to get error about hard goals
-        MockCruiseControl.setupCCRebalanceBadGoalsError(ccServer, endpoint);
+        ccServer.setupCCRebalanceBadGoalsError(endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -1143,7 +1142,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     ccServer.reset();
                     try {
                         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-                        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+                        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
                     } catch (IOException | URISyntaxException e) {
                         context.failNow(e);
                     }
@@ -1208,7 +1207,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalDelete(VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -1292,9 +1291,9 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalDelete(VertxTestContext context, int pendingCalls, int activeCalls, int inExecutionCalls, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Setup the rebalance and user tasks endpoints with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
-        MockCruiseControl.setupCCStopResponse(ccServer);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
+        ccServer.setupCCStopResponse();
 
         Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).resource(kr).create();
 
@@ -1479,7 +1478,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     @Test
     public void testRebalanceUsesUnknownProperty(VertxTestContext context) throws IOException, URISyntaxException {
         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0, CruiseControlEndpoints.REBALANCE);
+        ccServer.setupCCRebalanceResponse(0, CruiseControlEndpoints.REBALANCE);
 
         String rebalanceString = "apiVersion: kafka.strimzi.io/v1beta2\n" +
                 "kind: KafkaRebalance\n" +
@@ -1599,7 +1598,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 .compose(v -> {
                     try {
                         // Setup the rebalance endpoint with the number of pending calls before a response is received.
-                        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0, CruiseControlEndpoints.REBALANCE);
+                        ccServer.setupCCRebalanceResponse(0, CruiseControlEndpoints.REBALANCE);
                     } catch (IOException | URISyntaxException e) {
                         context.failNow(e);
                     }
@@ -1679,7 +1678,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
         // Setup the rebalance endpoint with the number of pending calls before a response is received
         // and with a delay on response higher than the client timeout to test timing out
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, 0, 10, CruiseControlEndpoints.REBALANCE);
+        ccServer.setupCCRebalanceResponse(0, 10, CruiseControlEndpoints.REBALANCE);
 
         KafkaRebalance kr =
                 createKafkaRebalance(CLUSTER_NAMESPACE, CLUSTER_NAME, RESOURCE_NAME, EMPTY_KAFKA_REBALANCE_SPEC, false);
@@ -1727,9 +1726,9 @@ public class KafkaRebalanceAssemblyOperatorTest {
         kcrao.reconcileRebalance(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME), kr)
             .onComplete(context.succeeding(v -> {
                 try {
-                    ccServer = MockCruiseControl.server(CruiseControl.REST_API_PORT);
-                } catch (IOException e) {
-                    context.failNow(e);
+                    ccServer = new MockCruiseControl(CruiseControl.REST_API_PORT);
+                } catch (Throwable t) {
+                    context.failNow(t);
                 }
                 // the resource moved from 'New' to 'NotReady' (mocked Cruise Control not reachable)
                 assertState(context, client, CLUSTER_NAMESPACE, RESOURCE_NAME,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -75,11 +74,11 @@ public class KafkaRebalanceStateMachineTest {
                     .withBrokers(3)
                     .build();
 
-    private static ClientAndServer ccServer;
+    private static MockCruiseControl ccServer;
 
     @BeforeAll
     public static void before() throws IOException, URISyntaxException {
-        ccServer = MockCruiseControl.server(CruiseControl.REST_API_PORT);
+        ccServer = new MockCruiseControl(CruiseControl.REST_API_PORT);
     }
 
     @AfterAll
@@ -224,7 +223,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krNewToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.ProposalReady,
@@ -247,7 +246,7 @@ public class KafkaRebalanceStateMachineTest {
     private void krNewWithNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         // Test the case where the user asks for a rebalance but there is not enough data, the returned status should
         // not contain an optimisation result
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.PendingProposal,
@@ -268,7 +267,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krNewToProposalPending(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.PendingProposal,
@@ -307,7 +306,7 @@ public class KafkaRebalanceStateMachineTest {
     private void krNewBadGoalsError(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         // Test the case where the user asks for a rebalance with custom goals which do not contain all the configured hard goals
         // In this case the computeNextStatus error will return a failed future with a message containing an illegal argument exception
-        MockCruiseControl.setupCCRebalanceBadGoalsError(ccServer, endpoint);
+        ccServer.setupCCRebalanceBadGoalsError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.NotReady,
@@ -354,7 +353,7 @@ public class KafkaRebalanceStateMachineTest {
     private void krNewBadGoalsErrorWithSkipHGCheck(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         // Test the case where the user asks for a rebalance with custom goals which do not contain all the configured hard goals
         // But we have set skip hard goals check to true
-        MockCruiseControl.setupCCRebalanceBadGoalsError(ccServer, endpoint);
+        ccServer.setupCCRebalanceBadGoalsError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.ProposalReady,
@@ -375,7 +374,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalPendingToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.PendingProposal, KafkaRebalanceState.ProposalReady,
@@ -396,7 +395,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalPendingToProposalReadyWithDelay(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.PendingProposal, KafkaRebalanceState.ProposalReady,
@@ -417,7 +416,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalPendingToStopped(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.PendingProposal, KafkaRebalanceState.Stopped,
@@ -438,7 +437,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyNoChange(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.ProposalReady,
@@ -459,7 +458,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyToRebalancingWithNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.PendingProposal,
@@ -480,7 +479,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.Rebalancing,
@@ -501,7 +500,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyToRebalancing(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.Rebalancing,
@@ -522,7 +521,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krAutoApprovalProposalReadyToRebalancing(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.Rebalancing,
@@ -543,7 +542,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.ProposalReady,
@@ -564,7 +563,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.PendingProposal,
@@ -585,7 +584,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krProposalReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.PendingProposal,
@@ -606,7 +605,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krRebalancingCompleted(Vertx vertx, VertxTestContext context, int activeCalls, int inExecutionCalls, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Ready,
@@ -630,7 +629,7 @@ public class KafkaRebalanceStateMachineTest {
         // This tests that the optimization proposal is added correctly if it was not ready when the rebalance(dryrun=false) was called.
         // The first poll should see active and then the second should see in execution and add the optimization and cancel the timer
         // so that the status is updated.
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Rebalancing,
@@ -651,8 +650,8 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krRebalancingToStopped(Vertx vertx, VertxTestContext context, int activeCalls, int inExecutionCalls, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, activeCalls, inExecutionCalls);
-        MockCruiseControl.setupCCStopResponse(ccServer);
+        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
+        ccServer.setupCCStopResponse();
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Stopped,
@@ -673,7 +672,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krRebalancingToStopped(Vertx vertx, VertxTestContext context, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCUserTasksCompletedWithError(ccServer);
+        ccServer.setupCCUserTasksCompletedWithError();
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.NotReady,
@@ -694,7 +693,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Stopped, KafkaRebalanceState.PendingProposal,
@@ -715,7 +714,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Stopped, KafkaRebalanceState.ProposalReady,
@@ -736,7 +735,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krStoppedRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Stopped, KafkaRebalanceState.PendingProposal,
@@ -757,7 +756,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Ready, KafkaRebalanceState.PendingProposal,
@@ -778,7 +777,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Ready, KafkaRebalanceState.ProposalReady,
@@ -799,7 +798,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Ready, KafkaRebalanceState.PendingProposal,
@@ -820,7 +819,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.NotReady, KafkaRebalanceState.PendingProposal,
@@ -841,7 +840,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.NotReady, KafkaRebalanceState.ProposalReady,
@@ -862,7 +861,7 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     private void krNotReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.NotReady, KafkaRebalanceState.PendingProposal,
@@ -898,7 +897,7 @@ public class KafkaRebalanceStateMachineTest {
                                               int pendingCalls, CruiseControlEndpoints endpoint,
                                               KafkaRebalance kcRebalance, KafkaRebalanceState kafkaRebalanceState,
                                               KafkaRebalanceAnnotation kafkaRebalanceAnnotation) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 kafkaRebalanceState, kafkaRebalanceState,
@@ -923,7 +922,7 @@ public class KafkaRebalanceStateMachineTest {
                                               int pendingCalls, CruiseControlEndpoints endpoint,
                                               KafkaRebalance kcRebalance, KafkaRebalanceState kafkaRebalanceState,
                                               KafkaRebalanceAnnotation kafkaRebalanceAnnotation) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         checkTransition(vertx, context,
                 kafkaRebalanceState, KafkaRebalanceState.ProposalReady,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -40,11 +39,11 @@ public class CruiseControlClientTest {
     private static final boolean API_AUTH_ENABLED = true;
     private static final boolean API_SSL_ENABLED = true;
 
-    private static ClientAndServer ccServer;
+    private static MockCruiseControl ccServer;
 
     @BeforeAll
     public static void setupServer() throws IOException {
-        ccServer = MockCruiseControl.server(PORT);
+        ccServer = new MockCruiseControl(PORT);
     }
 
     @AfterAll
@@ -63,7 +62,7 @@ public class CruiseControlClientTest {
 
     @Test
     public void testGetCCState(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCStateResponse(ccServer);
+        ccServer.setupCCStateResponse();
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -115,7 +114,7 @@ public class CruiseControlClientTest {
     @Test
     public void testCCGetRebalanceUserTask(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, 0);
+        ccServer.setupCCUserTasksResponseNoGoals(0, 0);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID;
@@ -243,7 +242,7 @@ public class CruiseControlClientTest {
     }
 
     private void ccRebalance(Vertx vertx, VertxTestContext context, int pendingCalls, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<CruiseControlRebalanceResponse> assertion) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -274,7 +273,7 @@ public class CruiseControlClientTest {
     }
 
     private void ccRebalanceVerbose(Vertx vertx, VertxTestContext context, int pendingCalls, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<CruiseControlRebalanceResponse> assertion) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -305,7 +304,7 @@ public class CruiseControlClientTest {
     }
 
     private void ccRebalanceNotEnoughValidWindowsException(Vertx vertx, VertxTestContext context, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<CruiseControlRebalanceResponse> assertion) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceNotEnoughDataError(ccServer, endpoint);
+        ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -336,7 +335,7 @@ public class CruiseControlClientTest {
     }
 
     private void ccRebalanceProposalNotReady(Vertx vertx, VertxTestContext context, int pendingCalls, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<CruiseControlRebalanceResponse> assertion) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCRebalanceResponse(ccServer, pendingCalls, endpoint);
+        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -367,7 +366,7 @@ public class CruiseControlClientTest {
     }
 
     private void ccBrokerDoesNotExist(Vertx vertx, VertxTestContext context, AbstractRebalanceOptions options, CruiseControlEndpoints endpoint, Consumer<Throwable> assertion) throws IOException, URISyntaxException {
-        MockCruiseControl.setupCCBrokerDoesNotExist(ccServer, endpoint);
+        ccServer.setupCCBrokerDoesNotExist(endpoint);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -45,7 +45,6 @@ import static org.mockserver.model.HttpResponse.response;
 public class MockCruiseControl {
 
     private static final String CC_JSON_ROOT = "io/strimzi/operator/cluster/operator/assembly/CruiseControlJSON/";
-    private static final String TEST_PREFIX = "mock-cc-";
 
     private static final int RESPONSE_DELAY_SEC = 0;
 
@@ -98,8 +97,10 @@ public class MockCruiseControl {
         try {
             ConfigurationProperties.logLevel("WARN");
 
-            File key = Files.createTempFile(TEST_PREFIX, ".key").toFile();
-            File cert = Files.createTempFile(TEST_PREFIX, ".crt").toFile();
+            File key = Files.createTempFile("key-", ".key").toFile();
+            key.deleteOnExit();
+            File cert = Files.createTempFile("crt-", ".crt").toFile();
+            cert.deleteOnExit();
 
             MockCertManager certManager = new MockCertManager();
             certManager.generateSelfSignedCert(key, cert, new Subject.Builder().withCommonName("Test CA").build(), 365);
@@ -128,12 +129,6 @@ public class MockCruiseControl {
     
     public void stop() {
         server.stop();
-        // cleanup temp files
-        for (File f : new File(System.getProperty("java.io.tmpdir")).listFiles()) {
-            if (f.getName().startsWith(TEST_PREFIX)) {
-                f.delete();
-            }
-        }
     }
 
     private static Header convertToHeader(HTTPHeader httpHeader) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControlTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -30,11 +29,11 @@ public class MockCruiseControlTest {
     private static final int PORT = 1080;
     private static final String HOST = "localhost";
 
-    private static ClientAndServer ccServer;
+    private static MockCruiseControl ccServer;
 
     @BeforeAll
-    public static void startUp() throws IOException {
-        ccServer = MockCruiseControl.server(PORT);
+    public static void startUp() {
+        ccServer = new MockCruiseControl(PORT);
     }
 
     @BeforeEach
@@ -54,7 +53,7 @@ public class MockCruiseControlTest {
 
     private void runTest(Vertx vertx, VertxTestContext context, String userTaskID, int pendingCalls) throws IOException, URISyntaxException {
 
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, pendingCalls);
+        ccServer.setupCCUserTasksResponseNoGoals(0, pendingCalls);
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
@@ -119,7 +118,7 @@ public class MockCruiseControlTest {
         //for test end to prevent premature test success
         Checkpoint completeTest = context.checkpoint();
 
-        MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, pendingCalls1);
+        ccServer.setupCCUserTasksResponseNoGoals(0, pendingCalls1);
 
         Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
 
@@ -145,7 +144,7 @@ public class MockCruiseControlTest {
         statusFuture = statusFuture.compose(response -> {
             try {
                 ccServer.reset();
-                MockCruiseControl.setupCCUserTasksResponseNoGoals(ccServer, 0, pendingCalls2);
+                ccServer.setupCCUserTasksResponseNoGoals(0, pendingCalls2);
             } catch (IOException | URISyntaxException e) {
                 return Future.failedFuture(e);
             }


### PR DESCRIPTION
Some tests leave a bunch of temporary files in the /tmp folder, which are used for certificate generation. This change adds code to clean them up after the test has finished. It also hides ClientAndServer in MockCruiseControl to isolate test classes from the mockserver dependency.