### PR TITLE
docs(uto): removes some references to using the bidirectional topic operator

### DIFF
--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -52,7 +52,6 @@ The ZooKeeper ports are used as follows:
 
 ZooKeeper Port (2181):: ZooKeeper port for connection to Kafka brokers.
 Additionally, the Cluster Operator communicates with ZooKeeper through this port.
-If you are using the Topic Operator in bidirectional mode, it also communicates with ZooKeeper through this port.
 ZooKeeper internodal communication port (2888):: ZooKeeper port for internodal communication between ZooKeeper nodes.
 ZooKeeper leader election port (3888):: ZooKeeper port for leader election among ZooKeeper nodes in a ZooKeeper cluster.
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -55,7 +55,12 @@ When deploying the Topic Operator to manage topics, the Cluster Operator enables
 This means that the Topic Operator only manages Kafka topics associated with `KafkaTopic` resources and does not interfere with topics managed independently within the Kafka cluster.
 
 Previously, the Topic Operator worked in bidirectional mode, which meant it could also perform operations on topics within the Kafka cluster.
-If you are switching from a version of Strimzi that uses the Bidirectional Topic Operator, after upgrading the Cluster Operator, perform some cleanup tasks to delete the internal topics that were used by the operator. 
+If you are switching from a version of Strimzi that uses the Bidirectional Topic Operator, after upgrading the Cluster Operator, perform some cleanup tasks on the following internal topics that were used by the operator: 
+
+* `strimzi-store-topic`
+* `strimzi-topic-operator`
+* `consumer-offsets`
+* `transaction-state`
 
 For the `strimzi-store-topic` and `strimzi-topic-operator` topics, delete the resources that were used to manage them:
 
@@ -77,6 +82,8 @@ Annotating the `KafkaTopic` resources with `strimzi.io/managed="false"` indicate
 kubectl annotate $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) strimzi.io/managed="false" \
   && kubectl annotate $(kubectl get kt -n <namespace> -o name | grep transaction-state) strimzi.io/managed="false"
 ----
+
+Check the statuses of the `KafkaTopic` resources to make sure the reconciliation was successful and the topics are no longer managed, as shown in the   xref:proc-converting-managed-topics-str[procedure to stop managing topics]. 
 
 Having discontinued their management, delete the `KafkaTopic` resources:
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -33,12 +33,6 @@ The `helm upgrade` command does not upgrade the {HelmCustomResourceDefinitions}.
 Install the new CRDs manually after upgrading the Cluster Operator.
 You can access the CRDs from the {ReleaseDownload} or find them in the `crd` subdirectory inside the Helm Chart.
 
-== Migrating to unidirectional topic management
-
-When deploying the Topic Operator to manage topics, the Cluster Operator enables unidirectional topic management by default. 
-If you are switching from a version of Strimzi that used bidirectional topic management, there are some cleanup tasks to perform after upgrading the Cluster Operator.
-For more information, see xref:proc-changing-topic-operator-mode-{context}[].
-
 [id='con-upgrade-cluster-operator-unsupported-kafka-{context}']
 == Upgrading the Cluster Operator returns Kafka version error
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -50,7 +50,7 @@ kubectl get kafka <kafka_cluster_name> -n <namespace> -o jsonpath='{.status.cond
 
 Replace <kafka_cluster_name> with the name of your Kafka cluster and <namespace> with the Kubernetes namespace where the pod is running.
 
-== Migrating from using the Bidirectional Topic Operator
+== Upgrading from a Strimzi version using the Bidirectional Topic Operator
 When deploying the Topic Operator to manage topics, the Cluster Operator enables unidirectional topic management.
 This means that the Topic Operator only manages Kafka topics associated with `KafkaTopic` resources and does not interfere with topics managed independently within the Kafka cluster.
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -62,8 +62,8 @@ For the `strimzi-store-topic` and `strimzi-topic-operator` topics, delete the re
 .Deleting internal topics used by the operator
 [source,shell,subs=+quotes]
 ----
-kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-store-topic) \
-  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
+kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-store-topic) \
+  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-topic-operator)
 ----
 
 For the internal topics for storing consumer offsets and transaction states, `consumer-offsets` and `transaction-state`, you want to retain them in Kafka, but you don't want them to be managed by the Topic Operator.
@@ -74,8 +74,8 @@ Annotating the `KafkaTopic` resources with `strimzi.io/managed="false"` indicate
 .Discontinuing management of internal topics
 [source,shell,subs=+quotes]
 ----
-kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) strimzi.io/managed="false" \
-  && kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep transaction-state) strimzi.io/managed="false"
+kubectl annotate $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) strimzi.io/managed="false" \
+  && kubectl annotate $(kubectl get kt -n <namespace> -o name | grep transaction-state) strimzi.io/managed="false"
 ----
 
 Having discontinued their management, delete the `KafkaTopic` resources:
