### PR TITLE
[ST] add skip mixed role annotation to ST. 

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MixedRoleNotSupported.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MixedRoleNotSupported.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MixedRoleNotSupportedCondition.class)
+public @interface MixedRoleNotSupported {
+    String value() default "Mixed role in Kafka Node Pools is not supported with configuration in this test case.";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/MixedRoleNotSupportedCondition.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/MixedRoleNotSupportedCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import io.strimzi.systemtest.Environment;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class MixedRoleNotSupportedCondition implements ExecutionCondition {
+    private static final Logger LOGGER = LogManager.getLogger(MixedRoleNotSupportedCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (Environment.isSeparateRolesMode() || !Environment.isKafkaNodePoolsEnabled() || !Environment.isKRaftModeEnabled()) {
+            return ConditionEvaluationResult.enabled("Test is enabled");
+        } else {
+            LOGGER.warn("According to {} env variable with value: {}, the mixed role mode is used, skipping this test because is not mixed role mode compliant",
+                    Environment.STRIMZI_NODE_POOLS_ROLE_MODE_ENV,
+                    Environment.STRIMZI_NODE_POOLS_ROLE_MODE);
+            return ConditionEvaluationResult.disabled("Test is disabled");
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

annotation to skip test if mixed role is not supported for given test case. 
additionally fix the test `testCruiseControlDuringBrokerScaleUpAndDown` which fails if kraft is disabled as it  attempts to create KNP with role `controller`. 






