### PR TITLE
[DOC] Suggest removal of unused fields from Kafka CR after migration to node pools

### DIFF
--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -91,5 +91,5 @@ kubectl apply -f <kafka_configuration_file>
 There is no change or rolling update.
 The resources remain identical to how they were before.
 
-. Once the `KafkaNodePool` resource is in use, you can remove the old fields from the `Kafka` custom resource.
-This includes all the fields that you copied to the `KafkaNodePool` resource in the previous steps such as the `.spec.kafka.replicas` or `.spec.kafka.storage`.
+. Remove the replicated properties from the `Kafka` custom resource.
+When the `KafkaNodePool` resource is in use, you can remove the properties that you copied to the `KafkaNodePool` resource, such as the `.spec.kafka.replicas` and `.spec.kafka.storage` properties.

--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -90,3 +90,6 @@ kubectl apply -f <kafka_configuration_file>
 +
 There is no change or rolling update.
 The resources remain identical to how they were before.
+
+. Once the `KafkaNodePool` resource is in use, you can remove the old fields from the `Kafka` custom resource.
+This includes all the fields that you copied to the `KafkaNodePool` resource in the previous steps such as the `.spec.kafka.replicas` or `.spec.kafka.stroage`.

--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -92,4 +92,4 @@ There is no change or rolling update.
 The resources remain identical to how they were before.
 
 . Once the `KafkaNodePool` resource is in use, you can remove the old fields from the `Kafka` custom resource.
-This includes all the fields that you copied to the `KafkaNodePool` resource in the previous steps such as the `.spec.kafka.replicas` or `.spec.kafka.stroage`.
+This includes all the fields that you copied to the `KafkaNodePool` resource in the previous steps such as the `.spec.kafka.replicas` or `.spec.kafka.storage`.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As the `.spec.kafka.replicas` and `spec.kafka.storage` fields are not required anymore int he `Kafka` CR, we should instruct users to remove them from the `Kafka` CR when migrating to node pools.

### Checklist

- [x] Update documentation