### PR TITLE
[ST] Set `STRIMZI_USE_NODE_POOLS_IN_TESTS` to `true` by default

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -224,7 +224,7 @@ public class Environment {
     public static final String STRIMZI_RBAC_SCOPE = getOrDefault(STRIMZI_RBAC_SCOPE_ENV, STRIMZI_RBAC_SCOPE_DEFAULT);
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
     public static final boolean STRIMZI_USE_KRAFT_IN_TESTS = getOrDefault(STRIMZI_USE_KRAFT_IN_TESTS_ENV, Boolean::parseBoolean, false);
-    public static final boolean STRIMZI_USE_NODE_POOLS_IN_TESTS = getOrDefault(STRIMZI_USE_NODE_POOLS_IN_TESTS_ENV, Boolean::parseBoolean, false);
+    public static final boolean STRIMZI_USE_NODE_POOLS_IN_TESTS = getOrDefault(STRIMZI_USE_NODE_POOLS_IN_TESTS_ENV, Boolean::parseBoolean, true);
     public static final NodePoolsRoleMode STRIMZI_NODE_POOLS_ROLE_MODE = getOrDefault(STRIMZI_NODE_POOLS_ROLE_MODE_ENV, value -> NodePoolsRoleMode.valueOf(value.toUpperCase(Locale.ENGLISH)), NodePoolsRoleMode.SEPARATE);
 
     // variables for kafka client app images


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

When running STs locally, we are assuming that we have NodePools enabled. But currently, those are disabled by default by `STRIMZI_USE_NODE_POOLS_IN_TESTS`. This PR sets this env variable to `true` by default.

### Checklist

- [ ] Make sure all tests pass