### PR TITLE
[DOC] Fix some leftovers from 0.40.0 release

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -576,10 +576,10 @@ For such containers, the requested memory should be significantly higher than th
 ----
 jvmOptions:
   "-XX":
-    "UseG1GC": true
-    "MaxGCPauseMillis": 20
-    "InitiatingHeapOccupancyPercent": 35
-    "ExplicitGCInvokesConcurrent": true
+    "UseG1GC": "true"
+    "MaxGCPauseMillis": "20"
+    "InitiatingHeapOccupancyPercent": "35"
+    "ExplicitGCInvokesConcurrent": "true"
 ----
 
 .JVM options resulting from the `-XX` configuration

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -97,7 +97,6 @@ The `Kafka` custom resource using KRaft mode must also have the annotation `stri
 
 Currently, the KRaft mode in Strimzi has the following major limitations:
 
-* Moving from Kafka clusters with ZooKeeper to KRaft clusters or the other way around is not supported.
 * Only the _Unidirectional_ Topic Operator is supported in KRaft mode.
   The _Bidirectional_ Topic Operator is not supported and when the `UnidirectionalTopicOperator` feature gate is disabled, the `spec.entityOperator.topicOperator` property *must be removed* from the `Kafka` custom resource.
 * JBOD storage is not supported. 


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes some documentation leftovers that should have been fixed originally in 0.40.0 docs:
* Removes the note about unsupported migration. Migration from ZooKeeper to KRaft is now supported. Migration from KRaft to ZooKeeper is AFAIK not planned by Kafka and will never be done (so it is not really some kind of temporary limitation).
* Fixes the example of the `-XX` option that now has to have String values only due to #9508

### Checklist

- [x] Update documentation