### PR TITLE
Added roles column definition for the KafkaNodePool CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -54,7 +54,12 @@ import java.util.Map;
                                 name = "Desired replicas",
                                 description = "The desired number of replicas",
                                 jsonPath = ".spec.replicas",
-                                type = "integer")
+                                type = "integer"),
+                    @Crd.Spec.AdditionalPrinterColumn(
+                                name = "Roles",
+                                description = "Roles of the nodes in the pool",
+                                jsonPath = ".spec.roles",
+                                type = "string")
                 }
         )
 )

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -58,7 +58,7 @@ import java.util.Map;
                     @Crd.Spec.AdditionalPrinterColumn(
                                 name = "Roles",
                                 description = "Roles of the nodes in the pool",
-                                jsonPath = ".spec.roles",
+                                jsonPath = ".status.roles",
                                 type = "string")
                 }
         )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -34,6 +34,10 @@ spec:
       description: The desired number of replicas
       jsonPath: .spec.replicas
       type: integer
+    - name: Roles
+      description: Roles of the nodes in the pool
+      jsonPath: .spec.roles
+      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -36,7 +36,7 @@ spec:
       type: integer
     - name: Roles
       description: Roles of the nodes in the pool
-      jsonPath: .spec.roles
+      jsonPath: .status.roles
       type: string
     schema:
       openAPIV3Schema:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -34,6 +34,10 @@ spec:
       description: The desired number of replicas
       jsonPath: .spec.replicas
       type: integer
+    - name: Roles
+      description: Roles of the nodes in the pool
+      jsonPath: .spec.roles
+      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -36,7 +36,7 @@ spec:
       type: integer
     - name: Roles
       description: Roles of the nodes in the pool
-      jsonPath: .spec.roles
+      jsonPath: .status.roles
       type: string
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Trivial PR to add the `ROLES` column definition to the `KafkaNodePool` CRD.
Using the `string` type from the possible ones from OpenAPI seems to be the way to print the list of roles.

```shell
NAME         DESIRED REPLICAS   ROLES
controller   3                  ["controller"]
kafka        3                  ["broker"]
```

and

```shell
NAME        DESIRED REPLICAS   ROLES
dual-role   3                  ["controller","broker"]
```