### PR TITLE
Bumped Vert.x 4.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         <fasterxml.jackson-annotations.version>2.16.1</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.1</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.1</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.6</vertx.version>
-        <vertx-junit5.version>4.5.6</vertx-junit5.version>
+        <vertx.version>4.5.7</vertx.version>
+        <vertx-junit5.version>4.5.7</vertx-junit5.version>
         <kafka.version>3.7.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.4</zookeeper.version>


### PR DESCRIPTION
Trivial PR to bump to Vert.x 4.5.7 because the previous fix in 4.5.6 for CVE-2024-29025 had some regression.