### PR TITLE
#9734 - added toString to whole model, including Password, PasswordSe…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,10 +65,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
@@ -78,6 +74,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.sundr</groupId>

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.bridge;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +81,7 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
+@ToString
 public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements Namespaced, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 
@@ -138,16 +138,6 @@ public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStat
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -18,6 +19,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -20,6 +21,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"port", "cors"})
 @EqualsAndHashCode
+@ToString
 public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"allowedOrigins", "allowedMethods"})
 @EqualsAndHashCode
+@ToString
 public class KafkaBridgeHttpCors implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -66,14 +68,5 @@ public class KafkaBridgeHttpCors implements UnknownPropertyPreserving, Serializa
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        return "KafkaBridgeHttpCors{" +
-            "allowedOrigins=" + allowedOrigins +
-            ", allowedMethods=" + allowedMethods +
-            ", additionalProperties=" + additionalProperties +
-            '}';
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -20,6 +21,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -26,6 +26,7 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @DescriptionFile
 @Buildable(
@@ -37,7 +38,8 @@ import lombok.EqualsAndHashCode;
     "replicas", "image", "bootstrapServers", "tls", "authentication", "http", "adminClient", "consumer",
     "producer", "resources", "jvmOptions", "logging", "clientRackInitImage", "rack",
     "enableMetrics", "livenessProbe", "readinessProbe", "template", "tracing"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe {
     private static final long serialVersionUID = 1L;
     private static final int DEFAULT_REPLICAS = 1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "clusterRoleBinding", "serviceAccount", "initContainer"})
 @EqualsAndHashCode
+@ToString
 public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents a certificate and private key pair inside a Secret
@@ -19,6 +20,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class CertAndKeySecretSource extends CertSecretSource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class CertSecretSource implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "generateCertificateAuthority", "generateSecretOwnerReference", "validityDays", "renewalDays" })
 @EqualsAndHashCode
+@ToString
 public class CertificateAuthority implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
@@ -9,6 +9,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class ClientTls implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class ExternalConfigurationReference implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Logging config comes from an existing, user-supplied config map
@@ -20,6 +22,8 @@ import io.sundr.builder.annotations.Buildable;
 @JsonPropertyOrder({"type", "valueFrom"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 // TODO remove this Note OneOf constraint declared on superclass
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ExternalLogging extends Logging {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class GenericSecretSource implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -20,6 +22,8 @@ import java.util.Map;
 )
 @JsonPropertyOrder({"type", "loggers"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class InlineLogging extends Logging {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class JvmOptions implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Logging implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class Password implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class PasswordSecretSource implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class PasswordSource implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class Probe implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class Rack implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class Sidecar implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class SystemProperty implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -18,6 +19,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class TlsClientAuthentication implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaClientAuthentication implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -25,7 +26,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using SASL PLAIN in client based components
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using one of the possible SASL SCRAM_SHA_* methods in client based
@@ -15,6 +16,7 @@ import lombok.EqualsAndHashCode;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class KafkaClientAuthenticationScram extends KafkaClientAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using SASL SCRAM_SHA_256 in client based components
@@ -22,6 +23,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using SASL SCRAM_SHA_512 in client based components
@@ -22,6 +23,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka client authentication using TLS client authentication in client based components
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 @JsonSubTypes({
     @JsonSubTypes.Type(name = KafkaJmxAuthenticationPassword.TYPE_PASSWORD, value = KafkaJmxAuthenticationPassword.class)
 })
+@ToString
 public abstract class KafkaJmxAuthentication implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the Kafka Brokers JMX port with username and password protected.
@@ -18,7 +19,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
     private KafkaJmxAuthentication authentication;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
@@ -11,6 +11,8 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.ExternalConfigurationReference;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +26,8 @@ import java.util.Map;
 )
 @JsonPropertyOrder({"type", "valueFrom"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class JmxPrometheusExporterMetrics extends MetricsConfig {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class MetricsConfig implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "pullSecret"})
 @EqualsAndHashCode
+@ToString
 public class BuildConfigTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @DescriptionFile
 @EqualsAndHashCode
+@ToString
 public class ContainerTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "deploymentStrategy"})
 @EqualsAndHashCode
+@ToString
 public class DeploymentTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "ipFamilyPolicy", "ipFamilies"})
 @EqualsAndHashCode
+@ToString
 public class InternalServiceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "deployment", "pod", "container", "serviceAccount", "additionalProperties" })
 @EqualsAndHashCode
