### PR TITLE
[ST] Fixups for few failing tests in nightlies

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -533,7 +533,7 @@ public interface TestConstants {
     /**
      * NodePool's name prefix based on role
      */
-    String MIXED_ROLE_PREFIX = "mixed-";
-    String BROKER_ROLE_PREFIX = "broker-";
-    String CONTROLLER_ROLE_PREFIX = "control-";
+    String MIXED_ROLE_PREFIX = "m-";
+    String BROKER_ROLE_PREFIX = "b-";
+    String CONTROLLER_ROLE_PREFIX = "c-";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/annotations/SkipDefaultNetworkPolicyCreation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/annotations/SkipDefaultNetworkPolicyCreation.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that determines if the default application of NetworkPolicies (ALLOW_ALL, DENY_ALL) should be skipped or not
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SkipDefaultNetworkPolicyCreation {
+    String value() default "";
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/NetworkPolicyResource.java
@@ -273,17 +273,19 @@ public class NetworkPolicyResource implements ResourceType<NetworkPolicy> {
     }
 
     public static void applyDefaultNetworkPolicySettings(List<String> namespaces) {
-        for (String namespace : namespaces) {
-            NetworkPolicy networkPolicy;
+        if (!StUtils.shouldSkipNetworkPoliciesCreation(ResourceManager.getTestContext())) {
+            for (String namespace : namespaces) {
+                NetworkPolicy networkPolicy;
 
-            if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES) {
-                networkPolicy = NetworkPolicyTemplates.defaultNetworkPolicy(namespace, DefaultNetworkPolicy.DEFAULT_TO_DENY);
-            } else {
-                networkPolicy = NetworkPolicyTemplates.defaultNetworkPolicy(namespace, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
+                if (Environment.DEFAULT_TO_DENY_NETWORK_POLICIES) {
+                    networkPolicy = NetworkPolicyTemplates.defaultNetworkPolicy(namespace, DefaultNetworkPolicy.DEFAULT_TO_DENY);
+                } else {
+                    networkPolicy = NetworkPolicyTemplates.defaultNetworkPolicy(namespace, DefaultNetworkPolicy.DEFAULT_TO_ALLOW);
+                }
+
+                ResourceManager.getInstance().createResourceWithWait(networkPolicy);
+                LOGGER.info("NetworkPolicy successfully set to: {} for Namespace: {}", Environment.DEFAULT_TO_DENY_NETWORK_POLICIES, namespace);
             }
-
-            ResourceManager.getInstance().createResourceWithWait(networkPolicy);
-            LOGGER.info("NetworkPolicy successfully set to: {} for Namespace: {}", Environment.DEFAULT_TO_DENY_NETWORK_POLICIES, namespace);
         }
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/storage/TestStorage.java
@@ -38,9 +38,7 @@ final public class TestStorage {
     private static final String CONSUMER = "hello-world-consumer";
     private static final String ADMIN = "admin-client";
     private static final String USER = "user";
-    private static final String CLUSTER_NAME_PREFIX = "my-cluster-";
-    private static final String BROKER_ROLE_PREFIX = "broker-";
-    private static final String CONTROLLER_ROLE_PREFIX = "controller-";
+    private static final String CLUSTER_NAME_PREFIX = "cluster-";
     private static final Random RANDOM = new Random();
 
     private ExtensionContext extensionContext;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.ContainerEnvVarBuilder;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.annotations.SkipDefaultNetworkPolicyCreation;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.StrimziPodSetResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
@@ -401,6 +402,10 @@ public class StUtils {
      */
     public static boolean isParallelNamespaceTest(Object annotationHolder) {
         return CONTAINS_ANNOTATION.apply(TestConstants.PARALLEL_NAMESPACE, annotationHolder);
+    }
+
+    public static boolean shouldSkipNetworkPoliciesCreation(Object annotationHolder) {
+        return CONTAINS_ANNOTATION.apply(SkipDefaultNetworkPolicyCreation.class.getName().toLowerCase(Locale.ROOT), annotationHolder);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -404,6 +404,12 @@ public class StUtils {
         return CONTAINS_ANNOTATION.apply(TestConstants.PARALLEL_NAMESPACE, annotationHolder);
     }
 
+    /**
+     * Checking if test case contains annotation {@link io.strimzi.systemtest.annotations.SkipDefaultNetworkPolicyCreation}
+     * @param annotationHolder context of the test case
+     * @return true if test case contains annotation {@link io.strimzi.systemtest.annotations.SkipDefaultNetworkPolicyCreation},
+     * otherwise false
+     */
     public static boolean shouldSkipNetworkPoliciesCreation(Object annotationHolder) {
         return CONTAINS_ANNOTATION.apply(SkipDefaultNetworkPolicyCreation.class.getName().toLowerCase(Locale.ROOT), annotationHolder);
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -59,7 +59,6 @@ public class MetricsUtils {
     }
 
     public static MetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace, String coScraperName) {
-
         LabelSelector scraperDeploymentPodLabel = new LabelSelector(null, Map.of(TestConstants.APP_POD_LABEL, coScraperName));
         String coScraperPodName = ResourceManager.kubeClient().listPods(coNamespace, scraperDeploymentPodLabel).get(0).getMetadata().getName();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
@@ -13,6 +13,7 @@ import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
+import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaBridgeTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
@@ -148,6 +149,8 @@ public class HttpBridgeCorsST extends AbstractST {
                 .withNamespace(suiteTestStorage.getNamespaceName())
             .endMetadata()
             .build());
+
+        NetworkPolicyResource.allowNetworkPolicySettingsForBridgeScraper(suiteTestStorage.getNamespaceName(), suiteTestStorage.getScraperPodName(), KafkaBridgeResources.componentName(suiteTestStorage.getClusterName()));
 
         KafkaBridgeHttpCors kafkaBridgeHttpCors = KafkaBridgeResource.kafkaBridgeClient().inNamespace(suiteTestStorage.getNamespaceName()).withName(suiteTestStorage.getClusterName()).get().getSpec().getHttp().getCors();
         LOGGER.info("Bridge with the following CORS settings {}", kafkaBridgeHttpCors.toString());

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/MultipleListenersST.java
@@ -45,6 +45,7 @@ import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.TestConstants.LOADBALANCER_SUPPORTED;
 import static io.strimzi.systemtest.TestConstants.NODEPORT_SUPPORTED;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
+import static io.strimzi.systemtest.TestConstants.ROUTE;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(REGRESSION)
@@ -103,6 +104,7 @@ public class MultipleListenersST extends AbstractST {
 
     @OpenShiftOnly
     @Tag(EXTERNAL_CLIENTS_USED)
+    @Tag(ROUTE)
     @IsolatedTest("Using more tha one Kafka cluster in one namespace")
     void testMultipleRoutes() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -28,6 +28,7 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaNodePoolResource;
 import io.strimzi.systemtest.resources.crd.KafkaRebalanceResource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
+import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaConnectTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaConnectorTemplates;
@@ -147,6 +148,10 @@ public class MultipleClusterOperatorsST extends AbstractST {
         MetricsCollector firstCoMetricsCollector = setupCOMetricsCollectorInNamespace(FIRST_CO_NAME, FIRST_NAMESPACE, firstCOScraper);
         String secondCOScraper = SECOND_NAMESPACE + "-" + TestConstants.SCRAPER_NAME;
         MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE, secondCOScraper);
+
+        // allowing NetworkPolicies for all scraper Pods to all CO Pods
+        NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(FIRST_NAMESPACE);
+        NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(SECOND_NAMESPACE);
 
         LOGGER.info("Deploying Namespace: {} to host all additional operands", testStorage.getNamespaceName());
         NamespaceManager.getInstance().createNamespaceAndPrepare(testStorage.getNamespaceName());
@@ -277,6 +282,8 @@ public class MultipleClusterOperatorsST extends AbstractST {
         LOGGER.info("Setting up metric collectors targeting Cluster Operator: {}", SECOND_CO_NAME);
         String coScraperName = testStorage.getNamespaceName() + "-" + TestConstants.SCRAPER_NAME;
         MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, testStorage.getNamespaceName(), coScraperName);
+        // allowing NetworkPolicies for all scraper Pods to all CO Pods
+        NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(testStorage.getNamespaceName());
 
         LOGGER.info("Deploying Kafka with {} selector of {}", FIRST_CO_NAME, FIRST_CO_SELECTOR);
         resourceManager.createResourceWithWait(

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -18,6 +18,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
+import io.strimzi.systemtest.annotations.SkipDefaultNetworkPolicyCreation;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.resources.ComponentType;
@@ -298,6 +299,8 @@ public class NetworkPoliciesST extends AbstractST {
 
     @IsolatedTest("Specific Cluster Operator for test case")
     @Tag(CRUISE_CONTROL)
+    @SkipDefaultNetworkPolicyCreation("NetworkPolicy generation from CO is disabled in this test, resulting in problems with connection" +
+        " in case of that DENY ALL global NetworkPolicy is used")
     void testNPGenerationEnvironmentVariable() {
         assumeTrue(!Environment.isHelmInstall() && !Environment.isOlmInstall());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes few failing tests in our nightlies, mainly for OCP:

- tests that are using `route` as a listener types are sometimes failing on the length of the hostname - that is hit because of long name of the NodePools. I changed it from `broker-`, `control-`, and `mixed-` prefixes to `b-`, `c-`, `m-` prefixes. In case that it will not be that readable, we can try different prefix and possibly shorter the suffix as well.
- changed `my-cluster-` prefix to `cluster-`
- added `ROUTE` tag to one test missing this tag
- created `SkipDefaultNetworkPolicyCreation` for tests that need skip of creation of the default NetworkPolicies -> for example test `testNPGenerationEnvironmentVariable` turns off creation of NetworkPolicies in CO -> and because the "default to deny" global network policy we would not be able to create the Kafka Pods, as it seems that the ZooKeeper throws "connection refused", but in the end it's just the default NetworkPolicies that blocks the connection requests to ZK
- added missing NP creation to HTTP CORS tests and `MultipleClusterOperatorsST`

### Checklist

- [ ] Make sure all tests pass

