### PR TITLE
[Enhancement] Shared Volume Mount Changes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.ClientTls;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.connect.build.Build;
+import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
@@ -29,7 +30,7 @@ import java.util.Map;
     "tls", "authentication", "config", "resources", "livenessProbe",
     "readinessProbe", "jvmOptions", "jmxOptions", "affinity", "tolerations",
     "logging", "clientRackInitImage", "rack", "metrics", "tracing",
-    "template", "externalConfiguration" })
+    "template", "externalConfiguration", "storage"})
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
@@ -43,6 +44,7 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Build build;
+    private SingleVolumeStorage storage;
 
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
@@ -92,5 +94,15 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     public void setBuild(Build build) {
         this.build = build;
+    }
+
+    @Description("Storage configuration (disk). Cannot be updated.")
+    @JsonProperty(required = true)
+    public SingleVolumeStorage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(SingleVolumeStorage storage) {
+        this.storage = storage;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -35,7 +35,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "podSet", "pod", "apiService", "headlessService", "connectContainer", "initContainer",
     "podDisruptionBudget", "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig",
-    "buildServiceAccount", "jmxSecret"})
+    "buildServiceAccount", "jmxSecret", "persistentVolumeClaim"})
 @EqualsAndHashCode
 public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
@@ -55,6 +55,7 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable,
     private ResourceTemplate serviceAccount;
     private ResourceTemplate buildServiceAccount;
     private ResourceTemplate jmxSecret;
