### PR TITLE
[ST] Fix and improve QuotasST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -399,11 +399,15 @@ public interface TestConstants {
      */
     String ROUTE = "route";
 
-
     /**
      * Tag for tests that focus on migration from ZK to KRaft
      */
     String MIGRATION = "migration";
+
+    /**
+     * Tag for tests that uses Strimzi quotas plugin
+     */
+    String QUOTAS_PLUGIN = "quotasplugin";
 
     /**
      * Tag for tests, without ARM,AARCH64 support

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -333,6 +333,7 @@ public class KubeClusterResource {
     public boolean isMicroShift() {
         return kubeClusterResource.cluster() instanceof Microshift;
     }
+
     public boolean isMinikube() {
         return kubeClusterResource.cluster() instanceof Minikube;
     }

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.strimzi.test.k8s.cluster.Kind;
 import io.strimzi.test.k8s.cluster.KubeCluster;
 import io.strimzi.test.k8s.cluster.Microshift;
+import io.strimzi.test.k8s.cluster.Minikube;
 import io.strimzi.test.k8s.cluster.OpenShift;
 import io.strimzi.test.k8s.cmdClient.KubeCmdClient;
 import org.apache.logging.log4j.LogManager;
@@ -331,6 +332,9 @@ public class KubeClusterResource {
 
     public boolean isMicroShift() {
         return kubeClusterResource.cluster() instanceof Microshift;
+    }
+    public boolean isMinikube() {
+        return kubeClusterResource.cluster() instanceof Minikube;
     }
 
     /** Returns list of currently deployed resources */


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #9754 
with correct broker Pod name. But during the work on the fix I found out that the `QuotasST` doesn't work at all:

- the test-clients were running out of memory on local clusters
- the ST doesn't work on clusters with local storage (e.g. `minikube`), which makes sense in terms of the calculation of the used storage
- the check for `disk is beyond soft limit` is flaky, as we can hit the soft limit really rarely, based on how the messages are send and how much free (or filled) storage we have during the test execution
- we are not running the test in any pipeline and it doesn't contain any tag for easier execution
- there is no note about "how we can actually run the test"

This PR should fix all of the above, it adds new tag `quotasplugin` for easier execution of the ST class, adds new method `isMinikube`, so it will be skipped on `minikube` clusters, and more.

Fixes #9754

### Checklist

- [x] Make sure all tests pass
