### PR TITLE
Fix report tool when getting CO replicasets

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -254,7 +254,9 @@ if [[ -n $CO_DEPLOY ]]; then
   if [[ -n $CO_RS ]]; then
     echo "    $CO_RS"
     CO_RS=$(echo "$CO_RS" | cut -d "/" -f 2) && readonly CO_RS
-    $KUBE_CLIENT get rs "$CO_RS" -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/replicasets/"$CO_RS".yaml
+    for res in $CO_RS; do
+      $KUBE_CLIENT get rs "$res" -o yaml -n "$NAMESPACE" > "$OUT_DIR"/reports/replicasets/"$res".yaml
+    done
   fi
   mapfile -t CO_PODS < <($KUBE_CLIENT get po -l strimzi.io/kind=cluster-operator -o name -n "$NAMESPACE" --ignore-not-found)
   if [[ ${#CO_PODS[@]} -ne 0 ]]; then


### PR DESCRIPTION
We can have up to 10 replicasets for the cluster operator, depending on the number of updates that have been done using deployment. The report tool fails with the following error when having more than one replicaset.

Error from server (NotFound): replicasets.apps "strimzi-cluster-operator-85b9b646cc\nstrimzi-cluster-operator-86948f6756" not found