+@ToString
 public class JmxTransTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({"labels", "annotations"})
 @DescriptionFile
 @EqualsAndHashCode
+@ToString
 public class MetadataTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "maxUnavailable"})
 @DescriptionFile
 @EqualsAndHashCode
+@ToString
 public class PodDisruptionBudgetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
@@ -22,6 +22,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds", "affinity",
     "tolerations", "topologySpreadConstraint", "priorityClassName", "schedulerName", "hostAliases", "tmpDirSizeLimit"})
 @EqualsAndHashCode
+@ToString
 @DescriptionFile
 public class PodTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata"})
 @EqualsAndHashCode
+@ToString
 public class ResourceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"metadata", "podManagementPolicy"})
 @EqualsAndHashCode
+@ToString
 public class StatefulSetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the tracing using the Jaeger OpenTracing implementation
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class JaegerTracing extends Tracing {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures the tracing using the Jaeger OpenTelemetry implementation
@@ -20,7 +21,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class OpenTelemetryTracing extends Tracing {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Tracing implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -26,6 +26,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
@@ -37,6 +38,7 @@ import lombok.EqualsAndHashCode;
     "logging", "clientRackInitImage", "rack", "metricsConfig", "tracing",
     "template", "externalConfiguration" })
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
+@ToString(callSuper = true)
 public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "connectorClass", "type", "version" })
 @EqualsAndHashCode
+@ToString
 public class ConnectorPlugin implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "env", "volumes" })
 @EqualsAndHashCode
+@ToString
 public class ExternalConfiguration implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class ExternalConfigurationEnv implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class ExternalConfigurationEnvVarSource implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class ExternalConfigurationVolumeSource implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
@@ -6,10 +6,7 @@ package io.strimzi.api.kafka.model.connect;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -22,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -73,7 +71,8 @@ import java.util.function.Predicate;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -123,16 +122,6 @@ public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectS
     @Description("The status of the Kafka Connect cluster.")
     public KafkaConnectStatus getStatus() {
         return super.getStatus();
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper().disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.connect;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaConnectAssembly>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaConnectList extends DefaultKubernetesResourceList<KafkaConnect> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectResources.java
@@ -4,10 +4,13 @@
  */
 package io.strimzi.api.kafka.model.connect;
 
+import lombok.ToString;
+
 /**
  * Encapsulates the naming scheme used for the resources which the Cluster Operator manages for a
  * {@code KafkaConnect} cluster.
  */
+@ToString
 public class KafkaConnectResources {
     protected KafkaConnectResources() { }
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +32,7 @@ import java.util.Map;
     "logging", "clientRackInitImage", "rack", "metrics", "tracing",
     "template", "externalConfiguration" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
@@ -24,7 +24,7 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectorPlugins" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -20,6 +20,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.Map;
     "podDisruptionBudget", "serviceAccount", "clusterRoleBinding", "buildPod", "buildContainer", "buildConfig",
     "buildServiceAccount", "jmxSecret"})
 @EqualsAndHashCode
+@ToString
 public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Artifact implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "output", "connectorPlugins", "resources" })
 @DescriptionFile
 @EqualsAndHashCode
+@ToString
 public class Build implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -23,7 +24,8 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "image", "pushSecret" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class DockerOutput extends Output {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
@@ -10,6 +10,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Artifact which can be just downloaded from an URL
@@ -20,6 +21,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class DownloadableArtifact extends Artifact {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Represents Docker output from the build
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "image" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ImageStreamOutput extends Output {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * JAR artifact represents an artifact which is simply downloaded
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class JarArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Maven artifact represents an artifact which is downloaded from Maven repository
@@ -22,6 +23,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "repository", "group", "artifact", "version" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class MavenArtifact extends Artifact {
     private static final long serialVersionUID = 1L;
     public static final String DEFAULT_REPOSITORY = "https://repo1.maven.org/maven2/";

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Other artifact represents an artifact of assorted types. Users can specify a name of the file under which it will be
@@ -22,6 +23,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "url", "sha512sum", "fileName", "insecure" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class OtherArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Output implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "name", "artifacts" })
 @EqualsAndHashCode
+@ToString
 public class Plugin implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * TGZ artifact represents an artifact which is downloaded and unpacked using TAR (with GZIP decompression)
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class TgzArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * ZIP artifact represents an artifact which is downloaded and unpacked using `unzip`
@@ -21,6 +22,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ZipArtifact extends DownloadableArtifact {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +29,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"pause", "tasksMax", "config", "state"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class AbstractConnectorSpec extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"enabled", "maxRestarts"})
 @EqualsAndHashCode
+@ToString
 public class AutoRestart implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
@@ -26,7 +26,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "count", "connectorName", "lastRestartTimestamp"})
 @EqualsAndHashCode
