### PR TITLE
[ST] Use correct Kafka resource for each mode (ZK without NP / ZK with NP / KRaft)

### DIFF
--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.0.1
+          image: quay.io/strimzi/drain-cleaner:1.1.0-rc1
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0-rc1
+          image: quay.io/strimzi/drain-cleaner:1.0.1
           ports:
             - containerPort: 8080
               name: http

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -22,11 +22,9 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
-import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.Status;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.user.KafkaUser;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.ConditionStatus;
@@ -185,24 +183,7 @@ public class ResourceManager {
                         resource.getKind(), resource.getMetadata().getNamespace(), resource.getMetadata().getName());
             }
 
-            if (resource.getKind().equals(Kafka.RESOURCE_KIND)) {
-                // in case we want to run tests with KafkaNodePools enabled, we want to use it for all the Kafka resources
-                if (Environment.isKafkaNodePoolsEnabled()) {
-                    Map<String, String> annotations = resource.getMetadata().getAnnotations();
-                    annotations.put(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled");
-                    // if the tests are running with UseKRaft enabled, the corresponding annotation is needed for all the Kafka resources
-                    if (Environment.isKRaftModeEnabled()) {
-                        annotations.put(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled");
-                    }
-                    resource.getMetadata().setAnnotations(annotations);
-                }
-            }
-
             if (Environment.isKRaftModeEnabled() && !Environment.isUnidirectionalTopicOperatorEnabled()) {
-                if (Objects.equals(resource.getKind(), Kafka.RESOURCE_KIND)) {
-                    // Remove TO when KRaft mode is enabled, because it is not supported
-                    ((Kafka) resource).getSpec().getEntityOperator().setTopicOperator(null);
-                }
                 if (Objects.equals(resource.getKind(), KafkaTopic.RESOURCE_KIND)) {
                     // Do not create KafkaTopic when KRaft is enabled
                     LOGGER.warn("KafkaTopic: {}/{} will not be created, because Topic Operator is not enabled with KRaft mode", resource.getMetadata().getNamespace(), resource.getMetadata().getName());

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -295,10 +295,10 @@ public class KafkaTemplates {
                 .endKafka()
             .endSpec();
 
-        applyDefaultSpecOfKafka(kb, kafkaReplicas);
-        applyDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
-        applyDefaultLogging(kb, true);
-        applyMemoryRequestsAndLimitsIfNeeded(kb, true);
+        setDefaultSpecOfKafka(kb, kafkaReplicas);
+        setDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
+        setDefaultLogging(kb, true);
+        setMemoryRequestsAndLimitsIfNeeded(kb, true);
 
         return kb;
     }
@@ -311,10 +311,10 @@ public class KafkaTemplates {
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
             .endMetadata();
 
-        applyDefaultSpecOfKafka(kb, kafkaReplicas);
-        applyDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
-        applyDefaultLogging(kb, true);
-        applyMemoryRequestsAndLimitsIfNeeded(kb, true);
+        setDefaultSpecOfKafka(kb, kafkaReplicas);
+        setDefaultConfigurationOfZookeeperKafka(kb, zookeeperReplicas);
+        setDefaultLogging(kb, true);
+        setMemoryRequestsAndLimitsIfNeeded(kb, true);
         kb = removeFieldsNotRelatedToParticularMode(kb, true);
 
         return kb;
@@ -334,9 +334,9 @@ public class KafkaTemplates {
                 .endKafka()
             .endSpec();
 
-        applyDefaultSpecOfKafka(kb, kafkaReplicas);
-        applyDefaultLogging(kb, false);
-        applyMemoryRequestsAndLimitsIfNeeded(kb, false);
+        setDefaultSpecOfKafka(kb, kafkaReplicas);
+        setDefaultLogging(kb, false);
+        setMemoryRequestsAndLimitsIfNeeded(kb, false);
         kb = removeFieldsNotRelatedToParticularMode(kb, false);
 
         return kb;
@@ -346,7 +346,7 @@ public class KafkaTemplates {
     // Application of defaults to the builders
     // -------------------------------------------------------------------------------------------
 
-    private static void applyDefaultConfigurationOfZookeeperKafka(KafkaBuilder kafkaBuilder, int zookeeperReplicas) {
+    private static void setDefaultConfigurationOfZookeeperKafka(KafkaBuilder kafkaBuilder, int zookeeperReplicas) {
         kafkaBuilder
             .editSpec()
                 .editKafka()
@@ -359,7 +359,7 @@ public class KafkaTemplates {
             .endSpec();
     }
 
-    private static void applyDefaultLogging(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
+    private static void setDefaultLogging(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
         kafkaBuilder
             .editSpec()
                 .editKafka()
@@ -393,7 +393,7 @@ public class KafkaTemplates {
         }
     }
 
-    private static void applyMemoryRequestsAndLimitsIfNeeded(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
+    private static void setMemoryRequestsAndLimitsIfNeeded(KafkaBuilder kafkaBuilder, boolean withZookeeper) {
         if (!Environment.isSharedMemory()) {
             // in case that we are using NodePools, the resource limits and requirements are specified in KafkaNodePool resources
             if (!Environment.isKafkaNodePoolsEnabled()) {
@@ -444,7 +444,7 @@ public class KafkaTemplates {
         }
     }
 
-    private static void applyDefaultSpecOfKafka(KafkaBuilder kafkaBuilder, int kafkaReplicas) {
+    private static void setDefaultSpecOfKafka(KafkaBuilder kafkaBuilder, int kafkaReplicas) {
         kafkaBuilder
             .editSpec()
                 .editKafka()

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -25,6 +25,8 @@ import io.strimzi.test.TestUtils;
 
 import java.util.Collections;
 
+import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
+
 public class KafkaTemplates {
 
     private KafkaTemplates() {}
@@ -285,6 +287,7 @@ public class KafkaTemplates {
         KafkaBuilder kb = new KafkaBuilder(kafka)
             .withNewMetadata()
                 .withName(clusterName)
+                .withNamespace(kubeClient().getNamespace())
             .endMetadata()
             .editSpec()
                 .editKafka()
@@ -304,6 +307,7 @@ public class KafkaTemplates {
         KafkaBuilder kb = new KafkaBuilder(kafka)
             .withNewMetadata()
                 .withName(clusterName)
+                .withNamespace(kubeClient().getNamespace())
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
             .endMetadata();
 
@@ -320,6 +324,7 @@ public class KafkaTemplates {
         KafkaBuilder kb = new KafkaBuilder(kafka)
             .withNewMetadata()
                 .withName(clusterName)
+                .withNamespace(kubeClient().getNamespace())
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                 .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
             .endMetadata()
@@ -392,7 +397,7 @@ public class KafkaTemplates {
         if (!Environment.isSharedMemory()) {
             // in case that we are using NodePools, the resource limits and requirements are specified in KafkaNodePool resources
             if (!Environment.isKafkaNodePoolsEnabled()) {
-                kb.editSpec()
+                kafkaBuilder.editSpec()
                         .editKafka()
                             // we use such values, because on environments where it is limited to 7Gi, we are unable to deploy
                             // Cluster Operator, two Kafka clusters and MirrorMaker/2. Such situation may result in an OOM problem.
@@ -405,7 +410,7 @@ public class KafkaTemplates {
                     .endSpec();
             }
 
-            kb.editSpec()
+            kafkaBuilder.editSpec()
                 .editEntityOperator()
                     .editUserOperator()
                         // For User Operator using 512Mi is too much and on the other hand 128Mi is causing OOM problem at the start.
@@ -480,8 +485,7 @@ public class KafkaTemplates {
         }
 
         kafka.getSpec().getKafka().setStorage(null);
-        // TODO: currently commented, as we are not able to set null or completely remove the .replicas field
-        // kafka.getSpec().getKafka().setReplicas();
+        kafka.getSpec().getKafka().setReplicas(null);
 
         return new KafkaBuilder(kafka);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -37,7 +37,7 @@ public class KafkaTemplates {
     private static final String KAFKA_METRICS_CONFIG_REF_KEY = "kafka-metrics-config.yml";
     private static final String ZOOKEEPER_METRICS_CONFIG_REF_KEY = "zookeeper-metrics-config.yml";
     private static final String METRICS_KAFKA_CONFIG_MAP_SUFFIX = "-kafka-metrics";
-    private static final String METRICS_CC_CONFIG_MAP_SUFFIX = "-kafka-metrics";
+    private static final String METRICS_CC_CONFIG_MAP_SUFFIX = "-cc-metrics";
 
     // -------------------------------------------------------------------------------------------
     // Kafka Ephemeral

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -471,7 +471,7 @@ class KafkaST extends AbstractST {
                 .allMatch(volume -> "false".equals(volume.getMetadata().getAnnotations().get("strimzi.io/delete-claim")))
         );
 
-        final int volumesCount = kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getClusterName()).size();
+        final int volumesCount = kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getBrokerComponentName()).size();
 
         LOGGER.info("Deleting Kafka: {}/{} cluster", testStorage.getNamespaceName(), testStorage.getClusterName());
         // we cannot use ResourceManager here, as it would delete all the PVCs (part of the KafkaResource#delete method)
@@ -481,10 +481,10 @@ class KafkaST extends AbstractST {
         }
 
         LOGGER.info("Waiting for PVCs deletion");
-        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(testStorage.getNamespaceName(), volumesCount, testStorage.getClusterName(), List.of(idZeroVolumeModified, idOneVolumeOriginal));
+        PersistentVolumeClaimUtils.waitForJbodStorageDeletion(testStorage.getNamespaceName(), volumesCount, testStorage.getBrokerComponentName(), List.of(idZeroVolumeModified, idOneVolumeOriginal));
 
         LOGGER.info("Verifying that PVC which are supposed to remain, really persist even after Kafka cluster un-deployment");
-        List<String> remainingPVCNames =  kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getClusterName()).stream().map(e -> e.getMetadata().getName()).toList();
+        List<String> remainingPVCNames =  kubeClient().listPersistentVolumeClaims(testStorage.getNamespaceName(), testStorage.getBrokerComponentName()).stream().map(e -> e.getMetadata().getName()).toList();
         brokerPods.keySet().forEach(broker -> assertThat("Kafka Broker: " + broker + " does not preserve its JBOD storage's PVC",
             remainingPVCNames.stream().anyMatch(e -> e.equals("data-0-" + broker))));
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -442,7 +442,7 @@ class KafkaST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPool(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), kafkaReplicas).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaJBOD(testStorage.getClusterName(), kafkaReplicas, jbodStorage).build());
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaJBOD(testStorage.getClusterName(), kafkaReplicas, 3, jbodStorage).build());
 
         Map<String, String> brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), testStorage.getBrokerSelector());
         // kafka cluster already deployed

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.common.InlineLogging;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.JvmOptionsBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
+import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerResources;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Resources;
@@ -567,10 +568,23 @@ class LogSettingST extends AbstractST {
                             .withGcLoggingEnabled(true)
                         .endJvmOptions()
                     .endSpec()
+                    .build(),
+                KafkaNodePoolTemplates.brokerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaNodePoolResource.getBrokerPoolName(GC_LOGGING_SET_NAME), GC_LOGGING_SET_NAME, 1)
+                    .editSpec()
+                        .withNewJvmOptions()
+                        .endJvmOptions()
+                    .endSpec()
+                    .build(),
+                KafkaNodePoolTemplates.controllerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaNodePoolResource.getControllerPoolName(GC_LOGGING_SET_NAME), GC_LOGGING_SET_NAME, 1)
+                    .editSpec()
+                        .withNewJvmOptions()
+                        .endJvmOptions()
+                    .endSpec()
                     .build()
             )
         );
-        resourceManager.createResourceWithoutWait(KafkaTemplates.kafkaPersistent(LOG_SETTING_CLUSTER_NAME, 3, 1)
+
+        Kafka logSettingKafka = KafkaTemplates.kafkaPersistent(LOG_SETTING_CLUSTER_NAME, 3, 1)
             .editMetadata()
                 .withNamespace(Environment.TEST_SUITE_NAMESPACE)
             .endMetadata()
@@ -614,26 +628,10 @@ class LogSettingST extends AbstractST {
                 .withNewKafkaExporter()
                 .endKafkaExporter()
             .endSpec()
-            .build());
+            .build();
 
 //         deploying second Kafka here because of MM and MM2 tests
-        resourceManager.createResourceWithWait(
-            NodePoolsConverter.convertNodePoolsIfNeeded(
-                KafkaNodePoolTemplates.brokerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaNodePoolResource.getBrokerPoolName(GC_LOGGING_SET_NAME), GC_LOGGING_SET_NAME, 1)
-                    .editSpec()
-                        .withNewJvmOptions()
-                        .endJvmOptions()
-                    .endSpec()
-                    .build(),
-                KafkaNodePoolTemplates.controllerPoolPersistentStorage(Environment.TEST_SUITE_NAMESPACE, KafkaNodePoolResource.getControllerPoolName(GC_LOGGING_SET_NAME), GC_LOGGING_SET_NAME, 1)
-                    .editSpec()
-                        .withNewJvmOptions()
-                        .endJvmOptions()
-                    .endSpec()
-                    .build()
-            )
-        );
-        resourceManager.createResourceWithoutWait(KafkaTemplates.kafkaPersistent(GC_LOGGING_SET_NAME, 1, 1)
+        Kafka gcLoggingKafka = KafkaTemplates.kafkaPersistent(GC_LOGGING_SET_NAME, 1, 1)
             .editMetadata()
                 .withNamespace(Environment.TEST_SUITE_NAMESPACE)
             .endMetadata()
@@ -657,7 +655,18 @@ class LogSettingST extends AbstractST {
                     .endUserOperator()
                 .endEntityOperator()
             .endSpec()
-            .build());
+            .build();
+
+        if (Environment.isKRaftModeEnabled()) {
+            logSettingKafka.getSpec().setZookeeper(null);
+            gcLoggingKafka.getSpec().setZookeeper(null);
+
+            if (!Environment.isUnidirectionalTopicOperatorEnabled()) {
+                logSettingKafka.getSpec().getEntityOperator().setTopicOperator(null);
+                gcLoggingKafka.getSpec().getEntityOperator().setTopicOperator(null);
+            }
+        }
+        resourceManager.createResourceWithoutWait(logSettingKafka, gcLoggingKafka);
 
         // sync point wait for all resources
         KafkaUtils.waitForKafkaReady(Environment.TEST_SUITE_NAMESPACE, LOG_SETTING_CLUSTER_NAME);

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -237,8 +237,8 @@ class LogSettingST extends AbstractST {
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(LOG_SETTING_CLUSTER_NAME, kafka -> {
             kafka.getSpec().getKafka().setJvmOptions(JVM_OPTIONS);
-            kafka.getSpec().getZookeeper().setJvmOptions(JVM_OPTIONS);
             if (!Environment.isKRaftModeEnabled()) {
+                kafka.getSpec().getZookeeper().setJvmOptions(JVM_OPTIONS);
                 kafka.getSpec().getEntityOperator().getTopicOperator().setJvmOptions(JVM_OPTIONS);
             }
             kafka.getSpec().getEntityOperator().getUserOperator().setJvmOptions(JVM_OPTIONS);

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -729,7 +729,7 @@ public class MetricsST extends AbstractST {
             KafkaTemplates.kafkaMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
             KafkaTemplates.cruiseControlMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
             // Kafka with CruiseControl and metrics
-            KafkaTemplates.kafkaWithMetricsAndCruiseControlWithMetrics(kafkaClusterFirstName, namespaceFirst, 3, 3)
+            KafkaTemplates.kafkaWithMetricsAndCruiseControlWithMetrics(namespaceFirst, kafkaClusterFirstName, 3, 3)
                 .editOrNewSpec()
                     .editEntityOperator()
                         .editTopicOperator()

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -726,6 +726,8 @@ public class MetricsST extends AbstractST {
             )
         );
         resourceManager.createResourceWithoutWait(
+            KafkaTemplates.kafkaMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
+            KafkaTemplates.cruiseControlMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
             // Kafka with CruiseControl and metrics
             KafkaTemplates.kafkaWithMetricsAndCruiseControlWithMetrics(kafkaClusterFirstName, namespaceFirst, 3, 3)
                 .editOrNewSpec()
@@ -739,7 +741,8 @@ public class MetricsST extends AbstractST {
                     .endEntityOperator()
                 .endSpec()
                 .build(),
-            KafkaTemplates.kafkaWithMetrics(kafkaClusterSecondName, namespaceSecond, 1, 1).build(),
+            KafkaTemplates.kafkaMetricsConfigMap(namespaceSecond, kafkaClusterSecondName),
+            KafkaTemplates.kafkaWithMetrics(namespaceSecond, kafkaClusterSecondName, 1, 1).build(),
             ScraperTemplates.scraperPod(TestConstants.CO_NAMESPACE, coScraperName).build(),
             ScraperTemplates.scraperPod(Environment.TEST_SUITE_NAMESPACE, testSuiteScraperName).build(),
             ScraperTemplates.scraperPod(namespaceFirst, scraperName).build(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -128,10 +128,9 @@ public class FeatureGatesST extends AbstractST {
         setupClusterOperatorWithFeatureGate("+KafkaNodePools,-UseKRaft");
 
         LOGGER.info("Deploying Kafka Cluster: {}/{} controlled by KafkaNodePool: {}", testStorage.getNamespaceName(), testStorage.getClusterName(), testStorage.getBrokerPoolName());
-        final Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas, 3)
+        final Kafka kafkaCr = KafkaTemplates.kafkaPersistentNodePools(testStorage.getClusterName(), kafkaReplicas, 3)
             .editOrNewMetadata()
                 .withNamespace(testStorage.getNamespaceName())
-                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
             .endMetadata()
             .build();
         

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -283,7 +283,10 @@ public class KafkaRollerST extends AbstractST {
 
         KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> {
             kafka.getSpec().getKafka().setImage("quay.io/strimzi/kafka:not-existent-tag");
-            kafka.getSpec().getZookeeper().setImage(kafkaImage);
+
+            if (!Environment.isKRaftModeEnabled()) {
+                kafka.getSpec().getZookeeper().setImage(kafkaImage);
+            }
         }, testStorage.getNamespaceName());
 
         KafkaUtils.waitForKafkaNotReady(testStorage.getNamespaceName(), testStorage.getClusterName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -282,11 +282,14 @@ public class NetworkPoliciesST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPoolPersistentStorage(secondNamespace, testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaWithMetrics(testStorage.getClusterName(), secondNamespace, 3, 3)
+        resourceManager.createResourceWithWait(
+            KafkaTemplates.kafkaMetricsConfigMap(secondNamespace, testStorage.getClusterName()),
+            KafkaTemplates.kafkaWithMetrics(secondNamespace, testStorage.getClusterName(), 3, 3)
             .editMetadata()
                 .addToLabels(labels)
             .endMetadata()
-            .build());
+            .build()
+        );
 
         checkNetworkPoliciesInNamespace(testStorage.getClusterName(), secondNamespace);
 

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -336,6 +336,25 @@ public final class TestUtils {
 
     }
 
+    public static <T> T configFromMultiYamlFile(String yamlFile, String expectedKind, Class<T> kindClass) {
+        return configFromMultiYamlFile(new File(yamlFile), expectedKind, kindClass);
+    }
+
+    public static <T> T configFromMultiYamlFile(File yamlFile, String expectedKind, Class<T> kindClass) {
+        try {
+            YAMLFactory yamlFactory = new YAMLFactory();
+            ObjectMapper mapper = new ObjectMapper();
+            YAMLParser yamlParser = yamlFactory.createParser(yamlFile);
+            List<Map<String, Object>> resources = mapper.readValues(yamlParser, new TypeReference<Map<String, Object>>() { }).readAll();
+
+            return mapper.convertValue(resources.stream().filter(resource -> resource.get("kind").equals(expectedKind)).findFirst().get(), kindClass);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static <T> T configFromYaml(File yamlFile, Class<T> c) {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {


### PR DESCRIPTION
### Type of change

- Bugfix / Enhancement

### Description

This PR refactors `KafkaTemplates` class, so during STs the correct Kafka resource is used. Currently, when we are running the STs, we are getting a lot of warnings about specified fields, that are not used:

In ZK with NodePools:
- `.spec.kafka.replicas` is used
- `.spec.kafka.storage` is used

In KRaft then:
- `.spec.zookeeper` is used
- LMFV and IBPV are used in config
- `metadataVersion` is not set (IIRC that's not a warning, but for LMFV and IBPV we are setting a version here, so we should do a same thing in KRaft as well)

Also, `kafkaWithMetrics` and `kafkaWithMetricsAndCruiseControlWithMetrics` contain creation of `ConfigMap`s, which IMHO shouldn't be part of the particular methods, but the creation should be done in `ResourceManager`, thus I removed it from those two methods and created separate one just for the `ConfigMap`s. Those have to applied before applying `Kafka` resource, but that's something what would user anyway do and it's not hidden.

As part of this PR I moved out common code and I created methods that are used in particular `default*` templates.

### Checklist

- [ ] Make sure all tests pass