### PR TITLE
Add Drain Cleaner 1.1.0 to the installation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
 * Support for the JmxTrans component is now completely removed.
   If you are upgrading from Strimzi 0.34 or earlier and have JmxTrans enabled in `.spec.jmxTrans` of the `Kafka` custom resource, you should disable it before the upgrade or delete it manually after the upgrade is complete.
 * The `api` module was refactored and classes were moved to new packages.
+* Strimzi Drain Cleaner 1.1.0 (included in the Strimzi 0.40.0 installation files) changes the way it handles Kubernetes eviction requests.
+  It denies them instead of allowing them.
+  This new behavior does not require the `PodDisruptionBudget` to be set to `maxUnavailable: 0`.
+  We expect this to improve the compatibility with various tools used for scaling Kubernetes clusters such as [Karpenter](https://karpenter.sh/).
+  If you observe any problems with your toolchain or just want to stick with the previous behavior, you can use the `STRIMZI_DENY_EVICTION` environment variable and set it to `false` to switch back to the old (legacy) mode.
 
 ## 0.39.0
 

--- a/documentation/assemblies/deploying/assembly-drain-cleaner.adoc
+++ b/documentation/assemblies/deploying/assembly-drain-cleaner.adoc
@@ -10,8 +10,6 @@ Kafka and ZooKeeper pods might be evicted during Kubernetes upgrades, maintenanc
 If your Kafka and ZooKeeper pods were deployed by Strimzi, you can use the Strimzi Drain Cleaner tool to handle the pod evictions.
 The Strimzi Drain Cleaner handles the eviction instead of Kubernetes.
 
-To use the Strimzi Drain Cleaner, you must set the `podDisruptionBudget` for your Kafka deployment to `0` (zero) so that Kubernetes is no longer allowed to evict pods automatically.
-
 By deploying the Strimzi Drain Cleaner, you can use the Cluster Operator to move Kafka pods instead of Kubernetes.
 The Cluster Operator ensures that topics are never under-replicated and Kafka can remain operational during the eviction process.
 The Cluster Operator waits for topics to synchronize, as the Kubernetes worker nodes drain consecutively.

--- a/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying-helm-chart.adoc
+++ b/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying-helm-chart.adoc
@@ -94,9 +94,9 @@ helm install strimzi-drain-cleaner oci://quay.io/strimzi-helm/strimzi-drain-clea
 Alternatively, you can use parameter values to install a specific version of the Drain Cleaner or specify any changes to the default configuration.
 +
 .Example configuration that installs a specific version of the Drain Cleaner and changes the number of replicas
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
-helm install strimzi-drain-cleaner --set replicaCount=2 --version 1.0.0 oci://quay.io/strimzi-helm/strimzi-drain-cleaner
+helm install strimzi-drain-cleaner --set replicaCount=2 --version {DrainCleanerVersion} oci://quay.io/strimzi-helm/strimzi-drain-cleaner
 ----
 
 . Verify that the Drain Cleaner has been deployed successfully:

--- a/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying.adoc
@@ -9,10 +9,10 @@
 Deploy the Strimzi Drain Cleaner to the Kubernetes cluster where the Cluster Operator and Kafka cluster are running.
 
 Strimzi Drain Cleaner can run in two different modes.
-By default, it denies (blocks) the Kubernetes eviction request to prevent Kubernetes from evicting the Pods and instead uses the Strimzi Cluster Operator to move the Pod.
+By default, the Drain Cleaner denies (blocks) the Kubernetes eviction request to prevent Kubernetes from evicting the pods and instead uses the Cluster Operator to move the pod.
 This mode has better compatibility with various cluster autoscaling tools and does not require any specific `PodDisuptionBudget` configuration.
-Alternatively, you can enable the legacy mode where it allows the eviction request while also instructing the Strimzi Cluster Operator to move the Pod.
-For the legacy mode to work, you have to configure the `PodDisruptionBudget` to not allow any Pod evictions by setting the `maxUnavailable` option to `0`.
+Alternatively, you can enable the legacy mode where it allows the eviction request while also instructing the Cluster Operator to move the pod.
+For the legacy mode to work, you have to configure the `PodDisruptionBudget` to not allow any pod evictions by setting the `maxUnavailable` option to `0`.
 
 .Prerequisites
 
@@ -42,7 +42,7 @@ spec:
 
 .Excluding Kafka or ZooKeeper
 
-If you don't want to include Kafka or ZooKeeper pods in Drain Cleaner operations, change the default environment variables in the Drain Cleaner `Deployment` configuration file.
+If you don't want to include Kafka or ZooKeeper pods in Drain Cleaner operations, or if you prefer to use the Drain Cleaner in legacy mode, change the default environment variables in the Drain Cleaner `Deployment` configuration file:
 
 * Set `STRIMZI_DENY_EVICTION` to `false` to use the legacy mode relying on the `PodDisruptionBudget` configuration
 * Set `STRIMZI_DRAIN_KAFKA` to `false` to exclude Kafka pods
@@ -73,7 +73,7 @@ spec:
 
 .Procedure
 
-. If you use the legacy mode activated by setting the `STRIMZI_DENY_EVICTION` environment variable to `false`, you have to configure the `PodDisruptionBudget` resource.
+. If you are using the legacy mode activated by setting the `STRIMZI_DENY_EVICTION` environment variable to `false`, you must also configure the `PodDisruptionBudget` resource.
   Set `maxUnavailable` to `0` (zero) in the Kafka and ZooKeeper sections of the `Kafka` resource using `template` settings.
 +
 .Specifying a pod disruption budget

--- a/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying.adoc
+++ b/documentation/modules/drain-cleaner/proc-drain-cleaner-deploying.adoc
@@ -8,13 +8,11 @@
 [role="_abstract"] 
 Deploy the Strimzi Drain Cleaner to the Kubernetes cluster where the Cluster Operator and Kafka cluster are running.
 
-Strimzi sets a default `PodDisruptionBudget` (PDB) that allows only one Kafka or ZooKeeper pod to be unavailable at any given time.
-To use the Drain Cleaner for planned maintenance or upgrades, you must set a PDB of zero.
-This is to prevent voluntary evictions of pods, and ensure that the Kafka or ZooKeeper cluster remains available.
-You do this by setting the `maxUnavailable` value to zero in the `Kafka` or `ZooKeeper` template. 
-`StrimziPodSet` custom resources manage Kafka and ZooKeeper pods using a custom controller that cannot use the `maxUnavailable` value directly.
-Instead, the `maxUnavailable` value is converted to a `minAvailable` value.
-For example, if there are three broker pods and the `maxUnavailable` property is set to `0` (zero), the `minAvailable` setting is `3`, requiring all three broker pods to be available and allowing zero pods to be unavailable.
+Strimzi Drain Cleaner can run in two different modes.
+By default, it denies (blocks) the Kubernetes eviction request to prevent Kubernetes from evicting the Pods and instead uses the Strimzi Cluster Operator to move the Pod.
+This mode has better compatibility with various cluster autoscaling tools and does not require any specific `PodDisuptionBudget` configuration.
+Alternatively, you can enable the legacy mode where it allows the eviction request while also instructing the Strimzi Cluster Operator to move the Pod.
+For the legacy mode to work, you have to configure the `PodDisruptionBudget` to not allow any Pod evictions by setting the `maxUnavailable` option to `0`.
 
 .Prerequisites
 
@@ -46,6 +44,7 @@ spec:
 
 If you don't want to include Kafka or ZooKeeper pods in Drain Cleaner operations, change the default environment variables in the Drain Cleaner `Deployment` configuration file.
 
+* Set `STRIMZI_DENY_EVICTION` to `false` to use the legacy mode relying on the `PodDisruptionBudget` configuration
 * Set `STRIMZI_DRAIN_KAFKA` to `false` to exclude Kafka pods
 * Set `STRIMZI_DRAIN_ZOOKEEPER` to `false` to exclude ZooKeeper pods
 
@@ -63,6 +62,8 @@ spec:
         - name: strimzi-drain-cleaner
           # ...
           env:
+            - name: STRIMZI_DENY_EVICTION
+              value: "true"
             - name: STRIMZI_DRAIN_KAFKA
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
@@ -72,7 +73,8 @@ spec:
 
 .Procedure
 
-. Set `maxUnavailable` to `0` (zero) in the Kafka and ZooKeeper sections of the `Kafka` resource using `template` settings.
+. If you use the legacy mode activated by setting the `STRIMZI_DENY_EVICTION` environment variable to `false`, you have to configure the `PodDisruptionBudget` resource.
+  Set `maxUnavailable` to `0` (zero) in the Kafka and ZooKeeper sections of the `Kafka` resource using `template` settings.
 +
 .Specifying a pod disruption budget
 [source,yaml,subs=attributes+]

--- a/documentation/modules/upgrading/con-upgrade-cluster.adoc
+++ b/documentation/modules/upgrading/con-upgrade-cluster.adoc
@@ -47,29 +47,7 @@ In a highly available environment, the Cluster Operator maintains a minimum numb
 
 == Rolling pods using the Strimzi Drain Cleaner
 
-When using the Strimzi Drain Cleaner to evict nodes during upgrade, it annotates pods with a manual rolling update annotation to inform the Cluster Operator to perform a rolling update of an evicted pod.
-
-A pod disruption budget limits the number of unavailable pods and ensures Kafka's availability during planned maintenance. 
-By default, the budget permits only one pod to be unavailable at a given time.
-To be able to use the Drain Cleaner to roll Kafka pods, you must set `maxUnavailable` to `0` (zero) in the template configuration of the `Kafka` resource.
-Reducing the pod disruption budget to zero prevents Kubernetes from evicting pods automatically, so pods must be evicted through Strimzi Drain Cleaner.
-
-.Specifying a pod disruption budget
-[source,yaml,subs=attributes+]
-----
-apiVersion: {KafkaApiVersion}
-kind: Kafka
-metadata:
-  name: my-cluster
-  namespace: myproject
-spec:
-  kafka:
-    # ...
-    template:
-      podDisruptionBudget:
-        maxUnavailable: 0
-# ...
-----
+When using the Strimzi Drain Cleaner to evict nodes during Kubernetes upgrade, it annotates pods with a manual rolling update annotation to inform the Cluster Operator to perform a rolling update of the pod that should be evicted and have it moved away from the Kubernetes node that is being upgraded.
 
 For more information, see xref:assembly-drain-cleaner-{context}[].
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -39,6 +39,9 @@
 // Bridge version
 :BridgeVersion: 0.27.0
 
+// Drain Cleaner Version
+:DrainCleanerVersion: 1.1.0
+
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]
 :supported-configurations: https://strimzi.io/downloads/
