### PR TITLE
Fix Connect's dynamic log level changes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -405,7 +405,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                     .write(buffer.toString());
                             request.result().send(response -> {
                                 if (response.succeeded()) {
-                                    if (response.result().statusCode() == 204) {
+                                    if (List.of(200, 204).contains(response.result().statusCode())) {
                                         response.result().bodyHandler(body -> {
                                             LOGGER.debugCr(reconciliation, "Logger {} updated to level {}", logger, level);
                                             result.complete();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -390,7 +390,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     private Future<Void> updateConnectorLogger(Reconciliation reconciliation, String host, int port, String logger, String level) {
-        String path = "/admin/loggers/" + logger;
+        String path = "/admin/loggers/" + logger + "?scope=cluster";
         JsonObject levelJO = new JsonObject();
         levelJO.put("level", level);
         LOGGER.debugCr(reconciliation, "Making PUT request to {} with body {}", path, levelJO);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -405,7 +405,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                     .write(buffer.toString());
                             request.result().send(response -> {
                                 if (response.succeeded()) {
-                                    if (response.result().statusCode() == 200) {
+                                    if (response.result().statusCode() == 204) {
                                         response.result().bodyHandler(body -> {
                                             LOGGER.debugCr(reconciliation, "Logger {} updated to level {}", logger, level);
                                             result.complete();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -54,12 +54,12 @@ public class KafkaConnectApiIT {
 
     @BeforeEach
     public void beforeEach() throws InterruptedException {
-        // Start a 3 node connect cluster
+        // Start a 1 node connect cluster
         connectCluster = new ConnectCluster()
                 .usingBrokers(cluster.getBootstrapServers())
-                .addConnectNodes(3);
+                .addConnectNodes(1);
         connectCluster.startup();
-        port = connectCluster.getPort(2);
+        port = connectCluster.getPort(0);
     }
 
     @AfterEach


### PR DESCRIPTION
The loggers endpoint now supports the scope parameter, which can be set to cluster in order to change level in all nodes at once. This change simply adds this parameter that works since Kafka 3.7, and causes no harm to previous versions.

This should close #9067.
