### PR TITLE
Move `ShutdownHook` class from `operator-common` to `cluster-operator`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -22,7 +22,6 @@ import io.strimzi.operator.common.MetricsProvider;
 import io.strimzi.operator.common.MicrometerMetricsProvider;
 import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.ShutdownHook;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ClusterRoleOperator;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.operator.common;
+package io.strimzi.operator.cluster;
 
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.cache.Indexer;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderFactory;
-import io.strimzi.operator.common.ShutdownHook;
 import io.strimzi.platform.KubernetesVersion;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ShutdownHookTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ShutdownHookTest.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.operator.common;
+package io.strimzi.operator.cluster;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;


### PR DESCRIPTION
### Type of change

- Task

### Description

The `ShutdownHook` class is now used only by the Cluster Operator. It is also Vert.x based, so it is unlikely it will be used by UO or TO. So it can be moved to the Cluster Operator module.

### Checklist

- [x] Make sure all tests pass