### PR TITLE
Update OAuth library version to 0.15.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -36,6 +36,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -37,10 +37,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -36,6 +36,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -37,10 +37,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -55,7 +55,7 @@
 :keycloak-server-install-doc: link:https://www.keycloak.org/operator/installation[Installing the Keycloak Operator^]
 :keycloak-authorization-services: link:https://www.keycloak.org/docs/latest/authorization_services/index.html[Keycloak Authorization Services^]
 :oauth-blog: link:https://strimzi.io/2019/10/25/kafka-authentication-using-oauth-2.0.html[Kafka authentication using OAuth 2.0^]
-:OAuthVersion: 0.14.0
+:OAuthVersion: 0.15.0
 :oauth-demo-keycloak: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples[Using Keycloak as the OAuth 2.0 authorization server^]
 :oauth-demo-hydra: link:https://github.com/strimzi/strimzi-kafka-oauth/tree/{OAuthVersion}/examples/docker#running-with-hydra-using-ssl-and-opaque-tokens[Using Hydra as the OAuth 2.0 authorization server^]
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
-        <strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <netty.version>4.1.107.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
@@ -193,6 +193,13 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
+        </repository>
+    </repositories>
+    
     <modules>
         <module>kafka-agent</module>
         <module>mirror-maker-agent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,6 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-
-    <repositories>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1208</url>
-        </repository>
-    </repositories>
     
     <modules>
         <module>kafka-agent</module>


### PR DESCRIPTION
### Type of change

- Bugfix


### Description

Update the version of OAuth to 0.15.0. This PR does not integrate the new features, but the new version of the librare provides some bug fixes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

