### PR TITLE
Avoid unnecessary patching when resources are being deleted

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/NetworkPolicyOperator.java
@@ -20,6 +20,8 @@ public class NetworkPolicyOperator extends AbstractNamespacedResourceOperator<Ku
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/creationTimestamp" +
+                    "|/metadata/deletionTimestamp" +
+                    "|/metadata/deletionGracePeriodSeconds" +
                     "|/metadata/resourceVersion" +
                     "|/metadata/generation" +
                     "|/metadata/uid" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/PvcOperator.java
@@ -28,6 +28,8 @@ public class PvcOperator extends AbstractNamespacedResourceOperator<KubernetesCl
                     "|/metadata/annotations/volume.kubernetes.io~1.*" +
                     "|/metadata/finalizers" +
                     "|/metadata/creationTimestamp" +
+                    "|/metadata/deletionTimestamp" +
+                    "|/metadata/deletionGracePeriodSeconds" +
                     "|/metadata/resourceVersion" +
                     "|/metadata/generation" +
                     "|/metadata/uid" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ResourceDiff.java
@@ -27,6 +27,8 @@ public class ResourceDiff<T extends HasMetadata> extends AbstractJsonDiff {
     public static final Pattern DEFAULT_IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/creationTimestamp" +
+                    "|/metadata/deletionTimestamp" +
+                    "|/metadata/deletionGracePeriodSeconds" +
                     "|/metadata/resourceVersion" +
                     "|/metadata/generation" +
                     "|/metadata/uid" +

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/ServiceOperator.java
@@ -31,6 +31,8 @@ public class ServiceOperator extends AbstractNamespacedResourceOperator<Kubernet
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
             "^(/metadata/managedFields" +
                     "|/metadata/creationTimestamp" +
+                    "|/metadata/deletionTimestamp" +
+                    "|/metadata/deletionGracePeriodSeconds" +
                     "|/metadata/resourceVersion" +
                     "|/metadata/generation" +
                     "|/metadata/uid" +


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, when diffing Kubernetes resources we do not ignore the deletion timestamp and the deletion grace period. As a result, we might patch a Kubernetes resource that is being deleted because these two fields trigger a diff. To avoid this, this adds them to the ignore lists.

One of the examples where this might cause a problem is when you delete a PVC -> it should not be deleted while being used by a pod. But because the operator patches the resource, it removes the finalizer and gets it deleted while still in use. In some environment, that seems to also wipe the PV and the data volume and fail the pod. In others, it seems the PV deletion will not happen until the pod rolls. But none of the cases is desired and this PR should mitigate it (the only other solution to deal with it even better in the future is using server-side-apply).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally