### PR TITLE
#2779 CrdGenerator validate `@JsonPropertyOrder`

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.bridge;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -18,6 +19,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -19,7 +19,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"config"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
@@ -21,7 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"config"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.bridge;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -20,6 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -21,7 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"config"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.bridge;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -20,6 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
@@ -21,7 +21,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "replicas", "labelSelector" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeStatus extends Status {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class CertAndKeySecretSource extends CertSecretSource {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"key", "secretName", "certificate"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class CertAndKeySecretSource extends CertSecretSource {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class CertSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"secretName", "certificate"})
 @EqualsAndHashCode
 @ToString
 public class CertSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
@@ -24,7 +24,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "generateCertificateAuthority", "generateSecretOwnerReference", "validityDays", "renewalDays" })
+@JsonPropertyOrder({ "generateCertificateAuthority", "generateSecretOwnerReference", "validityDays",
+    "renewalDays", "certificateExpirationPolicy" })
 @EqualsAndHashCode
 @ToString
 public class CertificateAuthority implements UnknownPropertyPreserving, Serializable {
@@ -35,8 +36,10 @@ public class CertificateAuthority implements UnknownPropertyPreserving, Serializ
     private boolean generateCertificateAuthority = true;
     private boolean generateSecretOwnerReference = true;
     private int renewalDays;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
     private CertificateExpirationPolicy certificateExpirationPolicy;
+
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
     public static final int DEFAULT_CERTS_VALIDITY_DAYS = 365;
     public static final int DEFAULT_CERTS_RENEWAL_DAYS = 30;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"trustedCertificates"})
 @EqualsAndHashCode
 @ToString
 public class ClientTls implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.sundr.builder.annotations.Buildable;
@@ -27,6 +28,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ClientTls implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"name", "value"})
 @EqualsAndHashCode
 @ToString
 public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -6,6 +6,7 @@
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
@@ -25,7 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"configMapKeyRef"})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationReference implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
@@ -24,6 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationReference implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class GenericSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"key", "secretName"})
 @EqualsAndHashCode
 @ToString
 public class GenericSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Pattern;
 import io.sundr.builder.annotations.Buildable;
@@ -25,6 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class JvmOptions implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
@@ -26,7 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"-XX", "-Xmx", "-Xms", "gcLoggingEnabled", "javaSystemProperties"})
 @EqualsAndHashCode
 @ToString
 public class JvmOptions implements UnknownPropertyPreserving, Serializable {
@@ -44,6 +44,7 @@ public class JvmOptions implements UnknownPropertyPreserving, Serializable {
     private boolean gcLoggingEnabled = DEFAULT_GC_LOGGING_ENABLED;
     private List<SystemProperty> javaSystemProperties;
     private Map<String, String> xx;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @JsonProperty("-Xmx")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class Password implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"valueFrom"})
 @EqualsAndHashCode
 @ToString
 public class Password implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class PasswordSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"secretName", "password"})
 @EqualsAndHashCode
 @ToString
 public class PasswordSecretSource implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
@@ -24,6 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class PasswordSource implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
@@ -25,7 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"secretKeyRef"})
 @EqualsAndHashCode
 @ToString
 public class PasswordSource implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
@@ -25,7 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"initialDelaySeconds", "timeoutSeconds", "periodSeconds", "successThreshold", "failureThreshold"})
 @EqualsAndHashCode
 @ToString
 public class Probe implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.sundr.builder.annotations.Buildable;
@@ -24,6 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class Probe implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
@@ -27,7 +27,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"topologyKey"})
 @EqualsAndHashCode
 @ToString
 public class Rack implements UnknownPropertyPreserving, Serializable {
@@ -35,6 +35,7 @@ public class Rack implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String topologyKey;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     public Rack() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
 import io.strimzi.crdgenerator.annotations.Example;
@@ -26,6 +27,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class Rack implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"name", "value"})
 @EqualsAndHashCode
 @ToString
 public class SystemProperty implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
@@ -6,6 +6,7 @@
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class SystemProperty implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -27,7 +27,10 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "clientId", "username", "scope", "audience", "tokenEndpointUri", "connectTimeoutSeconds",
+    "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientSecret", "passwordSecret", "accessToken",
+    "refreshToken", "tlsTrustedCertificates", "disableTlsHostnameVerification", "maxTokenExpirySeconds",
+    "accessTokenIsJwt", "enableMetrics", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
@@ -26,6 +27,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -22,6 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
@@ -23,7 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "username", "passwordSecret"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
@@ -23,7 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "username", "passwordSecret"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -22,6 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.PasswordSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -22,6 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
@@ -23,7 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "username", "passwordSecret"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.authentication;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -22,6 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
@@ -23,7 +23,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "certificateAndKey"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.jmx;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -19,6 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.common.jmx;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -24,6 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
@@ -25,12 +25,14 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"authentication"})
 @EqualsAndHashCode
 @ToString
 public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
+
     private KafkaJmxAuthentication authentication;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Authentication configuration for connecting to the JMX port")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.common.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.ContainerEnvVar;
@@ -29,6 +30,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @DescriptionFile
 @EqualsAndHashCode
 @ToString

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -30,7 +30,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"env", "securityContext"})
 @DescriptionFile
 @EqualsAndHashCode
 @ToString

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
@@ -38,7 +38,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"metadata", "imagePullSecrets", "securityContext", "terminationGracePeriodSeconds", "affinity",
-    "tolerations", "topologySpreadConstraint", "priorityClassName", "schedulerName", "hostAliases", "tmpDirSizeLimit"})
+    "tolerations", "topologySpreadConstraints", "priorityClassName", "schedulerName", "hostAliases",
+    "enableServiceLinks", "tmpDirSizeLimit"})
 @EqualsAndHashCode
 @ToString
 @DescriptionFile
@@ -57,6 +58,7 @@ public class PodTemplate implements HasMetadataTemplate, Serializable, UnknownPr
     private List<HostAlias> hostAliases;
     private Boolean enableServiceLinks;
     private String tmpDirSizeLimit;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metadata applied to the resource.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
