### PR TITLE
[ST] fix CC failing test due to default topic rep. factor

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -104,9 +104,8 @@ public class CruiseControlUtils {
             kafkaProperties.getProperty(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_PASSWORD.getValue()).equals("${CERTS_STORE_PASSWORD}"));
     }
 
-    public static void verifyThatCruiseControlSamplesTopicsArePresent(String namespaceName, long timeout) {
+    public static void verifyThatCruiseControlSamplesTopicsArePresent(String namespaceName, int defaultBrokerReplicaCount, long timeout) {
         final int numberOfPartitionsSamplesTopic = 32;
-        final int numberOfReplicasSamplesTopic = 2;
 
         TestUtils.waitFor("Verify that Kafka contains CruiseControl Topics with related configuration.",
             TestConstants.GLOBAL_POLL_INTERVAL, timeout, () -> {
@@ -119,8 +118,8 @@ public class CruiseControlUtils {
                             partitionsMetricsSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic;
 
                     boolean hasTopicCorrectReplicasCount =
-                            modelTrainingSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic &&
-                            partitionsMetricsSamples.getSpec().getReplicas() == numberOfReplicasSamplesTopic;
+                            modelTrainingSamples.getSpec().getReplicas() == defaultBrokerReplicaCount &&
+                            partitionsMetricsSamples.getSpec().getReplicas() == defaultBrokerReplicaCount;
 
                     return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
                 }
@@ -129,9 +128,8 @@ public class CruiseControlUtils {
             });
     }
 
-    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(String namespaceName, long timeout) {
+    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(String namespaceName, int defaultBrokerReplicaCount, long timeout) {
         final int numberOfPartitionsMetricTopic = 1;
-        final int numberOfReplicasMetricTopic = 3;
 
         TestUtils.waitFor("Verify that Kafka contains CruiseControl topics with related configuration.",
             TestConstants.GLOBAL_POLL_INTERVAL, timeout, () -> {
@@ -141,15 +139,15 @@ public class CruiseControlUtils {
                     metrics.getSpec().getPartitions() == numberOfPartitionsMetricTopic;
 
                 boolean hasTopicCorrectReplicasCount =
-                    metrics.getSpec().getReplicas() == numberOfReplicasMetricTopic;
+                    metrics.getSpec().getReplicas() == defaultBrokerReplicaCount;
 
                 return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
             });
     }
 
-    public static void verifyThatCruiseControlTopicsArePresent(String namespaceName) {
-        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(namespaceName, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
-        verifyThatCruiseControlSamplesTopicsArePresent(namespaceName, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+    public static void verifyThatCruiseControlTopicsArePresent(String namespaceName, int defaultBrokerReplicaCount) {
+        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(namespaceName, defaultBrokerReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        verifyThatCruiseControlSamplesTopicsArePresent(namespaceName, defaultBrokerReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
     }
 
     public static Properties getKafkaCruiseControlMetricsReporterConfiguration(String namespaceName, String clusterName) throws IOException {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -104,7 +104,7 @@ public class CruiseControlUtils {
             kafkaProperties.getProperty(CruiseControlConfigurationParameters.METRICS_REPORTER_SSL_TRUSTSTORE_PASSWORD.getValue()).equals("${CERTS_STORE_PASSWORD}"));
     }
 
-    public static void verifyThatCruiseControlSamplesTopicsArePresent(String namespaceName, int defaultBrokerReplicaCount, long timeout) {
+    public static void verifyThatCruiseControlSamplesTopicsArePresent(String namespaceName, int defaultReplicaCount, long timeout) {
         final int numberOfPartitionsSamplesTopic = 32;
 
         TestUtils.waitFor("Verify that Kafka contains CruiseControl Topics with related configuration.",
@@ -118,8 +118,8 @@ public class CruiseControlUtils {
                             partitionsMetricsSamples.getSpec().getPartitions() == numberOfPartitionsSamplesTopic;
 
                     boolean hasTopicCorrectReplicasCount =
-                            modelTrainingSamples.getSpec().getReplicas() == defaultBrokerReplicaCount &&
-                            partitionsMetricsSamples.getSpec().getReplicas() == defaultBrokerReplicaCount;
+                            modelTrainingSamples.getSpec().getReplicas() == defaultReplicaCount &&
+                            partitionsMetricsSamples.getSpec().getReplicas() == defaultReplicaCount;
 
                     return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
                 }
@@ -128,7 +128,7 @@ public class CruiseControlUtils {
             });
     }
 
-    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(String namespaceName, int defaultBrokerReplicaCount, long timeout) {
+    public static void verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(String namespaceName, int defaultReplicaCount, long timeout) {
         final int numberOfPartitionsMetricTopic = 1;
 
         TestUtils.waitFor("Verify that Kafka contains CruiseControl topics with related configuration.",
@@ -139,15 +139,15 @@ public class CruiseControlUtils {
                     metrics.getSpec().getPartitions() == numberOfPartitionsMetricTopic;
 
                 boolean hasTopicCorrectReplicasCount =
-                    metrics.getSpec().getReplicas() == defaultBrokerReplicaCount;
+                    metrics.getSpec().getReplicas() == defaultReplicaCount;
 
                 return hasTopicCorrectPartitionsCount && hasTopicCorrectReplicasCount;
             });
     }
 
-    public static void verifyThatCruiseControlTopicsArePresent(String namespaceName, int defaultBrokerReplicaCount) {
-        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(namespaceName, defaultBrokerReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
-        verifyThatCruiseControlSamplesTopicsArePresent(namespaceName, defaultBrokerReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+    public static void verifyThatCruiseControlTopicsArePresent(String namespaceName, int defaultReplicaCount) {
+        verifyThatKafkaCruiseControlMetricReporterTopicIsPresent(namespaceName, defaultReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
+        verifyThatCruiseControlSamplesTopicsArePresent(namespaceName, defaultReplicaCount, TestConstants.GLOBAL_CRUISE_CONTROL_TIMEOUT);
     }
 
     public static Properties getKafkaCruiseControlMetricsReporterConfiguration(String namespaceName, String clusterName) throws IOException {


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

tests `testDeployAndUnDeployCruiseControl` and `testAutoCreationOfCruiseControlTopicsWithResources` are assuming 2 replicas on CC related topics, which is no longer true. These topics from now follow default topic replication factor as of https://github.com/strimzi/strimzi-kafka-operator/pull/9471 . 
 
now `default.replication.factor` is set explicitly to the same number is is the number of brokers (just to avoid accidental changes). 




