### PR TITLE
Improve UTO logs

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
@@ -20,6 +20,8 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
+import static io.strimzi.operator.topic.v2.TopicOperatorUtil.topicName;
+
 /**
  * Encapsulates a queue (actually a deque) of {@link TopicEvent}s and a pool of threads (see {@link LoopRunnable}) servicing
  * the reconciliation of those events using a {@link BatchingTopicController}.
@@ -200,15 +202,16 @@ class BatchingLoop {
                 }
 
                 if (batch.size() > 0) {
-                    LOGGER.debugOp("[Batch #{}] Reconciling {} topics", batchId, batch.size());
+                    LOGGER.infoOp("[Batch #{}] Reconciling batch of {} topics", batchId, batch.size());
                     // perform reconciliation on new batch
                     if (!batch.toUpdate.isEmpty()) {
                         controller.onUpdate(batch.toUpdate.stream().map(upsert -> lookup(batchId, upsert)).filter(Objects::nonNull).toList());
                     }
                     if (!batch.toDelete.isEmpty()) {
-                        controller.onDelete(batch.toDelete.stream().map(td -> new ReconcilableTopic(new Reconciliation("delete", "KafkaTopic", td.namespace(), td.name()), td.topic(), BatchingTopicController.topicName(td.topic()))).toList());
+                        controller.onDelete(batch.toDelete.stream().map(td -> new ReconcilableTopic(
+                            new Reconciliation("delete", "KafkaTopic", td.namespace(), td.name()), td.topic(), topicName(td.topic()))).toList());
                     }
-                    LOGGER.debugOp("[Batch #{}] Reconciled batch", batchId);
+                    LOGGER.infoOp("[Batch #{}] Batch reconciliation completed", batchId);
                 } else {
                     LOGGER.traceOp("[Batch #{}] Empty batch", batchId);
                 }
@@ -229,7 +232,7 @@ class BatchingLoop {
                         batchId, topicUpsert, BatchingTopicController.resourceVersion(kt));
                 var r = new Reconciliation("upsert", "KafkaTopic", topicUpsert.namespace(), topicUpsert.name());
                 LOGGER.debugOp("[Batch #{}] contains {}", batchId, r);
-                return new ReconcilableTopic(r, kt, BatchingTopicController.topicName(kt));
+                return new ReconcilableTopic(r, kt, topicName(kt));
             } else {
                 // Null can happen if the KafkaTopic has been deleted from Kube and we've not yet processed
                 // the corresponding delete event
@@ -246,20 +249,20 @@ class BatchingLoop {
             final long deadlineNanoTime = System.nanoTime() + maxBatchLingerMs * 1_000_000;
             while (true) {
                 if (batch.size() >= maxBatchSize) {
-                    LOGGER.traceOp("[Batch #{}] reached maxBatchSize, batch complete", batchId, maxBatchSize);
+                    LOGGER.traceOp("[Batch #{}] Reached maxBatchSize, batch complete", batchId, maxBatchSize);
                     break;
                 }
 
                 long timeoutNs = deadlineNanoTime - System.nanoTime();
                 if (timeoutNs <= 0) {
-                    LOGGER.traceOp("[Batch #{}] {}ms linger expired", batchId, maxBatchLingerMs);
+                    LOGGER.traceOp("[Batch #{}] {}ms Linger expired", batchId, maxBatchLingerMs);
                     break;
                 }
                 LOGGER.traceOp("[Batch #{}] Taking next item from deque head with timeout {}ns", batchId, timeoutNs);
                 TopicEvent topicEvent = queue.pollFirst(timeoutNs, TimeUnit.NANOSECONDS);
 
                 if (topicEvent == null) {
-                    LOGGER.traceOp("[Batch #{}] linger expired, batch complete", batchId);
+                    LOGGER.traceOp("[Batch #{}] Linger expired, batch complete", batchId);
                     break;
                 }
                 addToBatch(batchId, batch, rejected, topicEvent);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingLoop.java
@@ -255,7 +255,7 @@ class BatchingLoop {
 
                 long timeoutNs = deadlineNanoTime - System.nanoTime();
                 if (timeoutNs <= 0) {
-                    LOGGER.traceOp("[Batch #{}] {}ms Linger expired", batchId, maxBatchLingerMs);
+                    LOGGER.traceOp("[Batch #{}] {}ms linger expired", batchId, maxBatchLingerMs);
                     break;
                 }
                 LOGGER.traceOp("[Batch #{}] Taking next item from deque head with timeout {}ns", batchId, timeoutNs);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -995,7 +995,7 @@ public class BatchingTopicController {
         String message = e.getMessage();
         String reason;
         if (e instanceof TopicOperatorException) {
-            LOGGER.errorCr(reconcilableTopic.reconciliation(), "Reconciliation failed: {}", e.getMessage());
+            LOGGER.warnCr(reconcilableTopic.reconciliation(), "Reconciliation failed: {}", e.getMessage());
             reason = ((TopicOperatorException) e).reason();
         } else {
             LOGGER.errorCr(reconcilableTopic.reconciliation(), "Reconciliation failed with unexpected exception", e);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/BatchingTopicController.java
@@ -59,6 +59,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.strimzi.operator.topic.v2.TopicOperatorUtil.topicName;
+
 /**
  * A unidirectional operator
  */
