### PR TITLE
Remove Kotlin from third party libs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.40.0
 
-* Migrate from OpenTelemetry tracing from using OkHttp sender to the JDK sender or GRPC sender thus remove the kotlin dependency. 
 * Add support for Apache Kafka 3.7.0.
   Remove support for Apache Kafka 3.5.0, 3.5.1, and 3.5.2.
 * The `UseKRaft` feature gate moves to beta stage and is enabled by default.
@@ -50,14 +49,6 @@
   This new behavior does not require the `PodDisruptionBudget` to be set to `maxUnavailable: 0`.
   We expect this to improve the compatibility with various tools used for scaling Kubernetes clusters such as [Karpenter](https://karpenter.sh/).
   If you observe any problems with your toolchain or just want to stick with the previous behavior, you can use the `STRIMZI_DENY_EVICTION` environment variable and set it to `false` to switch back to the old (legacy) mode.
-* The following dependencies have been removed from the third-party libs.
-  * `com.squareup.okhttp3:okhttp:jar:4.10.0`
-  * `com.squareup.okio:okio-jvm:jar:3.0.0`
-  * `org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31`
-  * `org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31`
-  * `org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31`
-  * `org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20`
-  * `org.jetbrains:annotations:jar:13.0`
 
 ## 0.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.40.0
 
+* Migrate from OpenTelemetry tracing from using OkHttp sender to the JDK sender or GRPC sender thus remove the kotlin dependency. 
 * Add support for Apache Kafka 3.7.0.
   Remove support for Apache Kafka 3.5.0, 3.5.1, and 3.5.2.
 * The `UseKRaft` feature gate moves to beta stage and is enabled by default.
@@ -49,6 +50,14 @@
   This new behavior does not require the `PodDisruptionBudget` to be set to `maxUnavailable: 0`.
   We expect this to improve the compatibility with various tools used for scaling Kubernetes clusters such as [Karpenter](https://karpenter.sh/).
   If you observe any problems with your toolchain or just want to stick with the previous behavior, you can use the `STRIMZI_DENY_EVICTION` environment variable and set it to `false` to switch back to the old (legacy) mode.
+* The following dependencies have been removed from the third-party libs.
+  * `com.squareup.okhttp3:okhttp:jar:4.10.0`
+  * `com.squareup.okio:okio-jvm:jar:3.0.0`
+  * `org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31`
+  * `org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31`
+  * `org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31`
+  * `org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20`
+  * `org.jetbrains:annotations:jar:13.0`
 
 ## 0.39.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
@@ -26,8 +26,8 @@ public class OpenTelemetryTracing extends Tracing {
 
     public static final String TYPE_OPENTELEMETRY = "opentelemetry";
 
-    public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.TracingConsumerInterceptor";
-    public static final String PRODUCER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.TracingProducerInterceptor";
+    public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingConsumerInterceptor";
+    public static final String PRODUCER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingProducerInterceptor";
 
     @Description("Must be `" + TYPE_OPENTELEMETRY + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -463,8 +463,8 @@ public class KafkaMirrorMaker2ConnectorsTest {
         expected.put("groups", "my-group-.*");
         expected.put("groups.exclude", "exclude-group-.*");
         expected.put("consumer.client.rack", "${file:/tmp/strimzi-connect.properties:consumer.client.rack}");
-        expected.put("consumer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.TracingConsumerInterceptor");
-        expected.put("producer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.TracingProducerInterceptor");
+        expected.put("consumer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingConsumerInterceptor");
+        expected.put("producer.interceptor.classes", "io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingProducerInterceptor");
 
         assertThat(new TreeMap<>(config), is(expected));
     }

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry.alpha-version}</version>
+            <version>${opentelemetry-alpha.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -115,12 +115,28 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- OAuth -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -115,6 +115,7 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
+            <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
             <exclusions>
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
@@ -127,6 +128,7 @@
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
+            <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry-alpha.version}</version>
+            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -27,8 +27,10 @@
         <jmx-prometheus-javaagent.version>0.20.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
-        <opentelemetry.version>1.19.0</opentelemetry.version>
-        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.34.1</opentelemetry.version>
+        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
+        <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
+        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
     </properties>
 
@@ -89,12 +91,36 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
-            <version>${opentelemetry.alpha-version}</version>
+            <version>${opentelemetry.instrumentation.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-exporter-sender-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+            <version>${opentelemetry-alpha.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc-netty-shaded.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <!-- OAuth -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry.alpha-version}</version>
+            <version>${opentelemetry-alpha.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -115,12 +115,28 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- OAuth -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -115,6 +115,7 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
+            <!-- excluded as we end up with conflicting copies in the image -->
             <exclusions>
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
@@ -127,6 +128,7 @@
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
+            <!-- excluded as we end up with conflicting copies in the image -->
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry-alpha.version}</version>
+            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -27,8 +27,10 @@
         <jmx-prometheus-javaagent.version>0.20.0</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
-        <opentelemetry.version>1.19.0</opentelemetry.version>
-        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.34.1</opentelemetry.version>
+        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
+        <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
+        <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
     </properties>
 
@@ -89,12 +91,36 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-kafka-clients-2.6</artifactId>
-            <version>${opentelemetry.alpha-version}</version>
+            <version>${opentelemetry.instrumentation.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-exporter-sender-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+            <version>${opentelemetry-alpha.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
+            <version>${opentelemetry.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc-netty-shaded.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <!-- OAuth -->
         <dependency>

--- a/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
+++ b/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
@@ -23,7 +23,7 @@ In each client application add the dependencies for the tracer:
 <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-    <version>{OpenTelemetryAlphaVersion}</version>
+    <version>{OpenTelemetryVersion}</version>
 </dependency>
 <dependency>
   <groupId>io.opentelemetry.instrumentation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,8 @@
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <quartz.version>2.3.2</quartz.version>
-        <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+        <opentelemetry.version>1.34.1</opentelemetry.version>
+        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
@@ -728,7 +729,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-                <version>${opentelemetry.alpha-version}</version>
+                <version>${opentelemetry-alpha.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -729,7 +729,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-                <version>${opentelemetry-alpha.version}</version>
+                <version>${opentelemetry.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
@@ -20,8 +20,8 @@ public class OpenTelemetryTracing implements Tracing {
         String serviceName = System.getenv("OTEL_SERVICE_NAME");
         if (serviceName != null) {
             LOGGER.info("Initializing OpenTelemetry tracing with service name {}", serviceName);
-            System.setProperty("otel.metrics.exporter", "none"); // disable otel metrics exporter. This has no effect on metrics in the bridge.
-            System.setProperty("otel.logs.exporter", "none"); // disable otel logs exporter. This has no effect on logging in the bridge.
+            System.setProperty("otel.metrics.exporter", "none"); // disable otel metrics exporter. This has no effect on metrics in Strimzi.
+            System.setProperty("otel.logs.exporter", "none"); // disable otel logs exporter. This has no effect on logging in Strimzi.
             AutoConfiguredOpenTelemetrySdk.initialize();
         } else {
             LOGGER.error("OpenTelemetry tracing cannot be initialized because OTEL_SERVICE_NAME environment variable is not defined");

--- a/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
+++ b/tracing-agent/src/main/java/io/strimzi/tracing/agent/OpenTelemetryTracing.java
@@ -20,7 +20,8 @@ public class OpenTelemetryTracing implements Tracing {
         String serviceName = System.getenv("OTEL_SERVICE_NAME");
         if (serviceName != null) {
             LOGGER.info("Initializing OpenTelemetry tracing with service name {}", serviceName);
-            System.setProperty("otel.metrics.exporter", "none"); // disable metrics
+            System.setProperty("otel.metrics.exporter", "none"); // disable otel metrics exporter. This has no effect on metrics in the bridge.
+            System.setProperty("otel.logs.exporter", "none"); // disable otel logs exporter. This has no effect on logging in the bridge.
             AutoConfiguredOpenTelemetrySdk.initialize();
         } else {
             LOGGER.error("OpenTelemetry tracing cannot be initialized because OTEL_SERVICE_NAME environment variable is not defined");


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the dependency on OkHttp and thus Kotlin in a fully backwards compatible fashion from the third-party libs for Kafka 3.6 and 3.7. It does this by replacing the opentelemetry-exporter-sender-okhttp (which is the OpenTelemetry default) with two separate senders. One for each transport.

- `opentelemetry-exporter-sender-jdk` enables sending traces using http/protobuf which is the lowest common denominator option, as its the only method required by the OpenTelemetry specifications.
- `opentelemetry-exporter-sender-grpc-managed-channel` enables support for sending traces using grpc and thus feature parity with the OkHttp sender.

This is the same approach as taken in https://github.com/strimzi/strimzi-kafka-bridge/pull/867

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

