### PR TITLE
Saved metadata state on /tmp file

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -57,7 +57,7 @@ echo ""
 
 STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat "$KAFKA_HOME"/custom-config/metadata.state)
 echo "Kafka metadata config state [${STRIMZI_KAFKA_METADATA_CONFIG_STATE}]"
-echo $STRIMZI_KAFKA_METADATA_CONFIG_STATE > /tmp/kafka/strimzi.kafka.metadata.config.state
+echo "$STRIMZI_KAFKA_METADATA_CONFIG_STATE" > /tmp/kafka/strimzi.kafka.metadata.config.state
 
 source ./kraft_utils.sh
 USE_KRAFT=$(useKRaft)

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -55,11 +55,13 @@ echo ""
 # Configure heap based on the available resources if needed
 . ./dynamic_resources.sh
 
+STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat "$KAFKA_HOME"/custom-config/metadata.state)
+echo "Kafka metadata config state [${STRIMZI_KAFKA_METADATA_CONFIG_STATE}]"
+echo $STRIMZI_KAFKA_METADATA_CONFIG_STATE > /tmp/strimzi.kafka.metadata.config.state
+
 source ./kraft_utils.sh
 USE_KRAFT=$(useKRaft)
-
-STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat "$KAFKA_HOME"/custom-config/metadata.state)
-echo "Kafka metadata config state [${STRIMZI_KAFKA_METADATA_CONFIG_STATE}], using KRaft [${USE_KRAFT}]"
+echo "Using KRaft [${USE_KRAFT}]"
 
 # Prepare for Kraft
 if [ "$USE_KRAFT" == "true" ]; then

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -57,7 +57,7 @@ echo ""
 
 STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat "$KAFKA_HOME"/custom-config/metadata.state)
 echo "Kafka metadata config state [${STRIMZI_KAFKA_METADATA_CONFIG_STATE}]"
-echo $STRIMZI_KAFKA_METADATA_CONFIG_STATE > /tmp/strimzi.kafka.metadata.config.state
+echo $STRIMZI_KAFKA_METADATA_CONFIG_STATE > /tmp/kafka/strimzi.kafka.metadata.config.state
 
 source ./kraft_utils.sh
 USE_KRAFT=$(useKRaft)

--- a/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
@@ -8,7 +8,7 @@ set -e
 # It returns "true" if the current node is using KRaft, "false" otherwise
 #
 function useKRaft {
-  STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat "$KAFKA_HOME"/custom-config/metadata.state)
+  STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat /tmp/strimzi.kafka.metadata.config.state)
 
   file=/tmp/strimzi.properties
   test -f $file

--- a/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
@@ -8,7 +8,7 @@ set -e
 # It returns "true" if the current node is using KRaft, "false" otherwise
 #
 function useKRaft {
-  STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat /tmp/strimzi.kafka.metadata.config.state)
+  STRIMZI_KAFKA_METADATA_CONFIG_STATE=$(cat /tmp/kafka/strimzi.kafka.metadata.config.state)
 
   file=/tmp/strimzi.properties
   test -f $file


### PR DESCRIPTION
This PR saves the metadata state at startup (got from the ConfigMap) to a tmp file, so that it's used by the probes to determine the cluster metadata state.
This is important for downgrades where the metadata state is not in the ConfigMap and probes would start to fail.