@@ -140,17 +142,6 @@ public class BatchingTopicController {
         } else {
             return false;
         }
-    }
-
-    static String topicName(KafkaTopic kt) {
-        String tn = null;
-        if (kt.getSpec() != null) {
-            tn = kt.getSpec().getTopicName();
-        }
-        if (tn == null) {
-            tn = kt.getMetadata().getName();
-        }
-        return tn;
     }
 
     static String resourceVersion(KafkaTopic kt) {
@@ -1004,10 +995,10 @@ public class BatchingTopicController {
         String message = e.getMessage();
         String reason;
         if (e instanceof TopicOperatorException) {
-            LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status for exception {}", e.toString());
+            LOGGER.errorCr(reconcilableTopic.reconciliation(), "Reconciliation failed: {}", e.getMessage());
             reason = ((TopicOperatorException) e).reason();
         } else {
-            LOGGER.warnCr(reconcilableTopic.reconciliation(), "Updating status for unexpected exception", e);
+            LOGGER.errorCr(reconcilableTopic.reconciliation(), "Reconciliation failed with unexpected exception", e);
             reason = e.getClass().getSimpleName();
         }
         Condition condition = new ConditionBuilder()
@@ -1059,16 +1050,16 @@ public class BatchingTopicController {
                         .withTopicName(newTopicName)
                         .withConditions(condition)
                     .endStatus().build();
-            LOGGER.debugCr(reconciliation, "Updating status with {}", updatedTopic.getStatus());
+            LOGGER.debugCr(reconciliation, "Updating status");
             Timer.Sample timerSample = startOperationTimer();
             var got = Crds.topicOperation(kubeClient)
                     .resource(updatedTopic)
                     .updateStatus();
             stopOperationTimer(timerSample, metrics::updateStatusTimer);
-            LOGGER.traceCr(reconciliation, "Updated status to observedGeneration {}, resourceVersion now {}",
-                    got.getStatus().getObservedGeneration());
+            LOGGER.debugCr(reconciliation, "Updated status to observedGeneration {}, resourceVersion {}",
+                    got.getStatus().getObservedGeneration(), got.getMetadata().getResourceVersion());
         } else {
-            LOGGER.traceCr(reconciliation, "Unchanged status of {}", kt.getStatus());
+            LOGGER.debugCr(reconciliation, "Unchanged status");
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorConfig.java
@@ -116,7 +116,7 @@ record TopicOperatorConfig(
         Map<String, Object> generatedMap = ConfigParameter.define(envMap, CONFIG_VALUES);
 
         TopicOperatorConfig topicOperatorConfig = new TopicOperatorConfig(generatedMap);
-        LOGGER.infoOp("Configuration {}", topicOperatorConfig);
+        LOGGER.infoOp("TopicOperator configuration is {}", topicOperatorConfig);
         return topicOperatorConfig;
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/v2/TopicOperatorUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.topic.v2;
+
+import io.strimzi.api.kafka.model.topic.KafkaTopic;
+
+/**
+ * Utility class.
+ */
+public class TopicOperatorUtil {
+    private TopicOperatorUtil() {
+    }
+
+    /**
+     * Get the topic name from a {@link KafkaTopic} resource.
+     * 
+     * @param kafkaTopic Topic resource.
+     * @return Topic name.
+     */
+    public static String topicName(KafkaTopic kafkaTopic) {
+        String tn = null;
+        if (kafkaTopic.getSpec() != null) {
+            tn = kafkaTopic.getSpec().getTopicName();
+        }
+        if (tn == null) {
+            tn = kafkaTopic.getMetadata().getName();
+        }
+        return tn;
+    }
+}

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/BatchingTopicControllerTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static io.strimzi.api.kafka.model.topic.KafkaTopic.RESOURCE_KIND;
+import static io.strimzi.operator.topic.v2.TopicOperatorUtil.topicName;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -129,7 +130,7 @@ class BatchingTopicControllerTest {
 
     private void assertOnUpdateThrowsInterruptedException(KubernetesClient client, Admin admin, KafkaTopic kt) throws ExecutionException, InterruptedException {
         controller = new BatchingTopicController(Map.of("key", "VALUE"), admin, client, true, metrics, NAMESPACE, false);
-        List<ReconcilableTopic> batch = List.of(new ReconcilableTopic(new Reconciliation("test", "KafkaTopic", NAMESPACE, NAME), kt, BatchingTopicController.topicName(kt)));
+        List<ReconcilableTopic> batch = List.of(new ReconcilableTopic(new Reconciliation("test", "KafkaTopic", NAMESPACE, NAME), kt, topicName(kt)));
         assertThrows(InterruptedException.class, () -> controller.onUpdate(batch));
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicControllerIT.java
@@ -978,8 +978,8 @@ class TopicControllerIT {
 
         // when: resync
         try (var logCaptor = LogCaptor.logMessageMatches(BatchingLoop.LoopRunnable.LOGGER,
-                Level.DEBUG,
-                "\\[Batch #[0-9]+\\] Reconciled batch",
+                Level.INFO,
+                "\\[Batch #[0-9]+\\] Batch reconciliation completed",
                 5L,
                 TimeUnit.SECONDS)) {
             LOGGER.debug("Waiting for a full resync");
@@ -1250,8 +1250,8 @@ class TopicControllerIT {
 
         // when
         try (var logCaptor = LogCaptor.logMessageMatches(BatchingLoop.LoopRunnable.LOGGER,
-                Level.DEBUG,
-                "\\[Batch #[0-9]+\\] Reconciled batch",
+                Level.INFO,
+                "\\[Batch #[0-9]+\\] Batch reconciliation completed",
                 5L,
                 TimeUnit.SECONDS)) {
             try (var logCaptor2 = LogCaptor.logMessageMatches(BatchingTopicController.LOGGER,

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/v2/TopicOperatorMetricsTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION;
 import static io.strimzi.api.kafka.model.topic.KafkaTopic.RESOURCE_KIND;
-import static io.strimzi.operator.topic.v2.BatchingTopicController.topicName;
+import static io.strimzi.operator.topic.v2.TopicOperatorUtil.topicName;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,8 +71,11 @@ public class TopicOperatorMetricsTest {
 
     @Test
     public void shouldHaveMetricsAfterSomeEvents() throws InterruptedException {
+        var config = TopicOperatorConfig.buildFromMap(Map.of(
+            TopicOperatorConfig.BOOTSTRAP_SERVERS.key(), "localhost:9092",
+            TopicOperatorConfig.NAMESPACE.key(), NAMESPACE));
         BatchingLoop mockQueue = mock(BatchingLoop.class);
-        TopicOperatorEventHandler eventHandler = new TopicOperatorEventHandler(mockQueue, true, metrics, NAMESPACE);
+        TopicOperatorEventHandler eventHandler = new TopicOperatorEventHandler(config, mockQueue, metrics);
         int numOfTestResources = 100;
         for (int i = 0; i < numOfTestResources; i++) {
             KafkaTopic kt = createKafkaTopic("t" + i, "100100");


### PR DESCRIPTION
This change improves the UTO logs. It now logs every periodic reconciliation and every batch reconciliation. It also logs individual topic reconciliations in case of failure. All YAML paylodas have been replaced with topic name.

Log example: [uto.log](https://github.com/strimzi/strimzi-kafka-operator/files/14349586/uto.log). This should close #9465.

---

The KafkaTopic informer resync configuration had a small issue which was causing the skip of some periodic reconciliations. They were often triggering at 4 minutes, instead of 2 minutes.

The informer interval acts like a heartbeat, then each handler interval will cause a resync at some interval of the overall heartbeat. The closer these values are together the more likely it is that the handler skips one informer intervals. Setting both intervals to the same value generates just enough skew that when the informer checks if the handler is ready for resync it sees that it still needs another couple of micro-seconds and skips to the next informer level resync.

This is fixed by introducing a small fixed resync period for the informer. The resync operation is all in memory and results in a noop most of the time, so this causes no harm.
