### PR TITLE
Use native epoll on Aarch64 and not only on x86_64

### DIFF
--- a/cluster-operator/pom.xml
+++ b/cluster-operator/pom.xml
@@ -246,6 +246,11 @@
             <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -694,6 +694,12 @@
                 <classifier>linux-x86_64</classifier>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+                <classifier>linux-aarch_64</classifier>
+            </dependency>
+            <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
                 <version>${quartz.version}</version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In Cluster Operator, we currently include the Netty native epoll for the x86_64 architecture. As we support Aarch64 as well, this PR also includes the Aarch64 version of the native epoll.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally