### PR TITLE
Added documentation about recommended Kubernetes labels

### DIFF
--- a/documentation/assemblies/configuring/assembly-config.adoc
+++ b/documentation/assemblies/configuring/assembly-config.adoc
@@ -142,6 +142,9 @@ include::../../assemblies/configuring/assembly-storage.adoc[leveloffset=+1]
 //configuring CPU and memory resources and limits
 include::../../modules/configuring/con-config-resources.adoc[leveloffset=+1]
 
+//Kubernetes labels
+include::../../modules/configuring/ref-kubernetes-labels.adoc[leveloffset=+1]
+
 //scheduling separate Kafka pods 
 include::assembly-scheduling.adoc[leveloffset=+1]
 

--- a/documentation/modules/configuring/ref-kubernetes-labels.adoc
+++ b/documentation/modules/configuring/ref-kubernetes-labels.adoc
@@ -14,7 +14,7 @@ These labels cannot be overridden through `template` configuration of Strimzi re
 * `app.kubernetes.io/part-of`: Similar to `app.kubernetes.io/instance`, but prefixed with `strimzi-`.
 * `app.kubernetes.io/managed-by`: Defines the application responsible for managing the operand, such as `strimzi-cluster-operator` or `strimzi-user-operator`.
 
-.Example Kubernetes labels on a Kafka Pod when deploying a `Kafka` custom resource named `my-cluster`
+.Example Kubernetes labels on a Kafka pod when deploying a `Kafka` custom resource named `my-cluster`
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}

--- a/documentation/modules/configuring/ref-kubernetes-labels.adoc
+++ b/documentation/modules/configuring/ref-kubernetes-labels.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// assembly-config.adoc
+
+[id='ref-kubernetes-labels-{context}']
+= Kubernetes labels
+
+The Kubernetes documentation defines some https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/[recommended labels] that could be set on the resources deployed within your application, in order to help describing objects in a way that all tools can understand.
+The Strimzi operator applies some of them to the operands it deploys:
+
+* `app.kubernetes.io/name`: it is the component type within Strimzi which could be `kafka`, `zookeeper`, `cruise-control`, and so on.
+* `app.kubernetes.io/instance`: it is the name of the custom resource to which the operand belong to (i.e. `my-cluster` as the name of the `Kafka` custom resource applied on the Kafka pods).
+* `app.kubernetes.io/part-of`: it is the same as the `app.kubernetes.io/instance` but with a `strimzi-` prefix.
+* `app.kubernetes.io/managed-by`: it defines which application is in charge of managing the operand like `strimzi-cluster-operator`, `strimzi-user-operator` and so on.
+
+.Example of Kubernetes labels on a Kafka Pod when deploying a `Kafka` custom resource named `my-cluster`
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaApiVersion}
+kind: Pod
+metadata:
+  name: my-cluster-kafka-0
+  labels:
+    app.kubernetes.io/instance: my-cluster                                                                                                                                                                                                 │
+    app.kubernetes.io/managed-by: strimzi-cluster-operator                                                                                                                                                                                 │
+    app.kubernetes.io/name: kafka                                                                                                                                                                                                          │
+    app.kubernetes.io/part-of: strimzi-my-cluster
+spec:
+  # ...
+----
+
+Those labels cannot be overridden by the user (i.e. by using templates).

--- a/documentation/modules/configuring/ref-kubernetes-labels.adoc
+++ b/documentation/modules/configuring/ref-kubernetes-labels.adoc
@@ -9,7 +9,7 @@ The Kubernetes documentation defines some https://kubernetes.io/docs/concepts/ov
 The Strimzi operator applies some of them to the operands it deploys:
 
 * `app.kubernetes.io/name`: it is the component type within Strimzi which could be `kafka`, `zookeeper`, `cruise-control`, and so on.
