### PR TITLE
[ST] (Kraft)KafkaUpgradeDowngrade decrease tests durations

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -49,7 +49,7 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftKafkaUpgradeDowngradeST.class);
 
     private final String continuousTopicName = "continuous-topic";
-    private final int continuousClientsMessageCount = 1000;
+    private final int continuousClientsMessageCount = 500;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -50,7 +50,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
 
     private final String continuousTopicName = "continuous-topic";
-    private final int continuousClientsMessageCount = 1000;
+    private final int continuousClientsMessageCount = 500;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description
Decreasing the time to send/receive messages for continuous producer and consumer per each test in `KRaftKafkaUpgradeDowngradeST` and `KafkaUpgradeDowngradeST`  to half, as wait that long is unnecessary.  

8 Tests in `KRaftKafkaUpgradeDowngradeST` and `KafkaUpgradeDowngradeST` are always waiting for consumer and producer to finish successfully before the end of the tests if we are sending 1000 messages = ~16 minutes.  Only ~7 minutes of this seems to be actually necessary, Causing almost 9 minutes of extra waiting per test.  

notice time of waiting in log under of one of the tests.
```
2024-03-18 10:45:39 [main] INFO  [ClientUtils:90] Waiting for producer: co-namespace/cluster-723aa64f-producer-continuous and consumer: co-namespace/cluster-723aa64f-consumer-continuous Jobs to finish successfully
2024-03-18 10:55:21 [main] INFO  [ResourceManager:397] ############################################################################
```
The wait is now only ~500 seconds which gives 20% extra in addition to most of observed execution times.  


execution of these tests under `upgrade` profile takes ~3hours, this would decrease it by almost half (8 * 9minutes). 

