### PR TITLE
[ST] PVC deletion directly in tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
@@ -19,7 +19,6 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.test.WaitException;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
@@ -83,12 +82,6 @@ public class QuotasST extends AbstractST {
         String hardLimitLog = "disk is full";
         assertThat("Kafka log doesn't contain '" + softLimitLog + "' log", kafkaLog, CoreMatchers.containsString(softLimitLog));
         assertThat("Kafka log doesn't contain '" + hardLimitLog + "' log", kafkaLog, CoreMatchers.containsString(hardLimitLog));
-    }
-
-    @AfterEach
-    void afterEach() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        kubeClient(testStorage.getNamespaceName()).getClient().persistentVolumeClaims().inNamespace(testStorage.getNamespaceName()).delete();
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -51,7 +51,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.x509.GeneralName;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
@@ -2515,12 +2514,6 @@ public class ListenersST extends AbstractST {
             assertThat(certificate.toString(), containsString(advertHostInternalList.get(index)));
             assertThat(certificate.toString(), containsString(advertHostExternalList.get(index++)));
         }
-    }
-
-    @AfterEach
-    void afterEach() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        kubeClient(testStorage.getNamespaceName()).getClient().persistentVolumeClaims().inNamespace(testStorage.getNamespaceName()).delete();
     }
 
     private ASN1Encodable[] retrieveKafkaBrokerSANs(final TestStorage testStorage) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This small PR modifies Kafka, Quota and Listeners STs, moving deletion of PVCs with delete claim false directly into tests utilizing them, PR also removes old code which handled deletion for openshift examples(they could not be handled using resource manager), they are not used anymore. 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

