### PR TITLE
Fix value for all topics and groups selected in `Strimzi Kafka Exporter` dashboard

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1556,7 +1556,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [
@@ -1584,7 +1584,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [

--- a/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1556,7 +1556,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [
@@ -1584,7 +1584,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1556,7 +1556,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [
@@ -1584,7 +1584,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
@@ -1556,7 +1556,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [
@@ -1584,7 +1584,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Related to: https://github.com/strimzi/strimzi-kafka-operator/issues/9537

With big number of topics and consumer groups, the Kafka Exporter Grafana Dashboard does not work because the API call being executed behind the panels is too long. Instead of including all topics name in api call, we'll now substitute `all` value with `.*` regex which will have the same result.

![image](https://github.com/strimzi/strimzi-kafka-operator/assets/135701313/ff6d8aaf-f9a9-4ab2-ad9e-202ad18fc055)

Tested with grafana `7.5.7`, `v10.3.3`

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