-@ToString(callSuper = true)
+@ToString
 public class AutoRestartStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
@@ -79,8 +79,8 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
-@ToString
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.connector;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaConnector>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaConnectorList extends DefaultKubernetesResourceList<KafkaConnector> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
@@ -19,6 +20,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"class", "tasksMax", "autoRestart", "config"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
@@ -25,7 +25,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "autoRestart", "connectorStatus", "tasksMax", "topics" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"outputType", "host", "port", "flushDelayInSeconds", "typeNames", "name"})
 @EqualsAndHashCode
+@ToString
 public class JmxTransOutputDefinitionTemplate implements Serializable, UnknownPropertyPreserving {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"targetMBean", "attributes", "outputs"})
 @EqualsAndHashCode
+@ToString
 public class JmxTransQueryTemplate implements Serializable, UnknownPropertyPreserving {
     private String targetMBean;
     private List<String> attributes;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
@@ -16,6 +16,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "image", "outputDefinitions", "logLevel", "kafkaQueries", "resources", "template" })
 @EqualsAndHashCode
+@ToString
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class JmxTransSpec implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Representation for ephemeral storage.
@@ -20,7 +21,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class EphemeralStorage extends SingleVolumeStorage {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -19,6 +21,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class JbodStorage extends Storage {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -6,10 +6,7 @@ package io.strimzi.api.kafka.model.kafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -22,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +81,8 @@ import java.util.function.Predicate;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -131,16 +130,6 @@ public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Nam
     @Description("The status of the Kafka and ZooKeeper clusters, and Topic Operator.")
     public KafkaStatus getStatus() {
         return super.getStatus();
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper().disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID);
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaAuthorization implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -25,7 +26,8 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "authorizerClass", "superUsers", "supportsAdminApi"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaAuthorizationCustom extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -31,6 +32,7 @@ import java.util.List;
     "grantsMaxIdleSeconds", "grantsGcPeriodSeconds", "grantsAlwaysLatest", "superUsers",
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "enableMetrics", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -26,7 +27,8 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"type", "url", "allowOnError", "initialCacheCapacity", "maximumCacheSize", "expireAfterMs", "tlsTrustedCertificates", "superUsers"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -25,7 +26,8 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "superUsers"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaAuthorizationSimple extends KafkaAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -31,6 +31,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.MinimumItems;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -50,6 +51,7 @@ import java.util.Map;
     "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
     "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
+@ToString
 public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.common.template.StatefulSetTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import java.util.Map;
     "externalBootstrapRoute", "perPodRoute", "externalBootstrapIngress", "perPodIngress", "persistentVolumeClaim",
     "podDisruptionBudget", "kafkaContainer", "initContainer", "clusterCaCert", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
+@ToString
 public class KafkaClusterTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.kafka;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaAssembly>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaList extends DefaultKubernetesResourceList<Kafka> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -7,8 +7,6 @@ package io.strimzi.api.kafka.model.kafka;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.CertificateAuthority;
 import io.strimzi.api.kafka.model.common.Constants;
@@ -22,6 +20,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -36,7 +35,8 @@ import java.util.List;
 @JsonPropertyOrder({ "kafka", "zookeeper", "topicOperator",
     "entityOperator", "clusterCa", "clientsCa",
     "maintenance"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaSpec extends Spec {
     private static final long serialVersionUID = 1L;
 
@@ -137,15 +137,4 @@ public class KafkaSpec extends Spec {
     public void setCruiseControl(CruiseControlSpec cruiseControl) {
         this.cruiseControl = cruiseControl;
     }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -24,7 +24,7 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "listeners", "kafkaNodePools", "clusterId", "operatorLastSuccessfulVersion", "kafkaVersion", "kafkaMetadataVersion", "kafkaMetadataState" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,8 @@ import java.util.Map;
 )
 @JsonPropertyOrder({"type", "size", "storageClass", "selector", "deleteClaim"})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class PersistentClaimStorage extends SingleVolumeStorage {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @EqualsAndHashCode
+@ToString
 public class PersistentClaimStorageOverride  implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
     @JsonSubTypes.Type(value = PersistentClaimStorage.class, name = Storage.TYPE_PERSISTENT_CLAIM)}
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public abstract class SingleVolumeStorage extends Storage {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class Storage implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "name" })
 @EqualsAndHashCode
+@ToString
 public class UsedNodePoolStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"disk", "cpuUtilization", "cpu", "inboundNetwork", "outboundNetwork", "overrides"})
 @EqualsAndHashCode
+@ToString
 public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"brokers", "cpu", "inboundNetwork", "outboundNetwork"})
 @EqualsAndHashCode