+    private ResourceTemplate persistentVolumeClaim;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Kafka Connect `Deployment`.")
@@ -209,6 +210,16 @@ public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable,
     }
     public void setJmxSecret(ResourceTemplate jmxSecret) {
         this.jmxSecret = jmxSecret;
+    }
+
+    @Description("Template for the Kafka Connect Persistent volume claim.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ResourceTemplate getPersistentVolumeClaim() {
+        return persistentVolumeClaim;
+    }
+
+    public void setPersistentVolumeClaim(ResourceTemplate persistentVolumeClaim) {
+        this.persistentVolumeClaim = persistentVolumeClaim;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -35,6 +35,8 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
     private Map<String, String> selector;
     private boolean deleteClaim;
     private List<PersistentClaimStorageOverride> overrides;
+    private String mountPath;
+    private String accessMode;
 
     private Integer id;
 
@@ -108,5 +110,23 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
 
     public void setOverrides(List<PersistentClaimStorageOverride> overrides) {
         this.overrides = overrides;
+    }
+
+    @Description("The mount path to use, overriding the default /var/lib/kafka/data.")
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public void setMountPath(String mountPath) {
+        this.mountPath = mountPath;
+    }
+
+    @Description("The storage access mode to use.")
+    public String getAccessMode() {
+        return accessMode;
+    }
+
+    public void setAccessMode(String accessMode) {
+        this.accessMode = accessMode;
     }
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectTest.java
@@ -3,9 +3,19 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.api.kafka.model.connect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 
 import io.strimzi.api.kafka.model.AbstractCrdTest;
-
+import io.strimzi.api.kafka.model.common.template.MetadataTemplate;
+import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 /**
  * The purpose of this test is to ensure:
  *
@@ -15,5 +25,54 @@ public class KafkaConnectTest extends AbstractCrdTest<KafkaConnect> {
 
     public KafkaConnectTest() {
         super(KafkaConnect.class);
+    }
+
+    @Test
+    public void testStorage() {
+        KafkaConnectSpec kafkaConnectSpec = new KafkaConnectSpec();
+        SingleVolumeStorage storage = new SingleVolumeStorage() {
+            @Override
+            public String getType() {
+                return "ephemeral";
+            }
+        };
+        storage.setId(1);
+
+        kafkaConnectSpec.setStorage(storage);
+        assertNotNull(kafkaConnectSpec.getStorage());
+        assertSame(storage, kafkaConnectSpec.getStorage());
+        assertEquals(1, kafkaConnectSpec.getStorage().getId());
+        assertEquals("ephemeral", kafkaConnectSpec.getStorage().getType());
+    }
+
+    @Test
+    public void testPersistentVolumeClaim() {
+        KafkaConnectTemplate kafkaConnectTemplate = new KafkaConnectTemplate();
+        ResourceTemplate resourceTemplate = new ResourceTemplate();
+
+        MetadataTemplate metadataTemplate = new MetadataTemplate();
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("label1", "value1");
+        labels.put("label2", "value2");
+        metadataTemplate.setLabels(labels);
+
+        Map<String, String> annotations = new HashMap<>();
+        annotations.put("annotation1", "value1");
+        annotations.put("annotation2", "value2");
+        metadataTemplate.setAnnotations(annotations);
+
+        resourceTemplate.setMetadata(metadataTemplate);
+
+        kafkaConnectTemplate.setPersistentVolumeClaim(resourceTemplate);
+
+        ResourceTemplate result = kafkaConnectTemplate.getPersistentVolumeClaim();
+
+        assertNotNull(result);
+        assertSame(resourceTemplate, result);
+
+        assertEquals(metadataTemplate, result.getMetadata());
+        assertEquals(labels, result.getMetadata().getLabels());
+        assertEquals(annotations, result.getMetadata().getAnnotations());
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -66,6 +66,39 @@ public class PersistentVolumeClaimUtilsTest {
         THREE_NODES.add(new NodeRef(NAME + "-" + 1, 1, null, false, true));
         THREE_NODES.add(new NodeRef(NAME + "-" + 2, 2, null, false, true));
     }
+    
+    @ParallelTest
+    public void testCreatePersistentVolumeClaimsWithAccessMode() {
+      // Arrange
+      String namespace = "test-namespace";
+      Set < NodeRef > nodes = new LinkedHashSet < > ();
+      nodes.add(new NodeRef("test-node", 0, null, false, true));
+      Storage storage = new PersistentClaimStorageBuilder()
+        .withStorageClass("test-storage-class")
+        .withSize("100Gi")
+        .build();
+      boolean jbod = false;
+      Labels labels = Labels.forStrimziKind("test-kind");
+      OwnerReference ownerReference = new OwnerReferenceBuilder()
+        .withApiVersion("v1")
+        .withKind("test-kind")
+        .withName("test-cluster")
+        .withUid("test-uid")
+        .withBlockOwnerDeletion(false)
+        .withController(false)
+        .build();
+      ResourceTemplate template = new ResourceTemplateBuilder().build();
+      String accessMode = "ReadWriteMany";
+
+      // Act
+      List < PersistentVolumeClaim > pvcs = PersistentVolumeClaimUtils.createPersistentVolumeClaims(
+        namespace, nodes, storage, jbod, labels, ownerReference, template, accessMode);
+
+      // Assert
+      assertThat(pvcs.size(), is(1));
+      PersistentVolumeClaim pvc = pvcs.get(0);
+      assertThat(pvc.getSpec().getAccessModes().get(0), is(accessMode));
+    }
 
     @ParallelTest
     public void testEphemeralStorage()  {

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -567,7 +567,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 [id='type-EphemeralStorage-{context}']
 = `EphemeralStorage` schema reference
 
-Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaNodePoolSpec-{context}[`KafkaNodePoolSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaNodePoolSpec-{context}[`KafkaNodePoolSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes use of the `EphemeralStorage` type from xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`].
@@ -589,7 +589,7 @@ It must have the value `ephemeral` for the type `EphemeralStorage`.
 [id='type-PersistentClaimStorage-{context}']
 = `PersistentClaimStorage` schema reference
 
-Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaNodePoolSpec-{context}[`KafkaNodePoolSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
+Used in: xref:type-JbodStorage-{context}[`JbodStorage`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaNodePoolSpec-{context}[`KafkaNodePoolSpec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
 The `type` property is a discriminator that distinguishes use of the `PersistentClaimStorage` type from xref:type-EphemeralStorage-{context}[`EphemeralStorage`].
@@ -608,12 +608,16 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
 |deleteClaim
 |boolean
+|accessMode   1.2+<.<a|The storage access mode to use.
+|string
 |Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |class
 |string
 |The storage class to use for dynamic volume allocation.
 |id
 |integer
+|mountPath    1.2+<.<a|The mount path to use, overriding the default /var/lib/kafka/data.
+|string
 |Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |overrides
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
@@ -2137,6 +2141,8 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
+|storage                1.2+<.<a|Storage configuration (disk). Cannot be updated. The type depends on the value of the `storage.type` property within the given object, which must be one of [ephemeral, persistent-claim].
+|xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`]
 |Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |build
 |xref:type-Build-{context}[`Build`]
@@ -2455,12 +2461,15 @@ Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-Kaf
 |buildConfig
 |xref:type-BuildConfigTemplate-{context}[`BuildConfigTemplate`]
 |Template for the Kafka Connect BuildConfig used to build new container images. The BuildConfig is used only on OpenShift.
-|buildServiceAccount
+|buildServiceAccount    1.2+<.<a
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |Template for the Kafka Connect Build service account.
-|jmxSecret
+|jmxSecret              1.2+<.<a
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |Template for Secret of the Kafka Connect Cluster JMX authentication.
+|persistentVolumeClaim  1.2+<.<a
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|Template for the Kafka Connect Persistent volume claim.
 |====
 
 [id='type-BuildConfigTemplate-{context}']

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -489,6 +489,9 @@ spec:
                   storage:
                     type: object
                     properties:
+                      accessMode:
+                        type: string
+                        description: The storage access mode to use.
                       class:
                         type: string
                         description: The storage class to use for dynamic volume allocation.
@@ -499,6 +502,9 @@ spec:
                         type: integer
                         minimum: 0
                         description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                      mountPath:
+                        type: string
+                        description: "The mount path to use, overriding the default /var/lib/kafka/data."
                       overrides:
                         type: array
                         items:
@@ -535,6 +541,9 @@ spec:
                         items:
                           type: object
                           properties:
+                            accessMode:
+                              type: string
+                              description: The storage access mode to use.
                             class:
                               type: string
                               description: The storage class to use for dynamic volume allocation.
@@ -545,6 +554,9 @@ spec:
                               type: integer
                               minimum: 0
                               description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                            mountPath:
+                              type: string
+                              description: "The mount path to use, overriding the default /var/lib/kafka/data."
                             overrides:
                               type: array
                               items:
@@ -1862,6 +1874,9 @@ spec:
                   storage:
                     type: object
                     properties:
+                      accessMode:
+                        type: string
+                        description: The storage access mode to use.
                       class:
                         type: string
                         description: The storage class to use for dynamic volume allocation.
@@ -1872,6 +1887,9 @@ spec:
                         type: integer
                         minimum: 0
                         description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                      mountPath:
+                        type: string
+                        description: "The mount path to use, overriding the default /var/lib/kafka/data."
                       overrides:
                         type: array
                         items:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1841,6 +1841,22 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
+                  persistentVolumeClaim:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the Kubernetes resource.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the Kubernetes resource.
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect Persistent volume claim.
                 description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
@@ -1935,6 +1951,57 @@ spec:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+              storage:
+                type: object
+                properties:
+                  accessMode:
+                    type: string
+                    description: The storage access mode to use.
+                  class:
+                    type: string
+                    description: The storage class to use for dynamic volume allocation.
+                  deleteClaim:
+                    type: boolean
+                    description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
+                  id:
+                    type: integer
+                    minimum: 0
+                    description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                  mountPath:
+                    type: string
+                    description: "The mount path to use, overriding the default /var/lib/kafka/data."
+                  overrides:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        class:
+                          type: string
+                          description: The storage class to use for dynamic volume allocation for this broker.
+                        broker:
+                          type: integer
+                          description: Id of the kafka broker (broker identifier).
+                    description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                  selector:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
+                  size:
+                    type: string
+                    description: "When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim."
+                  sizeLimit:
+                    type: string
+                    pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                    description: "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi)."
+                  type:
+                    type: string
+                    enum:
+                    - ephemeral
+                    - persistent-claim
+                    description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                required:
+                - type
+                description: Storage configuration (disk). Cannot be updated.
               build:
                 type: object
                 properties:
@@ -2066,6 +2133,7 @@ spec:
                 description: Metrics configuration.
             required:
             - bootstrapServers
+            - storage
             description: The specification of the Kafka Connect cluster.
           status:
             type: object

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1986,6 +1986,22 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
+                  persistentVolumeClaim:
+                    type: object
+                    properties:
+                      metadata:
+                        type: object
+                        properties:
+                          labels:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Labels added to the Kubernetes resource.
+                          annotations:
+                            x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            description: Annotations added to the Kubernetes resource.
+                        description: Metadata applied to the resource.
+                    description: Template for the Kafka Connect Persistent volume claim.
                 description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -56,6 +56,9 @@ spec:
               storage:
                 type: object
                 properties:
+                  accessMode:
+                    type: string
+                    description: The storage access mode to use.
                   class:
                     type: string
                     description: The storage class to use for dynamic volume allocation.
@@ -66,6 +69,9 @@ spec:
                     type: integer
                     minimum: 0
                     description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                  mountPath:
+                    type: string
+                    description: "The mount path to use, overriding the default /var/lib/kafka/data."
                   overrides:
                     type: array
                     items:
@@ -102,6 +108,9 @@ spec:
                     items:
                       type: object
                       properties:
+                        accessMode:
+                          type: string
+                          description: The storage access mode to use.
                         class:
                           type: string
                           description: The storage class to use for dynamic volume allocation.
@@ -112,6 +121,9 @@ spec:
                           type: integer
                           minimum: 0
                           description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                        mountPath:
+                          type: string
+                          description: "The mount path to use, overriding the default /var/lib/kafka/data."
                         overrides:
                           type: array
                           items:


### PR DESCRIPTION

### Type of change

- Enhancement

### Description

This PR introduces enhancements to the Strimzi Kafka Operator for managing shared volume mounts, improving task resiliency across nodes. Key changes include:

1) **mountPath:** A string property to specify the container directory for mounting the storage volume. While the default is /var/lib/kafka/data, this allows for custom path specification. By default, it will try to mount read write many storage if accessMode is not specified.

2) **accessMode:** An optional string property defining the storage access mode, determining permissions like read-only or read-write.

These changes, tested successfully with Read-Write-Many on Ceph-block storage and NFS, provide greater control over volume configuration and usage, improving operator performance in distributed environments. 

**Sample Test**

 - This test case is to test the strimzi operator customization that allows mounting of shared volume across kafka-connect pods 
 - Ensure that files created in shared volume in one pod are visible to the other pods

**kafkaConnect.yaml**
```
    storage:
      type: persistent-claim
      size: 1Gi
      class: rook-cephfs
      deleteClaim: false
      mountPath: /mnt/shared
    template:
      pod:
        securityContext:
          runAsNonRoot: false
          fsGroup: 1001
```

**Outcome**

-  After deploying all the necessary charts and kafka-connect with the above yaml, ensure only one pvc data-odf-connect-cluster-connect is created, mounted and shared by all the connect pods

```
    $ kubectl get pvc
    NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    data-odf-cluster-kafka-0           Bound    pvc-7a09ed64-2216-48fa-b040-65ecec708472   2Gi        RWO            local-path     143m
    data-odf-cluster-kafka-1           Bound    pvc-4385d70e-da6a-4ed5-b52b-527ae2ea4feb   2Gi        RWO            local-path     143m
    data-odf-cluster-kafka-2           Bound    pvc-5b6cc835-529a-4265-9a42-b46403fbe795   2Gi        RWO            local-path     143m
    data-odf-cluster-zookeeper-0       Bound    pvc-5f505af1-077b-438b-a9fb-3974a7dae9d7   2Gi        RWO            local-path     143m
    data-odf-cluster-zookeeper-1       Bound    pvc-5177af7e-6cc9-4993-bcad-42ce5a422fdc   2Gi        RWO            local-path     143m
    data-odf-cluster-zookeeper-2       Bound    pvc-27e9587f-0ead-4e08-85a9-1177076be843   2Gi        RWO            local-path     143m
    data-odf-connect-cluster-connect   Bound    pvc-1f2eadb0-e2be-4277-9bb4-b2f5dfb8dcdf   3Gi        RWX            rook-cephfs    143m
    sftp-output-file-odf-sftp-0        Bound    pvc-c11a68fa-5865-4310-9194-624a3942b872   100Gi      RWO            rook-cephfs    20h
```

- Get a terminal to one of the kafka-connect pod and create a file at /mnt/shared as below
```
    $ kubectl exec -it odf-connect-cluster-connect-7fbd9589c-d4tx6 -- bash
        [kafka@odf-connect-cluster-connect-7fbd9589c-d4tx6 kafka]$ cd /mnt/shared/
        [kafka@odf-connect-cluster-connect-7fbd9589c-d4tx6 shared]$ ls -lah
        total 0
        drwxrwsr-x 2 root  1001  1 Aug 23 09:27 .
        drwxr-xr-x 1 root  root 20 Aug 23 09:22 ..
        -rw-r--r-- 1 kafka 1001  0 Aug 23 09:27 testFile
```

- Get a terminal to another one of the kafka-connect pod and ensure the created file is visible
```
    $ kubectl exec -it odf-connect-cluster-connect-7fbd9589c-d4tx6 -- bash
        [kafka@odf-connect-cluster-connect-7fbd9589c-d4tx6 kafka]$ cd /mnt/shared/
        [kafka@odf-connect-cluster-connect-7fbd9589c-d4tx6 shared]$ ls -lah
        total 0
        drwxrwsr-x 2 root  1001  1 Aug 23 09:27 .
        drwxr-xr-x 1 root  root 20 Aug 23 09:22 ..
        -rw-r--r-- 1 kafka 1001  0 Aug 23 09:27 testFile
```