### PR TITLE
Remove Vert.x dependency from `MicrometerMetricsProvider`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -35,6 +35,7 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -91,7 +92,7 @@ public class Main {
         shutdownHook.register(() -> ShutdownHook.shutdownVertx(vertx, SHUTDOWN_TIMEOUT));
 
         // Setup Micrometer Metrics provider
-        MetricsProvider metricsProvider = new MicrometerMetricsProvider();
+        MetricsProvider metricsProvider = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         KubernetesClient client = new OperatorKubernetesClientBuilder("strimzi-cluster-operator", strimziVersion).build();
 
         maybeCreateClusterRoles(vertx, config, client)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperatorTest.java
@@ -25,6 +25,7 @@ import io.vertx.core.shareddata.Lock;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ class AbstractOperatorTest {
     void testWithLockCallableSuccessfulReleasesLock(VertxTestContext context) {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(BackendRegistries.getDefaultNow()), null);
         Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
         String lockName = target.getLockName(reconciliation);
 
@@ -96,7 +97,7 @@ class AbstractOperatorTest {
     void testWithLockCallableHandledExceptionReleasesLock(VertxTestContext context) {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(BackendRegistries.getDefaultNow()), null);
         Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
         String lockName = target.getLockName(reconciliation);
 
@@ -131,7 +132,7 @@ class AbstractOperatorTest {
     void testWithLockCallableUnhandledExceptionReleasesLock(VertxTestContext context) {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(BackendRegistries.getDefaultNow()), null);
         Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
         String lockName = target.getLockName(reconciliation);
 
@@ -169,7 +170,7 @@ class AbstractOperatorTest {
     void testWithLockFailHandlerUnhandledExceptionReleasesLock(VertxTestContext context) {
         var resourceOperator = new DefaultWatchableStatusedResourceOperator<>(vertx, null, "TestResource");
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(), null);
+        var target = new DefaultOperator(vertx, "Test", resourceOperator, new MicrometerMetricsProvider(BackendRegistries.getDefaultNow()), null);
         Reconciliation reconciliation = new Reconciliation("test", "TestResource", "my-namespace", "my-resource");
         String lockName = target.getLockName(reconciliation);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -36,6 +36,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -143,7 +144,7 @@ public class KafkaConnectorIT {
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, false, config);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
                 new ZookeeperLeaderFinder(vertx,
                         // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -213,7 +214,7 @@ public class KafkaConnectorIT {
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, false, config);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
                 new ZookeeperLeaderFinder(vertx,
                         // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -262,7 +263,7 @@ public class KafkaConnectorIT {
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, false, config);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
                 new ZookeeperLeaderFinder(vertx,
                         // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -322,7 +323,7 @@ public class KafkaConnectorIT {
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, true, config);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
             new ZookeeperLeaderFinder(vertx,
                 // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -371,7 +372,7 @@ public class KafkaConnectorIT {
         KafkaConnector connector = createKafkaConnector(namespace, connectorName, true, config);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(connector).create();
 
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         ResourceOperatorSupplier ros = new ResourceOperatorSupplier(vertx, client,
             new ZookeeperLeaderFinder(vertx,
                 // Retry up to 3 times (4 attempts), with overall max delay of 35000ms
@@ -501,7 +502,7 @@ public class KafkaConnectorIT {
             JsonObject connectorStatus = new JsonObject(kafkaConnector.getStatus().getConnectorStatus());
             assertThat(connectorStatus.getJsonObject("connector"), notNullValue());
             assertThat(connectorStatus.getJsonObject("connector").getString("state"), is("RESTARTING"));
-            MetricsProvider metrics = new MicrometerMetricsProvider();
+            MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
             MeterRegistry registry = metrics.meterRegistry();
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "auto.restarts").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(1.0));
         });
@@ -522,7 +523,7 @@ public class KafkaConnectorIT {
             assertThat(connectorStatus.getJsonArray("tasks"), notNullValue());
             assertThat(connectorStatus.getJsonArray("tasks").size(), is(1));
             assertThat(connectorStatus.getJsonArray("tasks").getJsonObject(0).getString("state"), is("RESTARTING"));
-            MetricsProvider metrics = new MicrometerMetricsProvider();
+            MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
             MeterRegistry registry = metrics.meterRegistry();
             assertThat(registry.get(AbstractOperator.METRICS_PREFIX + "auto.restarts").tag("kind", KafkaConnector.RESOURCE_KIND).counter().count(), CoreMatchers.is(1.0));
         });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
@@ -30,6 +30,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -486,7 +487,7 @@ public class OperatorMetricsTest {
      * @return  Clean MetricsProvider
      */
     public MetricsProvider createCleanMetricsProvider() {
-        MetricsProvider metrics = new MicrometerMetricsProvider();
+        MetricsProvider metrics = new MicrometerMetricsProvider(BackendRegistries.getDefaultNow());
         MeterRegistry registry = metrics.meterRegistry();
 
         registry.forEachMeter(registry::remove);

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -188,11 +188,6 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-micrometer-metrics</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>mockkube</artifactId>
             <scope>test</scope>

--- a/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/MicrometerMetricsProvider.java
@@ -9,7 +9,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import io.vertx.micrometer.backends.BackendRegistries;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -19,13 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class MicrometerMetricsProvider implements MetricsProvider {
     protected final MeterRegistry metrics;
-
-    /**
-     * Constructor of the Micrometer metrics provider which uses the Vert.x provided metrics registry
-     */
-    public MicrometerMetricsProvider() {
-        this.metrics = BackendRegistries.getDefaultNow();
-    }
 
     /**
      * Constructor of the Micrometer metrics provider.


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the Vert.x dependency from `MicrometerMetricsProvider` in `operator-common` and remove the related Maven dependency. This is now used only from the Cluster Operator module and shifting the Vert.x logic there will help to reduce the Vert.x footprint in `operator-common`.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally