### PR TITLE
[DOC] Make logging examples less confusing

### DIFF
--- a/documentation/assemblies/configuring/assembly-logging-configuration.adoc
+++ b/documentation/assemblies/configuring/assembly-logging-configuration.adoc
@@ -22,26 +22,25 @@ You specify a logging `type` in your logging specification:
 .Example `inline` logging configuration
 [source,shell,subs="+quotes,attributes"]
 ----
-spec:
-  # ...
-  logging:
-    type: inline
-    loggers:
-      kafka.root.logger.level: INFO
+# ...
+logging:
+  type: inline
+  loggers:
+    kafka.root.logger.level: INFO
+# ...
 ----
-
 
 .Example `external` logging configuration
 [source,shell,subs="+quotes,attributes"]
 ----
-spec:
-  # ...
-  logging:
-    type: external
-    valueFrom:
-      configMapKeyRef:
-        name: my-config-map
-        key: my-config-map-key
+# ...
+logging:
+  type: external
+  valueFrom:
+    configMapKeyRef:
+      name: my-config-map
+      key: my-config-map-key
+# ...
 ----
 
 Values for the `name` and `key` of the ConfigMap are mandatory.

--- a/documentation/modules/configuring/con-configuration-points-configmaps.adoc
+++ b/documentation/modules/configuring/con-configuration-points-configmaps.adoc
@@ -27,14 +27,14 @@ You add the reference to the `logging` configuration.
 .Example ConfigMap for logging
 [source,shell,subs="+quotes,attributes"]
 ----
-spec:
-  # ...
-  logging:
-    type: external
-    valueFrom:
-      configMapKeyRef:
-        name: my-config-map
-        key: my-config-map-key
+# ...
+logging:
+  type: external
+  valueFrom:
+    configMapKeyRef:
+      name: my-config-map
+      key: my-config-map-key
+# ...
 ----
 
 To use a ConfigMap for metrics configuration, you add a reference to the `metricsConfig` configuration of the component in the same way.

--- a/documentation/modules/configuring/proc-creating-configmap.adoc
+++ b/documentation/modules/configuring/proc-creating-configmap.adoc
@@ -56,14 +56,14 @@ kafka.root.logger.level="INFO"
 +
 [source,shell,subs="+quotes,attributes"]
 ----
-spec:
-  # ...
-  logging:
-    type: external
-    valueFrom:
-      configMapKeyRef:
-        name: logging-configmap
-        key: log4j.properties
+# ...
+logging:
+  type: external
+  valueFrom:
+    configMapKeyRef:
+      name: logging-configmap
+      key: log4j.properties
+# ...
 ----
 
 . Create or update the resource.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The `logging` section in our API can be placed into different sections depending on the custom resource. E.g. `.spec.logging` in Kafka Connect or Bridge, but `.spec.kafka.logging` for Kafka etc. Some of the example snippets in our docs seem to be confusing as they include the `spec:` marker and suggest this should be placed always directly under `.spec`. This PR removes the `spec:` part to leave it more open where the placement is.

### Checklist

- [x] Update documentation