+@ToString
 public class BrokerCapacityOverride implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -24,6 +24,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ import java.util.Map;
     "image", "tlsSidecar", "resources", "livenessProbe", "readinessProbe", "jvmOptions", "logging", "template",
     "brokerCapacity", "config", "metricsConfig"})
 @EqualsAndHashCode
+@ToString
 public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import java.util.Map;
 @JsonPropertyOrder({
     "deployment", "pod", "apiService", "podDisruptionBudget", "cruiseControlContainer", "tlsSidecarContainer", "serviceAccount"})
 @EqualsAndHashCode
+@ToString
 public class CruiseControlTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"topicOperator", "userOperator", "tlsSidecar", "template"})
 @EqualsAndHashCode
+@ToString
 public class EntityOperatorSpec implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount", "entityOperatorRole", "topicOperatorRoleBinding", "userOperatorRoleBinding"})
 @EqualsAndHashCode
+@ToString
 public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
     private DeploymentTemplate deployment;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
@@ -22,6 +22,7 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import java.util.Map;
     "startupProbe", "livenessProbe", "readinessProbe",
     "resources", "topicMetadataMaxAttempts", "logging", "jvmOptions"})
 @EqualsAndHashCode
+@ToString
 public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, HasStartupProbe, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
@@ -23,6 +23,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import java.util.Map;
     "secretPrefix", "livenessProbe", "readinessProbe",
     "resources", "logging", "jvmOptions"})
 @EqualsAndHashCode
+@ToString
 public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class TlsSidecar extends Sidecar implements HasLivenessProbe, HasReadinessProbe {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
@@ -16,6 +16,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import java.util.Map;
     "resources", "logging",
     "enableSaramaLogging", "showAllOffsets", "template"})
 @EqualsAndHashCode
+@ToString
 public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
@@ -17,6 +17,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "service", "container", "serviceAccount"})
 @EqualsAndHashCode
+@ToString
 public class KafkaExporterTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
@@ -17,6 +17,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.Map;
 @JsonPropertyOrder({"name", "port", "type", "tls", "authentication", "configuration", "networkPolicyPeers"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class GenericKafkaListener implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -18,6 +18,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import static java.util.Collections.emptyMap;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @EqualsAndHashCode
+@ToString
 public class GenericKafkaListenerConfiguration implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @EqualsAndHashCode
+@ToString
 public class GenericKafkaListenerConfigurationBootstrap implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import static java.util.Collections.emptyMap;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @EqualsAndHashCode
+@ToString
 public class GenericKafkaListenerConfigurationBroker implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaListenerAuthentication implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthentication {
 
     public static final String FORBIDDEN_PREFIXES = "ssl.";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -15,6 +15,7 @@ import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -26,7 +27,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures a listener to use SASL SCRAM-SHA-512 for authentication.
@@ -18,7 +19,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthentication {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures a listener to use mutual TLS authentication.
@@ -18,7 +19,8 @@ import lombok.EqualsAndHashCode;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
@@ -29,7 +29,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "address", "host", "port" })
 @EqualsAndHashCode
-@ToString(callSuper = true)
+@ToString
 public class ListenerAddress implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "type", "name", "addresses", "bootstrapServers", "certificates" })
 @EqualsAndHashCode
