### PR TITLE
Add Quotas API to Kafka CR and upgrade Strimzi Quotas Plugin to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@
 * Add support for setting `publishNotReadyAddresses` on services for listener types other than internal.
 * Update HTTP bridge to latest 0.29.0 release
 * Uncommented and enabled (by default) KRaft-related metrics in the `kafka-metrics.yaml` example file.
+* Added support for configuring the quotas plugin with type `strimzi` or `kafka` in the `Kafka` custom resource.
+  The Strimzi Quotas plugin version was updated to 0.3.1.
 
 ### Changes, deprecations and removals
 
 * The `reconciliationIntervalSeconds` configuration for the Topic and User Operators is deprecated, and will be removed when upgrading schemas to v1.
   Use `reconciliationIntervalMs` converting the value to milliseconds.
+* Usage of Strimzi Quotas plugin version 0.2.0 is not supported, the plugin was updated to 0.3.1 and changed significantly.
+  Additionally, from Strimzi 0.42.0 the plugin should be configured in `.spec.kafka.quotas` section - the configuration of the plugin inside `.spec.kafka.config` should be removed.
 
 ## 0.41.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * The `reconciliationIntervalSeconds` configuration for the Topic and User Operators is deprecated, and will be removed when upgrading schemas to v1.
   Use `reconciliationIntervalMs` converting the value to milliseconds.
 * Usage of Strimzi Quotas plugin version 0.2.0 is not supported, the plugin was updated to 0.3.1 and changed significantly.