@@ -83,8 +83,8 @@ Having discontinued their management, delete the `KafkaTopic` resources:
 .Deleting the resources for managing internal topics
 [source,shell,subs=+quotes]
 ----
-kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) \
-  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep transaction-state)
+kubectl delete $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) \
+  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep transaction-state)
 ----
 
 By discontinuing their management, they won't also be deleted in Kafka.

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -50,4 +50,45 @@ kubectl get kafka <kafka_cluster_name> -n <namespace> -o jsonpath='{.status.cond
 
 Replace <kafka_cluster_name> with the name of your Kafka cluster and <namespace> with the Kubernetes namespace where the pod is running.
 
+== Migrating from using the Bidirectional Topic Operator
+When deploying the Topic Operator to manage topics, the Cluster Operator enables unidirectional topic management.
+This means that the Topic Operator only manages Kafka topics associated with `KafkaTopic` resources and does not interfere with topics managed independently within the Kafka cluster.
+
+Previously, the Topic Operator worked in bidirectional mode, which meant it could also perform operations on topics within the Kafka cluster.
+If you are switching from a version of Strimzi that uses the Bidirectional Topic Operator, after upgrading the Cluster Operator, perform some cleanup tasks to delete the internal topics that were used by the operator. 
+
+For the `strimzi-store-topic` and `strimzi-topic-operator` topics, delete the resources that were used to manage them:
+
+.Deleting internal topics used by the operator
+[source,shell,subs=+quotes]
+----
+kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-store-topic) \
+  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep strimzi-topic-operator)
+----
+
+For the internal topics for storing consumer offsets and transaction states, `consumer-offsets` and `transaction-state`, you want to retain them in Kafka, but you don't want them to be managed by the Topic Operator.
+
+Discontinue their management before deleting their resources.
+Annotating the `KafkaTopic` resources with `strimzi.io/managed="false"` indicates that the Topic Operator should no longer manage those topics: 
+
+.Discontinuing management of internal topics
+[source,shell,subs=+quotes]
+----
+kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) strimzi.io/managed="false" \
+  && kubectl annotate $(kubectl get kt -n <namespace_name> -o name | grep transaction-state) strimzi.io/managed="false"
+----
+
+Having discontinued their management, delete the `KafkaTopic` resources:
+
+.Deleting the resources for managing internal topics
+[source,shell,subs=+quotes]
+----
+kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep consumer-offsets) \
+  && kubectl delete $(kubectl get kt -n <namespace_name> -o name | grep transaction-state)
+----
+
+By discontinuing their management, they won't also be deleted in Kafka.
+
+
+
 

--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -88,7 +88,3 @@ kubectl delete $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) 
 ----
 
 By discontinuing their management, they won't also be deleted in Kafka.
-
-
-
-

--- a/documentation/modules/cruise-control/proc-cruise-control-topic-replication.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-topic-replication.adoc
@@ -16,12 +16,10 @@ One or more replication factor updates are then sent to Cruise Control for proce
 
 Progress is reflected in the status of the `KafkaTopic` resource.
 
-NOTE: This operation requires the unidirectional Topic Operator. It does not work when using the bidirectional Topic Operator.
-
 .Prerequisites
 
 * xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
-* xref:deploying-the-topic-operator-using-the-cluster-operator-str[The Topic Operator must be deployed] and running in unidirectional mode to manage topics through the `KafkaTopic` custom resource. 
+* xref:deploying-the-topic-operator-using-the-cluster-operator-str[The Topic Operator must be deployed] to manage topics through the `KafkaTopic` custom resource. 
 * xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
 
 .Procedure

--- a/documentation/modules/drain-cleaner/proc-drain-cleaner-certs.adoc
+++ b/documentation/modules/drain-cleaner/proc-drain-cleaner-certs.adoc
@@ -63,7 +63,7 @@ openssl req -new -key tls.key -subj "/CN=strimzi-drain-cleaner.strimzi-drain-cle
 +
 A `tls.crt` file is created.
 +
-NOTE: If you change the name of the Strimzi Drain Cleaner service or install it into a different namespace, you must change the SAN (Subject Alternative Name) of the certificate, following the format `<service_name>.<namespace_name>.svc`.
+NOTE: If you change the name of the Strimzi Drain Cleaner service or install it into a different namespace, you must change the SAN (Subject Alternative Name) of the certificate, following the format `<service_name>.<namespace>.svc`.
 
 . Encode the CA public certificate into base64.
 +


### PR DESCRIPTION
**Documentation**

Removes some outmoded references to the bidirectional topic operator

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