+@ToString
 public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class RemoteStorageManager implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
     protected Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class TieredStorage implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Configures a tieredStorage to use custom type.
@@ -22,6 +23,7 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class TieredStorageCustom extends TieredStorage {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.mirrormaker;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -22,6 +20,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -86,7 +85,8 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 @Deprecated
@@ -149,15 +149,4 @@ public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, Kafka
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"numStreams", "offsetCommitInterval", "bootstrapServers", "groupId", "logging"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerList.java
@@ -5,11 +5,13 @@
 package io.strimzi.api.kafka.model.mirrormaker;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaMirrorMaker>} required for using Fabric8 CRD support.
  */
 @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
+@ToString(callSuper = true)
 public class KafkaMirrorMakerList extends DefaultKubernetesResourceList<KafkaMirrorMaker> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -22,6 +23,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "bootstrapServers", "abortOnSendFailure", "logging"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
@@ -28,6 +28,7 @@ import io.strimzi.crdgenerator.annotations.OneOf;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @DescriptionFile
 @Buildable(
@@ -39,7 +40,8 @@ import lombok.EqualsAndHashCode;
     "version", "replicas", "image", "consumer", "producer", "resources", "whitelist", "include", "jvmOptions",
     "logging", "metricsConfig", "tracing", "template"})
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("include")), @OneOf.Alternative(@OneOf.Alternative.Property("whitelist"))})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"conditions", "observedGeneration"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "podDisruptionBudget", "mirrorMakerContainer", "serviceAccount"})
 @EqualsAndHashCode
+@ToString
 public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.mirrormaker2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +71,8 @@ import java.util.function.Predicate;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "apiVersion", "kind", "metadata", "spec", "status" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
@@ -121,16 +121,6 @@ public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, Kaf
     @Description("The status of the Kafka MirrorMaker 2 cluster.")
     public KafkaMirrorMaker2Status getStatus() {
         return super.getStatus();
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
@@ -16,6 +16,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "alias", "bootstrapServers", "tls", "authentication", "config"})
 @EqualsAndHashCode
+@ToString
 public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, Serializable {
 
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.connector.AbstractConnectorSpec;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
@@ -18,6 +19,7 @@ import lombok.EqualsAndHashCode;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"tasksMax", "config"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2List.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2List.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.mirrormaker2;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaMirrorMaker2>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaMirrorMaker2List extends DefaultKubernetesResourceList<KafkaMirrorMaker2> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({"sourceCluster", "targetCluster", "sourceConnector", "heartbeatConnector", "checkpointConnector",
     "topicsPattern", "topicsBlacklistPattern", "topicsExcludePattern", "groupsPattern", "groupsBlacklistPattern", "groupsExcludePattern"})
 @EqualsAndHashCode
+@ToString
 public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.connect.AbstractKafkaConnectSpec;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -26,6 +27,7 @@ import java.util.List;
     "clientRackInitImage", "rack", "metrics", "tracing",
     "template", "externalConfiguration" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true)
 public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "mirrorMaker2Container", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
+@ToString
 public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.nodepool;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -20,6 +18,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +66,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePoolStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -122,15 +122,5 @@ public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePo
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.nodepool;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaNodePool>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaNodePoolList extends DefaultKubernetesResourceList<KafkaNodePool> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
@@ -17,6 +17,7 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -30,6 +31,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"replicas", "storage", "roles", "resources", "jvmOptions", "template"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaNodePoolSpec extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
@@ -14,6 +14,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"podSet", "pod", "perPodService", "perPodRoute", "perPodIngress", "persistentVolumeClaim",
                     "kafkaContainer", "initContainer"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaNodePoolTemplate extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.podset;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +81,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @DescriptionFile
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_CORE_GROUP_NAME)
 public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodSetStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -134,15 +134,5 @@ public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodS
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.podset;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<StrimziPodSet>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class StrimziPodSetList extends DefaultKubernetesResourceList<StrimziPodSet> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"selector", "pods"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class StrimziPodSetSpec extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.rebalance;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -87,7 +86,8 @@ import java.util.function.Predicate;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -144,16 +144,6 @@ public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaReba
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.rebalance;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaRebalance>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaRebalanceList extends DefaultKubernetesResourceList<KafkaRebalance> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
@@ -12,6 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -23,7 +24,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "mode", "brokers", "goals", "skipHardGoalCheck", "rebalanceDisk", "excludedTopics", "concurrentPartitionMovementsPerBroker",
     "concurrentIntraBrokerPartitionMovements", "concurrentLeaderMovements", "replicationThrottle", "replicaMovementStrategies" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaRebalanceSpec extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
