### PR TITLE
[ST] Fix NetworkPolicies for Oauth tests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/keycloak/SetupKeycloak.java
@@ -4,11 +4,17 @@
  */
 package io.strimzi.systemtest.resources.keycloak;
 
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyBuilder;
+import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 import io.strimzi.systemtest.resources.ResourceItem;
 import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.templates.kubernetes.NetworkPolicyTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StatefulSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
@@ -45,6 +51,9 @@ public class SetupKeycloak {
     public final static String PATH_TO_KEYCLOAK_PREPARE_SCRIPT = "../systemtest/src/test/resources/oauth2/prepare_keycloak_operator.sh";
     public final static String PATH_TO_KEYCLOAK_TEARDOWN_SCRIPT = "../systemtest/src/test/resources/oauth2/teardown_keycloak_operator.sh";
 
+    private static final String KEYCLOAK = "keycloak";
+    private static final String POSTGRES = "postgres";
+
     private static final Logger LOGGER = LogManager.getLogger(SetupKeycloak.class);
 
     public static void deployKeycloakOperator(final String deploymentNamespace, final String watchNamespace) {
@@ -66,8 +75,11 @@ public class SetupKeycloak {
 
     public static KeycloakInstance deployKeycloakAndImportRealms(String namespaceName) {
         deployPostgres(namespaceName);
+        allowNetworkPolicyBetweenKeycloakAndPostgres(namespaceName);
         deployKeycloak(namespaceName);
+
         KeycloakInstance keycloakInstance = createKeycloakInstance(namespaceName);
+        allowNetworkPolicySettingsForKeycloak(namespaceName);
         importRealms(namespaceName, keycloakInstance);
 
         return keycloakInstance;
@@ -142,6 +154,47 @@ public class SetupKeycloak {
                 throw new RuntimeException(String.format("Unable to load file with path: %s due to exception: %n", path) + e);
             }
         });
+    }
+
+    public static void allowNetworkPolicyBetweenKeycloakAndPostgres(String namespaceName) {
+        LabelSelector labelSelector = new LabelSelectorBuilder()
+            .addToMatchLabels(TestConstants.APP_POD_LABEL, KEYCLOAK)
+            .build();
+
+        LOGGER.info("Apply NetworkPolicy access to {} from Pods with LabelSelector {}", KEYCLOAK, labelSelector);
+
+        NetworkPolicy networkPolicy = NetworkPolicyTemplates.networkPolicyBuilder(namespaceName, KEYCLOAK + "-" + POSTGRES, labelSelector)
+            .editSpec()
+                .withNewPodSelector()
+                    .addToMatchLabels(TestConstants.APP_POD_LABEL, POSTGRES)
+                .endPodSelector()
+            .endSpec()
+            .build();
+
+        ResourceManager.getInstance().createResourceWithWait(networkPolicy);
+    }
+
+    public static void allowNetworkPolicySettingsForKeycloak(String namespaceName) {
+        LOGGER.info("Apply NetworkPolicy access to {} from all Pods", KEYCLOAK);
+
+        NetworkPolicy networkPolicy = new NetworkPolicyBuilder()
+            .withApiVersion("networking.k8s.io/v1")
+            .withKind(TestConstants.NETWORK_POLICY)
+            .withNewMetadata()
+                .withName(KEYCLOAK + "-allow")
+                .withNamespace(namespaceName)
+            .endMetadata()
+            .editSpec()
+                // keeping ingress empty to allow all connections to the Keycloak Pod
+                .addNewIngress()
+                .endIngress()
+                .withNewPodSelector()
+                    .addToMatchLabels(TestConstants.APP_POD_LABEL, KEYCLOAK)
+                .endPodSelector()
+            .endSpec()
+            .build();
+
+        ResourceManager.getInstance().createResourceWithWait(networkPolicy);
     }
 
     private static void deleteKeycloak(String namespaceName) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After enabling deployment of NetworkPolicies back in one of the previous PRs, I broke few things - such as Keycloak deployment and access to Keycloak/Postgres Pods when the NetworkPolicies are globally set to deny all.

This PR fixes the NetworkPolicy creation for Oauth tests.

### Checklist

- [x] Make sure all tests pass