-* `app.kubernetes.io/instance`: it is the name of the custom resource to which the operand belong to (i.e. `my-cluster` as the name of the `Kafka` custom resource applied on the Kafka pods).
+* `app.kubernetes.io/instance`: it is the name of the custom resource to which the operand belong to (that is, `my-cluster` as the name of the `Kafka` custom resource applied on the Kafka pods).
 * `app.kubernetes.io/part-of`: it is the same as the `app.kubernetes.io/instance` but with a `strimzi-` prefix.
 * `app.kubernetes.io/managed-by`: it defines which application is in charge of managing the operand like `strimzi-cluster-operator`, `strimzi-user-operator` and so on.
 
@@ -29,4 +29,4 @@ spec:
   # ...
 ----
 
-Those labels cannot be overridden by the user (i.e. by using templates).
+Those labels cannot be overridden by the user (that is, by using templates).

--- a/documentation/modules/configuring/ref-kubernetes-labels.adoc
+++ b/documentation/modules/configuring/ref-kubernetes-labels.adoc
@@ -21,9 +21,9 @@ kind: Pod
 metadata:
   name: my-cluster-kafka-0
   labels:
-    app.kubernetes.io/instance: my-cluster                                                                                                                                                                                                 │
-    app.kubernetes.io/managed-by: strimzi-cluster-operator                                                                                                                                                                                 │
-    app.kubernetes.io/name: kafka                                                                                                                                                                                                          │
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: kafka
     app.kubernetes.io/part-of: strimzi-my-cluster
 spec:
   # ...

--- a/documentation/modules/configuring/ref-kubernetes-labels.adoc
+++ b/documentation/modules/configuring/ref-kubernetes-labels.adoc
@@ -3,17 +3,18 @@
 // assembly-config.adoc
 
 [id='ref-kubernetes-labels-{context}']
-= Kubernetes labels
+= Restrictions on Kubernetes labels
 
-The Kubernetes documentation defines some https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/[recommended labels] that could be set on the resources deployed within your application, in order to help describing objects in a way that all tools can understand.
-The Strimzi operator applies some of them to the operands it deploys:
+https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/[Kubernetes labels] make it easier to organize, manage, and discover Kubernetes resources within your applications.
+The Cluster Operator is responsible for applying the following Kubernetes labels to the operands it deploys.
+These labels cannot be overridden through `template` configuration of Strimzi resources:
 
-* `app.kubernetes.io/name`: it is the component type within Strimzi which could be `kafka`, `zookeeper`, `cruise-control`, and so on.
-* `app.kubernetes.io/instance`: it is the name of the custom resource to which the operand belong to (that is, `my-cluster` as the name of the `Kafka` custom resource applied on the Kafka pods).
-* `app.kubernetes.io/part-of`: it is the same as the `app.kubernetes.io/instance` but with a `strimzi-` prefix.
-* `app.kubernetes.io/managed-by`: it defines which application is in charge of managing the operand like `strimzi-cluster-operator`, `strimzi-user-operator` and so on.
+* `app.kubernetes.io/name`: Identifies the component type within Strimzi, such as `kafka`, `zookeeper`,  and`cruise-control`.
+* `app.kubernetes.io/instance`: Represents the name of the custom resource to which the operand belongs to. For instance, if a Kafka custom resource is named `my-cluster`, this label will bear that name on the associated pods.
+* `app.kubernetes.io/part-of`: Similar to `app.kubernetes.io/instance`, but prefixed with `strimzi-`.
+* `app.kubernetes.io/managed-by`: Defines the application responsible for managing the operand, such as `strimzi-cluster-operator` or `strimzi-user-operator`.
 
-.Example of Kubernetes labels on a Kafka Pod when deploying a `Kafka` custom resource named `my-cluster`
+.Example Kubernetes labels on a Kafka Pod when deploying a `Kafka` custom resource named `my-cluster`
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaApiVersion}
@@ -28,5 +29,3 @@ metadata:
 spec:
   # ...
 ----
-
-Those labels cannot be overridden by the user (that is, by using templates).


### PR DESCRIPTION
This PR adds some documentation around the recommended Kubernetes labels that we set on operands and cannot be overwritten by users when using templates.
This is related to https://github.com/strimzi/strimzi-kafka-operator/issues/9735