### PR TITLE
Promote `KafkaNodePools` feature gate to GA

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -16,7 +17,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -27,7 +29,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -38,7 +41,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -49,7 +53,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -60,7 +65,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -71,7 +77,8 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -21,7 +22,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -34,7 +36,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -47,7 +50,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -60,7 +64,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -73,7 +78,8 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -86,6 +92,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-KafkaNodePools,-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_feature_gates: '-UnidirectionalTopicOperator,-UseKRaft'
+      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -13,6 +13,7 @@ parameters:
   run_parallel: false
   releaseVersion: "latest"
   strimzi_use_kraft_in_tests: "false"
+  strimzi_use_node_pools_in_tests: "true"
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'
@@ -142,6 +143,7 @@ jobs:
         CLUSTER_OPERATOR_INSTALL_TYPE: '${{ parameters.cluster_operator_install_type }}'
         STRIMZI_FEATURE_GATES: '${{ parameters.strimzi_feature_gates }}'
         STRIMZI_USE_KRAFT_IN_TESTS: '${{ parameters.strimzi_use_kraft_in_tests }}'
+        STRIMZI_USE_NODE_POOLS_IN_TESTS: '${{ parameters.strimzi_use_node_pools_in_tests }}'
         BUILD_ID: $(Agent.JobName)
         RESOURCE_ALLOCATION_STRATEGY: "NOT_SHARED"
         TEST_LOG_DIR: $(test_log_dir)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.41.0
 
 * Added support for topic replication factor change to the Unidirectional Topic Operator when Cruise Control integration is enabled.
+* The `KafkaNodePools` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
+  To use the Kafka Node Pool resources, you still need to use the `strimzi.io/node-pools: enabled` annotation on the `Kafka` custom resources.
 
 ## 0.40.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -117,14 +117,12 @@ public class ClusterOperator extends AbstractVerticle {
                 }));
             }
 