@@ -26,7 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "connectorClass", "type", "version" })
+@JsonPropertyOrder({ "class", "type", "version" })
 @EqualsAndHashCode
 @ToString
 public class ConnectorPlugin implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -26,7 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"name", "valueFrom"})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnv implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.connect;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -25,6 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnv implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -28,7 +28,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"secretKeyRef", "configMapKeyRef"})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnvVarSource implements Serializable, UnknownPropertyPreserving {
@@ -37,6 +37,7 @@ public class ExternalConfigurationEnvVarSource implements Serializable, UnknownP
 
     private SecretKeySelector secretKeyRef;
     private ConfigMapKeySelector configMapKeyRef;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     // TODO: We should make it possible to generate a CRD configuring that exactly one of secretKeyRef and configMapKeyRef has to be defined.

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.connect;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.strimzi.api.kafka.model.common.Constants;
@@ -27,6 +28,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnvVarSource implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -29,7 +29,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"name", "secret", "configMap"})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationVolumeSource implements Serializable, UnknownPropertyPreserving {
@@ -39,6 +39,7 @@ public class ExternalConfigurationVolumeSource implements Serializable, UnknownP
     private String name;
     private SecretVolumeSource secret;
     private ConfigMapVolumeSource configMap;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Name of the volume which will be added to the Kafka Connect pods.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.connect;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
 import io.strimzi.api.kafka.model.common.Constants;
@@ -28,6 +29,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationVolumeSource implements Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -29,8 +29,8 @@ import java.util.Map;
 @JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers",
     "tls", "authentication", "config", "resources", "livenessProbe",
     "readinessProbe", "jvmOptions", "jmxOptions", "affinity", "tolerations",
-    "logging", "clientRackInitImage", "rack", "metrics", "tracing",
-    "template", "externalConfiguration" })
+    "logging", "clientRackInitImage", "rack", "metricsConfig", "tracing",
+    "template", "externalConfiguration", "build" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
@@ -23,7 +23,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectorPlugins" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectorPlugins", "replicas", "labelSelector" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
@@ -30,7 +30,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "output", "connectorPlugins", "resources" })
+@JsonPropertyOrder({ "output", "plugins", "resources" })
 @DescriptionFile
 @EqualsAndHashCode
 @ToString

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -23,7 +23,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "image", "pushSecret" })
+@JsonPropertyOrder({ "image", "pushSecret", "additionalKanikoOptions", "type" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class DockerOutput extends Output {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
@@ -21,13 +21,11 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "image" })
+@JsonPropertyOrder({ "type", "image" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ImageStreamOutput extends Output {
     private static final long serialVersionUID = 1L;
-
-    private String image;
 
     @Description("Must be `" + TYPE_IMAGESTREAM + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -40,11 +38,8 @@ public class ImageStreamOutput extends Output {
             "For example `my-custom-connect:latest`. " +
             "Required")
     @JsonProperty(required = true)
+    @Override
     public String getImage() {
         return super.getImage();
-    }
-
-    public void setImage(String image) {
-        super.setImage(image);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
+@JsonPropertyOrder({ "type", "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JarArtifact extends DownloadableArtifact {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
@@ -21,7 +21,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "repository", "group", "artifact", "version" })
+@JsonPropertyOrder({ "type", "repository", "group", "artifact", "version", "insecure" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class MavenArtifact extends Artifact {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
@@ -21,7 +21,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum", "fileName", "insecure" })
+@JsonPropertyOrder({ "type", "url", "sha512sum", "fileName", "insecure" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class OtherArtifact extends DownloadableArtifact {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
+@JsonPropertyOrder({ "type", "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TgzArtifact extends DownloadableArtifact {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "url", "sha512sum", "insecure" })
+@JsonPropertyOrder({ "type", "url", "sha512sum", "insecure" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ZipArtifact extends DownloadableArtifact {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
@@ -18,7 +18,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"class", "tasksMax", "autoRestart", "config"})
+@JsonPropertyOrder({"class", "tasksMax", "autoRestart", "config", "pause", "state"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorSpec extends AbstractConnectorSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
@@ -22,7 +22,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"id", "sizeLimit", "type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class EphemeralStorage extends SingleVolumeStorage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
@@ -21,6 +22,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class EphemeralStorage extends SingleVolumeStorage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
@@ -22,7 +22,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "volumes"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JbodStorage extends Storage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -21,6 +22,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JbodStorage extends Storage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -28,8 +28,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"type", "clientId", "tokenEndpointUri",
     "tlsTrustedCertificates", "disableTlsHostnameVerification",
-    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize",
-    "grantsMaxIdleSeconds", "grantsGcPeriodSeconds", "grantsAlwaysLatest", "superUsers",
+    "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize", "grantsMaxIdleTimeSeconds",
+    "grantsMaxIdleSeconds", "grantsGcPeriodSeconds", "grantsAlwaysLatest", "KafkaAuthorizationKeycloak", "superUsers",
     "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "enableMetrics", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -26,7 +26,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({"type", "url", "allowOnError", "initialCacheCapacity", "maximumCacheSize", "expireAfterMs", "tlsTrustedCertificates", "superUsers"})
+@JsonPropertyOrder({"type", "url", "allowOnError", "initialCacheCapacity", "maximumCacheSize", "expireAfterMs",
+    "tlsTrustedCertificates", "superUsers", "enableMetrics"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationOpa extends KafkaAuthorization {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -48,8 +48,9 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack", "brokerRackInitImage",
-    "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig", "logging", "template"})
+    "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack",
+    "brokerRackInitImage", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig",
+    "logging", "template", "tieredStorage"})
 @EqualsAndHashCode
 @ToString
 public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -36,7 +36,8 @@ import java.util.Map;
 @JsonPropertyOrder({
     "statefulset", "pod", "bootstrapService", "brokersService", "externalBootstrapService", "perPodService",
     "externalBootstrapRoute", "perPodRoute", "externalBootstrapIngress", "perPodIngress", "persistentVolumeClaim",
-    "podDisruptionBudget", "kafkaContainer", "initContainer", "clusterCaCert", "serviceAccount", "jmxSecret"})
+    "podDisruptionBudget", "kafkaContainer", "initContainer", "clusterCaCert", "serviceAccount", "jmxSecret",
+    "clusterRoleBinding", "podSet"})
 @EqualsAndHashCode
 @ToString
 public class KafkaClusterTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -34,7 +34,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "kafka", "zookeeper", "topicOperator",
     "entityOperator", "clusterCa", "clientsCa",
-    "maintenance"})
+    "maintenance", "cruiseControl", "jmxTrans", "kafkaExporter", "maintenanceTimeWindows"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaSpec extends Spec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -24,7 +24,7 @@ import java.util.Map;
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
-@JsonPropertyOrder({"type", "size", "storageClass", "selector", "deleteClaim"})
+@JsonPropertyOrder({"id", "type", "size", "class", "selector", "deleteClaim", "overrides"})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -37,8 +37,6 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
     private Map<String, String> selector;
     private boolean deleteClaim;
     private List<PersistentClaimStorageOverride> overrides;
-
-    private Integer id;
 
     @Description("Must be `" + TYPE_PERSISTENT_CLAIM + "`")
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
@@ -23,7 +23,7 @@ import static java.util.Collections.emptyMap;
 /**
  * Configures persistent claim overrides for storage - allows to override storage class with per broker configuration
  */
-@JsonPropertyOrder({"class"})
+@JsonPropertyOrder({"class", "broker"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
         editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.kafka.entityoperator;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.HasLivenessProbe;
 import io.strimzi.api.kafka.model.common.HasReadinessProbe;
@@ -29,6 +30,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TlsSidecar extends Sidecar implements HasLivenessProbe, HasReadinessProbe {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
@@ -30,7 +30,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"image", "resources", "livenessProbe", "readinessProbe", "logLevel"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TlsSidecar extends Sidecar implements HasLivenessProbe, HasReadinessProbe {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @JsonPropertyOrder({
     "image", "groupRegex", "topicRegex", 
     "groupExcludeRegex", "topicExcludeRegex",
-    "resources", "logging",
+    "resources", "logging", "livenessProbe", "readinessProbe",
     "enableSaramaLogging", "showAllOffsets", "template"})
 @EqualsAndHashCode
 @ToString
@@ -53,6 +53,7 @@ public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, U
     private boolean enableSaramaLogging;
     private boolean showAllOffsets = true;
     private KafkaExporterTemplate template;
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The container image used for the Kafka Exporter pods. "

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -31,8 +31,9 @@ import static java.util.Collections.emptyMap;
  * Configures Kafka listeners
  */
 @DescriptionFile
-@JsonPropertyOrder({"brokerCertChainAndKey", "ingressClass", "preferredAddressType", "externalTrafficPolicy",
-    "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService"})
+@JsonPropertyOrder({"brokerCertChainAndKey", "class", "preferredAddressType", "externalTrafficPolicy",
+    "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService",
+    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -23,7 +23,8 @@ import java.util.Map;
  * Configures listener bootstrap configuration
  */
 @DescriptionFile
-@JsonPropertyOrder({"alternativeNames", "host", "dnsAnnotations", "nodePort", "loadBalancerIP"})
+@JsonPropertyOrder({"alternativeNames", "host", "dnsAnnotations", "nodePort", "loadBalancerIP",
+    "annotations", "labels"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -25,7 +25,8 @@ import static java.util.Collections.emptyMap;
  * Configures listener per-broker configuration
  */
 @DescriptionFile
-@JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host", "dnsAnnotations", "nodePort", "loadBalancerIP"})
+@JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host", "dnsAnnotations", "nodePort",
+    "loadBalancerIP", "annotations", "labels"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -25,6 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -26,7 +26,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "sasl", "listenerConfig", "secrets"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -28,7 +28,14 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "clientId", "clientSecret", "validIssuerUri", "checkIssuer", "checkAudience",
+    "jwksEndpointUri", "jwksRefreshSeconds", "jwksMinRefreshPauseSeconds", "jwksExpirySeconds", "jwksIgnoreKeyUse",
+    "introspectionEndpointUri", "userNameClaim", "fallbackUserNameClaim", "fallbackUserNamePrefix",
+    "groupsClaim", "groupsClaimDelimiter", "userInfoEndpointUri", "checkAccessTokenType", "validTokenType",
+    "accessTokenIsJwt", "tlsTrustedCertificates", "disableTlsHostnameVerification", "enableECDSA",
+    "maxSecondsWithoutReauthentication", "enablePlain", "tokenEndpointUri", "enableOauthBearer", "customClaimCheck",
+    "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "httpRetryPauseMs", "clientScope", "clientAudience",
+    "enableMetrics", "failFast", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.Constants;
@@ -27,6 +28,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -19,6 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -19,6 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
@@ -20,7 +20,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -26,15 +26,17 @@ import java.util.Map;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"className", "classPath", "config"})
 @EqualsAndHashCode
 @ToString
 public class RemoteStorageManager implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
-    protected Map<String, Object> additionalProperties;
+
     private String className;
     private String classPath;
     private Map<String, String> config;
+
+    protected Map<String, Object> additionalProperties;
 
     @Override
     public Map<String, Object> getAdditionalProperties() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -6,6 +6,7 @@
 package io.strimzi.api.kafka.model.kafka.tieredstorage;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -25,6 +26,7 @@ import java.util.Map;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class RemoteStorageManager implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
@@ -23,7 +23,7 @@ import lombok.ToString;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "remoteStorageManager"})
 @EqualsAndHashCode
 @ToString
 public class TieredStorageCustom extends TieredStorage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
@@ -6,6 +6,7 @@
 package io.strimzi.api.kafka.model.kafka.tieredstorage;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
@@ -22,6 +23,7 @@ import lombok.ToString;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class TieredStorageCustom extends TieredStorage {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -24,7 +24,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"numStreams", "offsetCommitInterval", "bootstrapServers", "groupId", "logging"})
+@JsonPropertyOrder({"numStreams", "offsetCommitInterval", "bootstrapServers", "groupId", "logging",
+    "authentication", "tls", "config", "livenessProbe", "readinessProbe"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -21,7 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "bootstrapServers", "abortOnSendFailure", "logging"})
+@JsonPropertyOrder({ "bootstrapServers", "abortOnSendFailure", "logging", "authentication", "config", "tls"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "version", "replicas", "image", "consumer", "producer", "resources", "whitelist", "include", "jvmOptions",
-    "logging", "metricsConfig", "tracing", "template"})
+    "logging", "metricsConfig", "tracing", "template", "livenessProbe", "readinessProbe"})
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("include")), @OneOf.Alternative(@OneOf.Alternative.Property("whitelist"))})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
@@ -21,7 +21,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"conditions", "observedGeneration"})
+@JsonPropertyOrder({"conditions", "observedGeneration", "labelSelector", "replicas"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerStatus extends Status {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
@@ -17,7 +17,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"tasksMax", "config"})
+@JsonPropertyOrder({"tasksMax", "pause", "config", "state", "autoRestart"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
@@ -24,7 +24,7 @@ import java.util.List;
 @JsonPropertyOrder({"version", "replicas", "image", "connectCluster",
     "clusters", "mirrors", "resources", "livenessProbe", "readinessProbe",
     "jvmOptions", "jmxOptions", "affinity", "tolerations", "logging",
-    "clientRackInitImage", "rack", "metrics", "tracing",
+    "clientRackInitImage", "rack", "metricsConfig", "tracing",
     "template", "externalConfiguration" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
@@ -26,7 +26,8 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "conditions", "observedGeneration", "url" })
+@JsonPropertyOrder({ "conditions", "observedGeneration", "url", "connectors", "autoRestartStatuses",
+    "connectorPlugins", "labelSelector", "replicas" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2Status extends KafkaConnectStatus {

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
@@ -22,7 +22,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"partitions", "replicas", "config"})
+@JsonPropertyOrder({"topicName", "partitions", "replicas", "config"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaTopicSpec extends Spec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
@@ -24,7 +24,7 @@ import static java.util.Collections.emptyMap;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "targetReplicas", "state", "userTaskId", "message" })
+@JsonPropertyOrder({ "targetReplicas", "state", "userTaskId", "message", "sessionId" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class ReplicasChangeStatus implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
@@ -31,7 +31,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"producerByteRate", "consumerByteRate", "requestPercentage", "controllerMutationRate"})
 @EqualsAndHashCode
 @ToString
 public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
@@ -6,6 +6,7 @@
 package io.strimzi.api.kafka.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -30,6 +31,7 @@ import static java.util.Collections.emptyMap;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.Password;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -17,6 +18,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
@@ -18,7 +18,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "password"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -18,7 +18,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "authentication", "authorization", "quotas" })
+@JsonPropertyOrder({ "authentication", "authorization", "quotas", "template" })
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
@@ -17,7 +17,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -16,6 +17,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
@@ -5,6 +5,7 @@
 package io.strimzi.api.kafka.model.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -16,6 +17,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsExternalClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
@@ -17,7 +17,7 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsExternalClientAuthentication extends KafkaUserAuthentication {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.user.acl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
@@ -30,6 +31,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({})
 @EqualsAndHashCode
 @ToString
 public class AclRule implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -31,7 +31,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({})
+@JsonPropertyOrder({"type", "resource", "host", "operation", "operations"})
 @EqualsAndHashCode
 @ToString
 public class AclRule implements UnknownPropertyPreserving, Serializable {

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
@@ -34,7 +34,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "statefulset", "pod", "clientService", "nodesService", "persistentVolumeClaim",
+    "statefulset", "podSet", "pod", "clientService", "nodesService", "persistentVolumeClaim",
     "podDisruptionBudget", "zookeeperContainer", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 @ToString

--- a/api/src/test/resources/io/strimzi/api/kafka/model/kafka/Kafka.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/kafka/Kafka.out.yaml
@@ -53,10 +53,10 @@ spec:
       initialDelaySeconds: 10
       timeoutSeconds: 4
     jvmOptions:
-      "-Xmx": "4G"
-      "-Xms": "2G"
       "-XX":
         foo: "bar"
+      "-Xmx": "4G"
+      "-Xms": "2G"
     resources:
       limits:
         memory: "5Gi"

--- a/api/src/test/resources/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.out.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   replicas: 3
   storage:
+    type: "jbod"
     volumes:
-    - type: "persistent-claim"
+    - id: 0
+      type: "persistent-claim"
       size: "100Gi"
       deleteClaim: true
-      id: 0
-    type: "jbod"
   roles:
   - "broker"
   - "controller"

--- a/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
+++ b/config-model-generator/src/main/java/io/strimzi/build/kafka/metadata/KafkaConfigModelGenerator.java
@@ -43,6 +43,14 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("unchecked")
 public class KafkaConfigModelGenerator {
+
+    /**
+     * Default private constructor
+     */
+    private KafkaConfigModelGenerator() {
+        // Not to be used
+    }
+
     /**
      * The main method to run the config model generator
      *

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -6,6 +6,7 @@ package io.strimzi.crdgenerator;
 
 import io.strimzi.api.annotations.ApiVersion;
 import io.strimzi.api.annotations.KubeVersion;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -21,79 +22,114 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CrdGeneratorTest {
+class CrdGeneratorTest {
+
+    private final CrdGenerator.Reporter crdGeneratorReporter = new CrdGenerator.Reporter() {
+        @Override
+        public void warn(String s) {
+        }
+
+        @Override
+        public void err(String err) {
+            if (err.contains("@JsonInclude") || err.contains("@JsonPropertyOrder")) {
+                // Currently we're only interested in testing @JsonInclude and @JsonPropertyOrder errors
+                // As we would otherwise need to add dependencies to test HashCode, Equals, ToString, Builder etc.
+                errors.add(err);
+            }
+        }
+    };
+    private final Set<String> errors = new HashSet<>();
+
+    @BeforeEach
+    public void beforeEachTest() {
+        errors.clear();
+    }
+
     @Test
-    public void simpleTest() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1);
+    void simpleTest() throws IOException {
         StringWriter w = new StringWriter();
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
+
+        assertTrue(errors.isEmpty(), "CrdGenerator should not report any errors: " + errors);
         assertEquals(CrdTestUtils.readResource("simpleTest.yaml"), s);
     }
 
     @Test
-    public void simpleTestWithoutDescriptions() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER, emptyMap(),
-                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), ApiVersion.parseRange("v1+"));
+    void simpleTestWithoutDescriptions() throws IOException {
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), ApiVersion.parseRange("v1+"));
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
+
+        assertTrue(errors.isEmpty(), "CrdGenerator should not report any errors: " + errors);
         assertEquals(CrdTestUtils.readResource("simpleTestWithoutDescriptions.yaml"), s);
     }
 
     @Test
-    public void simpleTestWithSubresources() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1);
+    void simpleTestWithSubResources() throws IOException {
         StringWriter w = new StringWriter();
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
         crdGenerator.generate(ExampleWithSubresourcesCrd.class, w);
         String s = w.toString();
+
+        assertTrue(errors.isEmpty(), "CrdGenerator should not report any errors: " + errors);
         assertEquals(CrdTestUtils.readResource("simpleTestWithSubresources.yaml"), s);
     }
 
     @Test
-    public void generateHelmMetadataLabels() throws IOException {
+    void generateHelmMetadataLabels() throws IOException {
         Map<String, String> labels = new LinkedHashMap<>();
         labels.put("app", "{{ template \"strimzi.name\" . }}");
         labels.put("chart", "{{ template \"strimzi.chart\" . }}");
         labels.put("component", "%plural%.%group%-crd");
         labels.put("release", "{{ .Release.Name }}");
         labels.put("heritage", "{{ .Release.Service }}");
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1,
-                CrdGenerator.YAML_MAPPER, labels,
-                new CrdGenerator.DefaultReporter(), emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), null);
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                labels, crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
+
         StringWriter w = new StringWriter();
         crdGenerator.generate(ExampleCrd.class, w);
         String s = w.toString();
+
+        assertTrue(errors.isEmpty(), "CrdGenerator should not report any errors: " + errors);
         assertEquals(CrdTestUtils.readResource("simpleTestHelmMetadata.yaml"), s);
     }
 
     @Test
-    public void versionedTest() throws IOException {
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1);
+    void versionedTest() throws IOException {
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
+
         StringWriter w = new StringWriter();
         crdGenerator.generate(VersionedExampleCrd.class, w);
         String s = w.toString();
+
+        assertTrue(errors.isEmpty(), "CrdGenerator should not report any errors: " + errors);
         assertEquals(CrdTestUtils.readResource("versionedTest.yaml"), s);
     }
 
     @Test
-    public void simpleTestWithoutType() throws IOException {
-        Set<String> errors = new HashSet<>();
-        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1,
-                CrdGenerator.YAML_MAPPER, emptyMap(), new CrdGenerator.Reporter() {
-                    @Override
-                    public void warn(String s) {
-                    }
-
-                    @Override
-                    public void err(String s) {
-                        errors.add(s);
-                    }
-                },
-                emptyList(), null, null, new CrdGenerator.NoneConversionStrategy(), null);
+    void simpleTestWithErrors() throws IOException {
+        CrdGenerator crdGenerator = new CrdGenerator(KubeVersion.V1_16_PLUS, ApiVersion.V1, CrdGenerator.YAML_MAPPER,
+                emptyMap(), crdGeneratorReporter, emptyList(), null, null,
+                new CrdGenerator.NoneConversionStrategy(), null);
         StringWriter w = new StringWriter();
-        crdGenerator.generate(ExampleCrd.class, w);
-        assertTrue(errors.contains("io.strimzi.crdgenerator.ExampleCrd.PolymorphicLeft#getDiscrim is not annotated with @JsonInclude(JsonInclude.Include.NON_NULL)"), errors.toString());
-        assertFalse(errors.contains("io.strimzi.crdgenerator.ExampleCrd.PolymorphicRight#getDiscrim is not annotated with @JsonInclude(JsonInclude.Include.NON_NULL)"), errors.toString());
+        crdGenerator.generate(ExampleCrdWithErrors.class, w);
+
+        assertTrue(errors.contains("class io.strimzi.crdgenerator.ExampleCrdWithErrors is missing @JsonInclude"), errors.toString());
+        assertFalse(errors.contains("class io.strimzi.crdgenerator.ExampleCrdWithErrors$ObjectProperty is missing @JsonInclude"), errors.toString());
+        assertTrue(errors.contains("class io.strimzi.crdgenerator.ExampleCrdWithErrors is missing @JsonPropertyOrder"), errors.toString());
+        assertFalse(errors.contains("class io.strimzi.crdgenerator.ExampleCrdWithErrors$ObjectProperty is missing @JsonPropertyOrder"), errors.toString());
+        assertTrue(errors.contains("class io.strimzi.crdgenerator.ExampleCrdWithErrors$ObjectProperty has a property bar which is not in the @JsonPropertyOrder"), errors.toString());
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -7,6 +7,7 @@ package io.strimzi.crdgenerator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.fabric8.kubernetes.api.model.Affinity;
@@ -55,6 +56,13 @@ import java.util.Map;
 )
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or")), @OneOf.Alternative({@OneOf.Alternative.Property("mapStringString"), @OneOf.Alternative.Property("mapStringObject")})})
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"ignored", "stringProperty", "intProperty", "longProperty", "booleanProperty", "normalEnum", "customisedEnum",
+        "objectProperty", "mapStringObject", "mapStringString", "polymorphicProperty", "affinity", "fieldProperty",
+        "arrayProperty", "arrayProperty2", "listOfInts", "listOfInts2", "listOfObjects", "listOfPolymorphic",
+        "rawList", "listOfRawList", "arrayOfList", "arrayOfRawList", "listOfArray", "arrayOfTypeVar", "listOfTypeVar",
+        "arrayOfBoundTypeVar", "listOfBoundTypeVar", "arrayOfBoundTypeVar2", "listOfBoundTypeVar2",
+        "listOfWildcardTypeVar1", "listOfWildcardTypeVar2", "listOfWildcardTypeVar3", "listOfWildcardTypeVar4",
+        "listOfCustomizedEnum", "listOfNormalEnum", "listOfMaps", "either", "or", "status", "spec"})
 public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource {
 
     private String ignored;
@@ -132,6 +140,8 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     public String or;
 
     @Description("Example of complex type.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"foo", "bar"})
     public static class ObjectProperty {
         private String foo;
         private String bar;
@@ -165,6 +175,7 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         @JsonSubTypes.Type(value = PolymorphicLeft.class, name = "left"),
         @JsonSubTypes.Type(value = PolymorphicRight.class, name = "right")
     })
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract static class PolymorphicTop {
         private String discrim;
         private String commonProperty;
@@ -186,6 +197,8 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"discrim", "commonProperty", "leftProperty"})
     public static class PolymorphicLeft extends PolymorphicTop {
         private String leftProperty;
 
@@ -199,11 +212,14 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         }
 
         @Override
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         public String getDiscrim() {
             return "left";
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"discrim", "commonProperty", "rightProperty"})
     public static class PolymorphicRight extends PolymorphicTop {
         private String rightProperty;
 

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -57,12 +57,12 @@ import java.util.Map;
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or")), @OneOf.Alternative({@OneOf.Alternative.Property("mapStringString"), @OneOf.Alternative.Property("mapStringObject")})})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"ignored", "stringProperty", "intProperty", "longProperty", "booleanProperty", "normalEnum", "customisedEnum",
-        "objectProperty", "mapStringObject", "mapStringString", "polymorphicProperty", "affinity", "fieldProperty",
-        "arrayProperty", "arrayProperty2", "listOfInts", "listOfInts2", "listOfObjects", "listOfPolymorphic",
-        "rawList", "listOfRawList", "arrayOfList", "arrayOfRawList", "listOfArray", "arrayOfTypeVar", "listOfTypeVar",
-        "arrayOfBoundTypeVar", "listOfBoundTypeVar", "arrayOfBoundTypeVar2", "listOfBoundTypeVar2",
-        "listOfWildcardTypeVar1", "listOfWildcardTypeVar2", "listOfWildcardTypeVar3", "listOfWildcardTypeVar4",
-        "listOfCustomizedEnum", "listOfNormalEnum", "listOfMaps", "either", "or", "status", "spec"})
+    "objectProperty", "mapStringObject", "mapStringString", "polymorphicProperty", "affinity", "fieldProperty",
+    "arrayProperty", "arrayProperty2", "listOfInts", "listOfInts2", "listOfObjects", "listOfPolymorphic",
+    "rawList", "listOfRawList", "arrayOfList", "arrayOfRawList", "listOfArray", "arrayOfTypeVar", "listOfTypeVar",
+    "arrayOfBoundTypeVar", "listOfBoundTypeVar", "arrayOfBoundTypeVar2", "listOfBoundTypeVar2",
+    "listOfWildcardTypeVar1", "listOfWildcardTypeVar2", "listOfWildcardTypeVar3", "listOfWildcardTypeVar4",
+    "listOfCustomizedEnum", "listOfNormalEnum", "listOfMaps", "either", "or", "status", "spec"})
 public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource {
 
     private String ignored;

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrdWithErrors.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrdWithErrors.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.crdgenerator.annotations.Crd;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.MinimumItems;
+import io.strimzi.crdgenerator.annotations.OneOf;
+
+import java.util.List;
+import java.util.Map;
+
+@Crd(
+    spec = @Crd.Spec(
+        group = "crdgenerator.strimzi.io",
+        names = @Crd.Spec.Names(
+            kind = "Example",
+            plural = "examples",
+            categories = {"strimzi"}),
+        scope = "Namespaced",
+        versions = {
+            @Crd.Spec.Version(name = "v1alpha1", served = true, storage = true),
+            @Crd.Spec.Version(name = "v1beta1", served = true, storage = false)
+        },
+        additionalPrinterColumns = {
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "Foo",
+                description = "The foo",
+                jsonPath = "...",
+                type = "integer"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                name = "configYaml",
+                description = "nest: This is a nested yaml\n" +
+                        "lines:\n" +
+                        "  - 2nd\n" +
+                        "  - 3rd",
+                jsonPath = "...",
+                type = "string")
+        }
+    )
+)
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("either")), @OneOf.Alternative(@OneOf.Alternative.Property("or")), @OneOf.Alternative({@OneOf.Alternative.Property("mapStringString"), @OneOf.Alternative.Property("mapStringObject")})})
+public class ExampleCrdWithErrors<T, U extends Number, V extends U> extends CustomResource {
+
+    private String ignored;
+
+    private String string;
+
+    private int intProperty;
+
+    private long longProperty;
+
+    private boolean booleanProperty;
+
+    public NormalEnum normalEnum;
+
+    public CustomisedEnum customisedEnum;
+
+    private ObjectProperty objectProperty;
+
+    private Affinity affinity;
+
+    @Description("Example of field property.")
+    public String fieldProperty;
+
+    @MinimumItems(1)
+    public String[] arrayProperty;
+
+    public String[][] arrayProperty2;
+
+    public List<Integer> listOfInts;
+
+    public List<List<Integer>> listOfInts2;
+
+    public List<ObjectProperty> listOfObjects;
+
+    public List rawList;
+
+    public List<List> listOfRawList;
+
+    public List<String>[] arrayOfList;
+
+    public List[] arrayOfRawList;
+
+    public List<String[]> listOfArray;
+
+    public T[] arrayOfTypeVar;
+
+    public List<T> listOfTypeVar;
+
+    public U[] arrayOfBoundTypeVar;
+
+    public List<U> listOfBoundTypeVar;
+
+    public V[] arrayOfBoundTypeVar2;
+
+    public List<V> listOfBoundTypeVar2;
+
+    public List<? extends String> listOfWildcardTypeVar1;
+
+    public List<? extends V> listOfWildcardTypeVar2;
+
+    public List<? extends U> listOfWildcardTypeVar3;
+
+    public List<? extends List<? extends U>> listOfWildcardTypeVar4;
+
+    public List<CustomisedEnum> listOfCustomizedEnum;
+
+    public List<NormalEnum> listOfNormalEnum;
+
+    public List<Map<String, Object>> listOfMaps;
+
+    public String either;
+
+    public String or;
+
+    @Description("Example of complex type.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"foo"})
+    public static class ObjectProperty {
+        private String foo;
+        private String bar;
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        public String getBar() {
+            return bar;
+        }
+
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
+    }
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleWithSubresourcesCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleWithSubresourcesCrd.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.crdgenerator;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.crdgenerator.annotations.Crd;
 
@@ -35,6 +37,8 @@ import io.strimzi.crdgenerator.annotations.Crd;
                 type = "integer")
         }
     ))
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"replicas", "spec", "status"})
 public class ExampleWithSubresourcesCrd<T, U extends Number, V extends U> extends CustomResource {
     private String replicas;
 

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/VersionedExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/VersionedExampleCrd.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.crdgenerator;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -61,13 +62,15 @@ import java.util.Objects;
         }
     ))
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status"})
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec", "status",
+    "someInt", "someOtherInt", "listWithMinimum", "removed", "added"})
 public class VersionedExampleCrd<T, U extends Number, V extends U> extends CustomResource {
 
     @Description(apiVersions = "v1", value = "V1 description")
     @Description(apiVersions = "v2", value = "V2 description")
     @Pattern(apiVersions = "v1", value = "v1Pattern")
     @Pattern(apiVersions = "v2", value = "v2Pattern")
+    @JsonIgnore
     public String ignored;
 
     @Minimum(apiVersions = "v1", value = 0)

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -5,56 +5,47 @@
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|stringProperty
+|string
+|
+|intProperty
+|integer
+|Added in Strimzi 0.0.1. An example int property.
+|longProperty
+|integer
+|An example long property.
+|booleanProperty
+|boolean
+|
+|normalEnum
+|string (one of [BAR, FOO])
+|
+|customisedEnum
+|string (one of [one, two])
+|
+|objectProperty
+|xref:type-ObjectProperty-{context}[`ObjectProperty`]
+|
+|mapStringObject
+|map
+|
+|mapStringString
+|map
+|
+|polymorphicProperty
+|xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`], xref:type-PolymorphicRight-{context}[`PolymorphicRight`]
+|
 |affinity
 |{KubeApiReferenceBase}#affinity-v1-core[Affinity]
 |
-|arrayOfBoundTypeVar
-|xref:type-Number-{context}[`Number`] array
-|
-|arrayOfBoundTypeVar2
-|xref:type-Number-{context}[`Number`] array
-|
-|arrayOfList
-|string array of dimension 2
-|
-|arrayOfRawList
-|object array of dimension 2
-|
-|arrayOfTypeVar
-|object array
-|
+|fieldProperty
+|string
+|Example of field property.
 |arrayProperty
 |string array
 |
 |arrayProperty2
 |string array of dimension 2
-|
-|booleanProperty
-|boolean
-|
-|customisedEnum
-|string (one of [one, two])
-|
-|either
-|string
-|
-|fieldProperty
-|string
-|Example of field property.
-|intProperty
-|integer
-|Added in Strimzi 0.0.1. An example int property.
-|listOfArray
-|string array of dimension 2
-|
-|listOfBoundTypeVar
-|xref:type-Number-{context}[`Number`] array
-|
-|listOfBoundTypeVar2
-|xref:type-Number-{context}[`Number`] array
-|
-|listOfCustomizedEnum
-|string (one or more of [one, two]) array
 |
 |listOfInts
 |integer array
@@ -62,23 +53,44 @@
 |listOfInts2
 |integer array of dimension 2
 |
-|listOfMaps
-|map array
-|
-|listOfNormalEnum
-|string (one or more of [BAR, FOO]) array
-|
 |listOfObjects
 |xref:type-ObjectProperty-{context}[`ObjectProperty`] array
 |
 |listOfPolymorphic
 |xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`], xref:type-PolymorphicRight-{context}[`PolymorphicRight`] array
 |
+|rawList
+|object array
+|
 |listOfRawList
 |object array of dimension 2
 |
+|arrayOfList
+|string array of dimension 2
+|
+|arrayOfRawList
+|object array of dimension 2
+|
+|listOfArray
+|string array of dimension 2
+|
+|arrayOfTypeVar
+|object array
+|
 |listOfTypeVar
 |object array
+|
+|arrayOfBoundTypeVar
+|xref:type-Number-{context}[`Number`] array
+|
+|listOfBoundTypeVar
+|xref:type-Number-{context}[`Number`] array
+|
+|arrayOfBoundTypeVar2
+|xref:type-Number-{context}[`Number`] array
+|
+|listOfBoundTypeVar2
+|xref:type-Number-{context}[`Number`] array
 |
 |listOfWildcardTypeVar1
 |string array
@@ -92,50 +104,27 @@
 |listOfWildcardTypeVar4
 |xref:type-Number-{context}[`Number`] array of dimension 2
 |
-|longProperty
-|integer
-|An example long property.
-|mapStringObject
-|map
+|listOfCustomizedEnum
+|string (one or more of [one, two]) array
 |
-|mapStringString
-|map
+|listOfNormalEnum
+|string (one or more of [BAR, FOO]) array
 |
-|normalEnum
-|string (one of [BAR, FOO])
+|listOfMaps
+|map array
 |
-|objectProperty
-|xref:type-ObjectProperty-{context}[`ObjectProperty`]
+|either
+|string
 |
 |or
 |string
 |
-|polymorphicProperty
-|xref:type-PolymorphicLeft-{context}[`PolymorphicLeft`], xref:type-PolymorphicRight-{context}[`PolymorphicRight`]
-|
-|rawList
-|object array
+|status
+|object
 |
 |spec
 |object
 |
-|status
-|object
-|
-|stringProperty
-|string
-|
-|====
-
-[id='type-Number-{context}']
-= `Number` schema reference
-
-Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
-
-
-[cols="2,2,3a",options="header"]
-|====
-|Property |Property type |Description
 |====
 
 [id='type-ObjectProperty-{context}']
@@ -148,10 +137,10 @@ Example of complex type.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|bar
+|foo
 |string
 |
-|foo
+|bar
 |string
 |
 |====
@@ -167,10 +156,10 @@ It must have the value `left` for the type `PolymorphicLeft`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|commonProperty
+|discrim
 |string
 |
-|discrim
+|commonProperty
 |string
 |
 |leftProperty
@@ -189,14 +178,25 @@ It must have the value `right` for the type `PolymorphicRight`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|commonProperty
+|discrim
 |string
 |
-|discrim
+|commonProperty
 |string
 |
 |rightProperty
 |string
 |when descrim=right, the right-hand property.
+|====
+
+[id='type-Number-{context}']
+= `Number` schema reference
+
+Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
 |====
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -43,6 +43,63 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example int property.
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example long property.
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+                description: "when descrim=left, the left-hand property."
+              rightProperty:
+                type: string
+                description: "when descrim=right, the right-hand property."
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -371,34 +428,9 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
+            description: Example of field property.
           arrayProperty:
             type: array
             minItems: 1
@@ -410,46 +442,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-            description: Example of field property.
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example int property.
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -460,26 +452,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -501,6 +481,11 @@ spec:
                   description: "when descrim=right, the right-hand property."
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -508,7 +493,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -534,64 +563,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example long property.
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-                description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}
@@ -637,6 +637,63 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example int property.
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example long property.
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+                description: "when descrim=left, the left-hand property."
+              rightProperty:
+                type: string
+                description: "when descrim=right, the right-hand property."
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -965,34 +1022,9 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
+            description: Example of field property.
           arrayProperty:
             type: array
             minItems: 1
@@ -1004,46 +1036,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-            description: Example of field property.
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example int property.
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -1054,26 +1046,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -1095,6 +1075,11 @@ spec:
                   description: "when descrim=right, the right-hand property."
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -1102,7 +1087,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -1128,64 +1157,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example long property.
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-                description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -49,6 +49,63 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example int property.
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example long property.
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+                description: "when descrim=left, the left-hand property."
+              rightProperty:
+                type: string
+                description: "when descrim=right, the right-hand property."
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -377,34 +434,9 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
+            description: Example of field property.
           arrayProperty:
             type: array
             minItems: 1
@@ -416,46 +448,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-            description: Example of field property.
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example int property.
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -466,26 +458,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -507,6 +487,11 @@ spec:
                   description: "when descrim=right, the right-hand property."
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -514,7 +499,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -540,64 +569,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example long property.
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-                description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}
@@ -643,6 +643,63 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example int property.
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+            description: An example long property.
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+                description: "when descrim=left, the left-hand property."
+              rightProperty:
+                type: string
+                description: "when descrim=right, the right-hand property."
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -971,34 +1028,9 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
+            description: Example of field property.
           arrayProperty:
             type: array
             minItems: 1
@@ -1010,46 +1042,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-            description: Example of field property.
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example int property.
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -1060,26 +1052,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -1101,6 +1081,11 @@ spec:
                   description: "when descrim=right, the right-hand property."
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -1108,7 +1093,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -1134,64 +1163,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-            description: An example long property.
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-                description: "when descrim=left, the left-hand property."
-              rightProperty:
-                type: string
-                description: "when descrim=right, the right-hand property."
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -43,6 +43,59 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+              rightProperty:
+                type: string
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -371,34 +424,8 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
           arrayProperty:
             type: array
             minItems: 1
@@ -410,44 +437,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -458,26 +447,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -497,6 +474,11 @@ spec:
                   type: string
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -504,7 +486,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -530,61 +556,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-              rightProperty:
-                type: string
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}
@@ -630,6 +630,59 @@ spec:
             description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
           metadata:
             type: object
+          stringProperty:
+            type: string
+            pattern: .*
+          intProperty:
+            type: integer
+            example: 42
+            minimum: 42
+          longProperty:
+            type: integer
+            example: 42
+            minimum: 42
+          booleanProperty:
+            type: boolean
+          normalEnum:
+            type: string
+            enum:
+            - FOO
+            - BAR
+          customisedEnum:
+            type: string
+            enum:
+            - one
+            - two
+          objectProperty:
+            type: object
+            properties:
+              foo:
+                type: string
+              bar:
+                type: string
+          mapStringObject:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          mapStringString:
+            additionalProperties:
+              type: string
+            type: object
+          polymorphicProperty:
+            type: object
+            properties:
+              commonProperty:
+                type: string
+              discrim:
+                type: string
+                enum:
+                - left
+                - right
+              leftProperty:
+                type: string
+              rightProperty:
+                type: string
+            required:
+            - discrim
           affinity:
             type: object
             properties:
@@ -958,34 +1011,8 @@ spec:
                             type: string
                         topologyKey:
                           type: string
-          arrayOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          arrayOfList:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          arrayOfRawList:
-            type: array
-            items:
-              type: array
-              items:
-                type: object
-                properties: {}
-          arrayOfTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
+          fieldProperty:
+            type: string
           arrayProperty:
             type: array
             minItems: 1
@@ -997,44 +1024,6 @@ spec:
               type: array
               items:
                 type: string
-          booleanProperty:
-            type: boolean
-          customisedEnum:
-            type: string
-            enum:
-            - one
-            - two
-          either:
-            type: string
-          fieldProperty:
-            type: string
-          intProperty:
-            type: integer
-            example: 42
-            minimum: 42
-          listOfArray:
-            type: array
-            items:
-              type: array
-              items:
-                type: string
-          listOfBoundTypeVar:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfBoundTypeVar2:
-            type: array
-            items:
-              type: object
-              properties: {}
-          listOfCustomizedEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - one
-              - two
           listOfInts:
             type: array
             items:
@@ -1045,26 +1034,14 @@ spec:
               type: array
               items:
                 type: integer
-          listOfMaps:
-            type: array
-            items:
-              x-kubernetes-preserve-unknown-fields: true
-              type: object
-          listOfNormalEnum:
-            type: array
-            items:
-              type: string
-              enum:
-              - FOO
-              - BAR
           listOfObjects:
             type: array
             items:
               type: object
               properties:
-                bar:
-                  type: string
                 foo:
+                  type: string
+                bar:
                   type: string
           listOfPolymorphic:
             type: array
@@ -1084,6 +1061,11 @@ spec:
                   type: string
               required:
               - discrim
+          rawList:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfRawList:
             type: array
             items:
@@ -1091,7 +1073,51 @@ spec:
               items:
                 type: object
                 properties: {}
+          arrayOfList:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfRawList:
+            type: array
+            items:
+              type: array
+              items:
+                type: object
+                properties: {}
+          listOfArray:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
+          arrayOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
           listOfTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar:
+            type: array
+            items:
+              type: object
+              properties: {}
+          arrayOfBoundTypeVar2:
+            type: array
+            items:
+              type: object
+              properties: {}
+          listOfBoundTypeVar2:
             type: array
             items:
               type: object
@@ -1117,61 +1143,35 @@ spec:
               items:
                 type: object
                 properties: {}
-          longProperty:
-            type: integer
-            example: 42
-            minimum: 42
-          mapStringObject:
-            x-kubernetes-preserve-unknown-fields: true
-            type: object
-          mapStringString:
-            additionalProperties:
-              type: string
-            type: object
-          normalEnum:
-            type: string
-            enum:
-            - FOO
-            - BAR
-          objectProperty:
-            type: object
-            properties:
-              bar:
-                type: string
-              foo:
-                type: string
-          or:
-            type: string
-          polymorphicProperty:
-            type: object
-            properties:
-              commonProperty:
-                type: string
-              discrim:
-                type: string
-                enum:
-                - left
-                - right
-              leftProperty:
-                type: string
-              rightProperty:
-                type: string
-            required:
-            - discrim
-          rawList:
+          listOfCustomizedEnum:
             type: array
             items:
+              type: string
+              enum:
+              - one
+              - two
+          listOfNormalEnum:
+            type: array
+            items:
+              type: string
+              enum:
+              - FOO
+              - BAR
+          listOfMaps:
+            type: array
+            items:
+              x-kubernetes-preserve-unknown-fields: true
               type: object
-              properties: {}
-          spec:
-            type: object
-            properties: {}
+          either:
+            type: string
+          or:
+            type: string
           status:
             type: object
             properties: {}
-          stringProperty:
-            type: string
-            pattern: .*
+          spec:
+            type: object
+            properties: {}
         oneOf:
         - properties:
             either: {}

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/versionedTest.yaml
@@ -47,16 +47,6 @@ spec:
           status:
             type: object
             properties: {}
-          ignored:
-            type: string
-            pattern: v1Pattern
-            description: V1 description.
-          listWithMinimum:
-            type: array
-            items:
-              type: string
-          removed:
-            type: string
           someInt:
             type: integer
             minimum: 0
@@ -64,6 +54,12 @@ spec:
           someOtherInt:
             type: integer
             maximum: 10
+          listWithMinimum:
+            type: array
+            items:
+              type: string
+          removed:
+            type: string
   - name: v2
     served: true
     storage: false
@@ -96,17 +92,6 @@ spec:
           status:
             type: object
             properties: {}
-          added:
-            type: string
-          ignored:
-            type: string
-            pattern: v2Pattern
-            description: V2 description.
-          listWithMinimum:
-            type: array
-            minItems: 2
-            items:
-              type: string
           someInt:
             type: integer
             minimum: 4
@@ -115,3 +100,10 @@ spec:
             type: integer
             minimum: 4
             maximum: 10
+          listWithMinimum:
+            type: array
+            minItems: 2
+            items:
+              type: string
+          added:
+            type: string

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -219,54 +219,45 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|accessTokenIsJwt
-|boolean
-|Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-|checkAccessTokenType
-|boolean
-|Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
-|checkAudience
-|boolean
-|Enable or disable audience checking. Audience checks identify the recipients of tokens. If audience checking is enabled, the OAuth Client ID also has to be configured using the `clientId` property. The Kafka broker will reject tokens that do not have its `clientId` in their `aud` (audience) claim.Default value is `false`.
-|checkIssuer
-|boolean
-|Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
-|clientAudience
+|type
 |string
-|The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|Must be `oauth`.
 |clientId
 |string
 |OAuth Client ID which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
-|clientScope
-|string
-|The scope to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
 |clientSecret
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
 |Link to Kubernetes Secret containing the OAuth client secret which the Kafka broker can use to authenticate against the authorization server and use the introspect endpoint URI.
-|connectTimeoutSeconds
-|integer
-|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
-|customClaimCheck
+|validIssuerUri
 |string
-|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
-|disableTlsHostnameVerification
+|URI of the token issuer used for authentication.
+|checkIssuer
 |boolean
-|Enable or disable TLS hostname verification. Default value is `false`.
-|enableECDSA
+|Enable or disable issuer checking. By default issuer is checked using the value configured by `validIssuerUri`. Default value is `true`.
+|checkAudience
 |boolean
-|**The `enableECDSA` property has been deprecated.** Enable or disable ECDSA support by installing BouncyCastle crypto provider. ECDSA support is always enabled. The BouncyCastle libraries are no longer packaged with Strimzi. Value is ignored.
-|enableMetrics
+|Enable or disable audience checking. Audience checks identify the recipients of tokens. If audience checking is enabled, the OAuth Client ID also has to be configured using the `clientId` property. The Kafka broker will reject tokens that do not have its `clientId` in their `aud` (audience) claim.Default value is `false`.
+|jwksEndpointUri
+|string
+|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
+|jwksRefreshSeconds
+|integer
+|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
+|jwksMinRefreshPauseSeconds
+|integer
+|The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.
+|jwksExpirySeconds
+|integer
+|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
+|jwksIgnoreKeyUse
 |boolean
-|Enable or disable OAuth metrics. Default value is `false`.
-|enableOauthBearer
-|boolean
-|Enable or disable OAuth authentication over SASL_OAUTHBEARER. Default value is `true`.
-|enablePlain
-|boolean
-|Enable or disable OAuth authentication over SASL_PLAIN. There is no re-authentication support when this mechanism is used. Default value is `false`.
-|failFast
-|boolean
-|Enable or disable termination of Kafka broker processes due to potentially recoverable runtime errors during startup. Default value is `true`.
+|Flag to ignore the 'use' attribute of `key` declarations in a JWKS endpoint response. Default value is `false`.
+|introspectionEndpointUri
+|string
+|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
+|userNameClaim
+|string
+|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
 |fallbackUserNameClaim
 |string
 |The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
@@ -279,60 +270,69 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 |groupsClaimDelimiter
 |string
 |A delimiter used to parse groups when they are extracted as a single String value rather than a JSON array. Default value is ',' (comma).
+|userInfoEndpointUri
+|string
+|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
+|checkAccessTokenType
+|boolean
+|Configure whether the access token type check is performed or not. This should be set to `false` if the authorization server does not include 'typ' claim in JWT token. Defaults to `true`.
+|validTokenType
+|string
+|Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
+|accessTokenIsJwt
+|boolean
+|Configure whether the access token is treated as JWT. This must be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|tlsTrustedCertificates
+|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
+|Trusted certificates for TLS connection to the OAuth server.
+|disableTlsHostnameVerification
+|boolean
+|Enable or disable TLS hostname verification. Default value is `false`.
+|enableECDSA
+|boolean
+|**The `enableECDSA` property has been deprecated.** Enable or disable ECDSA support by installing BouncyCastle crypto provider. ECDSA support is always enabled. The BouncyCastle libraries are no longer packaged with Strimzi. Value is ignored.
+|maxSecondsWithoutReauthentication
+|integer
+|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
+|enablePlain
+|boolean
+|Enable or disable OAuth authentication over SASL_PLAIN. There is no re-authentication support when this mechanism is used. Default value is `false`.
+|tokenEndpointUri
+|string
+|URI of the Token Endpoint to use with SASL_PLAIN mechanism when the client authenticates with `clientId` and a `secret`. If set, the client can authenticate over SASL_PLAIN by either setting `username` to `clientId`, and setting `password` to client `secret`, or by setting `username` to account username, and `password` to access token prefixed with `$accessToken:`. If this option is not set, the `password` is always interpreted as an access token (without a prefix), and `username` as the account username (a so called 'no-client-credentials' mode).
+|enableOauthBearer
+|boolean
+|Enable or disable OAuth authentication over SASL_OAUTHBEARER. Default value is `true`.
+|customClaimCheck
+|string
+|JsonPath filter query to be applied to the JWT token or to the response of the introspection endpoint for additional token validation. Not set by default.
+|connectTimeoutSeconds
+|integer
+|The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
+|readTimeoutSeconds
+|integer
+|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
 |httpRetries
 |integer
 |The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.
 |httpRetryPauseMs
 |integer
 |The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.
+|clientScope
+|string
+|The scope to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|clientAudience
+|string
+|The audience to use when making requests to the authorization server's token endpoint. Used for inter-broker authentication and for configuring OAuth 2.0 over PLAIN using the `clientId` and `secret` method.
+|enableMetrics
+|boolean
+|Enable or disable OAuth metrics. Default value is `false`.
+|failFast
+|boolean
+|Enable or disable termination of Kafka broker processes due to potentially recoverable runtime errors during startup. Default value is `true`.
 |includeAcceptHeader
 |boolean
 |Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
-|introspectionEndpointUri
-|string
-|URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
-|jwksEndpointUri
-|string
-|URI of the JWKS certificate endpoint, which can be used for local JWT validation.
-|jwksExpirySeconds
-|integer
-|Configures how often are the JWKS certificates considered valid. The expiry interval has to be at least 60 seconds longer then the refresh interval specified in `jwksRefreshSeconds`. Defaults to 360 seconds.
-|jwksIgnoreKeyUse
-|boolean
-|Flag to ignore the 'use' attribute of `key` declarations in a JWKS endpoint response. Default value is `false`.
-|jwksMinRefreshPauseSeconds
-|integer
-|The minimum pause between two consecutive refreshes. When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Defaults to 1 second.
-|jwksRefreshSeconds
-|integer
-|Configures how often are the JWKS certificates refreshed. The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in `jwksExpirySeconds`. Defaults to 300 seconds.
-|maxSecondsWithoutReauthentication
-|integer
-|Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`).
-|readTimeoutSeconds
-|integer
-|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
-|tlsTrustedCertificates
-|xref:type-CertSecretSource-{context}[`CertSecretSource`] array
-|Trusted certificates for TLS connection to the OAuth server.
-|tokenEndpointUri
-|string
-|URI of the Token Endpoint to use with SASL_PLAIN mechanism when the client authenticates with `clientId` and a `secret`. If set, the client can authenticate over SASL_PLAIN by either setting `username` to `clientId`, and setting `password` to client `secret`, or by setting `username` to account username, and `password` to access token prefixed with `$accessToken:`. If this option is not set, the `password` is always interpreted as an access token (without a prefix), and `username` as the account username (a so called 'no-client-credentials' mode).
-|type
-|string
-|Must be `oauth`.
-|userInfoEndpointUri
-|string
-|URI of the User Info Endpoint to use as a fallback to obtaining the user id when the Introspection Endpoint does not return information that can be used for the user id. 
-|userNameClaim
-|string
-|Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`.
-|validIssuerUri
-|string
-|URI of the token issuer used for authentication.
-|validTokenType
-|string
-|Valid value for the `token_type` attribute returned by the Introspection Endpoint. No default value, and not checked by default.
 |====
 
 [id='type-GenericSecretSource-{context}']
@@ -361,12 +361,12 @@ Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizatio
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|certificate
-|string
-|The name of the file certificate in the Secret.
 |secretName
 |string
 |The name of the Secret containing the certificate.
+|certificate
+|string
+|The name of the file certificate in the Secret.
 |====
 
 [id='type-KafkaListenerAuthenticationCustom-{context}']
@@ -387,18 +387,18 @@ It must have the value `custom` for the type `KafkaListenerAuthenticationCustom`
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|listenerConfig
-|map
-|Configuration to be used for a specific listener. All values are prefixed with listener.name._<listener_name>_.
-|sasl
-|boolean
-|Enable or disable SASL on this listener.
-|secrets
-|xref:type-GenericSecretSource-{context}[`GenericSecretSource`] array
-|Secrets to be mounted to /opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_.
 |type
 |string
 |Must be `custom`.
+|sasl
+|boolean
+|Enable or disable SASL on this listener.
+|listenerConfig
+|map
+|Configuration to be used for a specific listener. All values are prefixed with listener.name._<listener_name>_.
+|secrets
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`] array
+|Secrets to be mounted to /opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_.
 |====
 
 [id='type-GenericKafkaListenerConfiguration-{context}']
@@ -420,6 +420,9 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 |brokerCertChainAndKey
 |xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
 |Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
+|class
+|string
+|Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources.
 |externalTrafficPolicy
 |string (one of [Local, Cluster])
 |Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.This field can be used only with `loadbalancer` or `nodeport` type listener.
@@ -441,18 +444,18 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 |createBootstrapService
 |boolean
 |Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
-|class
-|string
-|Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources.
 |finalizers
 |string array
 |A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners.
-|maxConnectionCreationRate
-|integer
-|The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
+|useServiceDnsDomain
+|boolean
+|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners.
 |maxConnections
 |integer
 |The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
+|maxConnectionCreationRate
+|integer
+|The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
 |preferredNodePortAddressType
 |string (one of [ExternalDNS, ExternalIP, Hostname, InternalIP, InternalDNS])
 |Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
@@ -464,9 +467,6 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 * `Hostname`
 
 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
-|useServiceDnsDomain
-|boolean
-|Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']
@@ -478,15 +478,15 @@ Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaList
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|certificate
-|string
-|The name of the file certificate in the Secret.
 |key
 |string
 |The name of the private key in the Secret.
 |secretName
 |string
 |The name of the Secret containing the certificate.
+|certificate
+|string
+|The name of the file certificate in the Secret.
 |====
 
 [id='type-GenericKafkaListenerConfigurationBootstrap-{context}']
@@ -600,24 +600,24 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|id
+|integer
+|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |type
 |string
 |Must be `persistent-claim`.
 |size
 |string
 |When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.
+|class
+|string
+|The storage class to use for dynamic volume allocation.
 |selector
 |map
 |Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
 |deleteClaim
 |boolean
 |Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
-|class
-|string
-|The storage class to use for dynamic volume allocation.
-|id
-|integer
-|Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
 |overrides
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
 |Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
@@ -767,6 +767,9 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |grantsRefreshPoolSize
 |integer
 |The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.
+|grantsMaxIdleTimeSeconds
+|integer
+|The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300.
 |grantsGcPeriodSeconds
 |integer
 |The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300.
@@ -791,9 +794,6 @@ It must have the value `keycloak` for the type `KafkaAuthorizationKeycloak`.
 |includeAcceptHeader
 |boolean
 |Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
-|grantsMaxIdleTimeSeconds
-|integer
-|The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300.
 |====
 
 [id='type-KafkaAuthorizationCustom-{context}']
@@ -858,21 +858,21 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|failureThreshold
-|integer
-|Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
 |initialDelaySeconds
 |integer
 |The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+|timeoutSeconds
+|integer
+|The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
 |periodSeconds
 |integer
 |How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
 |successThreshold
 |integer
 |Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-|timeoutSeconds
+|failureThreshold
 |integer
-|The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+|Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
 |====
 
 [id='type-JvmOptions-{context}']
@@ -887,12 +887,12 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-E
 |-XX
 |map
 |A map of -XX options to the JVM.
-|-Xms
-|string
-|-Xms option to to the JVM.
 |-Xmx
 |string
 |-Xmx option to to the JVM.
+|-Xms
+|string
+|-Xms option to to the JVM.
 |gcLoggingEnabled
 |boolean
 |Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -1169,6 +1169,9 @@ include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leve
 |tolerations
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[Toleration] array
 |The pod's tolerations.
+|topologySpreadConstraints
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
+|The pod's topology spread constraints.
 |priorityClassName
 |string
 |The name of the priority class used to assign priority to the pods. 
@@ -1178,15 +1181,12 @@ include::../api/io.strimzi.api.kafka.model.common.template.PodTemplate.adoc[leve
 |hostAliases
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostalias-v1-core[HostAlias] array
 |The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-|tmpDirSizeLimit
-|string
-|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
 |enableServiceLinks
 |boolean
 |Indicates whether information about services should be injected into Pod's environment variables.
-|topologySpreadConstraints
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[TopologySpreadConstraint] array
-|The pod's topology spread constraints.
+|tmpDirSizeLimit
+|string
+|Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
 |====
 
 [id='type-InternalServiceTemplate-{context}']
@@ -1306,12 +1306,12 @@ It must have the value `custom` for the type `TieredStorageCustom`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|remoteStorageManager
-|xref:type-RemoteStorageManager-{context}[`RemoteStorageManager`]
-|Configuration for the Remote Storage Manager.
 |type
 |string
 |Must be `custom`.
+|remoteStorageManager
+|xref:type-RemoteStorageManager-{context}[`RemoteStorageManager`]
+|Configuration for the Remote Storage Manager.
 |====
 
 [id='type-RemoteStorageManager-{context}']
@@ -1400,6 +1400,9 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |statefulset
 |xref:type-StatefulSetTemplate-{context}[`StatefulSetTemplate`]
 |**The `statefulset` property has been deprecated.** Support for StatefulSets was removed in Strimzi 0.35.0. This property is ignored. Template for ZooKeeper `StatefulSet`.
+|podSet
+|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
+|Template for ZooKeeper `StrimziPodSet` resource.
 |pod
 |xref:type-PodTemplate-{context}[`PodTemplate`]
 |Template for ZooKeeper `Pods`.
@@ -1424,9 +1427,6 @@ Used in: xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 |jmxSecret
 |xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
 |Template for Secret of the Zookeeper Cluster JMX authentication.
-|podSet
-|xref:type-ResourceTemplate-{context}[`ResourceTemplate`]
-|Template for ZooKeeper `StrimziPodSet` resource.
 |====
 
 [id='type-EntityOperatorSpec-{context}']
@@ -1570,18 +1570,18 @@ include::../api/io.strimzi.api.kafka.model.kafka.entityoperator.TlsSidecar.adoc[
 |image
 |string
 |The docker image for the container.
-|livenessProbe
-|xref:type-Probe-{context}[`Probe`]
-|Pod liveness checking.
-|logLevel
-|string (one of [emerg, debug, crit, err, alert, warning, notice, info])
-|The log level for the TLS sidecar. Default value is `notice`.
-|readinessProbe
-|xref:type-Probe-{context}[`Probe`]
-|Pod readiness checking.
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
 |CPU and memory resources to reserve.
+|livenessProbe
+|xref:type-Probe-{context}[`Probe`]
+|Pod liveness checking.
+|readinessProbe
+|xref:type-Probe-{context}[`Probe`]
+|Pod readiness checking.
+|logLevel
+|string (one of [emerg, debug, crit, err, alert, warning, notice, info])
+|The log level for the TLS sidecar. Default value is `notice`.
 |====
 
 [id='type-EntityOperatorTemplate-{context}']
@@ -1941,6 +1941,12 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |logging
 |string
 |Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`.
+|livenessProbe
+|xref:type-Probe-{context}[`Probe`]
+|Pod liveness check.
+|readinessProbe
+|xref:type-Probe-{context}[`Probe`]
+|Pod readiness check.
 |enableSaramaLogging
 |boolean
 |Enable Sarama logging, a Go client library used by the Kafka Exporter.
@@ -1950,12 +1956,6 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |template
 |xref:type-KafkaExporterTemplate-{context}[`KafkaExporterTemplate`]
 |Customization of deployment templates and pods.
-|livenessProbe
-|xref:type-Probe-{context}[`Probe`]
-|Pod liveness check.
-|readinessProbe
-|xref:type-Probe-{context}[`Probe`]
-|Pod readiness check.
 |====
 
 [id='type-KafkaExporterTemplate-{context}']
@@ -2181,6 +2181,9 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |rack
 |xref:type-Rack-{context}[`Rack`]
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
+|metricsConfig
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
+|Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |The configuration of tracing in Kafka Connect.
@@ -2193,9 +2196,6 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |build
 |xref:type-Build-{context}[`Build`]
 |Configures how the Connect container image should be built. Optional.
-|metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|Metrics configuration.
 |====
 
 [id='type-ClientTls-{context}']
@@ -2237,12 +2237,12 @@ It must have the value `tls` for the type `KafkaClientAuthenticationTls`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|certificateAndKey
-|xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
-|Reference to the `Secret` which holds the certificate and private key pair.
 |type
 |string
 |Must be `tls`.
+|certificateAndKey
+|xref:type-CertAndKeySecretSource-{context}[`CertAndKeySecretSource`]
+|Reference to the `Secret` which holds the certificate and private key pair.
 |====
 
 [id='type-KafkaClientAuthenticationScramSha256-{context}']
@@ -2261,15 +2261,15 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|passwordSecret
-|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
-|Reference to the `Secret` which holds the password.
 |type
 |string
 |Must be `scram-sha-256`.
 |username
 |string
 |Username used for the authentication.
+|passwordSecret
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|Reference to the `Secret` which holds the password.
 |====
 
 [id='type-PasswordSecretSource-{context}']
@@ -2281,12 +2281,12 @@ Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenti
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|password
-|string
-|The name of the key in the Secret under which the password is stored.
 |secretName
 |string
 |The name of the Secret containing the password.
+|password
+|string
+|The name of the key in the Secret under which the password is stored.
 |====
 
 [id='type-KafkaClientAuthenticationScramSha512-{context}']
@@ -2305,15 +2305,15 @@ include::../api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuth
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|passwordSecret
-|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
-|Reference to the `Secret` which holds the password.
 |type
 |string
 |Must be `scram-sha-512`.
 |username
 |string
 |Username used for the authentication.
+|passwordSecret
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|Reference to the `Secret` which holds the password.
 |====
 
 [id='type-KafkaClientAuthenticationPlain-{context}']
@@ -2334,15 +2334,15 @@ It must have the value `plain` for the type `KafkaClientAuthenticationPlain`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|passwordSecret
-|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
-|Reference to the `Secret` which holds the password.
 |type
 |string
 |Must be `plain`.
 |username
 |string
 |Username used for the authentication.
+|passwordSecret
+|xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
+|Reference to the `Secret` which holds the password.
 |====
 
 [id='type-KafkaClientAuthenticationOAuth-{context}']
@@ -2363,66 +2363,66 @@ It must have the value `oauth` for the type `KafkaClientAuthenticationOAuth`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|accessToken
-|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
-|accessTokenIsJwt
-|boolean
-|Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
-|audience
+|type
 |string
-|OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request.
+|Must be `oauth`.
 |clientId
 |string
 |OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
-|clientSecret
-|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
-|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
+|username
+|string
+|Username used for the authentication.
+|scope
+|string
+|OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
+|audience
+|string
+|OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request.
+|tokenEndpointUri
+|string
+|Authorization server token endpoint URI.
 |connectTimeoutSeconds
 |integer
 |The connect timeout in seconds when connecting to authorization server. If not set, the effective connect timeout is 60 seconds.
-|disableTlsHostnameVerification
-|boolean
-|Enable or disable TLS hostname verification. Default value is `false`.
-|enableMetrics
-|boolean
-|Enable or disable OAuth metrics. Default value is `false`.
+|readTimeoutSeconds
+|integer
+|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
 |httpRetries
 |integer
 |The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.
 |httpRetryPauseMs
 |integer
 |The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.
-|includeAcceptHeader
-|boolean
-|Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
-|maxTokenExpirySeconds
-|integer
-|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+|clientSecret
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the OAuth client secret which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
 |passwordSecret
 |xref:type-PasswordSecretSource-{context}[`PasswordSecretSource`]
 |Reference to the `Secret` which holds the password.
-|readTimeoutSeconds
-|integer
-|The read timeout in seconds when connecting to authorization server. If not set, the effective read timeout is 60 seconds.
+|accessToken
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Link to Kubernetes Secret containing the access token which was obtained from the authorization server.
 |refreshToken
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
 |Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
-|scope
-|string
-|OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
 |tlsTrustedCertificates
 |xref:type-CertSecretSource-{context}[`CertSecretSource`] array
 |Trusted certificates for TLS connection to the OAuth server.
-|tokenEndpointUri
-|string
-|Authorization server token endpoint URI.
-|type
-|string
-|Must be `oauth`.
-|username
-|string
-|Username used for the authentication.
+|disableTlsHostnameVerification
+|boolean
+|Enable or disable TLS hostname verification. Default value is `false`.
+|maxTokenExpirySeconds
+|integer
+|Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
+|accessTokenIsJwt
+|boolean
+|Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+|enableMetrics
+|boolean
+|Enable or disable OAuth metrics. Default value is `false`.
+|includeAcceptHeader
+|boolean
+|Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
 |====
 
 [id='type-JaegerTracing-{context}']
@@ -2582,12 +2582,12 @@ Used in: xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|configMapKeyRef
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[ConfigMapKeySelector]
-|Reference to a key in a ConfigMap.
 |secretKeyRef
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretkeyselector-v1-core[SecretKeySelector]
 |Reference to a key in a Secret.
+|configMapKeyRef
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapkeyselector-v1-core[ConfigMapKeySelector]
+|Reference to a key in a ConfigMap.
 |====
 
 [id='type-ExternalConfigurationVolumeSource-{context}']
@@ -2599,15 +2599,15 @@ Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|configMap
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
-|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
 |name
 |string
 |Name of the volume which will be added to the Kafka Connect pods.
 |secret
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretvolumesource-v1-core[SecretVolumeSource]
 |Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+|configMap
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapvolumesource-v1-core[ConfigMapVolumeSource]
+|Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
 |====
 
 [id='type-Build-{context}']
@@ -2629,12 +2629,12 @@ include::../api/io.strimzi.api.kafka.model.connect.build.Build.adoc[leveloffset=
 |output
 |xref:type-DockerOutput-{context}[`DockerOutput`], xref:type-ImageStreamOutput-{context}[`ImageStreamOutput`]
 |Configures where should the newly built image be stored. Required.
-|resources
-|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
-|CPU and memory resources to reserve for the build.
 |plugins
 |xref:type-Plugin-{context}[`Plugin`] array
 |List of connector plugins which should be added to the Kafka Connect. Required.
+|resources
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[ResourceRequirements]
+|CPU and memory resources to reserve for the build.
 |====
 
 [id='type-DockerOutput-{context}']
@@ -2673,12 +2673,12 @@ It must have the value `imagestream` for the type `ImageStreamOutput`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|image
-|string
-|The name and tag of the ImageStream where the newly built image will be pushed. For example `my-custom-connect:latest`. Required.
 |type
 |string
 |Must be `imagestream`.
+|image
+|string
+|The name and tag of the ImageStream where the newly built image will be pushed. For example `my-custom-connect:latest`. Required.
 |====
 
 [id='type-Plugin-{context}']
@@ -2707,6 +2707,9 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string
+|Must be `jar`.
 |url
 |string
 |URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
@@ -2716,9 +2719,6 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
-|type
-|string
-|Must be `jar`.
 |====
 
 [id='type-TgzArtifact-{context}']
@@ -2730,6 +2730,9 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string
+|Must be `tgz`.
 |url
 |string
 |URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
@@ -2739,9 +2742,6 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
-|type
-|string
-|Must be `tgz`.
 |====
 
 [id='type-ZipArtifact-{context}']
@@ -2753,6 +2753,9 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string
+|Must be `zip`.
 |url
 |string
 |URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
@@ -2762,9 +2765,6 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
-|type
-|string
-|Must be `zip`.
 |====
 
 [id='type-MavenArtifact-{context}']
@@ -2778,6 +2778,9 @@ It must have the value `maven` for the type `MavenArtifact`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string
+|Must be `maven`.
 |repository
 |string
 |Maven repository to download the artifact from. Applicable to the `maven` artifact type only.
@@ -2793,9 +2796,6 @@ It must have the value `maven` for the type `MavenArtifact`.
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifacts will be downloaded, even when the server is considered insecure.
-|type
-|string
-|Must be `maven`.
 |====
 
 [id='type-OtherArtifact-{context}']
@@ -2807,6 +2807,9 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string
+|Must be `other`.
 |url
 |string
 |URL of the artifact which will be downloaded. Strimzi does not do any security scanning of the downloaded artifacts. For security reasons, you should first verify the artifacts manually and configure the checksum verification to make sure the same artifact is used in the automated build. Required for `jar`, `zip`, `tgz` and `other` artifacts. Not applicable to the `maven` artifact type.
@@ -2819,9 +2822,6 @@ Used in: xref:type-Plugin-{context}[`Plugin`]
 |insecure
 |boolean
 |By default, connections using TLS are verified to check they are secure. The server certificate used must be valid, trusted, and contain the server name. By setting this option to `true`, all TLS verification is disabled and the artifact will be downloaded, even when the server is considered insecure.
-|type
-|string
-|Must be `other`.
 |====
 
 [id='type-KafkaConnectStatus-{context}']
@@ -2845,12 +2845,12 @@ Used in: xref:type-KafkaConnect-{context}[`KafkaConnect`]
 |connectorPlugins
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
 |The list of connector plugins available in this Kafka Connect deployment.
-|labelSelector
-|string
-|Label selector for pods providing this resource.
 |replicas
 |integer
 |The current number of pods being used to provide this resource.
+|labelSelector
+|string
+|Label selector for pods providing this resource.
 |====
 
 [id='type-ConnectorPlugin-{context}']
@@ -2862,15 +2862,15 @@ Used in: xref:type-KafkaConnectStatus-{context}[`KafkaConnectStatus`], xref:type
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|class
+|string
+|The class of the connector plugin.
 |type
 |string
 |The type of the connector plugin. The available types are `sink` and `source`.
 |version
 |string
 |The version of the connector plugin.
-|class
-|string
-|The class of the connector plugin.
 |====
 
 [id='type-KafkaTopic-{context}']
@@ -2897,6 +2897,9 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|topicName
+|string
+|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
 |partitions
 |integer
 |The number of partitions the topic should have. This cannot be decreased after topic creation. It can be increased after topic creation, but it is important to understand the consequences that has, especially for topics with semantic partitioning. When absent this will default to the broker configuration for `num.partitions`.
@@ -2906,9 +2909,6 @@ Used in: xref:type-KafkaTopic-{context}[`KafkaTopic`]
 |config
 |map
 |The topic configuration.
-|topicName
-|string
-|The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
 |====
 
 [id='type-KafkaTopicStatus-{context}']
@@ -3048,12 +3048,12 @@ It must have the value `scram-sha-512` for the type `KafkaUserScramSha512ClientA
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|password
-|xref:type-Password-{context}[`Password`]
-|Specify the password for the user. If not set, a new password is generated by the User Operator.
 |type
 |string
 |Must be `scram-sha-512`.
+|password
+|xref:type-Password-{context}[`Password`]
+|Specify the password for the user. If not set, a new password is generated by the User Operator.
 |====
 
 [id='type-Password-{context}']
@@ -3119,6 +3119,12 @@ include::../api/io.strimzi.api.kafka.model.user.acl.AclRule.adoc[leveloffset=+1]
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
+|type
+|string (one of [allow, deny])
+|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+|resource
+|xref:type-AclRuleTopicResource-{context}[`AclRuleTopicResource`], xref:type-AclRuleGroupResource-{context}[`AclRuleGroupResource`], xref:type-AclRuleClusterResource-{context}[`AclRuleClusterResource`], xref:type-AclRuleTransactionalIdResource-{context}[`AclRuleTransactionalIdResource`]
+|Indicates the resource for which given ACL rule applies.
 |host
 |string
 |The host from which the action described in the ACL rule is allowed or denied.
@@ -3128,12 +3134,6 @@ include::../api/io.strimzi.api.kafka.model.user.acl.AclRule.adoc[leveloffset=+1]
 |operations
 |string (one or more of [Read, Write, Delete, Alter, Describe, All, IdempotentWrite, ClusterAction, Create, AlterConfigs, DescribeConfigs]) array
 |List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.
-|resource
-|xref:type-AclRuleTopicResource-{context}[`AclRuleTopicResource`], xref:type-AclRuleGroupResource-{context}[`AclRuleGroupResource`], xref:type-AclRuleClusterResource-{context}[`AclRuleClusterResource`], xref:type-AclRuleTransactionalIdResource-{context}[`AclRuleTransactionalIdResource`]
-|Indicates the resource for which given ACL rule applies.
-|type
-|string (one of [allow, deny])
-|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
 |====
 
 [id='type-AclRuleTopicResource-{context}']
@@ -3234,18 +3234,18 @@ include::../api/io.strimzi.api.kafka.model.user.KafkaUserQuotas.adoc[leveloffset
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|consumerByteRate
-|integer
-|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-|controllerMutationRate
-|number
-|A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
 |producerByteRate
 |integer
 |A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+|consumerByteRate
+|integer
+|A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
 |requestPercentage
 |integer
 |A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+|controllerMutationRate
+|number
+|A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted.
 |====
 
 [id='type-KafkaUserTemplate-{context}']
@@ -3404,12 +3404,12 @@ include::../api/io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerConsumerS
 |authentication
 |xref:type-KafkaClientAuthenticationTls-{context}[`KafkaClientAuthenticationTls`], xref:type-KafkaClientAuthenticationScramSha256-{context}[`KafkaClientAuthenticationScramSha256`], xref:type-KafkaClientAuthenticationScramSha512-{context}[`KafkaClientAuthenticationScramSha512`], xref:type-KafkaClientAuthenticationPlain-{context}[`KafkaClientAuthenticationPlain`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`]
 |Authentication configuration for connecting to the cluster.
-|config
-|map
-|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |tls
 |xref:type-ClientTls-{context}[`ClientTls`]
 |TLS configuration for connecting MirrorMaker to the cluster.
+|config
+|map
+|The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |====
 
 [id='type-KafkaMirrorMakerProducerSpec-{context}']
@@ -3734,12 +3734,12 @@ Used in: xref:type-KafkaBridge-{context}[`KafkaBridge`]
 |url
 |string
 |The URL at which external client applications can access the Kafka Bridge.
-|labelSelector
-|string
-|Label selector for pods providing this resource.
 |replicas
 |integer
 |The current number of pods being used to provide this resource.
+|labelSelector
+|string
+|Label selector for pods providing this resource.
 |====
 
 [id='type-KafkaConnector-{context}']
@@ -3925,6 +3925,9 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |rack
 |xref:type-Rack-{context}[`Rack`]
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
+|metricsConfig
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
+|Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |The configuration of tracing in Kafka Connect.
@@ -3934,9 +3937,6 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-|metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`]
-|Metrics configuration.
 |====
 
 [id='type-KafkaMirrorMaker2ClusterSpec-{context}']
@@ -4028,18 +4028,18 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 |tasksMax
 |integer
 |The maximum number of tasks for the Kafka Connector.
-|config
-|map
-|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
-|autoRestart
-|xref:type-AutoRestart-{context}[`AutoRestart`]
-|Automatic restart of connector and tasks configuration.
 |pause
 |boolean
 |**The `pause` property has been deprecated.** Deprecated in Strimzi 0.38.0, use state instead. Whether the connector should be paused. Defaults to false.
+|config
+|map
+|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
 |state
 |string (one of [running, paused, stopped])
 |The state the connector should be in. Defaults to running.
+|autoRestart
+|xref:type-AutoRestart-{context}[`AutoRestart`]
+|Automatic restart of connector and tasks configuration.
 |====
 
 [id='type-KafkaMirrorMaker2Status-{context}']
@@ -4060,15 +4060,15 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |url
 |string
 |The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+|connectors
+|map array
+|List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API.
 |autoRestartStatuses
 |xref:type-AutoRestartStatus-{context}[`AutoRestartStatus`] array
 |List of MirrorMaker 2 connector auto restart statuses.
 |connectorPlugins
 |xref:type-ConnectorPlugin-{context}[`ConnectorPlugin`] array
 |The list of connector plugins available in this Kafka Connect deployment.
-|connectors
-|map array
-|List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API.
 |labelSelector
 |string
 |Label selector for pods providing this resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -241,15 +241,15 @@ spec:
                                 items:
                                   type: object
                                   properties:
-                                    certificate:
-                                      type: string
-                                      description: The name of the file certificate in the Secret.
                                     secretName:
                                       type: string
                                       description: The name of the Secret containing the certificate.
+                                    certificate:
+                                      type: string
+                                      description: The name of the file certificate in the Secret.
                                   required:
-                                    - certificate
                                     - secretName
+                                    - certificate
                                 description: Trusted certificates for TLS connection to the OAuth server.
                               tokenEndpointUri:
                                 type: string
@@ -283,20 +283,23 @@ spec:
                               brokerCertChainAndKey:
                                 type: object
                                 properties:
-                                  certificate:
-                                    type: string
-                                    description: The name of the file certificate in the Secret.
                                   key:
                                     type: string
                                     description: The name of the private key in the Secret.
                                   secretName:
                                     type: string
                                     description: The name of the Secret containing the certificate.
+                                  certificate:
+                                    type: string
+                                    description: The name of the file certificate in the Secret.
                                 required:
-                                  - certificate
                                   - key
                                   - secretName
+                                  - certificate
                                 description: Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
+                              class:
+                                type: string
+                                description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                               externalTrafficPolicy:
                                 type: string
                                 enum:
@@ -390,20 +393,20 @@ spec:
                               createBootstrapService:
                                 type: boolean
                                 description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
-                              class:
-                                type: string
-                                description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                               finalizers:
                                 type: array
                                 items:
                                   type: string
                                 description: "A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners."
-                              maxConnectionCreationRate:
-                                type: integer
-                                description: The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
+                              useServiceDnsDomain:
+                                type: boolean
+                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                               maxConnections:
                                 type: integer
                                 description: The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
+                              maxConnectionCreationRate:
+                                type: integer
+                                description: The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
                               preferredNodePortAddressType:
                                 type: string
                                 enum:
@@ -422,9 +425,6 @@ spec:
                                   * `Hostname`
 
                                   This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
-                              useServiceDnsDomain:
-                                type: boolean
-                                description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array
@@ -663,15 +663,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - secretName
+                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -707,14 +707,14 @@ spec:
                     livenessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -723,22 +723,22 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -747,10 +747,10 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod readiness checking.
                     jvmOptions:
                       type: object
@@ -760,14 +760,14 @@ spec:
                             type: string
                           type: object
                           description: A map of -XX options to the JVM.
-                        "-Xms":
-                          type: string
-                          pattern: "^[0-9]+[mMgG]?$"
-                          description: -Xms option to to the JVM.
                         "-Xmx":
                           type: string
                           pattern: "^[0-9]+[mMgG]?$"
                           description: -Xmx option to to the JVM.
+                        "-Xms":
+                          type: string
+                          pattern: "^[0-9]+[mMgG]?$"
+                          description: -Xms option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -1330,31 +1330,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -1397,6 +1372,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for Kafka `Pods`.
                         bootstrapService:
                           type: object
@@ -1943,14 +1943,14 @@ spec:
                     livenessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -1959,22 +1959,22 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod liveness checking.
                     readinessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -1983,10 +1983,10 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod readiness checking.
                     jvmOptions:
                       type: object
@@ -1996,14 +1996,14 @@ spec:
                             type: string
                           type: object
                           description: A map of -XX options to the JVM.
-                        "-Xms":
-                          type: string
-                          pattern: "^[0-9]+[mMgG]?$"
-                          description: -Xms option to to the JVM.
                         "-Xmx":
                           type: string
                           pattern: "^[0-9]+[mMgG]?$"
                           description: -Xmx option to to the JVM.
+                        "-Xms":
+                          type: string
+                          pattern: "^[0-9]+[mMgG]?$"
+                          description: -Xms option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -2136,6 +2136,24 @@ spec:
                                 - Parallel
                               description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                           description: Template for ZooKeeper `StatefulSet`.
+                        podSet:
+                          type: object
+                          properties:
+                            metadata:
+                              type: object
+                              properties:
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                  description: Labels added to the Kubernetes resource.
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                  description: Annotations added to the Kubernetes resource.
+                              description: Metadata applied to the resource.
+                          description: Template for ZooKeeper `StrimziPodSet` resource.
                         pod:
                           type: object
                           properties:
@@ -2566,31 +2584,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -2633,6 +2626,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for ZooKeeper `Pods`.
                         clientService:
                           type: object
@@ -2850,24 +2868,6 @@ spec:
                                   description: Annotations added to the Kubernetes resource.
                               description: Metadata applied to the resource.
                           description: Template for Secret of the Zookeeper Cluster JMX authentication.
-                        podSet:
-                          type: object
-                          properties:
-                            metadata:
-                              type: object
-                              properties:
-                                labels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                  description: Labels added to the Kubernetes resource.
-                                annotations:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                  description: Annotations added to the Kubernetes resource.
-                              description: Metadata applied to the resource.
-                          description: Template for ZooKeeper `StrimziPodSet` resource.
                       description: Template for ZooKeeper cluster resources. The template allows users to specify how the Kubernetes resources are generated.
                   required:
                     - replicas
@@ -2896,14 +2896,14 @@ spec:
                         startupProbe:
                           type: object
                           properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             initialDelaySeconds:
                               type: integer
                               minimum: 0
                               description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                             periodSeconds:
                               type: integer
                               minimum: 1
@@ -2912,22 +2912,22 @@ spec:
                               type: integer
                               minimum: 1
                               description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
+                            failureThreshold:
                               type: integer
                               minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           description: Pod startup checking.
                         livenessProbe:
                           type: object
                           properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             initialDelaySeconds:
                               type: integer
                               minimum: 0
                               description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                             periodSeconds:
                               type: integer
                               minimum: 1
@@ -2936,22 +2936,22 @@ spec:
                               type: integer
                               minimum: 1
                               description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
+                            failureThreshold:
                               type: integer
                               minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           description: Pod liveness checking.
                         readinessProbe:
                           type: object
                           properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             initialDelaySeconds:
                               type: integer
                               minimum: 0
                               description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                             periodSeconds:
                               type: integer
                               minimum: 1
@@ -2960,10 +2960,10 @@ spec:
                               type: integer
                               minimum: 1
                               description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
+                            failureThreshold:
                               type: integer
                               minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           description: Pod readiness checking.
                         resources:
                           type: object
@@ -3025,14 +3025,14 @@ spec:
                                 type: string
                               type: object
                               description: A map of -XX options to the JVM.
-                            "-Xms":
-                              type: string
-                              pattern: "^[0-9]+[mMgG]?$"
-                              description: -Xms option to to the JVM.
                             "-Xmx":
                               type: string
                               pattern: "^[0-9]+[mMgG]?$"
                               description: -Xmx option to to the JVM.
+                            "-Xms":
+                              type: string
+                              pattern: "^[0-9]+[mMgG]?$"
+                              description: -Xms option to to the JVM.
                             gcLoggingEnabled:
                               type: boolean
                               description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3073,14 +3073,14 @@ spec:
                         livenessProbe:
                           type: object
                           properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             initialDelaySeconds:
                               type: integer
                               minimum: 0
                               description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                             periodSeconds:
                               type: integer
                               minimum: 1
@@ -3089,22 +3089,22 @@ spec:
                               type: integer
                               minimum: 1
                               description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
+                            failureThreshold:
                               type: integer
                               minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           description: Pod liveness checking.
                         readinessProbe:
                           type: object
                           properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                             initialDelaySeconds:
                               type: integer
                               minimum: 0
                               description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                             periodSeconds:
                               type: integer
                               minimum: 1
@@ -3113,10 +3113,10 @@ spec:
                               type: integer
                               minimum: 1
                               description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
+                            failureThreshold:
                               type: integer
                               minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           description: Pod readiness checking.
                         resources:
                           type: object
@@ -3174,14 +3174,14 @@ spec:
                                 type: string
                               type: object
                               description: A map of -XX options to the JVM.
-                            "-Xms":
-                              type: string
-                              pattern: "^[0-9]+[mMgG]?$"
-                              description: -Xms option to to the JVM.
                             "-Xmx":
                               type: string
                               pattern: "^[0-9]+[mMgG]?$"
                               description: -Xmx option to to the JVM.
+                            "-Xms":
+                              type: string
+                              pattern: "^[0-9]+[mMgG]?$"
+                              description: -Xms option to to the JVM.
                             gcLoggingEnabled:
                               type: boolean
                               description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3205,66 +3205,6 @@ spec:
                         image:
                           type: string
                           description: The docker image for the container.
-                        livenessProbe:
-                          type: object
-                          properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                            initialDelaySeconds:
-                              type: integer
-                              minimum: 0
-                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                            periodSeconds:
-                              type: integer
-                              minimum: 1
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                            successThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
-                              type: integer
-                              minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                          description: Pod liveness checking.
-                        logLevel:
-                          type: string
-                          enum:
-                            - emerg
-                            - alert
-                            - crit
-                            - err
-                            - warning
-                            - notice
-                            - info
-                            - debug
-                          description: The log level for the TLS sidecar. Default value is `notice`.
-                        readinessProbe:
-                          type: object
-                          properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                            initialDelaySeconds:
-                              type: integer
-                              minimum: 0
-                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                            periodSeconds:
-                              type: integer
-                              minimum: 1
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                            successThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
-                              type: integer
-                              minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                          description: Pod readiness checking.
                         resources:
                           type: object
                           properties:
@@ -3282,6 +3222,66 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
                           description: CPU and memory resources to reserve.
+                        livenessProbe:
+                          type: object
+                          properties:
+                            initialDelaySeconds:
+                              type: integer
+                              minimum: 0
+                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            periodSeconds:
+                              type: integer
+                              minimum: 1
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                            successThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                            failureThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Pod liveness checking.
+                        readinessProbe:
+                          type: object
+                          properties:
+                            initialDelaySeconds:
+                              type: integer
+                              minimum: 0
+                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            periodSeconds:
+                              type: integer
+                              minimum: 1
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                            successThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                            failureThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Pod readiness checking.
+                        logLevel:
+                          type: string
+                          enum:
+                            - emerg
+                            - alert
+                            - crit
+                            - err
+                            - warning
+                            - notice
+                            - info
+                            - debug
+                          description: The log level for the TLS sidecar. Default value is `notice`.
                       description: TLS sidecar configuration.
                     template:
                       type: object
@@ -3740,31 +3740,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -3807,6 +3782,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for Entity Operator `Pods`.
                         topicOperatorContainer:
                           type: object
@@ -4164,66 +4164,6 @@ spec:
                         image:
                           type: string
                           description: The docker image for the container.
-                        livenessProbe:
-                          type: object
-                          properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                            initialDelaySeconds:
-                              type: integer
-                              minimum: 0
-                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                            periodSeconds:
-                              type: integer
-                              minimum: 1
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                            successThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
-                              type: integer
-                              minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                          description: Pod liveness checking.
-                        logLevel:
-                          type: string
-                          enum:
-                            - emerg
-                            - alert
-                            - crit
-                            - err
-                            - warning
-                            - notice
-                            - info
-                            - debug
-                          description: The log level for the TLS sidecar. Default value is `notice`.
-                        readinessProbe:
-                          type: object
-                          properties:
-                            failureThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                            initialDelaySeconds:
-                              type: integer
-                              minimum: 0
-                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                            periodSeconds:
-                              type: integer
-                              minimum: 1
-                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                            successThreshold:
-                              type: integer
-                              minimum: 1
-                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                            timeoutSeconds:
-                              type: integer
-                              minimum: 1
-                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                          description: Pod readiness checking.
                         resources:
                           type: object
                           properties:
@@ -4241,6 +4181,66 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
                           description: CPU and memory resources to reserve.
+                        livenessProbe:
+                          type: object
+                          properties:
+                            initialDelaySeconds:
+                              type: integer
+                              minimum: 0
+                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            periodSeconds:
+                              type: integer
+                              minimum: 1
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                            successThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                            failureThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Pod liveness checking.
+                        readinessProbe:
+                          type: object
+                          properties:
+                            initialDelaySeconds:
+                              type: integer
+                              minimum: 0
+                              description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                            timeoutSeconds:
+                              type: integer
+                              minimum: 1
+                              description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            periodSeconds:
+                              type: integer
+                              minimum: 1
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                            successThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                            failureThreshold:
+                              type: integer
+                              minimum: 1
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Pod readiness checking.
+                        logLevel:
+                          type: string
+                          enum:
+                            - emerg
+                            - alert
+                            - crit
+                            - err
+                            - warning
+                            - notice
+                            - info
+                            - debug
+                          description: The log level for the TLS sidecar. Default value is `notice`.
                       description: TLS sidecar configuration.
                     resources:
                       type: object
@@ -4262,14 +4262,14 @@ spec:
                     livenessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -4278,22 +4278,22 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod liveness checking for the Cruise Control container.
                     readinessProbe:
                       type: object
                       properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         initialDelaySeconds:
                           type: integer
                           minimum: 0
                           description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                         periodSeconds:
                           type: integer
                           minimum: 1
@@ -4302,10 +4302,10 @@ spec:
                           type: integer
                           minimum: 1
                           description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
+                        failureThreshold:
                           type: integer
                           minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       description: Pod readiness checking for the Cruise Control container.
                     jvmOptions:
                       type: object
@@ -4315,14 +4315,14 @@ spec:
                             type: string
                           type: object
                           description: A map of -XX options to the JVM.
-                        "-Xms":
-                          type: string
-                          pattern: "^[0-9]+[mMgG]?$"
-                          description: -Xms option to to the JVM.
                         "-Xmx":
                           type: string
                           pattern: "^[0-9]+[mMgG]?$"
                           description: -Xmx option to to the JVM.
+                        "-Xms":
+                          type: string
+                          pattern: "^[0-9]+[mMgG]?$"
+                          description: -Xms option to to the JVM.
                         gcLoggingEnabled:
                           type: boolean
                           description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -4827,31 +4827,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -4894,6 +4869,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for Cruise Control `Pods`.
                         apiService:
                           type: object
@@ -5733,31 +5733,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -5800,6 +5775,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for JmxTrans `Pods`.
                         container:
                           type: object
@@ -5936,6 +5936,54 @@ spec:
                     logging:
                       type: string
                       description: "Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`."
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        periodSeconds:
+                          type: integer
+                          minimum: 1
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          minimum: 1
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                        failureThreshold:
+                          type: integer
+                          minimum: 1
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                      description: Pod liveness check.
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        periodSeconds:
+                          type: integer
+                          minimum: 1
+                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                        successThreshold:
+                          type: integer
+                          minimum: 1
+                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                        failureThreshold:
+                          type: integer
+                          minimum: 1
+                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                      description: Pod readiness check.
                     enableSaramaLogging:
                       type: boolean
                       description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
@@ -6399,31 +6447,6 @@ spec:
                                   value:
                                     type: string
                               description: The pod's tolerations.
-                            priorityClassName:
-                              type: string
-                              description: 'The name of the priority class used to assign priority to the pods. '
-                            schedulerName:
-                              type: string
-                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                            hostAliases:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  hostnames:
-                                    type: array
-                                    items:
-                                      type: string
-                                  ip:
-                                    type: string
-                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                            tmpDirSizeLimit:
-                              type: string
-                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                            enableServiceLinks:
-                              type: boolean
-                              description: Indicates whether information about services should be injected into Pod's environment variables.
                             topologySpreadConstraints:
                               type: array
                               items:
@@ -6466,6 +6489,31 @@ spec:
                                   whenUnsatisfiable:
                                     type: string
                               description: The pod's topology spread constraints.
+                            priorityClassName:
+                              type: string
+                              description: 'The name of the priority class used to assign priority to the pods. '
+                            schedulerName:
+                              type: string
+                              description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                            hostAliases:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  hostnames:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ip:
+                                    type: string
+                              description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                            enableServiceLinks:
+                              type: boolean
+                              description: Indicates whether information about services should be injected into Pod's environment variables.
+                            tmpDirSizeLimit:
+                              type: string
+                              pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                              description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                           description: Template for Kafka Exporter `Pods`.
                         service:
                           type: object
@@ -6578,54 +6626,6 @@ spec:
                               description: Metadata applied to the resource.
                           description: Template for the Kafka Exporter service account.
                       description: Customization of deployment templates and pods.
-                    livenessProbe:
-                      type: object
-                      properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                        initialDelaySeconds:
-                          type: integer
-                          minimum: 0
-                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                        periodSeconds:
-                          type: integer
-                          minimum: 1
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                        successThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
-                          type: integer
-                          minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                      description: Pod liveness check.
-                    readinessProbe:
-                      type: object
-                      properties:
-                        failureThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                        initialDelaySeconds:
-                          type: integer
-                          minimum: 0
-                          description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                        periodSeconds:
-                          type: integer
-                          minimum: 1
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                        successThreshold:
-                          type: integer
-                          minimum: 1
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                        timeoutSeconds:
-                          type: integer
-                          minimum: 1
-                          description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                      description: Pod readiness check.
                   description: "Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition."
                 maintenanceTimeWindows:
                   type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -74,15 +74,15 @@ spec:
                       items:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                          - certificate
                           - secretName
+                          - certificate
                       description: Trusted certificates for TLS connection.
                   description: TLS configuration.
                 authentication:
@@ -110,19 +110,19 @@ spec:
                     certificateAndKey:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
                           description: The name of the private key in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                        - certificate
                         - key
                         - secretName
+                        - certificate
                       description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
@@ -164,15 +164,15 @@ spec:
                     passwordSecret:
                       type: object
                       properties:
-                        password:
-                          type: string
-                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
+                        password:
+                          type: string
+                          description: The name of the key in the Secret under which the password is stored.
                       required:
-                        - password
                         - secretName
+                        - password
                       description: Reference to the `Secret` which holds the password.
                     readTimeoutSeconds:
                       type: integer
@@ -198,15 +198,15 @@ spec:
                       items:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                          - certificate
                           - secretName
+                          - certificate
                       description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
@@ -250,14 +250,14 @@ spec:
                 livenessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -266,22 +266,22 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -290,10 +290,10 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -303,14 +303,14 @@ spec:
                         type: string
                       type: object
                       description: A map of -XX options to the JVM.
-                    "-Xms":
-                      type: string
-                      pattern: "^[0-9]+[mMgG]?$"
-                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: "^[0-9]+[mMgG]?$"
                       description: -Xmx option to to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xms option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -386,6 +386,32 @@ spec:
                   required:
                     - topologyKey
                   description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+                metricsConfig:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - jmxPrometheusExporter
+                      description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                    valueFrom:
+                      type: object
+                      properties:
+                        configMapKeyRef:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to the key in the ConfigMap containing the configuration.
+                      description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
+                  required:
+                    - type
+                    - valueFrom
+                  description: Metrics configuration.
                 tracing:
                   type: object
                   properties:
@@ -873,31 +899,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -940,6 +941,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
                       type: object
@@ -1643,31 +1669,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1710,6 +1711,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:
                       type: object
@@ -1857,16 +1883,6 @@ spec:
                           valueFrom:
                             type: object
                             properties:
-                              configMapKeyRef:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                description: Reference to a key in a ConfigMap.
                               secretKeyRef:
                                 type: object
                                 properties:
@@ -1877,6 +1893,16 @@ spec:
                                   optional:
                                     type: boolean
                                 description: Reference to a key in a Secret.
+                              configMapKeyRef:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: Reference to a key in a ConfigMap.
                             description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                         required:
                           - name
@@ -1887,27 +1913,6 @@ spec:
                       items:
                         type: object
                         properties:
-                          configMap:
-                            type: object
-                            properties:
-                              defaultMode:
-                                type: integer
-                              items:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      type: integer
-                                    path:
-                                      type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                           name:
                             type: string
                             description: Name of the volume which will be added to the Kafka Connect pods.
@@ -1932,6 +1937,27 @@ spec:
                               secretName:
                                 type: string
                             description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                          configMap:
+                            type: object
+                            properties:
+                              defaultMode:
+                                type: integer
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      type: integer
+                                    path:
+                                      type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                         required:
                           - name
                       description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
@@ -1963,23 +1989,6 @@ spec:
                         - image
                         - type
                       description: Configures where should the newly built image be stored. Required.
-                    resources:
-                      type: object
-                      properties:
-                        claims:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                        limits:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        requests:
-                          x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                      description: CPU and memory resources to reserve for the build.
                     plugins:
                       type: array
                       items:
@@ -2035,36 +2044,27 @@ spec:
                           - name
                           - artifacts
                       description: List of connector plugins which should be added to the Kafka Connect. Required.
+                    resources:
+                      type: object
+                      properties:
+                        claims:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                        limits:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        requests:
+                          x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      description: CPU and memory resources to reserve for the build.
                   required:
                     - output
                     - plugins
                   description: Configures how the Connect container image should be built. Optional.
-                metricsConfig:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      enum:
-                        - jmxPrometheusExporter
-                      description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                    valueFrom:
-                      type: object
-                      properties:
-                        configMapKeyRef:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to the key in the ConfigMap containing the configuration.
-                      description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
-                  required:
-                    - type
-                    - valueFrom
-                  description: Metrics configuration.
               required:
                 - bootstrapServers
               description: The specification of the Kafka Connect cluster.
@@ -2103,20 +2103,20 @@ spec:
                   items:
                     type: object
                     properties:
+                      class:
+                        type: string
+                        description: The class of the connector plugin.
                       type:
                         type: string
                         description: The type of the connector plugin. The available types are `sink` and `source`.
                       version:
                         type: string
                         description: The version of the connector plugin.
-                      class:
-                        type: string
-                        description: The class of the connector plugin.
                   description: The list of connector plugins available in this Kafka Connect deployment.
-                labelSelector:
-                  type: string
-                  description: Label selector for pods providing this resource.
                 replicas:
                   type: integer
                   description: The current number of pods being used to provide this resource.
+                labelSelector:
+                  type: string
+                  description: Label selector for pods providing this resource.
               description: The status of the Kafka Connect cluster.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
@@ -58,6 +58,9 @@ spec:
             spec:
               type: object
               properties:
+                topicName:
+                  type: string
+                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
                 partitions:
                   type: integer
                   minimum: 1
@@ -71,9 +74,6 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
                   description: The topic configuration.
-                topicName:
-                  type: string
-                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               description: The specification of the topic.
             status:
               type: object
@@ -165,6 +165,9 @@ spec:
             spec:
               type: object
               properties:
+                topicName:
+                  type: string
+                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
                 partitions:
                   type: integer
                   minimum: 1
@@ -178,9 +181,6 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
                   description: The topic configuration.
-                topicName:
-                  type: string
-                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               description: The specification of the topic.
             status:
               type: object
@@ -272,6 +272,9 @@ spec:
             spec:
               type: object
               properties:
+                topicName:
+                  type: string
+                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
                 partitions:
                   type: integer
                   minimum: 1
@@ -285,9 +288,6 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
                   description: The topic configuration.
-                topicName:
-                  type: string
-                  description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               description: The specification of the topic.
             status:
               type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -99,6 +99,35 @@ spec:
                       items:
                         type: object
                         properties:
+                          type:
+                            type: string
+                            enum:
+                              - allow
+                              - deny
+                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          resource:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                              patternType:
+                                type: string
+                                enum:
+                                  - literal
+                                  - prefix
+                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                              type:
+                                type: string
+                                enum:
+                                  - topic
+                                  - group
+                                  - cluster
+                                  - transactionalId
+                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                            required:
+                              - type
+                            description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
                             description: The host from which the action described in the ACL rule is allowed or denied.
@@ -134,35 +163,6 @@ spec:
                                 - IdempotentWrite
                                 - All
                             description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                          resource:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                              patternType:
-                                type: string
-                                enum:
-                                  - literal
-                                  - prefix
-                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                              type:
-                                type: string
-                                enum:
-                                  - topic
-                                  - group
-                                  - cluster
-                                  - transactionalId
-                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                            required:
-                              - type
-                            description: Indicates the resource for which given ACL rule applies.
-                          type:
-                            type: string
-                            enum:
-                              - allow
-                              - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
                           - resource
                       description: List of ACL rules which should be applied to this user.
@@ -178,22 +178,22 @@ spec:
                 quotas:
                   type: object
                   properties:
-                    consumerByteRate:
-                      type: integer
-                      minimum: 0
-                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                    controllerMutationRate:
-                      type: number
-                      minimum: 0
-                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                     producerByteRate:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    consumerByteRate:
+                      type: integer
+                      minimum: 0
+                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                     requestPercentage:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
                 template:
                   type: object
@@ -330,6 +330,35 @@ spec:
                       items:
                         type: object
                         properties:
+                          type:
+                            type: string
+                            enum:
+                              - allow
+                              - deny
+                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          resource:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                              patternType:
+                                type: string
+                                enum:
+                                  - literal
+                                  - prefix
+                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                              type:
+                                type: string
+                                enum:
+                                  - topic
+                                  - group
+                                  - cluster
+                                  - transactionalId
+                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                            required:
+                              - type
+                            description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
                             description: The host from which the action described in the ACL rule is allowed or denied.
@@ -365,35 +394,6 @@ spec:
                                 - IdempotentWrite
                                 - All
                             description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                          resource:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                              patternType:
-                                type: string
-                                enum:
-                                  - literal
-                                  - prefix
-                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                              type:
-                                type: string
-                                enum:
-                                  - topic
-                                  - group
-                                  - cluster
-                                  - transactionalId
-                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                            required:
-                              - type
-                            description: Indicates the resource for which given ACL rule applies.
-                          type:
-                            type: string
-                            enum:
-                              - allow
-                              - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
                           - resource
                       description: List of ACL rules which should be applied to this user.
@@ -409,22 +409,22 @@ spec:
                 quotas:
                   type: object
                   properties:
-                    consumerByteRate:
-                      type: integer
-                      minimum: 0
-                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                    controllerMutationRate:
-                      type: number
-                      minimum: 0
-                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                     producerByteRate:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    consumerByteRate:
+                      type: integer
+                      minimum: 0
+                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                     requestPercentage:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
                 template:
                   type: object
@@ -561,6 +561,35 @@ spec:
                       items:
                         type: object
                         properties:
+                          type:
+                            type: string
+                            enum:
+                              - allow
+                              - deny
+                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          resource:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                              patternType:
+                                type: string
+                                enum:
+                                  - literal
+                                  - prefix
+                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                              type:
+                                type: string
+                                enum:
+                                  - topic
+                                  - group
+                                  - cluster
+                                  - transactionalId
+                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                            required:
+                              - type
+                            description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
                             description: The host from which the action described in the ACL rule is allowed or denied.
@@ -596,35 +625,6 @@ spec:
                                 - IdempotentWrite
                                 - All
                             description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                          resource:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                              patternType:
-                                type: string
-                                enum:
-                                  - literal
-                                  - prefix
-                                description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                              type:
-                                type: string
-                                enum:
-                                  - topic
-                                  - group
-                                  - cluster
-                                  - transactionalId
-                                description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                            required:
-                              - type
-                            description: Indicates the resource for which given ACL rule applies.
-                          type:
-                            type: string
-                            enum:
-                              - allow
-                              - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                         required:
                           - resource
                       description: List of ACL rules which should be applied to this user.
@@ -640,22 +640,22 @@ spec:
                 quotas:
                   type: object
                   properties:
-                    consumerByteRate:
-                      type: integer
-                      minimum: 0
-                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                    controllerMutationRate:
-                      type: number
-                      minimum: 0
-                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                     producerByteRate:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                    consumerByteRate:
+                      type: integer
+                      minimum: 0
+                      description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                     requestPercentage:
                       type: integer
                       minimum: 0
                       description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                    controllerMutationRate:
+                      type: number
+                      minimum: 0
+                      description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
                 template:
                   type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -115,19 +115,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             key:
                               type: string
                               description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                            - certificate
                             - key
                             - secretName
+                            - certificate
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -169,15 +169,15 @@ spec:
                         passwordSecret:
                           type: object
                           properties:
-                            password:
-                              type: string
-                              description: The name of the key in the Secret under which the password is stored.
                             secretName:
                               type: string
                               description: The name of the Secret containing the password.
+                            password:
+                              type: string
+                              description: The name of the key in the Secret under which the password is stored.
                           required:
-                            - password
                             - secretName
+                            - password
                           description: Reference to the `Secret` which holds the password.
                         readTimeoutSeconds:
                           type: integer
@@ -203,15 +203,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - secretName
+                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -231,10 +231,6 @@ spec:
                       required:
                         - type
                       description: Authentication configuration for connecting to the cluster.
-                    config:
-                      x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                      description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                     tls:
                       type: object
                       properties:
@@ -243,17 +239,21 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - secretName
+                              - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker to the cluster.
+                    config:
+                      x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                      description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                   required:
                     - bootstrapServers
                     - groupId
@@ -292,19 +292,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             key:
                               type: string
                               description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                            - certificate
                             - key
                             - secretName
+                            - certificate
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -346,15 +346,15 @@ spec:
                         passwordSecret:
                           type: object
                           properties:
-                            password:
-                              type: string
-                              description: The name of the key in the Secret under which the password is stored.
                             secretName:
                               type: string
                               description: The name of the Secret containing the password.
+                            password:
+                              type: string
+                              description: The name of the key in the Secret under which the password is stored.
                           required:
-                            - password
                             - secretName
+                            - password
                           description: Reference to the `Secret` which holds the password.
                         readTimeoutSeconds:
                           type: integer
@@ -380,15 +380,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - secretName
+                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -420,15 +420,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - secretName
+                              - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker to the cluster.
                   required:
@@ -465,14 +465,14 @@ spec:
                         type: string
                       type: object
                       description: A map of -XX options to the JVM.
-                    "-Xms":
-                      type: string
-                      pattern: "^[0-9]+[mMgG]?$"
-                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: "^[0-9]+[mMgG]?$"
                       description: -Xmx option to to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xms option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -1015,31 +1015,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1082,6 +1057,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka MirrorMaker `Pods`.
                     podDisruptionBudget:
                       type: object
@@ -1201,14 +1201,14 @@ spec:
                 livenessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -1217,22 +1217,22 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -1241,10 +1241,10 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod readiness checking.
               oneOf:
                 - properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -77,15 +77,15 @@ spec:
                       items:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                          - certificate
                           - secretName
+                          - certificate
                       description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting Kafka Bridge to the cluster.
                 authentication:
@@ -113,19 +113,19 @@ spec:
                     certificateAndKey:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         key:
                           type: string
                           description: The name of the private key in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                        - certificate
                         - key
                         - secretName
+                        - certificate
                       description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
@@ -167,15 +167,15 @@ spec:
                     passwordSecret:
                       type: object
                       properties:
-                        password:
-                          type: string
-                          description: The name of the key in the Secret under which the password is stored.
                         secretName:
                           type: string
                           description: The name of the Secret containing the password.
+                        password:
+                          type: string
+                          description: The name of the key in the Secret under which the password is stored.
                       required:
-                        - password
                         - secretName
+                        - password
                       description: Reference to the `Secret` which holds the password.
                     readTimeoutSeconds:
                       type: integer
@@ -201,15 +201,15 @@ spec:
                       items:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                          - certificate
                           - secretName
+                          - certificate
                       description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string
@@ -303,14 +303,14 @@ spec:
                         type: string
                       type: object
                       description: A map of -XX options to the JVM.
-                    "-Xms":
-                      type: string
-                      pattern: "^[0-9]+[mMgG]?$"
-                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: "^[0-9]+[mMgG]?$"
                       description: -Xmx option to to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xms option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -377,14 +377,14 @@ spec:
                 livenessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -393,22 +393,22 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -417,10 +417,10 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod readiness checking.
                 template:
                   type: object
@@ -879,31 +879,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -946,6 +921,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka Bridge `Pods`.
                     apiService:
                       type: object
@@ -1232,10 +1232,10 @@ spec:
                 url:
                   type: string
                   description: The URL at which external client applications can access the Kafka Bridge.
-                labelSelector:
-                  type: string
-                  description: Label selector for pods providing this resource.
                 replicas:
                   type: integer
                   description: The current number of pods being used to provide this resource.
+                labelSelector:
+                  type: string
+                  description: Label selector for pods providing this resource.
               description: The status of the Kafka Bridge.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -86,15 +86,15 @@ spec:
                             items:
                               type: object
                               properties:
-                                certificate:
-                                  type: string
-                                  description: The name of the file certificate in the Secret.
                                 secretName:
                                   type: string
                                   description: The name of the Secret containing the certificate.
+                                certificate:
+                                  type: string
+                                  description: The name of the file certificate in the Secret.
                               required:
-                                - certificate
                                 - secretName
+                                - certificate
                             description: Trusted certificates for TLS connection.
                         description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                       authentication:
@@ -122,19 +122,19 @@ spec:
                           certificateAndKey:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               key:
                                 type: string
                                 description: The name of the private key in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                              - certificate
                               - key
                               - secretName
+                              - certificate
                             description: Reference to the `Secret` which holds the certificate and private key pair.
                           clientId:
                             type: string
@@ -176,15 +176,15 @@ spec:
                           passwordSecret:
                             type: object
                             properties:
-                              password:
-                                type: string
-                                description: The name of the key in the Secret under which the password is stored.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the password.
+                              password:
+                                type: string
+                                description: The name of the key in the Secret under which the password is stored.
                             required:
-                              - password
                               - secretName
+                              - password
                             description: Reference to the `Secret` which holds the password.
                           readTimeoutSeconds:
                             type: integer
@@ -210,15 +210,15 @@ spec:
                             items:
                               type: object
                               properties:
-                                certificate:
-                                  type: string
-                                  description: The name of the file certificate in the Secret.
                                 secretName:
                                   type: string
                                   description: The name of the Secret containing the certificate.
+                                certificate:
+                                  type: string
+                                  description: The name of the file certificate in the Secret.
                               required:
-                                - certificate
                                 - secretName
+                                - certificate
                             description: Trusted certificates for TLS connection to the OAuth server.
                           tokenEndpointUri:
                             type: string
@@ -264,10 +264,20 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          pause:
+                            type: boolean
+                            description: Whether the connector should be paused. Defaults to false.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                           autoRestart:
                             type: object
                             properties:
@@ -278,16 +288,6 @@ spec:
                                 type: integer
                                 description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
-                          pause:
-                            type: boolean
-                            description: Whether the connector should be paused. Defaults to false.
-                          state:
-                            type: string
-                            enum:
-                              - paused
-                              - stopped
-                              - running
-                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 source connector.
                       heartbeatConnector:
                         type: object
@@ -296,10 +296,20 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          pause:
+                            type: boolean
+                            description: Whether the connector should be paused. Defaults to false.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                           autoRestart:
                             type: object
                             properties:
@@ -310,16 +320,6 @@ spec:
                                 type: integer
                                 description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
-                          pause:
-                            type: boolean
-                            description: Whether the connector should be paused. Defaults to false.
-                          state:
-                            type: string
-                            enum:
-                              - paused
-                              - stopped
-                              - running
-                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                       checkpointConnector:
                         type: object
@@ -328,10 +328,20 @@ spec:
                             type: integer
                             minimum: 1
                             description: The maximum number of tasks for the Kafka Connector.
+                          pause:
+                            type: boolean
+                            description: Whether the connector should be paused. Defaults to false.
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                             description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          state:
+                            type: string
+                            enum:
+                              - paused
+                              - stopped
+                              - running
+                            description: The state the connector should be in. Defaults to running.
                           autoRestart:
                             type: object
                             properties:
@@ -342,16 +352,6 @@ spec:
                                 type: integer
                                 description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                             description: Automatic restart of connector and tasks configuration.
-                          pause:
-                            type: boolean
-                            description: Whether the connector should be paused. Defaults to false.
-                          state:
-                            type: string
-                            enum:
-                              - paused
-                              - stopped
-                              - running
-                            description: The state the connector should be in. Defaults to running.
                         description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                       topicsPattern:
                         type: string
@@ -395,14 +395,14 @@ spec:
                 livenessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -411,22 +411,22 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod liveness checking.
                 readinessProbe:
                   type: object
                   properties:
-                    failureThreshold:
-                      type: integer
-                      minimum: 1
-                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     initialDelaySeconds:
                       type: integer
                       minimum: 0
                       description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                     periodSeconds:
                       type: integer
                       minimum: 1
@@ -435,10 +435,10 @@ spec:
                       type: integer
                       minimum: 1
                       description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                    timeoutSeconds:
+                    failureThreshold:
                       type: integer
                       minimum: 1
-                      description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   description: Pod readiness checking.
                 jvmOptions:
                   type: object
@@ -448,14 +448,14 @@ spec:
                         type: string
                       type: object
                       description: A map of -XX options to the JVM.
-                    "-Xms":
-                      type: string
-                      pattern: "^[0-9]+[mMgG]?$"
-                      description: -Xms option to to the JVM.
                     "-Xmx":
                       type: string
                       pattern: "^[0-9]+[mMgG]?$"
                       description: -Xmx option to to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xms option to to the JVM.
                     gcLoggingEnabled:
                       type: boolean
                       description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -531,6 +531,32 @@ spec:
                   required:
                     - topologyKey
                   description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+                metricsConfig:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - jmxPrometheusExporter
+                      description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                    valueFrom:
+                      type: object
+                      properties:
+                        configMapKeyRef:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to the key in the ConfigMap containing the configuration.
+                      description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
+                  required:
+                    - type
+                    - valueFrom
+                  description: Metrics configuration.
                 tracing:
                   type: object
                   properties:
@@ -1018,31 +1044,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1085,6 +1086,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
                       type: object
@@ -1788,31 +1814,6 @@ spec:
                               value:
                                 type: string
                           description: The pod's tolerations.
-                        priorityClassName:
-                          type: string
-                          description: 'The name of the priority class used to assign priority to the pods. '
-                        schedulerName:
-                          type: string
-                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                        hostAliases:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              hostnames:
-                                type: array
-                                items:
-                                  type: string
-                              ip:
-                                type: string
-                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                        tmpDirSizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                        enableServiceLinks:
-                          type: boolean
-                          description: Indicates whether information about services should be injected into Pod's environment variables.
                         topologySpreadConstraints:
                           type: array
                           items:
@@ -1855,6 +1856,31 @@ spec:
                               whenUnsatisfiable:
                                 type: string
                           description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:
                       type: object
@@ -2002,16 +2028,6 @@ spec:
                           valueFrom:
                             type: object
                             properties:
-                              configMapKeyRef:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                description: Reference to a key in a ConfigMap.
                               secretKeyRef:
                                 type: object
                                 properties:
@@ -2022,6 +2038,16 @@ spec:
                                   optional:
                                     type: boolean
                                 description: Reference to a key in a Secret.
+                              configMapKeyRef:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: Reference to a key in a ConfigMap.
                             description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                         required:
                           - name
@@ -2032,27 +2058,6 @@ spec:
                       items:
                         type: object
                         properties:
-                          configMap:
-                            type: object
-                            properties:
-                              defaultMode:
-                                type: integer
-                              items:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    mode:
-                                      type: integer
-                                    path:
-                                      type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                           name:
                             type: string
                             description: Name of the volume which will be added to the Kafka Connect pods.
@@ -2077,36 +2082,31 @@ spec:
                               secretName:
                                 type: string
                             description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                          configMap:
+                            type: object
+                            properties:
+                              defaultMode:
+                                type: integer
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      type: integer
+                                    path:
+                                      type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                         required:
                           - name
                       description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
                   description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-                metricsConfig:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      enum:
-                        - jmxPrometheusExporter
-                      description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                    valueFrom:
-                      type: object
-                      properties:
-                        configMapKeyRef:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to the key in the ConfigMap containing the configuration.
-                      description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
-                  required:
-                    - type
-                    - valueFrom
-                  description: Metrics configuration.
               required:
                 - connectCluster
               description: The specification of the Kafka MirrorMaker 2 cluster.
@@ -2140,6 +2140,12 @@ spec:
                 url:
                   type: string
                   description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+                connectors:
+                  type: array
+                  items:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
                 autoRestartStatuses:
                   type: array
                   items:
@@ -2160,22 +2166,16 @@ spec:
                   items:
                     type: object
                     properties:
+                      class:
+                        type: string
+                        description: The class of the connector plugin.
                       type:
                         type: string
                         description: The type of the connector plugin. The available types are `sink` and `source`.
                       version:
                         type: string
                         description: The version of the connector plugin.
-                      class:
-                        type: string
-                        description: The class of the connector plugin.
                   description: The list of connector plugins available in this Kafka Connect deployment.
-                connectors:
-                  type: array
-                  items:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                  description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
                 labelSelector:
                   type: string
                   description: Label selector for pods providing this resource.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -181,14 +181,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -656,31 +656,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -723,6 +698,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka `Pods`.
                   perPodService:
                     type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -240,15 +240,15 @@ spec:
                               items:
                                 type: object
                                 properties:
-                                  certificate:
-                                    type: string
-                                    description: The name of the file certificate in the Secret.
                                   secretName:
                                     type: string
                                     description: The name of the Secret containing the certificate.
+                                  certificate:
+                                    type: string
+                                    description: The name of the file certificate in the Secret.
                                 required:
-                                - certificate
                                 - secretName
+                                - certificate
                               description: Trusted certificates for TLS connection to the OAuth server.
                             tokenEndpointUri:
                               type: string
@@ -282,20 +282,23 @@ spec:
                             brokerCertChainAndKey:
                               type: object
                               properties:
-                                certificate:
-                                  type: string
-                                  description: The name of the file certificate in the Secret.
                                 key:
                                   type: string
                                   description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
                                   description: The name of the Secret containing the certificate.
+                                certificate:
+                                  type: string
+                                  description: The name of the file certificate in the Secret.
                               required:
-                              - certificate
                               - key
                               - secretName
+                              - certificate
                               description: Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
+                            class:
+                              type: string
+                              description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                             externalTrafficPolicy:
                               type: string
                               enum:
@@ -389,20 +392,20 @@ spec:
                             createBootstrapService:
                               type: boolean
                               description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
-                            class:
-                              type: string
-                              description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
                             finalizers:
                               type: array
                               items:
                                 type: string
                               description: "A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners."
-                            maxConnectionCreationRate:
-                              type: integer
-                              description: The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
+                            useServiceDnsDomain:
+                              type: boolean
+                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                             maxConnections:
                               type: integer
                               description: The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
+                            maxConnectionCreationRate:
+                              type: integer
+                              description: The maximum connection creation rate we allow in this listener at any time. New connections will be throttled if the limit is reached.
                             preferredNodePortAddressType:
                               type: string
                               enum:
@@ -421,9 +424,6 @@ spec:
                                 * `Hostname`
 
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
-                            useServiceDnsDomain:
-                              type: boolean
-                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array
@@ -662,15 +662,15 @@ spec:
                         items:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - secretName
+                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -706,14 +706,14 @@ spec:
                   livenessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -722,22 +722,22 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -746,10 +746,10 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -759,14 +759,14 @@ spec:
                           type: string
                         type: object
                         description: A map of -XX options to the JVM.
-                      "-Xms":
-                        type: string
-                        pattern: "^[0-9]+[mMgG]?$"
-                        description: -Xms option to to the JVM.
                       "-Xmx":
                         type: string
                         pattern: "^[0-9]+[mMgG]?$"
                         description: -Xmx option to to the JVM.
+                      "-Xms":
+                        type: string
+                        pattern: "^[0-9]+[mMgG]?$"
+                        description: -Xms option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -1329,31 +1329,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -1396,6 +1371,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -1942,14 +1942,14 @@ spec:
                   livenessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -1958,22 +1958,22 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod liveness checking.
                   readinessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -1982,10 +1982,10 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod readiness checking.
                   jvmOptions:
                     type: object
@@ -1995,14 +1995,14 @@ spec:
                           type: string
                         type: object
                         description: A map of -XX options to the JVM.
-                      "-Xms":
-                        type: string
-                        pattern: "^[0-9]+[mMgG]?$"
-                        description: -Xms option to to the JVM.
                       "-Xmx":
                         type: string
                         pattern: "^[0-9]+[mMgG]?$"
                         description: -Xmx option to to the JVM.
+                      "-Xms":
+                        type: string
+                        pattern: "^[0-9]+[mMgG]?$"
+                        description: -Xms option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -2135,6 +2135,24 @@ spec:
                             - Parallel
                             description: PodManagementPolicy which will be used for this StatefulSet. Valid values are `Parallel` and `OrderedReady`. Defaults to `Parallel`.
                         description: Template for ZooKeeper `StatefulSet`.
+                      podSet:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                            properties:
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                description: Labels added to the Kubernetes resource.
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                description: Annotations added to the Kubernetes resource.
+                            description: Metadata applied to the resource.
+                        description: Template for ZooKeeper `StrimziPodSet` resource.
                       pod:
                         type: object
                         properties:
@@ -2565,31 +2583,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -2632,6 +2625,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -2849,24 +2867,6 @@ spec:
                                 description: Annotations added to the Kubernetes resource.
                             description: Metadata applied to the resource.
                         description: Template for Secret of the Zookeeper Cluster JMX authentication.
-                      podSet:
-                        type: object
-                        properties:
-                          metadata:
-                            type: object
-                            properties:
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                                description: Labels added to the Kubernetes resource.
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                                description: Annotations added to the Kubernetes resource.
-                            description: Metadata applied to the resource.
-                        description: Template for ZooKeeper `StrimziPodSet` resource.
                     description: Template for ZooKeeper cluster resources. The template allows users to specify how the Kubernetes resources are generated.
                 required:
                 - replicas
@@ -2895,14 +2895,14 @@ spec:
                       startupProbe:
                         type: object
                         properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           initialDelaySeconds:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                           periodSeconds:
                             type: integer
                             minimum: 1
@@ -2911,22 +2911,22 @@ spec:
                             type: integer
                             minimum: 1
                             description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
+                          failureThreshold:
                             type: integer
                             minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         description: Pod startup checking.
                       livenessProbe:
                         type: object
                         properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           initialDelaySeconds:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                           periodSeconds:
                             type: integer
                             minimum: 1
@@ -2935,22 +2935,22 @@ spec:
                             type: integer
                             minimum: 1
                             description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
+                          failureThreshold:
                             type: integer
                             minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           initialDelaySeconds:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                           periodSeconds:
                             type: integer
                             minimum: 1
@@ -2959,10 +2959,10 @@ spec:
                             type: integer
                             minimum: 1
                             description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
+                          failureThreshold:
                             type: integer
                             minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3024,14 +3024,14 @@ spec:
                               type: string
                             type: object
                             description: A map of -XX options to the JVM.
-                          "-Xms":
-                            type: string
-                            pattern: "^[0-9]+[mMgG]?$"
-                            description: -Xms option to to the JVM.
                           "-Xmx":
                             type: string
                             pattern: "^[0-9]+[mMgG]?$"
                             description: -Xmx option to to the JVM.
+                          "-Xms":
+                            type: string
+                            pattern: "^[0-9]+[mMgG]?$"
+                            description: -Xms option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3072,14 +3072,14 @@ spec:
                       livenessProbe:
                         type: object
                         properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           initialDelaySeconds:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                           periodSeconds:
                             type: integer
                             minimum: 1
@@ -3088,22 +3088,22 @@ spec:
                             type: integer
                             minimum: 1
                             description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
+                          failureThreshold:
                             type: integer
                             minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         description: Pod liveness checking.
                       readinessProbe:
                         type: object
                         properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                           initialDelaySeconds:
                             type: integer
                             minimum: 0
                             description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                           periodSeconds:
                             type: integer
                             minimum: 1
@@ -3112,10 +3112,10 @@ spec:
                             type: integer
                             minimum: 1
                             description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
+                          failureThreshold:
                             type: integer
                             minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                         description: Pod readiness checking.
                       resources:
                         type: object
@@ -3173,14 +3173,14 @@ spec:
                               type: string
                             type: object
                             description: A map of -XX options to the JVM.
-                          "-Xms":
-                            type: string
-                            pattern: "^[0-9]+[mMgG]?$"
-                            description: -Xms option to to the JVM.
                           "-Xmx":
                             type: string
                             pattern: "^[0-9]+[mMgG]?$"
                             description: -Xmx option to to the JVM.
+                          "-Xms":
+                            type: string
+                            pattern: "^[0-9]+[mMgG]?$"
+                            description: -Xms option to to the JVM.
                           gcLoggingEnabled:
                             type: boolean
                             description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -3204,66 +3204,6 @@ spec:
                       image:
                         type: string
                         description: The docker image for the container.
-                      livenessProbe:
-                        type: object
-                        properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                          initialDelaySeconds:
-                            type: integer
-                            minimum: 0
-                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                          periodSeconds:
-                            type: integer
-                            minimum: 1
-                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                          successThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
-                            type: integer
-                            minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                        description: Pod liveness checking.
-                      logLevel:
-                        type: string
-                        enum:
-                        - emerg
-                        - alert
-                        - crit
-                        - err
-                        - warning
-                        - notice
-                        - info
-                        - debug
-                        description: The log level for the TLS sidecar. Default value is `notice`.
-                      readinessProbe:
-                        type: object
-                        properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                          initialDelaySeconds:
-                            type: integer
-                            minimum: 0
-                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                          periodSeconds:
-                            type: integer
-                            minimum: 1
-                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                          successThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
-                            type: integer
-                            minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                        description: Pod readiness checking.
                       resources:
                         type: object
                         properties:
@@ -3281,6 +3221,66 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                         description: CPU and memory resources to reserve.
+                      livenessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          periodSeconds:
+                            type: integer
+                            minimum: 1
+                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          successThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                          failureThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        description: Pod liveness checking.
+                      readinessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          periodSeconds:
+                            type: integer
+                            minimum: 1
+                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          successThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                          failureThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        description: Pod readiness checking.
+                      logLevel:
+                        type: string
+                        enum:
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                        description: The log level for the TLS sidecar. Default value is `notice`.
                     description: TLS sidecar configuration.
                   template:
                     type: object
@@ -3739,31 +3739,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -3806,6 +3781,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for Entity Operator `Pods`.
                       topicOperatorContainer:
                         type: object
@@ -4163,66 +4163,6 @@ spec:
                       image:
                         type: string
                         description: The docker image for the container.
-                      livenessProbe:
-                        type: object
-                        properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                          initialDelaySeconds:
-                            type: integer
-                            minimum: 0
-                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                          periodSeconds:
-                            type: integer
-                            minimum: 1
-                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                          successThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
-                            type: integer
-                            minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                        description: Pod liveness checking.
-                      logLevel:
-                        type: string
-                        enum:
-                        - emerg
-                        - alert
-                        - crit
-                        - err
-                        - warning
-                        - notice
-                        - info
-                        - debug
-                        description: The log level for the TLS sidecar. Default value is `notice`.
-                      readinessProbe:
-                        type: object
-                        properties:
-                          failureThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                          initialDelaySeconds:
-                            type: integer
-                            minimum: 0
-                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                          periodSeconds:
-                            type: integer
-                            minimum: 1
-                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                          successThreshold:
-                            type: integer
-                            minimum: 1
-                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                          timeoutSeconds:
-                            type: integer
-                            minimum: 1
-                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                        description: Pod readiness checking.
                       resources:
                         type: object
                         properties:
@@ -4240,6 +4180,66 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
                         description: CPU and memory resources to reserve.
+                      livenessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          periodSeconds:
+                            type: integer
+                            minimum: 1
+                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          successThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                          failureThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        description: Pod liveness checking.
+                      readinessProbe:
+                        type: object
+                        properties:
+                          initialDelaySeconds:
+                            type: integer
+                            minimum: 0
+                            description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                          timeoutSeconds:
+                            type: integer
+                            minimum: 1
+                            description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                          periodSeconds:
+                            type: integer
+                            minimum: 1
+                            description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          successThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                          failureThreshold:
+                            type: integer
+                            minimum: 1
+                            description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                        description: Pod readiness checking.
+                      logLevel:
+                        type: string
+                        enum:
+                        - emerg
+                        - alert
+                        - crit
+                        - err
+                        - warning
+                        - notice
+                        - info
+                        - debug
+                        description: The log level for the TLS sidecar. Default value is `notice`.
                     description: TLS sidecar configuration.
                   resources:
                     type: object
@@ -4261,14 +4261,14 @@ spec:
                   livenessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -4277,22 +4277,22 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod liveness checking for the Cruise Control container.
                   readinessProbe:
                     type: object
                     properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                       initialDelaySeconds:
                         type: integer
                         minimum: 0
                         description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                       periodSeconds:
                         type: integer
                         minimum: 1
@@ -4301,10 +4301,10 @@ spec:
                         type: integer
                         minimum: 1
                         description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
+                      failureThreshold:
                         type: integer
                         minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                     description: Pod readiness checking for the Cruise Control container.
                   jvmOptions:
                     type: object
@@ -4314,14 +4314,14 @@ spec:
                           type: string
                         type: object
                         description: A map of -XX options to the JVM.
-                      "-Xms":
-                        type: string
-                        pattern: "^[0-9]+[mMgG]?$"
-                        description: -Xms option to to the JVM.
                       "-Xmx":
                         type: string
                         pattern: "^[0-9]+[mMgG]?$"
                         description: -Xmx option to to the JVM.
+                      "-Xms":
+                        type: string
+                        pattern: "^[0-9]+[mMgG]?$"
+                        description: -Xms option to to the JVM.
                       gcLoggingEnabled:
                         type: boolean
                         description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -4826,31 +4826,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -4893,6 +4868,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -5732,31 +5732,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -5799,6 +5774,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -5935,6 +5935,54 @@ spec:
                   logging:
                     type: string
                     description: "Only log messages with the given severity or above. Valid levels: [`info`, `debug`, `trace`]. Default log level is `info`."
+                  livenessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                        description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      periodSeconds:
+                        type: integer
+                        minimum: 1
+                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                      successThreshold:
+                        type: integer
+                        minimum: 1
+                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                      failureThreshold:
+                        type: integer
+                        minimum: 1
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                    description: Pod liveness check.
+                  readinessProbe:
+                    type: object
+                    properties:
+                      initialDelaySeconds:
+                        type: integer
+                        minimum: 0
+                        description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                      timeoutSeconds:
+                        type: integer
+                        minimum: 1
+                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                      periodSeconds:
+                        type: integer
+                        minimum: 1
+                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                      successThreshold:
+                        type: integer
+                        minimum: 1
+                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                      failureThreshold:
+                        type: integer
+                        minimum: 1
+                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                    description: Pod readiness check.
                   enableSaramaLogging:
                     type: boolean
                     description: "Enable Sarama logging, a Go client library used by the Kafka Exporter."
@@ -6398,31 +6446,6 @@ spec:
                                 value:
                                   type: string
                             description: The pod's tolerations.
-                          priorityClassName:
-                            type: string
-                            description: 'The name of the priority class used to assign priority to the pods. '
-                          schedulerName:
-                            type: string
-                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                          hostAliases:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                hostnames:
-                                  type: array
-                                  items:
-                                    type: string
-                                ip:
-                                  type: string
-                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                          tmpDirSizeLimit:
-                            type: string
-                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                          enableServiceLinks:
-                            type: boolean
-                            description: Indicates whether information about services should be injected into Pod's environment variables.
                           topologySpreadConstraints:
                             type: array
                             items:
@@ -6465,6 +6488,31 @@ spec:
                                 whenUnsatisfiable:
                                   type: string
                             description: The pod's topology spread constraints.
+                          priorityClassName:
+                            type: string
+                            description: 'The name of the priority class used to assign priority to the pods. '
+                          schedulerName:
+                            type: string
+                            description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                          hostAliases:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                hostnames:
+                                  type: array
+                                  items:
+                                    type: string
+                                ip:
+                                  type: string
+                            description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                          enableServiceLinks:
+                            type: boolean
+                            description: Indicates whether information about services should be injected into Pod's environment variables.
+                          tmpDirSizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object
@@ -6577,54 +6625,6 @@ spec:
                             description: Metadata applied to the resource.
                         description: Template for the Kafka Exporter service account.
                     description: Customization of deployment templates and pods.
-                  livenessProbe:
-                    type: object
-                    properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                      initialDelaySeconds:
-                        type: integer
-                        minimum: 0
-                        description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                      periodSeconds:
-                        type: integer
-                        minimum: 1
-                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                      successThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
-                        type: integer
-                        minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                    description: Pod liveness check.
-                  readinessProbe:
-                    type: object
-                    properties:
-                      failureThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
-                      initialDelaySeconds:
-                        type: integer
-                        minimum: 0
-                        description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
-                      periodSeconds:
-                        type: integer
-                        minimum: 1
-                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-                      successThreshold:
-                        type: integer
-                        minimum: 1
-                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                      timeoutSeconds:
-                        type: integer
-                        minimum: 1
-                        description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
-                    description: Pod readiness check.
                 description: "Configuration of the Kafka Exporter. Kafka Exporter can provide additional metrics, for example lag of consumer group at topic/partition."
               maintenanceTimeWindows:
                 type: array

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -73,15 +73,15 @@ spec:
                     items:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                      - certificate
                       - secretName
+                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration.
               authentication:
@@ -109,19 +109,19 @@ spec:
                   certificateAndKey:
                     type: object
                     properties:
-                      certificate:
-                        type: string
-                        description: The name of the file certificate in the Secret.
                       key:
                         type: string
                         description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
                     required:
-                    - certificate
                     - key
                     - secretName
+                    - certificate
                     description: Reference to the `Secret` which holds the certificate and private key pair.
                   clientId:
                     type: string
@@ -163,15 +163,15 @@ spec:
                   passwordSecret:
                     type: object
                     properties:
-                      password:
-                        type: string
-                        description: The name of the key in the Secret under which the password is stored.
                       secretName:
                         type: string
                         description: The name of the Secret containing the password.
+                      password:
+                        type: string
+                        description: The name of the key in the Secret under which the password is stored.
                     required:
-                    - password
                     - secretName
+                    - password
                     description: Reference to the `Secret` which holds the password.
                   readTimeoutSeconds:
                     type: integer
@@ -197,15 +197,15 @@ spec:
                     items:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                      - certificate
                       - secretName
+                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string
@@ -249,14 +249,14 @@ spec:
               livenessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -265,22 +265,22 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod liveness checking.
               readinessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -289,10 +289,10 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod readiness checking.
               jvmOptions:
                 type: object
@@ -302,14 +302,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -385,6 +385,32 @@ spec:
                 required:
                 - topologyKey
                 description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+              metricsConfig:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jmxPrometheusExporter
+                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
+                required:
+                - type
+                - valueFrom
+                description: Metrics configuration.
               tracing:
                 type: object
                 properties:
@@ -872,31 +898,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -939,6 +940,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
                     type: object
@@ -1642,31 +1668,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1709,6 +1710,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:
                     type: object
@@ -1856,16 +1882,6 @@ spec:
                         valueFrom:
                           type: object
                           properties:
-                            configMapKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a ConfigMap.
                             secretKeyRef:
                               type: object
                               properties:
@@ -1876,6 +1892,16 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a Secret.
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a ConfigMap.
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -1886,27 +1912,6 @@ spec:
                     items:
                       type: object
                       properties:
-                        configMap:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                         name:
                           type: string
                           description: Name of the volume which will be added to the Kafka Connect pods.
@@ -1931,6 +1936,27 @@ spec:
                             secretName:
                               type: string
                           description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                        configMap:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
@@ -1962,23 +1988,6 @@ spec:
                     - image
                     - type
                     description: Configures where should the newly built image be stored. Required.
-                  resources:
-                    type: object
-                    properties:
-                      claims:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                      limits:
-                        x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      requests:
-                        x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                    description: CPU and memory resources to reserve for the build.
                   plugins:
                     type: array
                     items:
@@ -2034,36 +2043,27 @@ spec:
                       - name
                       - artifacts
                     description: List of connector plugins which should be added to the Kafka Connect. Required.
+                  resources:
+                    type: object
+                    properties:
+                      claims:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      limits:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      requests:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    description: CPU and memory resources to reserve for the build.
                 required:
                 - output
                 - plugins
                 description: Configures how the Connect container image should be built. Optional.
-              metricsConfig:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jmxPrometheusExporter
-                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
-                required:
-                - type
-                - valueFrom
-                description: Metrics configuration.
             required:
             - bootstrapServers
             description: The specification of the Kafka Connect cluster.
@@ -2102,20 +2102,20 @@ spec:
                 items:
                   type: object
                   properties:
+                    class:
+                      type: string
+                      description: The class of the connector plugin.
                     type:
                       type: string
                       description: The type of the connector plugin. The available types are `sink` and `source`.
                     version:
                       type: string
                       description: The version of the connector plugin.
-                    class:
-                      type: string
-                      description: The class of the connector plugin.
                 description: The list of connector plugins available in this Kafka Connect deployment.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
               replicas:
                 type: integer
                 description: The current number of pods being used to provide this resource.
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
             description: The status of the Kafka Connect cluster.

--- a/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
+++ b/packaging/install/cluster-operator/043-Crd-kafkatopic.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -70,9 +73,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object
@@ -164,6 +164,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -177,9 +180,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object
@@ -271,6 +271,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -284,9 +287,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -98,6 +98,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -133,35 +162,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -177,22 +177,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object
@@ -329,6 +329,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -364,35 +393,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -408,22 +408,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object
@@ -560,6 +560,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -595,35 +624,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -639,22 +639,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -114,19 +114,19 @@ spec:
                       certificateAndKey:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           key:
                             type: string
                             description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                        - certificate
                         - key
                         - secretName
+                        - certificate
                         description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
@@ -168,15 +168,15 @@ spec:
                       passwordSecret:
                         type: object
                         properties:
-                          password:
-                            type: string
-                            description: The name of the key in the Secret under which the password is stored.
                           secretName:
                             type: string
                             description: The name of the Secret containing the password.
+                          password:
+                            type: string
+                            description: The name of the key in the Secret under which the password is stored.
                         required:
-                        - password
                         - secretName
+                        - password
                         description: Reference to the `Secret` which holds the password.
                       readTimeoutSeconds:
                         type: integer
@@ -202,15 +202,15 @@ spec:
                         items:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - secretName
+                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -230,10 +230,6 @@ spec:
                     required:
                     - type
                     description: Authentication configuration for connecting to the cluster.
-                  config:
-                    x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                   tls:
                     type: object
                     properties:
@@ -242,17 +238,21 @@ spec:
                         items:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - secretName
+                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
+                  config:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    description: "The MirrorMaker consumer config. Properties with the following prefixes cannot be set: ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                 required:
                 - bootstrapServers
                 - groupId
@@ -291,19 +291,19 @@ spec:
                       certificateAndKey:
                         type: object
                         properties:
-                          certificate:
-                            type: string
-                            description: The name of the file certificate in the Secret.
                           key:
                             type: string
                             description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
+                          certificate:
+                            type: string
+                            description: The name of the file certificate in the Secret.
                         required:
-                        - certificate
                         - key
                         - secretName
+                        - certificate
                         description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
@@ -345,15 +345,15 @@ spec:
                       passwordSecret:
                         type: object
                         properties:
-                          password:
-                            type: string
-                            description: The name of the key in the Secret under which the password is stored.
                           secretName:
                             type: string
                             description: The name of the Secret containing the password.
+                          password:
+                            type: string
+                            description: The name of the key in the Secret under which the password is stored.
                         required:
-                        - password
                         - secretName
+                        - password
                         description: Reference to the `Secret` which holds the password.
                       readTimeoutSeconds:
                         type: integer
@@ -379,15 +379,15 @@ spec:
                         items:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - secretName
+                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -419,15 +419,15 @@ spec:
                         items:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - secretName
+                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
                 required:
@@ -464,14 +464,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -1014,31 +1014,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1081,6 +1056,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka MirrorMaker `Pods`.
                   podDisruptionBudget:
                     type: object
@@ -1200,14 +1200,14 @@ spec:
               livenessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -1216,22 +1216,22 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod liveness checking.
               readinessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -1240,10 +1240,10 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod readiness checking.
             oneOf:
             - properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -76,15 +76,15 @@ spec:
                     items:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                      - certificate
                       - secretName
+                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration for connecting Kafka Bridge to the cluster.
               authentication:
@@ -112,19 +112,19 @@ spec:
                   certificateAndKey:
                     type: object
                     properties:
-                      certificate:
-                        type: string
-                        description: The name of the file certificate in the Secret.
                       key:
                         type: string
                         description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
+                      certificate:
+                        type: string
+                        description: The name of the file certificate in the Secret.
                     required:
-                    - certificate
                     - key
                     - secretName
+                    - certificate
                     description: Reference to the `Secret` which holds the certificate and private key pair.
                   clientId:
                     type: string
@@ -166,15 +166,15 @@ spec:
                   passwordSecret:
                     type: object
                     properties:
-                      password:
-                        type: string
-                        description: The name of the key in the Secret under which the password is stored.
                       secretName:
                         type: string
                         description: The name of the Secret containing the password.
+                      password:
+                        type: string
+                        description: The name of the key in the Secret under which the password is stored.
                     required:
-                    - password
                     - secretName
+                    - password
                     description: Reference to the `Secret` which holds the password.
                   readTimeoutSeconds:
                     type: integer
@@ -200,15 +200,15 @@ spec:
                     items:
                       type: object
                       properties:
-                        certificate:
-                          type: string
-                          description: The name of the file certificate in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
+                        certificate:
+                          type: string
+                          description: The name of the file certificate in the Secret.
                       required:
-                      - certificate
                       - secretName
+                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string
@@ -302,14 +302,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -376,14 +376,14 @@ spec:
               livenessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -392,22 +392,22 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod liveness checking.
               readinessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -416,10 +416,10 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod readiness checking.
               template:
                 type: object
@@ -878,31 +878,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -945,6 +920,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka Bridge `Pods`.
                   apiService:
                     type: object
@@ -1231,10 +1231,10 @@ spec:
               url:
                 type: string
                 description: The URL at which external client applications can access the Kafka Bridge.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
               replicas:
                 type: integer
                 description: The current number of pods being used to provide this resource.
+              labelSelector:
+                type: string
+                description: Label selector for pods providing this resource.
             description: The status of the Kafka Bridge.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -85,15 +85,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                            - certificate
                             - secretName
+                            - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                     authentication:
@@ -121,19 +121,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            certificate:
-                              type: string
-                              description: The name of the file certificate in the Secret.
                             key:
                               type: string
                               description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
+                            certificate:
+                              type: string
+                              description: The name of the file certificate in the Secret.
                           required:
-                          - certificate
                           - key
                           - secretName
+                          - certificate
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -175,15 +175,15 @@ spec:
                         passwordSecret:
                           type: object
                           properties:
-                            password:
-                              type: string
-                              description: The name of the key in the Secret under which the password is stored.
                             secretName:
                               type: string
                               description: The name of the Secret containing the password.
+                            password:
+                              type: string
+                              description: The name of the key in the Secret under which the password is stored.
                           required:
-                          - password
                           - secretName
+                          - password
                           description: Reference to the `Secret` which holds the password.
                         readTimeoutSeconds:
                           type: integer
@@ -209,15 +209,15 @@ spec:
                           items:
                             type: object
                             properties:
-                              certificate:
-                                type: string
-                                description: The name of the file certificate in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
+                              certificate:
+                                type: string
+                                description: The name of the file certificate in the Secret.
                             required:
-                            - certificate
                             - secretName
+                            - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -263,10 +263,20 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                         autoRestart:
                           type: object
                           properties:
@@ -277,16 +287,6 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                        state:
-                          type: string
-                          enum:
-                          - paused
-                          - stopped
-                          - running
-                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 source connector.
                     heartbeatConnector:
                       type: object
@@ -295,10 +295,20 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                         autoRestart:
                           type: object
                           properties:
@@ -309,16 +319,6 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                        state:
-                          type: string
-                          enum:
-                          - paused
-                          - stopped
-                          - running
-                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                     checkpointConnector:
                       type: object
@@ -327,10 +327,20 @@ spec:
                           type: integer
                           minimum: 1
                           description: The maximum number of tasks for the Kafka Connector.
+                        pause:
+                          type: boolean
+                          description: Whether the connector should be paused. Defaults to false.
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
                           description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                         autoRestart:
                           type: object
                           properties:
@@ -341,16 +351,6 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
-                        pause:
-                          type: boolean
-                          description: Whether the connector should be paused. Defaults to false.
-                        state:
-                          type: string
-                          enum:
-                          - paused
-                          - stopped
-                          - running
-                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                     topicsPattern:
                       type: string
@@ -394,14 +394,14 @@ spec:
               livenessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -410,22 +410,22 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod liveness checking.
               readinessProbe:
                 type: object
                 properties:
-                  failureThreshold:
-                    type: integer
-                    minimum: 1
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                   initialDelaySeconds:
                     type: integer
                     minimum: 0
                     description: The initial delay before first the health is first checked. Default to 15 seconds. Minimum value is 0.
+                  timeoutSeconds:
+                    type: integer
+                    minimum: 1
+                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
                   periodSeconds:
                     type: integer
                     minimum: 1
@@ -434,10 +434,10 @@ spec:
                     type: integer
                     minimum: 1
                     description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
-                  timeoutSeconds:
+                  failureThreshold:
                     type: integer
                     minimum: 1
-                    description: The timeout for each attempted health check. Default to 5 seconds. Minimum value is 1.
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                 description: Pod readiness checking.
               jvmOptions:
                 type: object
@@ -447,14 +447,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -530,6 +530,32 @@ spec:
                 required:
                 - topologyKey
                 description: Configuration of the node label which will be used as the `client.rack` consumer configuration.
+              metricsConfig:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - jmxPrometheusExporter
+                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
+                  valueFrom:
+                    type: object
+                    properties:
+                      configMapKeyRef:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        description: Reference to the key in the ConfigMap containing the configuration.
+                    description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
+                required:
+                - type
+                - valueFrom
+                description: Metrics configuration.
               tracing:
                 type: object
                 properties:
@@ -1017,31 +1043,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1084,6 +1085,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
                     type: object
@@ -1787,31 +1813,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -1854,6 +1855,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:
                     type: object
@@ -2001,16 +2027,6 @@ spec:
                         valueFrom:
                           type: object
                           properties:
-                            configMapKeyRef:
-                              type: object
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: Reference to a key in a ConfigMap.
                             secretKeyRef:
                               type: object
                               properties:
@@ -2021,6 +2037,16 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a Secret.
+                            configMapKeyRef:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: Reference to a key in a ConfigMap.
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -2031,27 +2057,6 @@ spec:
                     items:
                       type: object
                       properties:
-                        configMap:
-                          type: object
-                          properties:
-                            defaultMode:
-                              type: integer
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    type: integer
-                                  path:
-                                    type: string
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                         name:
                           type: string
                           description: Name of the volume which will be added to the Kafka Connect pods.
@@ -2076,36 +2081,31 @@ spec:
                             secretName:
                               type: string
                           description: Reference to a key in a Secret. Exactly one Secret or ConfigMap has to be specified.
+                        configMap:
+                          type: object
+                          properties:
+                            defaultMode:
+                              type: integer
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    type: integer
+                                  path:
+                                    type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
                 description: Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
-              metricsConfig:
-                type: object
-                properties:
-                  type:
-                    type: string
-                    enum:
-                    - jmxPrometheusExporter
-                    description: Metrics type. Only 'jmxPrometheusExporter' supported currently.
-                  valueFrom:
-                    type: object
-                    properties:
-                      configMapKeyRef:
-                        type: object
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        description: Reference to the key in the ConfigMap containing the configuration.
-                    description: 'ConfigMap entry where the Prometheus JMX Exporter configuration is stored. '
-                required:
-                - type
-                - valueFrom
-                description: Metrics configuration.
             required:
             - connectCluster
             description: The specification of the Kafka MirrorMaker 2 cluster.
@@ -2139,6 +2139,12 @@ spec:
               url:
                 type: string
                 description: The URL of the REST API endpoint for managing and monitoring Kafka Connect connectors.
+              connectors:
+                type: array
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
               autoRestartStatuses:
                 type: array
                 items:
@@ -2159,22 +2165,16 @@ spec:
                 items:
                   type: object
                   properties:
+                    class:
+                      type: string
+                      description: The class of the connector plugin.
                     type:
                       type: string
                       description: The type of the connector plugin. The available types are `sink` and `source`.
                     version:
                       type: string
                       description: The version of the connector plugin.
-                    class:
-                      type: string
-                      description: The class of the connector plugin.
                 description: The list of connector plugins available in this Kafka Connect deployment.
-              connectors:
-                type: array
-                items:
-                  x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                description: "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API."
               labelSelector:
                 type: string
                 description: Label selector for pods providing this resource.

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -181,14 +181,14 @@ spec:
                       type: string
                     type: object
                     description: A map of -XX options to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
                   "-Xmx":
                     type: string
                     pattern: "^[0-9]+[mMgG]?$"
                     description: -Xmx option to to the JVM.
+                  "-Xms":
+                    type: string
+                    pattern: "^[0-9]+[mMgG]?$"
+                    description: -Xms option to to the JVM.
                   gcLoggingEnabled:
                     type: boolean
                     description: Specifies whether the Garbage Collection logging is enabled. The default is false.
@@ -656,31 +656,6 @@ spec:
                             value:
                               type: string
                         description: The pod's tolerations.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
                       topologySpreadConstraints:
                         type: array
                         items:
@@ -723,6 +698,31 @@ spec:
                             whenUnsatisfiable:
                               type: string
                         description: The pod's topology spread constraints.
+                      priorityClassName:
+                        type: string
+                        description: 'The name of the priority class used to assign priority to the pods. '
+                      schedulerName:
+                        type: string
+                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                      hostAliases:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            hostnames:
+                              type: array
+                              items:
+                                type: string
+                            ip:
+                              type: string
+                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                      enableServiceLinks:
+                        type: boolean
+                        description: Indicates whether information about services should be injected into Pod's environment variables.
+                      tmpDirSizeLimit:
+                        type: string
+                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
                     description: Template for Kafka `Pods`.
                   perPodService:
                     type: object

--- a/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
+++ b/packaging/install/topic-operator/04-Crd-kafkatopic.yaml
@@ -57,6 +57,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -70,9 +73,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object
@@ -164,6 +164,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -177,9 +180,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object
@@ -271,6 +271,9 @@ spec:
           spec:
             type: object
             properties:
+              topicName:
+                type: string
+                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
               partitions:
                 type: integer
                 minimum: 1
@@ -284,9 +287,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
                 description: The topic configuration.
-              topicName:
-                type: string
-                description: The name of the topic. When absent this will default to the metadata.name of the topic. It is recommended to not set this unless the topic name is not a valid Kubernetes resource name.
             description: The specification of the topic.
           status:
             type: object

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -98,6 +98,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -133,35 +162,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -177,22 +177,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object
@@ -329,6 +329,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -364,35 +393,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -408,22 +408,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object
@@ -560,6 +560,35 @@ spec:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          enum:
+                          - allow
+                          - deny
+                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                        resource:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
+                            patternType:
+                              type: string
+                              enum:
+                              - literal
+                              - prefix
+                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
+                            type:
+                              type: string
+                              enum:
+                              - topic
+                              - group
+                              - cluster
+                              - transactionalId
+                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
+                          required:
+                          - type
+                          description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
                           description: The host from which the action described in the ACL rule is allowed or denied.
@@ -595,35 +624,6 @@ spec:
                             - IdempotentWrite
                             - All
                           description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
-                        resource:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name of resource for which given ACL rule applies. Can be combined with `patternType` field to use prefix pattern.
-                            patternType:
-                              type: string
-                              enum:
-                              - literal
-                              - prefix
-                              description: "Describes the pattern used in the resource field. The supported types are `literal` and `prefix`. With `literal` pattern type, the resource field will be used as a definition of a full name. With `prefix` pattern type, the resource name will be used only as a prefix. Default value is `literal`."
-                            type:
-                              type: string
-                              enum:
-                              - topic
-                              - group
-                              - cluster
-                              - transactionalId
-                              description: "Resource type. The available resource types are `topic`, `group`, `cluster`, and `transactionalId`."
-                          required:
-                          - type
-                          description: Indicates the resource for which given ACL rule applies.
-                        type:
-                          type: string
-                          enum:
-                          - allow
-                          - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -639,22 +639,22 @@ spec:
               quotas:
                 type: object
                 properties:
-                  consumerByteRate:
-                    type: integer
-                    minimum: 0
-                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
-                  controllerMutationRate:
-                    type: number
-                    minimum: 0
-                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                   producerByteRate:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum bytes per-second that each client group can publish to a broker before the clients in the group are throttled. Defined on a per-broker basis.
+                  consumerByteRate:
+                    type: integer
+                    minimum: 0
+                    description: A quota on the maximum bytes per-second that each client group can fetch from a broker before the clients in the group are throttled. Defined on a per-broker basis.
                   requestPercentage:
                     type: integer
                     minimum: 0
                     description: A quota on the maximum CPU utilization of each client group as a percentage of network and I/O threads.
+                  controllerMutationRate:
+                    type: number
+                    minimum: 0
+                    description: "A quota on the rate at which mutations are accepted for the create topics request, the create partitions request and the delete topics request. The rate is accumulated by the number of partitions created or deleted."
                 description: Quotas on requests to control the broker resources used by clients. Network bandwidth and request rate quotas can be enforced.Kafka documentation for Kafka User quotas can be found at http://kafka.apache.org/documentation/#design_quotas.
               template:
                 type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature: https://github.com/strimzi/strimzi-kafka-operator/issues/2779
- Refactoring

### Description
Validating existence of `@JsonPropertyOrder` and that all relevant fields in class are present in the `@JsonPropertyOrder`

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