@@ -26,7 +26,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "sessionId", "optimizationResult" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.topic;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +79,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -137,16 +137,6 @@ public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus>
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.topic;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<Topic>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaTopicList extends DefaultKubernetesResourceList<KafkaTopic> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Maximum;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.Map;
 
@@ -22,7 +23,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"partitions", "replicas", "config"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaTopicSpec extends Spec {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
@@ -6,9 +6,7 @@ package io.strimzi.api.kafka.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -21,6 +19,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +78,8 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements Namespaced, UnknownPropertyPreserving {
@@ -136,16 +136,6 @@ public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> im
     @Override
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
-    }
-
-    @Override
-    public String toString() {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaUserAuthentication implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -23,6 +24,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class KafkaUserAuthorization implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.user.acl.AclRule;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -24,7 +25,8 @@ import java.util.List;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "acls"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaUserAuthorizationSimple extends KafkaUserAuthorization {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserList.java
@@ -5,10 +5,12 @@
 package io.strimzi.api.kafka.model.user;
 
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.ToString;
 
 /**
  * A {@code DefaultKubernetesResourceList<KafkaUser>} required for using Fabric8 CRD support.
  */
+@ToString(callSuper = true)
 public class KafkaUserList extends DefaultKubernetesResourceList<KafkaUser> {
     private static final long serialVersionUID = 1L;
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import static java.util.Collections.emptyMap;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
@@ -10,13 +10,15 @@ import io.strimzi.api.kafka.model.common.Password;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Spec;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
@@ -18,7 +19,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "authentication", "authorization", "quotas" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "conditions", "observedGeneration", "username", "secret" })
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserStatus extends Status {
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
@@ -13,6 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"secret"})
 @DescriptionFile
 @EqualsAndHashCode
+@ToString
 public class KafkaUserTemplate implements Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
@@ -9,13 +9,15 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
@@ -9,13 +9,15 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class KafkaUserTlsExternalClientAuthentication extends KafkaUserAuthentication {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -14,6 +14,7 @@ import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode
+@ToString
 public class AclRule implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * A representation of a cluster resource for ACLs
@@ -20,7 +21,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AclRuleClusterResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * A representation of a group resource for ACLs
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"type", "name", "patternType"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AclRuleGroupResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.Map;
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
+@ToString
 public abstract class AclRuleResource implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * A representation of a topic resource for ACLs
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "name", "patternType"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AclRuleTopicResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
@@ -11,6 +11,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * A representation of a transactional ID resource for ACLs
@@ -21,7 +22,8 @@ import lombok.EqualsAndHashCode;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"type", "name", "patternType"})
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AclRuleTransactionalIdResource extends AclRuleResource {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
@@ -27,6 +27,7 @@ import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import java.util.Map;
     "replicas", "image", "storage", "config", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources",
     "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
+@ToString
 public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.common.template.StatefulSetTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import java.util.Map;
     "statefulset", "pod", "clientService", "nodesService", "persistentVolumeClaim",
     "podDisruptionBudget", "zookeeperContainer", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
+@ToString
 public class ZookeeperClusterTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
…cretSource and PasswordSource classes

### Type of change

- Bugfix

### Description

Implementation of the issue #9734
All classes in the model package and sub-packages now contain toString generated by Lombok's `@ToString`.
Additionally:
 - each class contains generate hashCode and equals using `@EqualsAndHashCode`
 - when class has a Parent, both `@EqualsAndHashCode` and `@ToString`  are using `callSuper=true`
 - existing toString methods were removed
 - toString is also within classes `Password`, `PasswordSecretSource`, `PasswordSource` as they in fact do not contain secrets
 - class `KubernetesVersion` is left intact with manual hashCode, equals, and toString