### PR TITLE
[ST] Fix the issue with creating Kafka in CC tests in KRaft mode with lower Kafka version

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -486,6 +486,8 @@ public class KafkaTemplates {
         // fields here
         if (!withZookeeper) {
             kafka.getSpec().setZookeeper(null);
+            kafka.getSpec().getKafka().getConfig().remove("log.message.format.version");
+            kafka.getSpec().getKafka().getConfig().remove("inter.broker.protocol.version");
 
             if (!Environment.isUnidirectionalTopicOperatorEnabled()) {
                 kafka.getSpec().getEntityOperator().setTopicOperator(null);

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -285,9 +285,9 @@ public class CruiseControlST extends AbstractST {
         if (Environment.isKafkaNodePoolsEnabled()) {
             KafkaNodePoolResource.replaceKafkaNodePoolResourceInSpecificNamespace(testStorage.getBrokerPoolName(), knp ->
                 knp.getSpec().setReplicas(scaleTo), testStorage.getNamespaceName());
+        } else {
+            KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> kafka.getSpec().getKafka().setReplicas(3), testStorage.getNamespaceName());
         }
-        // should be moved to else block once the issue - https://github.com/strimzi/strimzi-kafka-operator/issues/8770 - will be fixed
-        KafkaResource.replaceKafkaResourceInSpecificNamespace(testStorage.getClusterName(), kafka -> kafka.getSpec().getKafka().setReplicas(3), testStorage.getNamespaceName());
         KafkaUtils.waitForKafkaReady(testStorage.getNamespaceName(), testStorage.getClusterName());
 
         kafkaStatus = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(testStorage.getClusterName()).get().getStatus();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issue described in #9805 where the Kafka with CC is not deployable because of the wrong version in `inter.broker.protocol.version`.
The issue is resolved by removing the LMFV and IBPV from the config, in case that we are running in KRaft mode.

Also this PR resolves one "TODO" inside the `CruiseControlST`

Fixes #9805 

### Checklist

- [ ] Make sure all tests pass