-            if (config.featureGates().kafkaNodePoolsEnabled())  {
-                // When node pools are enabled, we create the NodePool watch
-                startFutures.add(kafkaAssemblyOperator.createNodePoolWatch(namespace).compose(w -> {
-                    LOGGER.info("Opened watch for {} operator", KafkaNodePool.RESOURCE_KIND);
-                    watchByKind.put(KafkaNodePool.RESOURCE_KIND, w);
-                    return Future.succeededFuture();
-                }));
-            }
+            // Start the NodePool watch
+            startFutures.add(kafkaAssemblyOperator.createNodePoolWatch(namespace).compose(w -> {
+                LOGGER.info("Opened watch for {} operator", KafkaNodePool.RESOURCE_KIND);
+                watchByKind.put(KafkaNodePool.RESOURCE_KIND, w);
+                return Future.succeededFuture();
+            }));
 
             // Start connector watch and add it to the map as well
             startFutures.add(kafkaConnectAssemblyOperator.createConnectorWatch(namespace).compose(w -> {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -17,12 +17,10 @@ public class FeatureGates {
     /* test */ static final FeatureGates NONE = new FeatureGates("");
 
     private static final String USE_KRAFT = "UseKRaft";
-    private static final String KAFKA_NODE_POOLS = "KafkaNodePools";
     private static final String UNIDIRECTIONAL_TOPIC_OPERATOR = "UnidirectionalTopicOperator";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
     private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, true);
-    private final FeatureGate kafkaNodePools = new FeatureGate(KAFKA_NODE_POOLS, true);
     private final FeatureGate unidirectionalTopicOperator = new FeatureGate(UNIDIRECTIONAL_TOPIC_OPERATOR, true);
 
     /**
@@ -48,9 +46,6 @@ public class FeatureGates {
                     case USE_KRAFT:
                         setValueOnlyOnce(useKRaft, value);
                         break;
-                    case KAFKA_NODE_POOLS:
-                        setValueOnlyOnce(kafkaNodePools, value);
-                        break;
                     case UNIDIRECTIONAL_TOPIC_OPERATOR:
                         setValueOnlyOnce(unidirectionalTopicOperator, value);
                         break;
@@ -64,14 +59,12 @@ public class FeatureGates {
     }
 
     /**
-     * Validates any dependencies between various feature gates. For example, the UseKRaft feature gate can be enabled
-     * only when KafkaNodePools feature gate is enabled as well. When the dependencies are not satisfied,
+     * Validates any dependencies between various feature gates. When the dependencies are not satisfied,
      * InvalidConfigurationException is thrown.
      */
     private void validateInterDependencies()    {
-        if (useKRaftEnabled() && !kafkaNodePoolsEnabled())  {
-            throw new InvalidConfigurationException("The UseKRaft feature gate can be enabled only together with the KafkaNodePools feature gate.");
-        }
+        // There are currently no interdependencies between different feature gates.
+        // But we keep this method as these might happen again in the future.
     }
 
     /**
@@ -97,13 +90,6 @@ public class FeatureGates {
     }
 
     /**
-     * @return  Returns true when the KafkaNodePools feature gate is enabled
-     */
-    public boolean kafkaNodePoolsEnabled() {
-        return kafkaNodePools.isEnabled();
-    }
-
-    /**
      * @return  Returns true when the UnidirectionalTopicOperator feature gate is enabled
      */
     public boolean unidirectionalTopicOperatorEnabled() {
@@ -118,7 +104,6 @@ public class FeatureGates {
     /*test*/ List<FeatureGate> allFeatureGates()  {
         return List.of(
                 useKRaft,
-                kafkaNodePools,
                 unidirectionalTopicOperator
         );
     }
@@ -127,7 +112,6 @@ public class FeatureGates {
     public String toString() {
         return "FeatureGates(" +
                 "UseKRaft=" + useKRaft.isEnabled() + "," +
-                "KafkaNodePools=" + kafkaNodePools.isEnabled() + "," +
                 "UnidirectionalTopicOperator=" + unidirectionalTopicOperator.isEnabled() +
                 ")";
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -217,7 +217,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         Promise<Void> chainPromise = Promise.promise();
 
         KafkaMetadataConfigurationState kafkaMetadataConfigState = reconcileState.kafkaMetadataStateManager.getMetadataConfigurationState();
-        boolean nodePoolsEnabled = featureGates.kafkaNodePoolsEnabled() && ReconcilerUtils.nodePoolsEnabled(reconcileState.kafkaAssembly);
+        boolean nodePoolsEnabled = ReconcilerUtils.nodePoolsEnabled(reconcileState.kafkaAssembly);
 
         // since PRE_MIGRATION phase (because it's when controllers are deployed during migration) we need to validate usage of node pools and features for KRaft
         if (kafkaMetadataConfigState.isPreMigrationToKRaft()) {
@@ -634,8 +634,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                     .withStrimziName(KafkaResources.kafkaComponentName(reconciliation.name()));
 
             Future<List<KafkaNodePool>> nodePoolFuture;
-            if (featureGates.kafkaNodePoolsEnabled()
-                    && ReconcilerUtils.nodePoolsEnabled(kafkaAssembly)) {
+            if (ReconcilerUtils.nodePoolsEnabled(kafkaAssembly)) {
                 // Node Pools are enabled
                 nodePoolFuture = nodePoolOperator.listAsync(namespace, Labels.fromMap(Map.of(Labels.STRIMZI_CLUSTER_LABEL, name)));
             } else {
@@ -651,8 +650,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                         List<StrimziPodSet> podSets = res.resultAt(1);
                         List<KafkaNodePool> nodePools = res.resultAt(2);
 
-                        if (config.featureGates().kafkaNodePoolsEnabled()
-                                && ReconcilerUtils.nodePoolsEnabled(kafkaAssembly)
+                        if (ReconcilerUtils.nodePoolsEnabled(kafkaAssembly)
                                 && (nodePools == null || nodePools.isEmpty())) {
                             throw new InvalidConfigurationException("KafkaNodePools are enabled, but no KafkaNodePools found for Kafka cluster " + name);
                         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -200,7 +200,7 @@ public class KafkaReconciler {
         this.operatorNamespace = config.getOperatorNamespace();
         this.operatorNamespaceLabels = config.getOperatorNamespaceLabels();
         this.isNetworkPolicyGeneration = config.isNetworkPolicyGeneration();
-        this.isKafkaNodePoolsEnabled = config.featureGates().kafkaNodePoolsEnabled() && ReconcilerUtils.nodePoolsEnabled(kafkaCr);
+        this.isKafkaNodePoolsEnabled = ReconcilerUtils.nodePoolsEnabled(kafkaCr);
         this.pfa = pfa;
         this.imagePullPolicy = config.getImagePullPolicy();
         this.imagePullSecrets = config.getImagePullSecrets();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -65,7 +65,6 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getConnectBuildTimeoutMs(), is(Long.parseLong(ClusterOperatorConfig.CONNECT_BUILD_TIMEOUT_MS.defaultValue())));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
         assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
-        assertThat(config.featureGates().kafkaNodePoolsEnabled(), is(true));
         assertThat(config.featureGates().useKRaftEnabled(), is(true));
         assertThat(config.isCreateClusterRoles(), is(false));
         assertThat(config.isNetworkPolicyGeneration(), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
@@ -60,13 +60,16 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testFeatureGatesParsing() {
         assertThat(new FeatureGates("+UseKRaft").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("+KafkaNodePools").kafkaNodePoolsEnabled(), is(true));
-        assertThat(new FeatureGates("-UseKRaft,-KafkaNodePools").useKRaftEnabled(), is(false));
-        assertThat(new FeatureGates("-UseKRaft,-KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
-        assertThat(new FeatureGates("  +UseKRaft    ,    +KafkaNodePools").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("  -UseKRaft    ,    -KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
-        assertThat(new FeatureGates("+KafkaNodePools,-UseKRaft").useKRaftEnabled(), is(false));
-        assertThat(new FeatureGates("+KafkaNodePools,-UseKRaft").kafkaNodePoolsEnabled(), is(true));
+        assertThat(new FeatureGates("-UseKRaft").useKRaftEnabled(), is(false));
+        assertThat(new FeatureGates("  -UseKRaft    ").useKRaftEnabled(), is(false));
+        // TODO: Add more tests with various feature gate combinations once we have multiple feature gates again.
+        //       The commented out code below shows the tests we used to have with multiple feature gates.
+        //assertThat(new FeatureGates("-UseKRaft,-KafkaNodePools").useKRaftEnabled(), is(false));
+        //assertThat(new FeatureGates("-UseKRaft,-KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
+        //assertThat(new FeatureGates("  +UseKRaft    ,    +KafkaNodePools").useKRaftEnabled(), is(true));
+        //assertThat(new FeatureGates("  -UseKRaft    ,    -KafkaNodePools").kafkaNodePoolsEnabled(), is(false));
+        //assertThat(new FeatureGates("+KafkaNodePools,-UseKRaft").useKRaftEnabled(), is(false));
+        //assertThat(new FeatureGates("+KafkaNodePools,-UseKRaft").kafkaNodePoolsEnabled(), is(true));
     }
 
     @ParallelTest
@@ -107,17 +110,5 @@ public class FeatureGatesTest {
     public void testNonExistingGate() {
         InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+RandomGate"));
         assertThat(e.getMessage(), containsString("Unknown feature gate RandomGate found in the configuration"));
-    }
-
-    @ParallelTest
-    public void testKraftAndKafkaNOdePoolsNotFulfilled() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft,-KafkaNodePools"));
-        assertThat(e.getMessage(), containsString("The UseKRaft feature gate can be enabled only together with the KafkaNodePools feature gate."));
-    }
-
-    @ParallelTest
-    public void testKraftAndKafkaNodePoolsFulfilled() {
-        assertThat(new FeatureGates("+UseKRaft,+KafkaNodePools").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("+UseKRaft").useKRaftEnabled(), is(true));
     }
 }

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -23,8 +23,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `StableConnectIdentities` feature gate moved to GA stage in Strimzi 0.39.
   It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate is in beta stage and is enabled by default.
-* The `KafkaNodePools` feature gate is in beta stage and is enabled by default.
-  It is expected to move to GA phase and be always enabled from Strimzi 0.41.
+* The `KafkaNodePools` feature gate moved to GA stage in Strimzi 0.41.
+  It is now permanently enabled and cannot be disabled.
 * The `UnidirectionalTopicOperator` feature gate is in beta stage and is enabled by default.
   It is expected to move to GA phase and be always enabled from Strimzi 0.41.
 
@@ -67,7 +67,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`KafkaNodePools`
 ¦0.36
 ¦0.39
-¦0.41 (planned)
+¦0.41
 
 ¦`UnidirectionalTopicOperator`
 ¦0.36

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -51,6 +51,29 @@ The `StableConnectIdentities` feature gate introduced the `StrimziPodSet` custom
 IMPORTANT: With the `StableConnectIdentities` feature gate permanently enabled, direct downgrades from Strimzi 0.39 and newer to Strimzi 0.33 or earlier are not possible.
 You must first downgrade through one of the Strimzi versions in-between, disable the `StableConnectIdentities` feature gate, and then downgrade to Strimzi 0.33 or earlier.
 
+[id='ref-operator-kafka-node-pools-feature-gate-{context}']
+=== KafkaNodePools feature gate
+
+The `KafkaNodePools` feature gate introduced a new `KafkaNodePool` custom resource that enables the configuration of different _pools_ of Apache Kafka nodes.
+
+A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
+Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
+You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool in the `.spec.roles` field.
+When used with a ZooKeeper-based Apache Kafka cluster, it must be set to the `broker` role.
+When used with the `UseKRaft` feature gate, it can be set to `broker`, `controller`, or both.
+
+In addition, a node pool can have its own configuration of resource requests and limits, Java JVM options, and resource templates.
+Configuration options not set in the `KafkaNodePool` resource are inherited from the `Kafka` custom resource.
+
+The `KafkaNodePool` resources use a `strimzi.io/cluster` label to indicate to which Kafka cluster they belong.
+The label must be set to the name of the `Kafka` custom resource.
+
+Examples of the `KafkaNodePool` resources can be found in the xref:config-examples-{context}[example configuration files] provided by Strimzi.
+
+.Downgrading from KafkaNodePools
+
+If your cluster already uses `KafkaNodePool` custom resources, and you wish to downgrade to an older version of Strimzi that does not support them or with the `KafkaNodePools` feature gate disabled, you must first migrate from `KafkaNodePool` custom resources to managing Kafka nodes using only `Kafka` custom resources.
+
 == Stable feature gates (Beta)
 
 Stable feature gates have reached a beta level of maturity, and are generally enabled by default for all users.
@@ -68,7 +91,6 @@ In KRaft mode, Kafka nodes take on the roles of brokers, controllers, or both.
 They collectively manage the metadata, which is replicated across partitions. 
 Controllers are responsible for coordinating operations and maintaining the cluster's state.
 
-Using the `UseKRaft` feature gate requires the `KafkaNodePools` feature gate to be enabled as well.
 To deploy a Kafka cluster in KRaft mode, you must use the `KafkaNodePool` resources.
 For more details and examples, see xref:deploying-kafka-node-pools-{context}[].
 The `Kafka` custom resource using KRaft mode must also have the annotation `strimzi.io/kraft="enabled"`.
@@ -84,36 +106,6 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 
 .Disabling the UseKRaft feature gate
 To disable the `UseKRaft` feature gate, specify `-UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-
-[id='ref-operator-kafka-node-pools-feature-gate-{context}']
-=== KafkaNodePools feature gate
-
-The `KafkaNodePools` feature gate has a default state of _enabled_.
-
-The `KafkaNodePools` feature gate introduces a new `KafkaNodePool` custom resource that enables the configuration of different _pools_ of Apache Kafka nodes.
-
-A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
-Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
-You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool in the `.spec.roles` field.
-When used with a ZooKeeper-based Apache Kafka cluster, it must be set to the `broker` role.
-When used with the `UseKRaft` feature gate, it can be set to `broker`, `controller`, or both.
-
-In addition, a node pool can have its own configuration of resource requests and limits, Java JVM options, and resource templates.
-Configuration options not set in the `KafkaNodePool` resource are inherited from the `Kafka` custom resource.
-
-The `KafkaNodePool` resources use a `strimzi.io/cluster` label to indicate to which Kafka cluster they belong.
-The label must be set to the name of the `Kafka` custom resource.
-
-Examples of the `KafkaNodePool` resources can be found in the xref:config-examples-{context}[example configuration files] provided by Strimzi.
-
-.Disabling the KafkaNodePools feature gate
-
-To disable the `KafkaNodePools` feature gate, specify `-KafkaNodePools` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
-The `Kafka` custom resource using the node pools must also have the annotation `strimzi.io/node-pools: enabled`.
-
-.Downgrading from KafkaNodePools
-
-If your cluster already uses `KafkaNodePool` custom resources, and you wish to downgrade to an older version of Strimzi that does not support them or with the `KafkaNodePools` feature gate disabled, you must first migrate from `KafkaNodePool` custom resources to managing Kafka nodes using only `Kafka` custom resources.
 
 [id='ref-operator-unidirectional-topic-operator-feature-gate-{context}']
 === UnidirectionalTopicOperator feature gate

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -58,7 +58,7 @@ The `KafkaNodePools` feature gate introduced a new `KafkaNodePool` custom resour
 
 A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
 Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
-You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool in the `.spec.roles` field.
+You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool using the `.spec.roles` property.
 When used with a ZooKeeper-based Apache Kafka cluster, it must be set to the `broker` role.
 When used with the `UseKRaft` feature gate, it can be set to `broker`, `controller`, or both.
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -143,6 +143,11 @@ public class Environment {
     public static final String STRIMZI_USE_KRAFT_IN_TESTS_ENV = "STRIMZI_USE_KRAFT_IN_TESTS";
 
     /**
+     * Controls whether tests should run with Node Pools or not
+     */
+    public static final String STRIMZI_USE_NODE_POOLS_IN_TESTS_ENV = "STRIMZI_USE_NODE_POOLS_IN_TESTS";
+
+    /**
      * Switch for changing NodePool roles in STs - separate roles or mixed roles
      */
     public static final String STRIMZI_NODE_POOLS_ROLE_MODE_ENV = "STRIMZI_NODE_POOLS_ROLE_MODE";
@@ -219,6 +224,7 @@ public class Environment {
     public static final String STRIMZI_RBAC_SCOPE = getOrDefault(STRIMZI_RBAC_SCOPE_ENV, STRIMZI_RBAC_SCOPE_DEFAULT);
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
     public static final boolean STRIMZI_USE_KRAFT_IN_TESTS = getOrDefault(STRIMZI_USE_KRAFT_IN_TESTS_ENV, Boolean::parseBoolean, false);
+    public static final boolean STRIMZI_USE_NODE_POOLS_IN_TESTS = getOrDefault(STRIMZI_USE_NODE_POOLS_IN_TESTS_ENV, Boolean::parseBoolean, false);
     public static final NodePoolsRoleMode STRIMZI_NODE_POOLS_ROLE_MODE = getOrDefault(STRIMZI_NODE_POOLS_ROLE_MODE_ENV, value -> NodePoolsRoleMode.valueOf(value.toUpperCase(Locale.ENGLISH)), NodePoolsRoleMode.SEPARATE);
 
     // variables for kafka client app images
@@ -298,7 +304,7 @@ public class Environment {
     }
 
     public static boolean isKafkaNodePoolsEnabled() {
-        return !STRIMZI_FEATURE_GATES.contains(TestConstants.DONT_USE_KAFKA_NODE_POOLS);
+        return STRIMZI_USE_NODE_POOLS_IN_TESTS;
     }
 
     public static boolean isUnidirectionalTopicOperatorEnabled() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -212,10 +212,8 @@ public interface TestConstants {
      * Feature gate related constants
      */
     String DONT_USE_KRAFT_MODE = "-UseKRaft";
-    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
     // kept for upgrade/downgrade tests in KRaft
     String USE_KRAFT_MODE = "+UseKRaft";
-    String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
     String DONT_USE_UNIDIRECTIONAL_TOPIC_OPERATOR = "-UnidirectionalTopicOperator";
     String USE_UNIDIRECTIONAL_TOPIC_OPERATOR = "+UnidirectionalTopicOperator";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -34,7 +34,7 @@ public class VersionModificationDataLoader {
     private static final Logger LOGGER = LogManager.getLogger(VersionModificationDataLoader.class);
     private OlmVersionModificationData olmUpgradeData;
     private List<BundleVersionModificationData> bundleVersionModificationDataList;
-    private static final String KRAFT_UPGRADE_FEATURE_GATES = String.join(",", TestConstants.USE_KRAFT_MODE, TestConstants.USE_KAFKA_NODE_POOLS, TestConstants.USE_UNIDIRECTIONAL_TOPIC_OPERATOR);
+    private static final String KRAFT_UPGRADE_FEATURE_GATES = String.join(",", TestConstants.USE_KRAFT_MODE, TestConstants.USE_UNIDIRECTIONAL_TOPIC_OPERATOR);
 
     public VersionModificationDataLoader(ModificationType upgradeType) {
         if (upgradeType == ModificationType.OLM_UPGRADE) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -121,7 +121,7 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     void setupEnvironment() {
         List<EnvVar> coEnvVars = new ArrayList<>();
         coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, String.join(",",
-            TestConstants.USE_KRAFT_MODE, TestConstants.USE_KAFKA_NODE_POOLS, TestConstants.USE_UNIDIRECTIONAL_TOPIC_OPERATOR), null));
+            TestConstants.USE_KRAFT_MODE, TestConstants.USE_UNIDIRECTIONAL_TOPIC_OPERATOR), null));
 
         clusterOperator
             .defaultInstallation()


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR promotes the `KafkaNodePools` feature gate to GA and basically removes it. The use of node pools is still gated by the annotation on the `Kafka` CR. This PR also updates the docs and the system tests. As we cannot disable the feature gate anymore, it adds a new environment variable to drive when the node pools are used and when they are not used with the intention to use them in `regression` and `kraft-regression` and not use them in `feature-gates-regression`.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md