@@ -135,7 +138,7 @@
 :DockerOrg: quay.io/strimzi
 :DockerTag: {ProductVersion}
 :BridgeDockerTag: {BridgeVersion}
-:DrainCleanerDockerTag: 1.0.1
+:DrainCleanerDockerTag: {DrainCleanerVersion}
 :DockerRepository: https://quay.io/organization/strimzi[Container Registry^]
 :DockerZookeeper: quay.io/strimzi/kafka:{DockerTag}-kafka-{DefaultKafkaVersion}
 :DockerKafkaImageCurrent: quay.io/strimzi/kafka:{DockerTag}-kafka-{KafkaVersionHigher}

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.0.1
+          image: quay.io/strimzi/drain-cleaner:1.1.0
           ports:
             - containerPort: 8080
               name: http
@@ -28,6 +28,8 @@ spec:
             - name: STRIMZI_DRAIN_KAFKA
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "true"
+            - name: STRIMZI_DENY_EVICTION
               value: "true"
             - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
               value: "true"

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.0.1
+          image: quay.io/strimzi/drain-cleaner:1.1.0
           ports:
             - containerPort: 8080
               name: http
@@ -28,6 +28,8 @@ spec:
             - name: STRIMZI_DRAIN_KAFKA
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "true"
+            - name: STRIMZI_DENY_EVICTION
               value: "true"
             - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
               value: "true"

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.0.1
+          image: quay.io/strimzi/drain-cleaner:1.1.0
           ports:
             - containerPort: 8080
               name: http
@@ -28,6 +28,8 @@ spec:
             - name: STRIMZI_DRAIN_KAFKA
               value: "true"
             - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "true"
+            - name: STRIMZI_DENY_EVICTION
               value: "true"
             - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
               value: "true"


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the Drain Cleaner 1.1.0 release to the installation files and updates the docs and STs accordingly.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md