### PR TITLE
Add a single node KRaft example for use in quickstarts

### DIFF
--- a/packaging/examples/kafka/kraft/README.md
+++ b/packaging/examples/kafka/kraft/README.md
@@ -4,7 +4,8 @@ The examples in this directory demonstrate how you can use Kraft (ZooKeeper-less
 * The [`kafka.yaml`](kafka.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes and one pool of _KRaft broker_ nodes.
 * The [`kafka-ephemeral.yaml`](kafka-ephemeral.yaml) deploys a Kafka cluster with one pool of _KRaft controller_ nodes, one pool of _KRaft broker_ nodes and ephemeral storage.
 * The [`kafka-with-dual-role-nodes.yaml`](kafka-with-dual-role-nodes.yaml) deploys a Kafka cluster with one pool of KRaft nodes that share the _broker_ and _controller_ roles.
+* The [`kafka-single-node.yaml`](kafka-single-node.yaml) deploys a Kafka cluster with a single Kafka node that has both _broker_ and _controller_ roles.
 
-To use KRaft, ensure that the `KafkaNodePools` and `UseKRaft` feature gates are not disabled.
-Please note that ZooKeeper-less Apache Kafka is still under development and lacks some critical features.
-For instance, JBOD storage is not supported (you can specify `type: jbod` storage in Strimzi custom resources, but it should contain only a single volume).
+To use KRaft, ensure that the and `UseKRaft` feature gate is not disabled.
+Please note that ZooKeeper-less Apache Kafka is still under development and has some limitations.
+For instance, scaling of controller node or JBOD storage (you can specify `type: jbod` storage in Strimzi custom resources, but it should contain only a single volume) are not supported.

--- a/packaging/examples/kafka/kraft/README.md
+++ b/packaging/examples/kafka/kraft/README.md
@@ -6,6 +6,6 @@ The examples in this directory demonstrate how you can use Kraft (ZooKeeper-less
 * The [`kafka-with-dual-role-nodes.yaml`](kafka-with-dual-role-nodes.yaml) deploys a Kafka cluster with one pool of KRaft nodes that share the _broker_ and _controller_ roles.
 * The [`kafka-single-node.yaml`](kafka-single-node.yaml) deploys a Kafka cluster with a single Kafka node that has both _broker_ and _controller_ roles.
 
-To use KRaft, ensure that the and `UseKRaft` feature gate is not disabled.
+To use KRaft, ensure that the `UseKRaft` feature gate is not disabled.
 Please note that ZooKeeper-less Apache Kafka is still under development and has some limitations.
 For instance, scaling of controller node or JBOD storage (you can specify `type: jbod` storage in Strimzi custom resources, but it should contain only a single volume) are not supported.

--- a/packaging/examples/kafka/kraft/kafka-single-node.yaml
+++ b/packaging/examples/kafka/kraft/kafka-single-node.yaml
@@ -1,31 +1,13 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
-  name: controller
+  name: dual-role
   labels:
     strimzi.io/cluster: my-cluster
 spec:
-  replicas: 3
+  replicas: 1
   roles:
     - controller
-  storage:
-    type: jbod
-    volumes:
-      - id: 0
-        type: persistent-claim
-        size: 100Gi
-        deleteClaim: false
----
-
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaNodePool
-metadata:
-  name: broker
-  labels:
-    strimzi.io/cluster: my-cluster
-spec:
-  replicas: 3
-  roles:
     - broker
   storage:
     type: jbod
@@ -57,11 +39,11 @@ spec:
         type: internal
         tls: true
     config:
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
-      default.replication.factor: 3
-      min.insync.replicas: 2
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/packaging/examples/kafka/kraft/kafka-with-dual-role-nodes.yaml
+++ b/packaging/examples/kafka/kraft/kafka-with-dual-role-nodes.yaml
@@ -14,7 +14,7 @@ spec:
     volumes:
       - id: 0
         type: persistent-claim
-        size: 20Gi
+        size: 100Gi
         deleteClaim: false
 ---
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds a new KRaft example for a single node KRaft cluster. This would be useful in the [quickstarts](https://strimzi.io/quickstarts/) on our website to replace the ZooKeeper which has DNS issues for some users.

It also fixes the 20Gi storage in some of the other Kraft examples - that seems a copy-paste error - and brings it in sync with our other examples where we use 100Gi.

It also updates the README file to correspond to the latest changes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally