### PR TITLE
[ST] Enhance DrainCleanerST

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest.resources.draincleaner;
 
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
@@ -23,6 +24,7 @@ import io.strimzi.systemtest.security.SystemTestCertAndKey;
 import io.strimzi.systemtest.security.SystemTestCertManager;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -37,33 +39,45 @@ import java.util.Map;
 
 public class SetupDrainCleaner {
 
-    public static final String PATH_TO_DC_CONFIG = TestUtils.USER_PATH + "/../packaging/install/drain-cleaner/kubernetes";
+    private static final String OPENSHIFT_DIRECTORY = "openshift";
+    private static final String KUBERNETES_DIRECTORY = "kubernetes";
+    public static final String DRAIN_CLEANER_DIRECTORY = KubeClusterResource.getInstance().isOpenShiftLikeCluster() ? OPENSHIFT_DIRECTORY : KUBERNETES_DIRECTORY;
+    public static final String PATH_TO_DC_CONFIG = TestUtils.USER_PATH + "/../packaging/install/drain-cleaner/" + DRAIN_CLEANER_DIRECTORY;
+
     private static final Logger LOGGER = LogManager.getLogger(SetupDrainCleaner.class);
 
     public void applyInstallFiles() {
+        LOGGER.info("Applying files from path: {}", PATH_TO_DC_CONFIG);
+
         List<File> drainCleanerFiles = Arrays.stream(new File(PATH_TO_DC_CONFIG).listFiles()).sorted()
             .filter(File::isFile)
             .toList();
 
-        // we need to create our own certificates before applying install-files
-        final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
-            .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
-                // add hostnames (i.e., SANs) to the certificate
-                new ASN1Encodable[] {
-                    new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME),
-                    new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME),
-                    new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
-                    new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
-                });
-        final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
+        SecretBuilder customDrainCleanerSecretBuilder = null;
 
-        final Map<String, String> certsPaths = new HashMap<>();
-        certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
-        certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
+        if (DRAIN_CLEANER_DIRECTORY.equals(KUBERNETES_DIRECTORY)) {
+            // we need to create our own certificates before applying install-files
+            final SystemTestCertAndKey drainCleanerKeyPair = SystemTestCertManager
+                .generateRootCaCertAndKey("C=CZ, L=Prague, O=Strimzi Drain Cleaner, CN=StrimziDrainCleanerCA",
+                    // add hostnames (i.e., SANs) to the certificate
+                    new ASN1Encodable[]{
+                        new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                        new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME),
+                        new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc"),
+                        new GeneralName(GeneralName.dNSName, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + "." + TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME + ".svc.cluster.local")
+                    });
+            final CertAndKeyFiles drainCleanerKeyPairPemFormat = SystemTestCertManager.exportToPemFiles(drainCleanerKeyPair);
 
-        final SecretBuilder customDrainCleanerSecretBuilder = SecretUtils.retrieveSecretBuilderFromFile(certsPaths,
-            TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME, TestConstants.DRAIN_CLEANER_NAMESPACE,
-            Collections.singletonMap("app", TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls");
+            final Map<String, String> certsPaths = new HashMap<>();
+            certsPaths.put("tls.crt", drainCleanerKeyPairPemFormat.getCertPath());
+            certsPaths.put("tls.key", drainCleanerKeyPairPemFormat.getKeyPath());
+
+            customDrainCleanerSecretBuilder = SecretUtils.retrieveSecretBuilderFromFile(certsPaths,
+                TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME, TestConstants.DRAIN_CLEANER_NAMESPACE,
+                Collections.singletonMap(TestConstants.APP_POD_LABEL, TestConstants.DRAIN_CLEANER_DEPLOYMENT_NAME), "kubernetes.io/tls");
+        }
+
+        final Secret customDrainCleanerSecret = customDrainCleanerSecretBuilder == null ? null : customDrainCleanerSecretBuilder.build();
 
         drainCleanerFiles.forEach(file -> {
             if (!file.getName().contains("README") && !file.getName().contains("Namespace") && !file.getName().contains("Deployment")) {
@@ -106,7 +120,7 @@ public class SetupDrainCleaner {
                         ResourceManager.getInstance().createResourceWithWait(new ClusterRoleBindingBuilder(clusterRoleBinding).build());
                         break;
                     case TestConstants.SECRET:
-                        ResourceManager.getInstance().createResourceWithWait(customDrainCleanerSecretBuilder.build());
+                        ResourceManager.getInstance().createResourceWithWait(customDrainCleanerSecret);
                         break;
                     case TestConstants.SERVICE:
                         Service service = TestUtils.configFromYaml(file, Service.class);
@@ -115,8 +129,11 @@ public class SetupDrainCleaner {
                     case TestConstants.VALIDATION_WEBHOOK_CONFIG:
                         ValidatingWebhookConfiguration webhookConfiguration = TestUtils.configFromYaml(file, ValidatingWebhookConfiguration.class);
 
-                        // we fetch public key from strimzi-drain-cleaner Secret and then patch ValidationWebhookConfiguration.
-                        webhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecretBuilder.getData().get("tls.crt"));
+                        // in case that we are running on OpenShift-like cluster, we are not creating the Secret, thus this step is not needed
+                        if (customDrainCleanerSecret != null) {
+                            // we fetch public key from strimzi-drain-cleaner Secret and then patch ValidationWebhookConfiguration.
+                            webhookConfiguration.getWebhooks().stream().findFirst().get().getClientConfig().setCaBundle(customDrainCleanerSecret.getData().get("tls.crt"));
+                        }
 
                         ResourceManager.getInstance().createResourceWithWait(webhookConfiguration);
                         break;

--- a/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
+++ b/test/src/main/java/io/strimzi/test/k8s/KubeClusterResource.java
@@ -325,6 +325,15 @@ public class KubeClusterResource {
         return kubeClusterResource.cluster() instanceof OpenShift;
     }
 
+    /**
+     * Method determining if the cluster we are running tests on are "kind of" OpenShift
+     * That means either OpenShift or MicroShift
+     * @return boolean determining if we are running tests on OpenShift-like cluster
+     */
+    public boolean isOpenShiftLikeCluster() {
+        return isOpenShift() || isMicroShift();
+    }
+
     public boolean isKind() {
         return kubeClusterResource.cluster() instanceof Kind;
     }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR enhances the `DrainCleanerST` with following:

- moves the test from `ACCEPTANCE` to `REGRESSION`
- evicts just one Pod of kind Kafka or ZK
- lower the number of messages
- uses correct installation files folder (`kubernetes`/`openshift`) based on cluster type
- cleans the whole test a bit
- fixes NetworkPolicy for webhook in case of OCP

Additionally, it adds new method `isOpenShiftLikeCluster()` to `KubeClusterResource`, which is useful in case that we want to determine, if the cluster is "OpenShift-like" -> in our case OpenShift or MicroShift.

### Checklist

- [x] Make sure all tests pass

