### PR TITLE
Pom refactoring on OpenTelemetry related dependencies

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -28,7 +28,7 @@
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
+        <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
         <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
@@ -115,11 +115,16 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
-            <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
             <exclusions>
+                <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <!-- Excluding Guava (which is the android version) because we bring the jre one directly already -->
+                <exclusion>
+                    <groupId>guava</groupId>
+                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -128,15 +133,21 @@
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
-            <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
             <exclusions>
+                <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
+                <!-- excluded as we end up with conflicting copies in the image detected by find-classpath-collision.sh -->
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <!-- Excluding Guava (which is the android version) because we bring the jre one directly -->
+                <exclusion>
+                    <groupId>guava</groupId>
+                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -121,11 +121,6 @@
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
-                <!-- Excluding Guava (which is the android version) because we bring the jre one directly already -->
-                <exclusion>
-                    <groupId>guava</groupId>
-                    <artifactId>com.google.guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -143,11 +138,6 @@
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <!-- Excluding Guava (which is the android version) because we bring the jre one directly -->
-                <exclusion>
-                    <groupId>guava</groupId>
-                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -28,7 +28,7 @@
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
-        <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
+        <opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
         <opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
         <grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
         <guava.version>32.1.3-jre</guava.version>
@@ -115,11 +115,16 @@
             <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
             <version>${opentelemetry.version}</version>
             <scope>runtime</scope>
-            <!-- excluded as we end up with conflicting copies in the image -->
             <exclusions>
+                <!-- excluded as we end up with conflicting copies in the image -->
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <!-- Excluding Guava (which is the android version) because we bring the jre one directly already -->
+                <exclusion>
+                    <groupId>guava</groupId>
+                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -128,15 +133,21 @@
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc-netty-shaded.version}</version>
             <scope>runtime</scope>
-            <!-- excluded as we end up with conflicting copies in the image -->
             <exclusions>
+                <!-- excluded as we end up with conflicting copies in the image -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
+                <!-- excluded as we end up with conflicting copies in the image -->
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <!-- Excluding Guava (which is the android version) because we bring the jre one directly -->
+                <exclusion>
+                    <groupId>guava</groupId>
+                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -121,11 +121,6 @@
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
-                <!-- Excluding Guava (which is the android version) because we bring the jre one directly already -->
-                <exclusion>
-                    <groupId>guava</groupId>
-                    <artifactId>com.google.guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -143,11 +138,6 @@
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <!-- Excluding Guava (which is the android version) because we bring the jre one directly -->
-                <exclusion>
-                    <groupId>guava</groupId>
-                    <artifactId>com.google.guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
This PR is similar to what is done on the bridge with https://github.com/strimzi/strimzi-kafka-bridge/pull/891

* avoid using a otel version property as variable to declare otel alpha version. OpenTelemetry is moving to deliver different artifacts at difference pace, also some of them will be non alpha at some point. It's better having the explicit version then.
* because guava "jre" is already a direct dependency, it just add an explicit exclusion from the corresponding "androd" from otel and grpc dependencies (NOTE: it's already happening implicitly, but I think it's better having it explicitly for clarity).