### PR TITLE
Fix flaky `testConnectorResourceMetricsScaledToZero`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -362,13 +362,13 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
 
         if (scaledToZero)   {
             return connectorOperator.listAsync(namespace, new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())
-                    .compose(connectors -> Future.join(
-                            connectors.stream()
-                                .filter(connector -> !Annotations.isReconciliationPausedWithAnnotation(connector))
-                                .map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
-                                .collect(Collectors.toList())
-                    ))
-                    .map((Void) null);
+                .compose(connectors -> Future.join(
+                    connectors.stream()
+                        .filter(connector -> !Annotations.isReconciliationPausedWithAnnotation(connector))
+                        .map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
+                        .collect(Collectors.toList())
+                ))
+                .map((Void) null);
         }
 
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -323,7 +323,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             List<Future<Void>> connectorFutures = new ArrayList<>();
             for (KafkaConnector connector : connectors) {
                 connectorFutures.add(maybeUpdateConnectorStatus(reconciliation, connector, null,
-                    noConnectCluster(reconciliation.namespace(), reconciliation.name())));
+                        noConnectCluster(reconciliation.namespace(), reconciliation.name())));
             }
             return Future.join(connectorFutures);
         }).map((Void) null);
@@ -362,13 +362,13 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
 
         if (scaledToZero)   {
             return connectorOperator.listAsync(namespace, new LabelSelectorBuilder().addToMatchLabels(Labels.STRIMZI_CLUSTER_LABEL, connectName).build())
-                .compose(connectors -> Future.join(
-                    connectors.stream()
-                        .filter(connector -> !Annotations.isReconciliationPausedWithAnnotation(connector))
-                        .map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
-                        .collect(Collectors.toList())
-                ))
-                .map((Void) null);
+                    .compose(connectors -> Future.join(
+                            connectors.stream()
+                                .filter(connector -> !Annotations.isReconciliationPausedWithAnnotation(connector))
+                                .map(connector -> maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
+                                .collect(Collectors.toList())
+                    ))
+                    .map((Void) null);
         }
 
         KafkaConnectApi apiClient = connectClientProvider.apply(vertx);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -2068,7 +2068,7 @@ public class ConnectorMockTest {
     }
 
     @Test
-    void testConnectorResourceMetricsScaledToZero(VertxTestContext context) throws InterruptedException {
+    void testConnectorResourceMetricsScaledToZero(VertxTestContext context) {
         String connectName = "cluster";
         String connectorName = "connector";
 
@@ -2101,7 +2101,7 @@ public class ConnectorMockTest {
         LOGGER.info("Pausing KafkaConnect reconciliations");
         KafkaConnect pausedConnect = new KafkaConnectBuilder(kafkaConnect)
             .editOrNewMetadata()
-            .addToAnnotations(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true")
+                .addToAnnotations(Annotations.ANNO_STRIMZI_IO_PAUSE_RECONCILIATION, "true")
             .endMetadata()
             .build();
         Crds.kafkaConnectOperation(client).inNamespace(namespace).resource(pausedConnect).update();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -2120,9 +2120,26 @@ public class ConnectorMockTest {
                 assertThat(requiredSearch.gauge().value(), matcher);
             } catch (MeterNotFoundException mnfe) {
                 try {
+<<<<<<< HEAD
                     TimeUnit.SECONDS.sleep(1);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
+=======
+                    for (Map.Entry<String, Double> metricEntry : expectedMetrics.entrySet()) {
+                        Gauge gauge = meterRegistry.get(metricEntry.getKey()).tags(tags).gauge();
+                        assertThat(gauge.value(), is(metricEntry.getValue()));
+                    }
+                    LOGGER.info("All assertions succeeded on attempt " + attempt);
+                    async.flag();
+                } catch (AssertionError e) {
+                    if (attempt < maxAttempts) {
+                        LOGGER.warn("Assertion failed on attempt " + attempt + ": " + e.getMessage());
+                        vertx.setTimer(1000, id -> attemptReconciliationAndAssertion(vertx, attempt + 1, maxAttempts, testContext, async, meterRegistry, tags, expectedMetrics));
+                    } else {
+                        LOGGER.error("All assertions failed after " + maxAttempts + " attempts.");
+                        testContext.failNow(e);
+                    }
+>>>>>>> 2882c39e8 (fix recursive call)
                 }
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

TLDR; This PR address https://github.com/strimzi/strimzi-kafka-operator/issues/9843. 

---

So playing around with this I found that:

1. Executing a single test case does not cause any failure as Federico pointed out (30 times in a row and it's passing).
2. Executing a whole test suite I was able to reproduce such a problem (1 run out of 5) 
```java
Caused by: java.lang.AssertionError: 
Expected: is <0.0>
     but: was <1.0>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at io.strimzi.operator.cluster.operator.assembly.ConnectorMockTest.lambda$testConnectorResourceMetricsScaledToZero$62(ConnectorMockTest.java:2107)
	at io.vertx.junit5.VertxTestContext.verify(VertxTestContext.java:376)
	at io.strimzi.operator.cluster.operator.assembly.ConnectorMockTest.lambda$testConnectorResourceMetricsScaledToZero$63(ConnectorMockTest.java:2101)
	at io.vertx.junit5.VertxTestContext.lambda$succeeding$2(VertxTestContext.java:223)
	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
	at io.vertx.core.Promise.tryComplete(Promise.java:121)
	at io.vertx.core.Promise.complete(Promise.java:77)
	at io.strimzi.operator.cluster.operator.assembly.ConnectorMockTest.lambda$testConnectorResourceMetricsScaledToZero$61(ConnectorMockTest.java:2098)
	at io.strimzi.operator.cluster.operator.assembly.KafkaConnectAssemblyOperator.lambda$reconcileThese$24(KafkaConnectAssemblyOperator.java:288)
	at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

and I tried:
1.  unique naming of connect, connectors -> did not help
2. adding a set time (at least 2s) to prove if we could prevent such failure by introducing a delay -> did not help
3. polling strategy -> solved the issue

### Checklist

- [ ] Make sure all tests pass