-  Additionally, from Strimzi 0.42.0 the plugin should be configured in `.spec.kafka.quotas` section - the configuration of the plugin inside `.spec.kafka.config` should be removed.
+  Additionally, from Strimzi 0.42.0 the plugin should be configured in `.spec.kafka.quotas` section - the configuration of the plugin inside `.spec.kafka.config` is ignored and should be removed.
 
 ## 0.41.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -22,6 +22,7 @@ import io.strimzi.api.kafka.model.common.jmx.HasJmxOptions;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPlugin;
 import io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorage;
 import io.strimzi.crdgenerator.annotations.AddedIn;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -49,7 +50,7 @@ import java.util.Map;
 @JsonPropertyOrder({
     "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack",
     "brokerRackInitImage", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig",
-    "logging", "template", "tieredStorage"})
+    "logging", "template", "tieredStorage", "quotas"})
 @EqualsAndHashCode
 @ToString
 public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving {
@@ -57,7 +58,9 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
             + "inter.broker.listener.name, sasl., ssl., security., password., log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, "
             + "cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, "
-            + "node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable"; // KRaft options
+            + "node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, " // KRaft options
+            + "client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, "
+            + "client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list";
 
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "zookeeper.connection.timeout.ms, sasl.server.max.receive.size, "
             + "ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, "
@@ -85,6 +88,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     private KafkaAuthorization authorization;
     private KafkaClusterTemplate template;
     private TieredStorage tieredStorage;
+    private QuotasPlugin quotas;
     private Map<String, Object> additionalProperties;
 
     @Description("The Kafka broker version. Defaults to the latest version. " +
@@ -290,6 +294,18 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     public void setTieredStorage(TieredStorage tieredStorage) {
         this.tieredStorage = tieredStorage;
+    }
+
+    @Description("Quotas plugin configuration for Kafka brokers allows setting quotas for disk usage, produce/fetch rates, and more. " +
+        "Supported plugin types include `kafka` (default) and `strimzi`. " +
+        "If not specified, the default `kafka` quotas plugin is used.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public QuotasPlugin getQuotas() {
+        return quotas;
+    }
+
+    public void setQuotas(QuotasPlugin quotas) {
+        this.quotas = quotas;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.quotas;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(name = QuotasPluginKafka.TYPE_KAFKA, value = QuotasPluginKafka.class),
+    @JsonSubTypes.Type(name = QuotasPluginStrimzi.TYPE_STRIMZI, value = QuotasPluginStrimzi.class),
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode
+@ToString
+public abstract class QuotasPlugin implements UnknownPropertyPreserving, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Map<String, Object> additionalProperties;
+
+    @Description("Quotas plugin type. " +
+        "Currently, the supported types are `kafka` and `strimzi`. " +
+        "`kafka` quotas type uses Kafka's built-in quotas plugin. " +
+        "`strimzi` quotas type uses Strimzi quotas plugin.")
+    public abstract String getType();
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(1);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPluginKafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPluginKafka.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.quotas;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Buildable(
+    editableEnabled = false,
+    builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"type", "producerByteRate", "consumerByteRate", "requestPercentage", "controllerMutationRate"})
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class QuotasPluginKafka extends QuotasPlugin {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_KAFKA = "kafka";
+
+    private Long producerByteRate;
+    private Long consumerByteRate;
+    private Integer requestPercentage;
+    private Double controllerMutationRate;
+
+    @Description("Must be `" + TYPE_KAFKA + "`")
+    @Override
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getType() {
+        return TYPE_KAFKA;
+    }
+
+    @Description("The default client quota on the maximum bytes per-second that each client can publish to each broker before " +
+        "it is throttled. Applied on a per-broker basis.")
+    @Minimum(0)
+    public Long getProducerByteRate() {
+        return producerByteRate;
+    }
+
+    public void setProducerByteRate(Long producerByteRate) {
+        this.producerByteRate = producerByteRate;
+    }
+
+    @Description("The default client quota on the maximum bytes per-second that each client can fetch from each broker before " +
+        "it is throttled. Applied on a per-broker basis.")
+    @Minimum(0)
+    public Long getConsumerByteRate() {
+        return consumerByteRate;
+    }
+
+    public void setConsumerByteRate(Long consumerByteRate) {
+        this.consumerByteRate = consumerByteRate;
+    }
+
+    @Description("The default client quota limits the maximum CPU utilization of each client as a percentage of the network and I/O threads of each broker. " +
+        "Applied on a per-broker basis.")
+    @Minimum(0)
+    public Integer getRequestPercentage() {
+        return requestPercentage;
+    }
+
+    public void setRequestPercentage(Integer requestPercentage) {
+        this.requestPercentage = requestPercentage;
+    }
+
+    @Description("The default client quota on the rate at which mutations are accepted per second for create topic requests, create partition requests, and delete topic requests, defined for each broker. " +
+        "The mutations rate is measured by the number of partitions created or deleted. " +
+        "Applied on a per-broker basis.")
+    @Minimum(0)
+    public Double getControllerMutationRate() {
+        return controllerMutationRate;
+    }
+
+    public void setControllerMutationRate(Double controllerMutationRate) {
+        this.controllerMutationRate = controllerMutationRate;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPluginStrimzi.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/quotas/QuotasPluginStrimzi.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka.quotas;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Maximum;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.List;
+
+@Buildable(
+    editableEnabled = false,
+    builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "producerByteRate", "consumerByteRate", "minAvailableBytesPerVolume", "minAvailableRatioPerVolume", "excludedPrincipals"})
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class QuotasPluginStrimzi extends QuotasPlugin {
+    private static final long serialVersionUID = 1L;
+
+    public static final String TYPE_STRIMZI = "strimzi";
+
+    private Long producerByteRate;
+    private Long consumerByteRate;
+    private Long minAvailableBytesPerVolume;
+    private Double minAvailableRatioPerVolume;
+    private List<String> excludedPrincipals;
+
+    @Description("Must be `" + TYPE_STRIMZI + "`")
+    @Override
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getType() {
+        return TYPE_STRIMZI;
+    }
+
+    @Description("A per-broker byte-rate quota for clients producing to a broker, independent of their number. " +
+        "If clients produce at maximum speed, the quota is shared equally between all non-excluded producers. " +
+        "Otherwise, the quota is divided based on each client's production rate.")
+    @Minimum(0)
+    public Long getProducerByteRate() {
+        return producerByteRate;
+    }
+
+    public void setProducerByteRate(Long producerByteRate) {
+        this.producerByteRate = producerByteRate;
+    }
+
+    @Description("A per-broker byte-rate quota for clients consuming from a broker, independent of their number. " +
+        "If clients consume at maximum speed, the quota is shared equally between all non-excluded consumers. " +
+        "Otherwise, the quota is divided based on each client's consumption rate.")
+    @Minimum(0)
+    public Long getConsumerByteRate() {
+        return consumerByteRate;
+    }
+
+    public void setConsumerByteRate(Long consumerByteRate) {
+        this.consumerByteRate = consumerByteRate;
+    }
+
+    @Description("Stop message production if the available size (in bytes) of the storage is lower than or equal " +
+        "to this specified value. This condition is mutually exclusive with `minAvailableRatioPerVolume`.")
+    @Minimum(0)
+    public Long getMinAvailableBytesPerVolume() {
+        return minAvailableBytesPerVolume;
+    }
+
+    public void setMinAvailableBytesPerVolume(Long minAvailableBytesPerVolume) {
+        this.minAvailableBytesPerVolume = minAvailableBytesPerVolume;
+    }
+
+    @Description("Stop message production if the percentage of available storage space falls below or equals the specified ratio (set as a decimal representing a percentage). " +
+        "This condition is mutually exclusive with `minAvailableBytesPerVolume`.")
+    @Minimum(0)
+    @Maximum(1)
+    public Double getMinAvailableRatioPerVolume() {
+        return minAvailableRatioPerVolume;
+    }
+
+    public void setMinAvailableRatioPerVolume(Double minAvailableRatioPerVolume) {
+        this.minAvailableRatioPerVolume = minAvailableRatioPerVolume;
+    }
+
+    @Description("List of principals that are excluded from the quota. " +
+        "The principals have to be prefixed with `User:`, for example `User:my-user;User:CN=my-other-user`.")
+    public List<String> getExcludedPrincipals() {
+        return excludedPrincipals;
+    }
+
+    public void setExcludedPrincipals(List<String> excludedPrincipals) {
+        this.excludedPrincipals = excludedPrincipals;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -580,6 +580,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     throw new InvalidResourceException("You cannot configure both `minAvailableBytesPerVolume` and `minAvailableRatioPerVolume`, they are mutually exclusive.");
                 }
             }
+
             if (configuration.getConfigOption(CLIENT_CALLBACK_CLASS_OPTION) != null) {
                 warnings.add(StatusUtils.buildWarningCondition("QuotasPluginConflict",
                     String.format("Quotas plugin class cannot be configured in .spec.kafka.config, " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -584,7 +584,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 warnings.add(StatusUtils.buildWarningCondition("QuotasPluginConflict",
                     String.format("Quotas plugin class cannot be configured in .spec.kafka.config, " +
                         "when .spec.kafka.quotas contains configuration of `%s` plugin. " +
-                        "The plugin from .spec.kafka.quotas will be used", QuotasPluginStrimzi.TYPE_STRIMZI)));
+                        "The plugin from .spec.kafka.quotas will be used", quotasPlugin.getType())));
 
                 configuration.removeConfigOption(CLIENT_CALLBACK_CLASS_OPTION);
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -139,8 +139,6 @@ public class DefaultKafkaQuotasManager {
 
                     return promise.future();
                 } else {
-                    LOGGER.debugCr(reconciliation, "No need to update default user quotas");
-
                     kafkaAdmin.close();
                     return Future.succeededFuture();
                 }
@@ -173,7 +171,7 @@ public class DefaultKafkaQuotasManager {
                         return Future.succeededFuture(false);
                     } else if (ops.stream().allMatch(op -> Objects.isNull(op.value()))) {
                         // 2. if the current quotas set in Kafka are null and quotas configuration in Kafka CR is type of `QuotasPluginKafka`, but there is no fields configured, skip alteration
-                        LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and no quotas are configured , skipping the alteration");
+                        LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and no quotas are configured, skipping the alteration");
                         return Future.succeededFuture(false);
                     } else {
                         // 3. in case that the current quotas are null, but desired quotas contains some non-null values, we should alter the quotas

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -130,7 +130,7 @@ public class DefaultKafkaQuotasManager {
                                 LOGGER.debugCr(reconciliation, "Successfully altered default user quotas");
                                 promise.complete();
                             } else {
-                                LOGGER.warnCr(reconciliation, "Failed to alter default user quotas", result.cause());
+                                LOGGER.errorCr(reconciliation, "Failed to alter default user quotas", result.cause());
                                 promise.fail(result.cause());
                             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPlugin;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafka;
+import io.strimzi.operator.cluster.model.KafkaCluster;
+import io.strimzi.operator.cluster.operator.VertxUtil;
+import io.strimzi.operator.common.AdminClientProvider;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.auth.PemAuthIdentity;
+import io.strimzi.operator.common.auth.PemTrustSet;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class containing methods for handling the configuration around {@link QuotasPluginKafka}
+ */
+public class DefaultKafkaQuotasManager {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(DefaultKafkaQuotasManager.class.getName());
+
+    /**
+     * {@link ClientQuotaEntity} for the default users entity
+     * When `null` is set for the ClientQuotaEntity with type USER, the default quotas for all users are used/configured
+     */
+    private static final ClientQuotaEntity DEFAULT_USER_ENTITY = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, null));
+    private static final String PRODUCER_BYTE_RATE_QUOTA = "producer_byte_rate";
+    private static final String CONSUMER_BYTE_RATE_QUOTA = "consumer_byte_rate";
+    private static final String REQUEST_PERCENTAGE_QUOTA = "request_percentage";
+    private static final String CONTROLLER_MUTATION_RATE_QUOTA = "controller_mutation_rate";
+
+    /**
+     * Returns empty instance of the {@link QuotasPluginKafka}
+     * This is used in case when we need to reset the default Kafka quotas
+     *
+     * @return  empty instance of the {@link QuotasPluginKafka}
+     */
+    /* test */ static QuotasPluginKafka emptyQuotasPluginKafka() {
+        QuotasPluginKafka quotasPluginKafka = new QuotasPluginKafka();
+
+        quotasPluginKafka.setConsumerByteRate(null);
+        quotasPluginKafka.setControllerMutationRate(null);
+        quotasPluginKafka.setProducerByteRate(null);
+        quotasPluginKafka.setRequestPercentage(null);
+
+        return quotasPluginKafka;
+    }
+
+    /**
+     * Creates list of {@link ClientQuotaAlteration.Op} based on the configuration in {@link QuotasPluginKafka}.
+     * This list will be then passed to the Admin client and the default user quotas will be set.
+     *
+     * @param quotasPluginKafka     configuration of the quotas
+     *
+     * @return  list of {@link ClientQuotaAlteration.Op}
+     */
+    /* test */ static List<ClientQuotaAlteration.Op> prepareQuotaConfigurationRequest(QuotasPluginKafka quotasPluginKafka) {
+        List<ClientQuotaAlteration.Op> ops = new ArrayList<>();
+
+        ops.add(new ClientQuotaAlteration.Op(PRODUCER_BYTE_RATE_QUOTA,
+            quotasPluginKafka.getProducerByteRate() != null ? Double.valueOf(quotasPluginKafka.getProducerByteRate()) : null));
+        ops.add(new ClientQuotaAlteration.Op(CONSUMER_BYTE_RATE_QUOTA,
+            quotasPluginKafka.getConsumerByteRate() != null ? Double.valueOf(quotasPluginKafka.getConsumerByteRate()) : null));
+        ops.add(new ClientQuotaAlteration.Op(REQUEST_PERCENTAGE_QUOTA,
+            quotasPluginKafka.getRequestPercentage() != null ? Double.valueOf(quotasPluginKafka.getRequestPercentage()) : null));
+        ops.add(new ClientQuotaAlteration.Op(CONTROLLER_MUTATION_RATE_QUOTA,
+            quotasPluginKafka.getControllerMutationRate() != null ? quotasPluginKafka.getControllerMutationRate() : null));
+
+        return ops;
+    }
+
+    /**
+     * Based on configuration in {@param quotasPlugin}, it configures the default user quota in Kafka.
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param vertx                     Vert.x instance
+     * @param adminClientProvider       Kafka Admin client provider
+     * @param pemTrustSet               Trust set for TLS authentication in PEM format
+     * @param pemAuthIdentity           Identity for TLS client authentication in PEM format
+     * @param quotasPlugin              Configuration of Kafka quotas plugin
+     *
+     * @return  Future that completes when the default user quota configuration is completed
+     */
+    public static Future<Void> reconcileDefaultUserQuotas(
+        Reconciliation reconciliation,
+        Vertx vertx,
+        AdminClientProvider adminClientProvider,
+        PemTrustSet pemTrustSet,
+        PemAuthIdentity pemAuthIdentity,
+        QuotasPlugin quotasPlugin
+    ) {
+        LOGGER.debugCr(reconciliation, "Reconciling default user quotas in Kafka");
+        String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
+
+        LOGGER.debugCr(reconciliation, "Creating AdminClient for setting default quota using {}", bootstrapHostname);
+        Admin kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, pemTrustSet, pemAuthIdentity);
+
+        boolean isNotKafkaPlugin = !(quotasPlugin instanceof QuotasPluginKafka);
+        QuotasPluginKafka quotasPluginKafka = isNotKafkaPlugin ? emptyQuotasPluginKafka() : (QuotasPluginKafka) quotasPlugin;
+
+        List<ClientQuotaAlteration.Op> ops = prepareQuotaConfigurationRequest(quotasPluginKafka);
+
+        return shouldAlterDefaultQuotasConfig(reconciliation, vertx, kafkaAdmin, ops, isNotKafkaPlugin)
+            .compose(shouldUpdateQuotas -> {
+                if (shouldUpdateQuotas) {
+                    Promise<Void> promise = Promise.promise();
+
+                    ClientQuotaAlteration clientQuotaAlteration = new ClientQuotaAlteration(DEFAULT_USER_ENTITY, ops);
+
+                    LOGGER.debugCr(reconciliation, "Default user quotas differ and will be updated");
+                    alterQuotas(reconciliation, vertx, kafkaAdmin, clientQuotaAlteration)
+                        .onComplete(result -> {
+                            if (result.succeeded()) {
+                                LOGGER.debugCr(reconciliation, "Successfully altered default user quotas");
+                                promise.complete();
+                            } else {
+                                LOGGER.warnCr(reconciliation, "Failed to alter default user quotas", result.cause());
+                                promise.fail(result.cause());
+                            }
+
+                            kafkaAdmin.close();
+                        });
+
+                    return promise.future();
+                } else {
+                    LOGGER.debugCr(reconciliation, "No need to update default user quotas");
+
+                    kafkaAdmin.close();
+                    return Future.succeededFuture();
+                }
+            });
+    }
+
+    /**
+     * Checks whether default quotas configuration needs to be altered with new configuration.
+     * It gets the current default quotas for users from Kafka and compares them with the desired configuration
+     *
+     * @param reconciliation          Reconciliation marker
+     * @param vertx                   Vert.x instance
+     * @param kafkaAdmin              Kafka Admin object
+     * @param ops                     List of {@link ClientQuotaAlteration.Op}
+     * @param isNotKafkaPlugin        boolean parameter determining if the Kafka built-in quotas plugin is used
+     *
+     * @return  result determining if the new quotas configuration should be applied or not
+     */
+    /* test */ static Future<Boolean> shouldAlterDefaultQuotasConfig(Reconciliation reconciliation, Vertx vertx, Admin kafkaAdmin, List<ClientQuotaAlteration.Op> ops, boolean isNotKafkaPlugin) {
+        return VertxUtil.kafkaFutureToVertxFuture(reconciliation,
+                vertx,
+                kafkaAdmin.describeClientQuotas(ClientQuotaFilter.containsOnly(List.of(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.USER)))).entities())
+            .compose(clientQuotaEntityMapMap -> {
+                Map<String, Double> currentQuotas = clientQuotaEntityMapMap.get(DEFAULT_USER_ENTITY);
+
+                if (currentQuotas == null) {
+                    if (isNotKafkaPlugin) {
+                        // 1. if the current quotas set in Kafka are null and quotas configuration in Kafka CR is not of type `QuotasPluginKafka`, skip alteration
+                        LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and the Kafka built-in plugin is not configured, skipping the alteration");
+                        return Future.succeededFuture(false);
+                    } else if (ops.stream().allMatch(op -> Objects.isNull(op.value()))) {
+                        // 2. if the current quotas set in Kafka are null and quotas configuration in Kafka CR is type of `QuotasPluginKafka`, but there is no fields configured, skip alteration
+                        LOGGER.debugCr(reconciliation, "There are no default user quotas set in Kafka and no quotas are configured , skipping the alteration");
+                        return Future.succeededFuture(false);
+                    } else {
+                        // 3. in case that the current quotas are null, but desired quotas contains some non-null values, we should alter the quotas
+                        return Future.succeededFuture(true);
+                    }
+                } else {
+                    return Future.succeededFuture(currentAndDesiredQuotasDiffer(currentQuotas, ops));
+                }
+            });
+    }
+
+    /**
+     * Method for altering the default Kafka user quotas using Kafka Admin client
+     *
+     * @param reconciliation            Reconciliation marker
+     * @param vertx                     Vert.x instance
+     * @param kafkaAdmin                Kafka Admin object
+     * @param clientQuotaAlteration     Quota alteration operation
+     *
+     * @return  Future after completion of the alter operation
+     */
+    private static Future<Void> alterQuotas(
+        Reconciliation reconciliation,
+        Vertx vertx,
+        Admin kafkaAdmin,
+        ClientQuotaAlteration clientQuotaAlteration
+    ) {
+        LOGGER.debugCr(reconciliation, "Altering default user quotas to: {}", clientQuotaAlteration.toString());
+
+        return VertxUtil
+            .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.alterClientQuotas(List.of(clientQuotaAlteration)).values().get(DEFAULT_USER_ENTITY))
+            .map((Void) null);
+    }
+
+    /**
+     * Method that compares the desired quotas, represented by List of {@link ClientQuotaAlteration.Op}, and current quotas
+     * set in Kafka, represented by Map.
+     *
+     * @param desiredQuotas     desired quotas, represented as List of {@link ClientQuotaAlteration.Op}
+     * @param currentQuotas     current quotas configured in Kafka, represented as Map
+     *
+     * @return  boolean result of the comparison. Returns true if both current and desired quotas are same, false otherwise
+     */
+    /* test */ static boolean currentAndDesiredQuotasDiffer(Map<String, Double> currentQuotas, List<ClientQuotaAlteration.Op> desiredQuotas) {
+        // desiredQuotas will always contain all quotas keys, because it is filled from `prepareQuotaConfigurationRequest`
+        // that's why we can iterate through the list and be sure that we cover all the quota keys
+        for (ClientQuotaAlteration.Op quota : desiredQuotas) {
+            Double currentValue = currentQuotas.get(quota.key());
+            Double desiredValue = quota.value();
+
+            if (!Objects.equals(currentValue, desiredValue)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -21,6 +21,7 @@ import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddress;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolList;
@@ -266,6 +267,7 @@ public class KafkaReconciler {
                 .compose(i -> serviceEndpointsReady())
                 .compose(i -> headlessServiceEndpointsReady())
                 .compose(i -> clusterId(kafkaStatus))
+                .compose(i -> defaultKafkaQuotas())
                 .compose(i -> metadataVersion(kafkaStatus))
                 .compose(i -> deletePersistentClaims())
                 .compose(i -> sharedKafkaConfigurationCleanup())
@@ -916,6 +918,15 @@ public class KafkaReconciler {
 
                     return null;
                 });
+    }
+
+    /**
+     * Configures the default users quota in Kafka in case that the {@link QuotasPluginKafka} is used
+     *
+     * @return  Future which completes when the default quotas are configured
+     */
+    protected Future<Void> defaultKafkaQuotas() {
+        return DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(reconciliation, vertx, adminClientProvider, this.coTlsPemIdentity.pemTrustSet(), this.coTlsPemIdentity.pemAuthIdentity(), kafka.quotas());
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
@@ -136,7 +136,7 @@ public class DefaultKafkaQuotasManagerTest {
 
         DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
             .onComplete(context.succeeding(result -> {
-                context.verify(() -> assertThat(result, is(false)));
+                assertThat(result, is(false));
 
                 checkpoint.flag();
             }));
@@ -167,7 +167,7 @@ public class DefaultKafkaQuotasManagerTest {
 
         DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
             .onComplete(context.succeeding(result -> {
-                context.verify(() -> assertThat(result, is(true)));
+                assertThat(result, is(true));
 
                 checkpoint.flag();
             }));
@@ -194,7 +194,7 @@ public class DefaultKafkaQuotasManagerTest {
 
         DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
             .onComplete(context.succeeding(result -> {
-                context.verify(() -> assertThat(result, is(true)));
+                assertThat(result, is(true));
 
                 checkpoint.flag();
             }));
@@ -225,7 +225,7 @@ public class DefaultKafkaQuotasManagerTest {
 
         DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
             .onComplete(context.succeeding(result -> {
-                context.verify(() -> assertThat(result, is(true)));
+                assertThat(result, is(true));
 
                 checkpoint.flag();
             }));
@@ -259,7 +259,7 @@ public class DefaultKafkaQuotasManagerTest {
 
         DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
             .onComplete(context.succeeding(result -> {
-                context.verify(() -> assertThat(result, is(false)));
+                assertThat(result, is(false));
 
                 checkpoint.flag();
             }));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManagerTest.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafka;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginKafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.quotas.QuotasPluginStrimzi;
+import io.strimzi.operator.common.AdminClientProvider;
+import io.strimzi.operator.common.Reconciliation;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterClientQuotasResult;
+import org.apache.kafka.clients.admin.DescribeClientQuotasResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.quota.ClientQuotaAlteration;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.common.quota.ClientQuotaFilter;
+import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.operator.common.auth.TlsPemIdentity.DUMMY_IDENTITY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class DefaultKafkaQuotasManagerTest {
+    private final static Long DEFAULT_PRODUCER_BYTE_RATE = 2000L;
+    private final static Long DEFAULT_CONSUMER_BYTE_RATE = 2000L;
+    private final static Double DEFAULT_MUTATION_RATE = 0.5;
+    private final static Integer DEFAULT_REQUEST_PERCENTAGE = 25;
+
+    private static Vertx vertx;
+
+    @BeforeAll
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    public static void after() {
+        vertx.close();
+    }
+
+    /**
+     * Checks whether {@link DefaultKafkaQuotasManager#currentAndDesiredQuotasDiffer(Map, List)} is able to handle the
+     * `null` values in both current and desired quotas and if it correctly returns the result.
+     */
+    @Test
+    void testCurrentAndDesiredQuotasDifferWithNullValuesInBothQuotas() {
+        Map<String, Double> currentQuotas = createMapOfCurrentQuotas(null, null, null, null);
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
+
+        assertThat(DefaultKafkaQuotasManager.currentAndDesiredQuotasDiffer(currentQuotas, desiredQuotas), is(false));
+    }
+
+    /**
+     * Checks whether {@link DefaultKafkaQuotasManager#currentAndDesiredQuotasDiffer(Map, List)} is able to handle the
+     * `null` values in different quotas inside current and desired quotas and if it correctly returns the result.
+     */
+    @Test
+    void testCurrentAndDesiredQuotasDifferWithNullValuesInDifferentQuotas() {
+        Map<String, Double> currentQuotas = createMapOfCurrentQuotas(null, 1000L, null, 0.5);
+        QuotasPluginKafka desiredQuotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withProducerByteRate(1000L)
+            .withRequestPercentage(2)
+            .build();
+
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(desiredQuotasPluginKafka);
+
+        assertThat(DefaultKafkaQuotasManager.currentAndDesiredQuotasDiffer(currentQuotas, desiredQuotas), is(true));
+    }
+
+    /**
+     * Checks whether {@link DefaultKafkaQuotasManager#currentAndDesiredQuotasDiffer(Map, List)} is able to correctly compare
+     * the current and desired quotas in case that only one (last) quota value is different and if it correctly returns the
+     * result.
+     */
+    @Test
+    void testCurrentAndDesiredQuotasDifferWithOneDifferentQuotaValue() {
+        Long producerByteRate = 1000L;
+        Long consumerByteRate = 1000L;
+        Integer requestPercentage = 25;
+
+        Map<String, Double> currentQuotas = createMapOfCurrentQuotas(producerByteRate, consumerByteRate, requestPercentage, 0.5);
+        QuotasPluginKafka desiredQuotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withProducerByteRate(producerByteRate)
+            .withConsumerByteRate(consumerByteRate)
+            .withRequestPercentage(requestPercentage)
+            .withControllerMutationRate(0.6)
+            .build();
+
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(desiredQuotasPluginKafka);
+
+        assertThat(DefaultKafkaQuotasManager.currentAndDesiredQuotasDiffer(currentQuotas, desiredQuotas), is(true));
+    }
+
+    /**
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * when there are no default Kafka quotas set and none (or Strimzi Quotas plugin) are desired.
+     * The result of this check should be false.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testShouldAlterQuotasWithNoneCurrentAndNotAKafkaQuotasPlugin(VertxTestContext context) {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultEmpty(mockAdminClient);
+
+        List<ClientQuotaAlteration.Op> noneQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
+            .onComplete(context.succeeding(result -> {
+                context.verify(() -> assertThat(result, is(false)));
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * when there are no default Kafka quotas set and there are Kafka quotas specified.
+     * The result of this check should be true.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testShouldAlterQuotasWithNoneCurrentAndFilledKafkaQuotas(VertxTestContext context) {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultEmpty(mockAdminClient);
+
+        QuotasPluginKafka quotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withProducerByteRate(1000L)
+            .build();
+
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
+            .onComplete(context.succeeding(result -> {
+                context.verify(() -> assertThat(result, is(true)));
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * when there are default Kafka quotas set and none (or Strimzi Quotas plugin) are desired.
+     * The result of this check should be true.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testShouldAlterQuotasWithFilledCurrentAndNotAKafkaQuotasPlugin(VertxTestContext context) {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        List<ClientQuotaAlteration.Op> noneQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, noneQuotas, true)
+            .onComplete(context.succeeding(result -> {
+                context.verify(() -> assertThat(result, is(true)));
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * when there are default Kafka quotas set and different Kafka quotas are desired.
+     * The result of this check should be true.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testShouldAlterQuotasWithFilledCurrentAndDifferentKafkaQuotas(VertxTestContext context) {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        QuotasPluginKafka quotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withProducerByteRate(1000L)
+            .build();
+
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
+            .onComplete(context.succeeding(result -> {
+                context.verify(() -> assertThat(result, is(true)));
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Checks if the result of {@link DefaultKafkaQuotasManager#shouldAlterDefaultQuotasConfig(Reconciliation, Vertx, Admin, List, boolean)}
+     * when there are default Kafka quotas set and same Kafka quotas are desired.
+     * The result of this check should be false.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testShouldAlterQuotasWithSameCurrentAndDesiredKafkaQuotas(VertxTestContext context) {
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        QuotasPluginKafka quotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withProducerByteRate(DEFAULT_PRODUCER_BYTE_RATE)
+            .withConsumerByteRate(DEFAULT_CONSUMER_BYTE_RATE)
+            .withControllerMutationRate(DEFAULT_MUTATION_RATE)
+            .withRequestPercentage(DEFAULT_REQUEST_PERCENTAGE)
+            .build();
+
+        List<ClientQuotaAlteration.Op> desiredQuotas = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        DefaultKafkaQuotasManager.shouldAlterDefaultQuotasConfig(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClient, desiredQuotas, false)
+            .onComplete(context.succeeding(result -> {
+                context.verify(() -> assertThat(result, is(false)));
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Tests that the default Kafka quotas are altered in case of different configuration specified by user.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testReconfigureDefaultQuotasSetInKafka(VertxTestContext context) {
+        long consumerByteRate = 1000;
+        long producerByteRate = 1000;
+        double mutationRate = 0.1;
+        int requestPercentage = 33;
+
+        Checkpoint checkpoint = context.checkpoint();
+
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        // Mock altering the default Kafka quotas
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ClientQuotaAlteration>> quotaAlterationCaptor = ArgumentCaptor.forClass(List.class);
+        mockAlterQuotas(mockAdminClient, quotaAlterationCaptor);
+
+        // Mock the Admin Client Provider
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+
+        QuotasPluginKafka quotasPluginKafka = new QuotasPluginKafkaBuilder()
+            .withConsumerByteRate(consumerByteRate)
+            .withProducerByteRate(producerByteRate)
+            .withControllerMutationRate(mutationRate)
+            .withRequestPercentage(requestPercentage)
+            .build();
+
+        List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(quotasPluginKafka);
+
+        // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), quotasPluginKafka)
+            .onComplete(context.succeeding(s -> {
+                verify(mockAdminClient, times(1)).describeClientQuotas(any());
+                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+
+                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+
+                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+                assertEquals(expectedResult, valuesSet);
+
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Tests that the default Kafka quotas are set to null (deleted) in case that none quotas plugin is specified by user.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testRemoveDefaultQuotasIfNoneQuotasPluginIsDesired(VertxTestContext context) {
+        Checkpoint checkpoint = context.checkpoint();
+
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        // Mock altering the default Kafka quotas
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ClientQuotaAlteration>> quotaAlterationCaptor = ArgumentCaptor.forClass(List.class);
+        mockAlterQuotas(mockAdminClient, quotaAlterationCaptor);
+
+        // Mock the Admin Client Provider
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+
+        List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
+
+        // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), null)
+            .onComplete(context.succeeding(s -> {
+                verify(mockAdminClient, times(1)).describeClientQuotas(any());
+                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+
+                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+
+                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+                assertEquals(expectedResult, valuesSet);
+                checkpoint.flag();
+            }));
+    }
+
+    /**
+     * Tests that the default Kafka quotas are set to null (deleted) in case that Strimzi quotas plugin is specified by user.
+     *
+     * @param context   Vertx test context
+     */
+    @Test
+    void testRemoveDefaultQuotasIfStrimziQuotasPluginIsDesired(VertxTestContext context) {
+        Checkpoint checkpoint = context.checkpoint();
+
+        // Mock the Admin client
+        Admin mockAdminClient = mock(Admin.class);
+
+        // Mock describing the current metadata version
+        mockDescribeQuotasResultPresent(mockAdminClient);
+
+        // Mock altering the default Kafka quotas
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ClientQuotaAlteration>> quotaAlterationCaptor = ArgumentCaptor.forClass(List.class);
+        mockAlterQuotas(mockAdminClient, quotaAlterationCaptor);
+
+        // Mock the Admin Client Provider
+        AdminClientProvider mockAdminClientProvider = mockAdminClientProvider(mockAdminClient);
+
+        List<ClientQuotaAlteration.Op> expectedResult = DefaultKafkaQuotasManager.prepareQuotaConfigurationRequest(DefaultKafkaQuotasManager.emptyQuotasPluginKafka());
+
+        // Scenario with configured QuotasPluginKafka and default user quota set in Kafka (all options) -> but with different values in both configurations
+        DefaultKafkaQuotasManager.reconcileDefaultUserQuotas(Reconciliation.DUMMY_RECONCILIATION, vertx, mockAdminClientProvider, DUMMY_IDENTITY.pemTrustSet(), DUMMY_IDENTITY.pemAuthIdentity(), new QuotasPluginStrimzi())
+            .onComplete(context.succeeding(s -> {
+                verify(mockAdminClient, times(1)).describeClientQuotas(any());
+                verify(mockAdminClient, times(1)).alterClientQuotas(any());
+
+                assertThat(quotaAlterationCaptor.getValue().isEmpty(), is(false));
+
+                List<ClientQuotaAlteration.Op> valuesSet = quotaAlterationCaptor.getValue().get(0).ops().stream().toList();
+                assertEquals(expectedResult, valuesSet);
+                checkpoint.flag();
+            }));
+    }
+
+    private Map<String, Double> createMapOfCurrentQuotas(
+        Long producerByteRate,
+        Long consumerByteRate,
+        Integer requestPercentage,
+        Double mutationRate
+    ) {
+        // we cannot pass null to Map.of()
+        Map<String, Double> currentQuotas = new HashMap<>();
+        currentQuotas.put("producer_byte_rate", producerByteRate == null ? null : Double.valueOf(producerByteRate));
+        currentQuotas.put("consumer_byte_rate", consumerByteRate == null ? null : Double.valueOf(consumerByteRate));
+        currentQuotas.put("request_percentage", requestPercentage == null ? null : Double.valueOf(requestPercentage));
+        currentQuotas.put("controller_mutation_rate", mutationRate);
+
+        return currentQuotas;
+    }
+
+    private void mockDescribeQuotasResultPresent(Admin mockAdminClient) {
+        Map<String, Double> mockedResult = createMapOfCurrentQuotas(DEFAULT_PRODUCER_BYTE_RATE, DEFAULT_CONSUMER_BYTE_RATE, DEFAULT_REQUEST_PERCENTAGE, DEFAULT_MUTATION_RATE);
+
+        DescribeClientQuotasResult result = mock(DescribeClientQuotasResult.class);
+        final ClientQuotaEntity defaultUserEntity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, null));
+        when(result.entities()).thenReturn(KafkaFuture.completedFuture(Map.of(defaultUserEntity, mockedResult)));
+
+        when(mockAdminClient.describeClientQuotas(ClientQuotaFilter.containsOnly(List.of(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.USER))))).thenReturn(result);
+    }
+
+    private void mockDescribeQuotasResultEmpty(Admin mockAdminClient) {
+        DescribeClientQuotasResult result = mock(DescribeClientQuotasResult.class);
+        when(result.entities()).thenReturn(KafkaFuture.completedFuture(Map.of()));
+        when(mockAdminClient.describeClientQuotas(ClientQuotaFilter.containsOnly(List.of(ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.USER))))).thenReturn(result);
+    }
+
+    private void mockAlterQuotas(Admin mockAdminClient, ArgumentCaptor<List<ClientQuotaAlteration>> quotaAlterationCaptor) {
+        when(mockAdminClient.alterClientQuotas(quotaAlterationCaptor.capture())).thenAnswer(i -> new AlterClientQuotasResult(Map.of()));
+    }
+
+    private AdminClientProvider mockAdminClientProvider(Admin adminClient)  {
+        AdminClientProvider mockAdminClientProvider = mock(AdminClientProvider.class);
+        when(mockAdminClientProvider.createAdminClient(anyString(), any(), any())).thenReturn(adminClient);
+
+        return mockAdminClientProvider;
+    }
+}

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.6.x/pom.xml
@@ -20,7 +20,7 @@
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
-        <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
+        <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.x/pom.xml
@@ -20,7 +20,7 @@
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
-        <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
+        <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -87,7 +87,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |Configures listeners of Kafka brokers.
 |config
 |map
-|Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms).
+|Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms).
 |storage
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`], xref:type-JbodStorage-{context}[`JbodStorage`]
 |Storage configuration (disk). Cannot be updated. This property is required when node pools are not used.
@@ -127,6 +127,9 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |tieredStorage
 |xref:type-TieredStorageCustom-{context}[`TieredStorageCustom`]
 |Configure the tiered storage feature for Kafka brokers.
+|quotas
+|xref:type-QuotasPluginKafka-{context}[`QuotasPluginKafka`], xref:type-QuotasPluginStrimzi-{context}[`QuotasPluginStrimzi`]
+|Quotas plugin configuration for Kafka brokers allows setting quotas for disk usage, produce/fetch rates, and more. Supported plugin types include `kafka` (default) and `strimzi`. If not specified, the default `kafka` quotas plugin is used.
 |====
 
 [id='type-GenericKafkaListener-{context}']
@@ -1350,6 +1353,65 @@ Used in: xref:type-TieredStorageCustom-{context}[`TieredStorageCustom`]
 |config
 |map
 |The additional configuration map for the `RemoteStorageManager` implementation. Keys will be automatically prefixed with `rsm.config.`, and added to Kafka broker configuration.
+|====
+
+[id='type-QuotasPluginKafka-{context}']
+= `QuotasPluginKafka` schema reference
+
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+
+
+The `type` property is a discriminator that distinguishes use of the `QuotasPluginKafka` type from xref:type-QuotasPluginStrimzi-{context}[`QuotasPluginStrimzi`].
+It must have the value `kafka` for the type `QuotasPluginKafka`.
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `kafka`.
+|producerByteRate
+|integer
+|The default client quota on the maximum bytes per-second that each client can publish to each broker before it is throttled. Applied on a per-broker basis.
+|consumerByteRate
+|integer
+|The default client quota on the maximum bytes per-second that each client can fetch from each broker before it is throttled. Applied on a per-broker basis.
+|requestPercentage
+|integer
+|The default client quota limits the maximum CPU utilization of each client as a percentage of the network and I/O threads of each broker. Applied on a per-broker basis.
+|controllerMutationRate
+|number
+|The default client quota on the rate at which mutations are accepted per second for create topic requests, create partition requests, and delete topic requests, defined for each broker. The mutations rate is measured by the number of partitions created or deleted. Applied on a per-broker basis.
+|====
+
+[id='type-QuotasPluginStrimzi-{context}']
+= `QuotasPluginStrimzi` schema reference
+
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+
+
+The `type` property is a discriminator that distinguishes use of the `QuotasPluginStrimzi` type from xref:type-QuotasPluginKafka-{context}[`QuotasPluginKafka`].
+It must have the value `strimzi` for the type `QuotasPluginStrimzi`.
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `strimzi`.
+|producerByteRate
+|integer
+|A per-broker byte-rate quota for clients producing to a broker, independent of their number. If clients produce at maximum speed, the quota is shared equally between all non-excluded producers. Otherwise, the quota is divided based on each client's production rate.
+|consumerByteRate
+|integer
+|A per-broker byte-rate quota for clients consuming from a broker, independent of their number. If clients consume at maximum speed, the quota is shared equally between all non-excluded consumers. Otherwise, the quota is divided based on each client's consumption rate.
+|minAvailableBytesPerVolume
+|integer
+|Stop message production if the available size (in bytes) of the storage is lower than or equal to this specified value. This condition is mutually exclusive with `minAvailableRatioPerVolume`.
+|minAvailableRatioPerVolume
+|number
+|Stop message production if the percentage of available storage space falls below or equals the specified ratio (set as a decimal representing a percentage). This condition is mutually exclusive with `minAvailableBytesPerVolume`.
+|excludedPrincipals
+|string array
+|List of principals that are excluded from the quota. The principals have to be prefixed with `User:`, for example `User:my-user;User:CN=my-other-user`.
 |====
 
 [id='type-ZookeeperClusterSpec-{context}']

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 Use the _Kafka Static Quota_ plugin to set throughput and storage limits on brokers in your Kafka cluster.
-You enable the plugin and set limits by configuring the `Kafka` resource.
+You enable the plugin and set limits by configuring the `quotas` section of the `Kafka` resource.
 You can set a byte-rate threshold and storage quotas to put limits on the clients interacting with your brokers.
 
 NOTE: Only one quota plugin can be used in Kafka. 
@@ -20,15 +20,11 @@ The total limit is distributed across all clients accessing the broker.
 For example, you can set a byte-rate threshold of 40 MBps for producers.
 If two producers are running, they are each limited to a throughput of 20 MBps.
 
-Storage quotas throttle Kafka disk storage limits between a soft limit and hard limit.
-The limits apply to all available disk space.
-Producers are slowed gradually between the soft and hard limit.
-The limits prevent disks filling up too quickly and exceeding their capacity.
+Storage quotas enforce the throttling of Kafka producers based on Kafka disk storage utilization when it reaches the specified limit.
+You can specify the limit in bytes or percentage of available disk space.
+The limit applies to every disk individually.
+It prevents disks filling up too quickly and exceeding their capacity.
 Full disks can lead to issues that are hard to rectify.
-The hard limit is the maximum storage limit.
-
-NOTE: For JBOD storage, the limit applies across all disks.
-If a broker is using two 1 TB disks and the quota is 1.1 TB, one disk might fill and the other disk will be almost empty.
 
 .Prerequisites
 
@@ -36,9 +32,9 @@ If a broker is using two 1 TB disks and the quota is 1.1 TB, one disk might fill
 
 .Procedure
 
-. Add the plugin properties to the `config` of the `Kafka` resource.
+. Add the plugin configuration to the `quotas` section of the `Kafka` resource.
 +
-The plugin properties are shown in this example configuration.
+The plugin configuration is shown in this example configuration.
 +
 .Example Kafka Static Quota plugin configuration
 [source,yaml,options="nowrap",subs="+attributes"]
@@ -50,27 +46,26 @@ metadata:
 spec:
   kafka:
     # ...
-    config:
-      client.quota.callback.class: io.strimzi.kafka.quotas.StaticQuotaCallback <1>
-      client.quota.callback.static.produce: 1000000 <2>
-      client.quota.callback.static.fetch: 1000000 <3>
-      client.quota.callback.static.storage.soft: 400000000000 <4>
-      client.quota.callback.static.storage.hard: 500000000000 <5>
-      client.quota.callback.static.storage.check-interval: 5 <6>
+    quotas:
+      type: strimzi
+      producerByteRate: 1000000 # <1>
+      consumerByteRate: 1000000 # <2>
+      minAvailableBytesPerVolume: 500000000000 # <3>
+      excludedPrincipals: # <4>
+        - my-user
 ----
-<1> Loads the Kafka Static Quota plugin.
-<2> Sets the producer byte-rate threshold. 1 MBps in this example.
-<3> Sets the consumer byte-rate threshold. 1 MBps in this example.
-<4> Sets the lower soft limit for storage. 400 GB in this example.
-<5> Sets the higher hard limit for storage. 500 GB in this example.
-<6> Sets the interval in seconds between checks on storage. 5 seconds in this example. You can set this to 0 to disable the check.
+<1> Sets the producer byte-rate threshold. 1 MBps in this example.
+<2> Sets the consumer byte-rate threshold. 1 MBps in this example.
+<3> Sets the available bytes limit for storage. 500 GB in this example.
+<4> Sets the list of excluded users that are removed from the quota. `my-user` in this example.
 
-. Update the resource.
-+
-[source,shell,subs=+quotes]
-kubectl apply -f _<kafka_configuration_file>_
+. Apply the changes to the `Kafka` configuration.
+
+NOTE: `minAvailableBytesPerVolume` and `minAvailableRatioPerVolume` are mutually exclusive.
+This means that only one of these parameters should be configured.
 
 [role="_additional-resources"]
 .Additional resources
 
+* link:{BookURLConfiguring}#type-QuotasPluginStrimzi-reference[`QuotasPluginStrimzi` schema reference^]
 * link:{BookURLConfiguring}#type-KafkaUserQuotas-reference[`KafkaUserQuotas` schema reference^]

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -514,7 +514,7 @@ spec:
                     config:
                       x-kubernetes-preserve-unknown-fields: true
                       type: object
-                      description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                      description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
                     storage:
                       type: object
                       properties:
@@ -1953,6 +1953,48 @@ spec:
                       required:
                         - type
                       description: Configure the tiered storage feature for Kafka brokers.
+                    quotas:
+                      type: object
+                      properties:
+                        consumerByteRate:
+                          type: integer
+                          minimum: 0
+                          description: "A per-broker byte-rate quota for clients consuming from a broker, independent of their number. If clients consume at maximum speed, the quota is shared equally between all non-excluded consumers. Otherwise, the quota is divided based on each client's consumption rate."
+                        controllerMutationRate:
+                          type: number
+                          minimum: 0
+                          description: "The default client quota on the rate at which mutations are accepted per second for create topic requests, create partition requests, and delete topic requests, defined for each broker. The mutations rate is measured by the number of partitions created or deleted. Applied on a per-broker basis."
+                        excludedPrincipals:
+                          type: array
+                          items:
+                            type: string
+                          description: "List of principals that are excluded from the quota. The principals have to be prefixed with `User:`, for example `User:my-user;User:CN=my-other-user`."
+                        minAvailableBytesPerVolume:
+                          type: integer
+                          minimum: 0
+                          description: Stop message production if the available size (in bytes) of the storage is lower than or equal to this specified value. This condition is mutually exclusive with `minAvailableRatioPerVolume`.
+                        minAvailableRatioPerVolume:
+                          type: number
+                          minimum: 0
+                          maximum: 1
+                          description: Stop message production if the percentage of available storage space falls below or equals the specified ratio (set as a decimal representing a percentage). This condition is mutually exclusive with `minAvailableBytesPerVolume`.
+                        producerByteRate:
+                          type: integer
+                          minimum: 0
+                          description: "A per-broker byte-rate quota for clients producing to a broker, independent of their number. If clients produce at maximum speed, the quota is shared equally between all non-excluded producers. Otherwise, the quota is divided based on each client's production rate."
+                        requestPercentage:
+                          type: integer
+                          minimum: 0
+                          description: The default client quota limits the maximum CPU utilization of each client as a percentage of the network and I/O threads of each broker. Applied on a per-broker basis.
+                        type:
+                          type: string
+                          enum:
+                            - kafka
+                            - strimzi
+                          description: "Quotas plugin type. Currently, the supported types are `kafka` and `strimzi`. `kafka` quotas type uses Kafka's built-in quotas plugin. `strimzi` quotas type uses Strimzi quotas plugin."
+                      required:
+                        - type
+                      description: "Quotas plugin configuration for Kafka brokers allows setting quotas for disk usage, produce/fetch rates, and more. Supported plugin types include `kafka` (default) and `strimzi`. If not specified, the default `kafka` quotas plugin is used."
                   required:
                     - listeners
                   description: Configuration of the Kafka cluster.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -513,7 +513,7 @@ spec:
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
                   storage:
                     type: object
                     properties:
@@ -1952,6 +1952,48 @@ spec:
                     required:
                     - type
                     description: Configure the tiered storage feature for Kafka brokers.
+                  quotas:
+                    type: object
+                    properties:
+                      consumerByteRate:
+                        type: integer
+                        minimum: 0
+                        description: "A per-broker byte-rate quota for clients consuming from a broker, independent of their number. If clients consume at maximum speed, the quota is shared equally between all non-excluded consumers. Otherwise, the quota is divided based on each client's consumption rate."
+                      controllerMutationRate:
+                        type: number
+                        minimum: 0
+                        description: "The default client quota on the rate at which mutations are accepted per second for create topic requests, create partition requests, and delete topic requests, defined for each broker. The mutations rate is measured by the number of partitions created or deleted. Applied on a per-broker basis."
+                      excludedPrincipals:
+                        type: array
+                        items:
+                          type: string
+                        description: "List of principals that are excluded from the quota. The principals have to be prefixed with `User:`, for example `User:my-user;User:CN=my-other-user`."
+                      minAvailableBytesPerVolume:
+                        type: integer
+                        minimum: 0
+                        description: Stop message production if the available size (in bytes) of the storage is lower than or equal to this specified value. This condition is mutually exclusive with `minAvailableRatioPerVolume`.
+                      minAvailableRatioPerVolume:
+                        type: number
+                        minimum: 0
+                        maximum: 1
+                        description: Stop message production if the percentage of available storage space falls below or equals the specified ratio (set as a decimal representing a percentage). This condition is mutually exclusive with `minAvailableBytesPerVolume`.
+                      producerByteRate:
+                        type: integer
+                        minimum: 0
+                        description: "A per-broker byte-rate quota for clients producing to a broker, independent of their number. If clients produce at maximum speed, the quota is shared equally between all non-excluded producers. Otherwise, the quota is divided based on each client's production rate."
+                      requestPercentage:
+                        type: integer
+                        minimum: 0
+                        description: The default client quota limits the maximum CPU utilization of each client as a percentage of the network and I/O threads of each broker. Applied on a per-broker basis.
+                      type:
+                        type: string
+                        enum:
+                        - kafka
+                        - strimzi
+                        description: "Quotas plugin type. Currently, the supported types are `kafka` and `strimzi`. `kafka` quotas type uses Kafka's built-in quotas plugin. `strimzi` quotas type uses Strimzi quotas plugin."
+                    required:
+                    - type
+                    description: "Quotas plugin configuration for Kafka brokers allows setting quotas for disk usage, produce/fetch rates, and more. Supported plugin types include `kafka` (default) and `strimzi`. If not specified, the default `kafka` quotas plugin is used."
                 required:
                 - listeners
                 description: Configuration of the Kafka cluster.

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -32,6 +32,7 @@ public interface TestConstants {
     long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
     long GLOBAL_POLL_INTERVAL_5_SECS = Duration.ofSeconds(5).toMillis();
     long GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10).toMillis();
+    long GLOBAL_POLL_INTERVAL_LONG = Duration.ofSeconds(30).toMillis();
     long PRODUCER_TIMEOUT = Duration.ofSeconds(25).toMillis();
     long METRICS_COLLECT_TIMEOUT = Duration.ofMinutes(1).toMillis();
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -29,6 +29,19 @@ public class JobUtils {
     private JobUtils() { }
 
     /**
+     * Wait until the Pod of Job with {@param jobName} contains specified {@param logMessage}
+     * @param namespaceName name of Namespace where the Pod is running
+     * @param jobName name of Job with which the Pod name obtained
+     * @param logMessage desired log message
+     */
+    public static void waitForJobContainingLogMessage(String namespaceName, String jobName, String logMessage) {
+        String jobPodName = kubeClient().listPodsByPrefixInName(namespaceName, jobName).get(0).getMetadata().getName();
+
+        TestUtils.waitFor("Job contains log message: " + logMessage, TestConstants.GLOBAL_POLL_INTERVAL_LONG, TestConstants.GLOBAL_TIMEOUT,
+            () -> kubeClient().logsInSpecificNamespace(namespaceName, jobPodName).contains(logMessage));
+    }
+
+    /**
      * Wait until all Jobs are deleted in given namespace.
      * @param namespace Delete all jobs in this namespace
      */

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/QuotasST.java
@@ -4,8 +4,12 @@
  */
 package io.strimzi.systemtest.kafka;
 
+import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
@@ -14,10 +18,12 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
-import io.strimzi.test.WaitException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +35,6 @@ import static io.strimzi.systemtest.TestConstants.INTERNAL_CLIENTS_USED;
 import static io.strimzi.systemtest.TestConstants.QUOTAS_PLUGIN;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
@@ -40,6 +45,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
  */
 @Tag(QUOTAS_PLUGIN)
 public class QuotasST extends AbstractST {
+    private static final Logger LOGGER = LogManager.getLogger(QuotasST.class);
 
     /**
      * Test to check Kafka Quotas Plugin for disk space
@@ -50,6 +56,8 @@ public class QuotasST extends AbstractST {
         assumeFalse(cluster.isMinikube() || cluster.isMicroShift());
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
+        final String excludedPrincipal = "User:" + testStorage.getUsername();
+        final String minAvailableBytes = "800000000";
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -57,33 +65,67 @@ public class QuotasST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 1).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1)
-            .editSpec()
-                .editKafka()
-                    .addToConfig("client.quota.callback.class", "io.strimzi.kafka.quotas.StaticQuotaCallback")
-                    .addToConfig("client.quota.callback.static.storage.hard", "55000000")
-                    .addToConfig("client.quota.callback.static.storage.soft", "20000000")
-                    .addToConfig("client.quota.callback.static.storage.check-interval", "5")
-                .endKafka()
-            .endSpec()
-            .build());
-        resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build());
+        resourceManager.createResourceWithWait(
+            KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1, 1)
+                .editSpec()
+                    .editKafka()
+                        .addToConfig("client.quota.callback.static.storage.check-interval", "5")
+                        .withNewQuotasPluginStrimziQuotas()
+                            .addToExcludedPrincipals(excludedPrincipal)
+                            .withProducerByteRate(10000000L)
+                            .withConsumerByteRate(10000000L)
+                            .withMinAvailableBytesPerVolume(Long.valueOf(minAvailableBytes))
+                        .endQuotasPluginStrimziQuotas()
+                        .withListeners(
+                            new GenericKafkaListenerBuilder()
+                                .withName(TestConstants.PLAIN_LISTENER_DEFAULT_NAME)
+                                .withPort(9092)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(false)
+                                .build(),
+                            new GenericKafkaListenerBuilder()
+                                .withName("scramsha")
+                                .withPort(9095)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(false)
+                                .withNewKafkaListenerAuthenticationScramSha512Auth()
+                                .endKafkaListenerAuthenticationScramSha512Auth()
+                                .build()
+                        )
+                    .endKafka()
+                .endSpec()
+                .build()
+        );
+        resourceManager.createResourceWithWait(
+            KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName()).build(),
+            KafkaUserTemplates.scramShaUser(testStorage).build()
+        );
 
-        final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
+        KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage, KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withMessageCount(100000)
-            .withMessage(String.join("", Collections.nCopies(1000, "#")))
+            .withMessage(String.join("", Collections.nCopies(10000, "#")))
+            .withAdditionalConfig("delivery.timeout.ms=10000\nrequest.timeout.ms=10000\n")
             .build();
 
+        LOGGER.info("Sending messages without any user, we should hit the quota");
         resourceManager.createResourceWithWait(clients.producerStrimzi());
-        // Kafka Quotas Plugin should stop producer in around 10-20 seconds with configured throughput
-        assertThrows(WaitException.class, () -> JobUtils.waitForJobFailure(testStorage.getProducerName(), Environment.TEST_SUITE_NAMESPACE, 120_000));
+        // Kafka Quotas Plugin should stop producer after it reaches the minimum available bytes
+        JobUtils.waitForJobContainingLogMessage(testStorage.getNamespaceName(), testStorage.getProducerName(), "Failed to send messages");
+        JobUtils.deleteJobWithWait(testStorage.getNamespaceName(), testStorage.getProducerName());
 
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
         String kafkaLog = kubeClient().logsInSpecificNamespace(testStorage.getNamespaceName(), brokerPodName);
-        String softLimitLog = "disk is beyond soft limit";
-        String hardLimitLog = "disk is full";
-        assertThat("Kafka log doesn't contain '" + softLimitLog + "' log", kafkaLog, CoreMatchers.containsString(softLimitLog));
-        assertThat("Kafka log doesn't contain '" + hardLimitLog + "' log", kafkaLog, CoreMatchers.containsString(hardLimitLog));
+
+        String belowLimitLog = String.format("below the limit of %s", minAvailableBytes);
+
+        assertThat("Kafka log doesn't contain '" + belowLimitLog + "' log", kafkaLog, CoreMatchers.containsString(belowLimitLog));
+
+        LOGGER.info("Sending messages with user that is specified in list of excluded principals, we should be able to send the messages without problem");
+
+        clients = ClientUtils.getInstantScramShaClientBuilder(testStorage, KafkaResources.bootstrapServiceName(testStorage.getClusterName()) + ":9095").build();
+
+        resourceManager.createResourceWithWait(clients.producerScramShaPlainStrimzi());
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
     }
 
     @AfterEach


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

This PR adds Quotas API to Kafka CR based on [Quotas management proposal](https://github.com/strimzi/proposals/blob/main/068-quotas-management.md) and updates Strimzi Quotas Plugin version to 0.3.1 (and also it reflects changes based on [Cluster Wide Volume Usage Quota Management](https://github.com/strimzi/proposals/blob/main/047-cluster-wide-volume-usage-quota-management.md)).

It also changes the `QuotasST`, which need to reflect changes done in Strimzi Quotas Plugin 0.3.1.

Closes #9097, #9859 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

