### PR TITLE
[ST] Add assumption about Kafka version and change Kafka template inside the migration tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -35,6 +35,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
@@ -338,7 +339,7 @@ public class MigrationST extends AbstractST {
         // create Kafka resource with ZK and Broker NodePool
         resourceManager.createResourceWithWait(
                 KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), brokerPoolName, testStorage.getClusterName(), 3).build(),
-                KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3, 3)
+                KafkaTemplates.kafkaPersistentNodePools(testStorage.getClusterName(), 3, 3)
                     .editMetadata()
                         .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                         .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "disabled")
@@ -689,6 +690,8 @@ public class MigrationST extends AbstractST {
 
     @BeforeAll
     void setup() {
+        // skip if Kafka version is lower than 3.7.0
+        assumeTrue(TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
         assumeTrue(Environment.isKafkaNodePoolsEnabled() && Environment.isKRaftForCOEnabled());
         this.clusterOperator = this.clusterOperator
             .defaultInstallation()


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR adds assumption to the MigrationST, so the tests will be skipped in lower versions of Kafka (lower than 3.7.0).
Also, it changes the Kafka template after the latest changes

### Checklist

- [ ] Make sure all tests pass
