### PR TITLE
[ST] Update test-clients to 0.7.0 after the release

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -195,8 +195,8 @@ public class Environment {
     private static final String RESOURCE_ALLOCATION_STRATEGY_DEFAULT = "SHARE_MEMORY_FOR_ALL_COMPONENTS";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
-    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.6.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.6.0";
+    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.7.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.38.0";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -196,7 +196,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.7.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.7.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.38.0";
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -146,6 +146,8 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withOauthClientId(TEAM_A_CLIENT)
             .withOauthClientSecret(TEAM_A_CLIENT_SECRET)
             .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            // by default it's set to 1000, which makes the job longer to fail
+            .withAdditionalConfig("retry.backoff.max.ms=100\n")
             .build();
 
         LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), testStorage.getTopicName());
@@ -258,6 +260,8 @@ public class OauthAuthorizationST extends OauthAbstractST {
             .withOauthClientId(TEAM_B_CLIENT)
             .withOauthClientSecret(TEAM_B_CLIENT_SECRET)
             .withOauthTokenEndpointUri(keycloakInstance.getOauthTokenEndpointUri())
+            // by default it's set to 1000, which makes the job longer to fail
+            .withAdditionalConfig("retry.backoff.max.ms=100\n")
             .build();
 
         LOGGER.info("Sending {} messages to Broker with Topic name {}", testStorage.getMessageCount(), testStorage.getTopicName());


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates version of `test-clients` to 0.7.0 and default clients' Kafka version to `3.7.0`.

### Checklist

- [ ] Make sure all tests pass
