### PR TITLE
Reuse Util.decodeFromBase64

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
@@ -10,6 +10,7 @@ import io.strimzi.api.kafka.model.common.CertificateExpirationPolicy;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -164,9 +165,9 @@ public class ClusterCaTest {
         // checking that the cluster CA related Secret was not touched by the operator
         Map<String, String> clusterCaCertDataInSecret = clusterCa.caCertSecret().getData();
         assertThat(clusterCaCertDataInSecret.size(), is(4));
-        assertThat(new String(Base64.getDecoder().decode(clusterCaCertDataInSecret.get(Ca.CA_CRT))).equals("new-dummy-crt"), is(true));
-        assertThat(new String(Base64.getDecoder().decode(clusterCaCertDataInSecret.get(Ca.CA_STORE))).equals("updated-dummy-p12"), is(true));
-        assertThat(new String(Base64.getDecoder().decode(clusterCaCertDataInSecret.get(Ca.CA_STORE_PASSWORD))).equals("dummy-password"), is(true));
-        assertThat(new String(Base64.getDecoder().decode(clusterCaCertDataInSecret.get("ca-2023-03-23T09-00-00Z.crt"))).equals("dummy-crt"), is(true));
+        assertThat(Util.decodeFromBase64(clusterCaCertDataInSecret.get(Ca.CA_CRT)).equals("new-dummy-crt"), is(true));
+        assertThat(Util.decodeFromBase64(clusterCaCertDataInSecret.get(Ca.CA_STORE)).equals("updated-dummy-p12"), is(true));
+        assertThat(Util.decodeFromBase64(clusterCaCertDataInSecret.get(Ca.CA_STORE_PASSWORD)).equals("dummy-password"), is(true));
+        assertThat(Util.decodeFromBase64(clusterCaCertDataInSecret.get("ca-2023-03-23T09-00-00Z.crt")).equals("dummy-crt"), is(true));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -35,6 +35,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -252,7 +253,7 @@ public class CaReconcilerTest {
         KeyStore trustStore = KeyStore.getInstance("PKCS12");
         trustStore.load(new ByteArrayInputStream(
                         Base64.getDecoder().decode(data.get(CA_STORE))),
-                new String(Base64.getDecoder().decode(data.get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII).toCharArray()
+                Util.decodeFromBase64(data.get(CA_STORE_PASSWORD)).toCharArray()
         );
         return trustStore;
     }
@@ -1111,7 +1112,7 @@ public class CaReconcilerTest {
         trustStoreFile.toFile().deleteOnExit();
         Files.write(certFile, Base64.getDecoder().decode(initialClusterCaCertSecret.getData().get("ca-2018-07-01T09-00-00.crt")));
         Files.write(trustStoreFile, Base64.getDecoder().decode(initialClusterCaCertSecret.getData().get(CA_STORE)));
-        String trustStorePassword = new String(Base64.getDecoder().decode(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII);
+        String trustStorePassword = Util.decodeFromBase64(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD));
         certManager.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
         initialClusterCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
         assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClusterCaCertSecret.getData()), is(true));
@@ -1140,7 +1141,7 @@ public class CaReconcilerTest {
         trustStoreFile = Files.createTempFile("tls", "-truststore");
         trustStoreFile.toFile().deleteOnExit();
         Files.write(trustStoreFile, Base64.getDecoder().decode(initialClientsCaCertSecret.getData().get(CA_STORE)));
-        trustStorePassword = new String(Base64.getDecoder().decode(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII);
+        trustStorePassword = Util.decodeFromBase64(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD));
         certManager.addCertToTrustStore(certFile.toFile(), "ca-2018-07-01T09-00-00.crt", trustStoreFile.toFile(), trustStorePassword);
         initialClientsCaCertSecret.getData().put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile)));
         assertThat(isCertInTrustStore("ca-2018-07-01T09-00-00.crt", initialClientsCaCertSecret.getData()), is(true));

--- a/operator-common/src/main/java/io/strimzi/operator/common/Util.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Util.java
@@ -19,6 +19,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -552,10 +553,22 @@ public class Util {
      *
      * @param data    String that should be decoded.
      *
-     * @return        Plain data.
+     * @return        Plain data using US ASCII charset.
      */
     public static String decodeFromBase64(String data)  {
-        return new String(Base64.getDecoder().decode(data), StandardCharsets.US_ASCII);
+        return decodeFromBase64(data, StandardCharsets.US_ASCII);
+    }
+    
+    /**
+     * Decodes a String from Base64.
+     *
+     * @param data    String that should be decoded.
+     * @param charset The charset for the return string
+     *
+     * @return        Plain data using specified charset.
+     */
+    public static String decodeFromBase64(String data, Charset charset)  {
+        return new String(Base64.getDecoder().decode(data), charset);
     }
 
     /**

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -401,7 +401,7 @@ public abstract class Ca {
                     decoder.decode(certData),
                     null,
                     decoder.decode(secret.getData().get(keyStore)),
-                    new String(decoder.decode(secret.getData().get(keyStorePassword)), StandardCharsets.US_ASCII));
+                    Util.decodeFromBase64(secret.getData().get(keyStorePassword)));
         }
     }
 
@@ -911,7 +911,7 @@ public abstract class Ca {
                 File trustStoreFile = Files.createTempFile("tls", "-truststore").toFile();
                 Files.write(trustStoreFile.toPath(), Base64.getDecoder().decode(newData.get(CA_STORE)));
                 try {
-                    String trustStorePassword = new String(Base64.getDecoder().decode(newData.get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII);
+                    String trustStorePassword = Util.decodeFromBase64(newData.get(CA_STORE_PASSWORD));
                     certManager.deleteFromTrustStore(removed, trustStoreFile, trustStorePassword);
                     newData.put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile.toPath())));
                 } finally {
@@ -1028,7 +1028,7 @@ public abstract class Ca {
                 }
                 try {
                     String trustStorePassword = certData.containsKey(CA_STORE_PASSWORD) ?
-                            new String(Base64.getDecoder().decode(certData.get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII) :
+                            Util.decodeFromBase64(certData.get(CA_STORE_PASSWORD)) :
                             passwordGenerator.generate();
                     certManager.addCertToTrustStore(certFile, alias, trustStoreFile, trustStorePassword);
                     certData.put(CA_STORE, Base64.getEncoder().encodeToString(Files.readAllBytes(trustStoreFile.toPath())));
@@ -1057,7 +1057,7 @@ public abstract class Ca {
                     // if secret already contains the truststore, we have to reuse it without changing password
                     if (certData.containsKey(CA_STORE)) {
                         Files.write(trustStoreFile.toPath(), Base64.getDecoder().decode(certData.get(CA_STORE)));
-                        trustStorePassword = new String(Base64.getDecoder().decode(certData.get(CA_STORE_PASSWORD)), StandardCharsets.US_ASCII);
+                        trustStorePassword = Util.decodeFromBase64(certData.get(CA_STORE_PASSWORD));
                     } else {
                         trustStorePassword = passwordGenerator.generate();
                     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/AbstractKafkaClientProperties.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/clientproperties/AbstractKafkaClientProperties.java
@@ -6,6 +6,7 @@ package io.strimzi.systemtest.kafkaclients.clientproperties;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.operator.common.Util;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.test.TestUtils;
@@ -176,7 +177,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
                             ts.store(tsOs, tsPassword.toCharArray());
                         }
                     } else {
-                        tsPassword = new String(Base64.getDecoder().decode(clusterCaCertSecret.getData().get("ca.password")), StandardCharsets.US_ASCII);
+                        tsPassword = Util.decodeFromBase64(clusterCaCertSecret.getData().get("ca.password"));
                         String truststore = clusterCaCertSecret.getData().get("ca.p12");
                         Files.write(tsFile.toPath(), Base64.getDecoder().decode(truststore));
                     }
@@ -191,7 +192,7 @@ abstract public class AbstractKafkaClientProperties<C extends AbstractKafkaClien
 
                     properties.setProperty(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
                     Secret userSecret = kubeClient().getSecret(namespaceName, kafkaUsername);
-                    String password = new String(Base64.getDecoder().decode(userSecret.getData().get("password")), StandardCharsets.UTF_8);
+                    String password = Util.decodeFromBase64(userSecret.getData().get("password"), StandardCharsets.UTF_8);
 
                     String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
                     String jaasCfg = String.format(jaasTemplate, kafkaUsername, password);

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.operator.common.Util;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.PodSecurityProfile;
@@ -21,9 +22,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -429,7 +428,7 @@ public class KafkaClients extends BaseClients {
         }
 
         final String saslJaasConfigEncrypted = ResourceManager.kubeClient().getSecret(this.getNamespaceName(), this.getUsername()).getData().get("sasl.jaas.config");
-        final String saslJaasConfigDecrypted = new String(Base64.getDecoder().decode(saslJaasConfigEncrypted), StandardCharsets.US_ASCII);
+        final String saslJaasConfigDecrypted = Util.decodeFromBase64(saslJaasConfigEncrypted);
 
         this.setAdditionalConfig(this.getAdditionalConfig() +
             // scram-sha

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/AdminClientTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/specific/AdminClientTemplates.java
@@ -8,13 +8,12 @@ import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.operator.common.Util;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.DeploymentTypes;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -93,7 +92,7 @@ public class AdminClientTemplates {
 
     private static String getAdminClientScramConfig(String namespaceName, String userName) {
         final String saslJaasConfigEncrypted = kubeClient().getSecret(namespaceName, userName).getData().get("sasl.jaas.config");
-        final String saslJaasConfigDecrypted = new String(Base64.getDecoder().decode(saslJaasConfigEncrypted), StandardCharsets.US_ASCII);
+        final String saslJaasConfigDecrypted = Util.decodeFromBase64(saslJaasConfigEncrypted);
 
         return "sasl.mechanism=SCRAM-SHA-512\n" +
             "security.protocol=" + SecurityProtocol.SASL_PLAINTEXT + "\n" +

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/SecretUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.kubeUtils.objects;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -166,7 +167,7 @@ public class SecretUtils {
         TestUtils.waitFor("cert to be replaced", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.TIMEOUT_FOR_CLUSTER_STABLE, () -> {
             Secret secret = kubeClient(namespaceName).getSecret(namespaceName, secretName);
             if (secret != null && secret.getData() != null && secret.getData().containsKey("ca.crt")) {
-                String currentCert = new String(Base64.getDecoder().decode(secret.getData().get("ca.crt")), StandardCharsets.US_ASCII);
+                String currentCert = Util.decodeFromBase64((secret.getData().get("ca.crt")));
                 boolean changed = !originalCert.equals(currentCert);
                 if (changed) {
                     LOGGER.info("Certificate in Secret: {}/{} changed, was: {}, is now: {}", namespaceName, secretName, originalCert, currentCert);
@@ -267,8 +268,8 @@ public class SecretUtils {
             String caKey = KubeClusterResource.kubeClient(namespaceName).getSecret(KafkaResources.clientsCaKeySecretName(clusterName)).getData().get("ca.key");
 
             File clientCert = OpenSsl.generateSignedCert(csr,
-                                                         SystemTestCertManager.exportCaDataToFile(new String(Base64.getDecoder().decode(caCrt), StandardCharsets.UTF_8), "ca", ".crt"),
-                                                         SystemTestCertManager.exportCaDataToFile(new String(Base64.getDecoder().decode(caKey), StandardCharsets.UTF_8), "ca", ".key"));
+                                                         SystemTestCertManager.exportCaDataToFile(Util.decodeFromBase64(caCrt, StandardCharsets.UTF_8), "ca", ".crt"),
+                                                         SystemTestCertManager.exportCaDataToFile(Util.decodeFromBase64(caKey, StandardCharsets.UTF_8), "ca", ".key"));
 
             Secret secretBuilder = new SecretBuilder()
                 .withNewMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/JmxUtils.java
@@ -5,13 +5,13 @@
 package io.strimzi.systemtest.utils.specific;
 
 import io.fabric8.kubernetes.api.model.Secret;
+import io.strimzi.operator.common.Util;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 import static io.strimzi.systemtest.resources.ResourceManager.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -64,8 +64,8 @@ public class JmxUtils {
         Secret jmxSecret = kubeClient(namespace).getSecret(secretName);
 
         LOGGER.info("Getting username and password for Service: {}/{} and Secret: {}/{}", namespace, serviceName, namespace, secretName);
-        String userName = new String(Base64.getDecoder().decode(jmxSecret.getData().get("jmx-username")), StandardCharsets.UTF_8);
-        String password = new String(Base64.getDecoder().decode(jmxSecret.getData().get("jmx-password")), StandardCharsets.UTF_8);
+        String userName = Util.decodeFromBase64(jmxSecret.getData().get("jmx-username"), StandardCharsets.UTF_8);
+        String password = Util.decodeFromBase64(jmxSecret.getData().get("jmx-password"), StandardCharsets.UTF_8);
 
         LOGGER.info("Creating script file for Service: {}/{}", namespace, serviceName);
         createScriptForJMXTermInPod(namespace, podName, serviceName, userName, password, commands);

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddress;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
@@ -334,7 +335,7 @@ public class ListenersST extends AbstractST {
 
         LOGGER.info("Checking if generated password has {} characters", passwordLength);
         String password = kubeClient().namespace(testStorage.getNamespaceName()).getSecret(testStorage.getUsername()).getData().get("password");
-        String decodedPassword = new String(Base64.getDecoder().decode(password));
+        String decodedPassword = Util.decodeFromBase64(password);
 
         assertEquals(decodedPassword.length(), passwordLength);
 

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -353,14 +353,14 @@ public class KafkaUserModel {
             }
 
             LOGGER.debugCr(reconciliation, "Loading request password from Kubernetes Secret {}", desiredPasswordSecretName());
-            this.scramSha512Password = new String(Base64.getDecoder().decode(password), StandardCharsets.US_ASCII);
+            this.scramSha512Password = Util.decodeFromBase64(password);
             return;
         } else if (userSecret != null) {
             // Secret already exists -> lets verify if it has a password
             String password = userSecret.getData().get(KEY_PASSWORD);
             if (password != null && !password.isEmpty()) {
                 LOGGER.debugCr(reconciliation, "Re-using password which already exists");
-                this.scramSha512Password = new String(Base64.getDecoder().decode(password), StandardCharsets.US_ASCII);
+                this.scramSha512Password = Util.decodeFromBase64(password);
                 return;
             }
         }

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.user.KafkaUserTlsClientAuthentication;
 import io.strimzi.api.kafka.model.user.KafkaUserTlsExternalClientAuthentication;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
@@ -373,8 +374,8 @@ public class KafkaUserModelTest {
         assertThat(generatedSecret.getData().keySet(), is(new HashSet<>(Arrays.asList(KafkaUserModel.KEY_PASSWORD, KafkaUserModel.KEY_SASL_JAAS_CONFIG))));
 
         String password = "aaaaaaaaaa";
-        assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(password));
-        assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
+        assertThat(Util.decodeFromBase64(generatedSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(password));
+        assertThat(Util.decodeFromBase64(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)),
                 is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + password + "\";"));
 
         // Check owner reference
@@ -445,8 +446,8 @@ public class KafkaUserModelTest {
 
         assertThat(generatedSecret.getData().keySet(), is(new HashSet<>(Arrays.asList(KafkaUserModel.KEY_PASSWORD, KafkaUserModel.KEY_SASL_JAAS_CONFIG))));
 
-        assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(DESIRED_PASSWORD));
-        assertThat(new String(Base64.getDecoder().decode(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
+        assertThat(Util.decodeFromBase64(generatedSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(DESIRED_PASSWORD));
+        assertThat(Util.decodeFromBase64(generatedSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)),
                 is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + DESIRED_PASSWORD + "\";"));
 
         // Check owner reference
@@ -492,8 +493,8 @@ public class KafkaUserModelTest {
                         .withStrimziKind(KafkaUser.RESOURCE_KIND)
                         .toMap()));
         assertThat(generated.getData().keySet(), is(new HashSet<>(Arrays.asList(KafkaUserModel.KEY_PASSWORD, KafkaUserModel.KEY_SASL_JAAS_CONFIG))));
-        assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))), is(DESIRED_PASSWORD));
-        assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
+        assertThat(Util.decodeFromBase64(generated.getData().get(KafkaUserModel.KEY_PASSWORD)), is(DESIRED_PASSWORD));
+        assertThat(Util.decodeFromBase64(generated.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)),
                 is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + DESIRED_PASSWORD + "\";"));
 
         // Check owner reference
@@ -604,8 +605,8 @@ public class KafkaUserModelTest {
         assertThat(generated.getData().keySet(), is(new HashSet<>(Arrays.asList(KafkaUserModel.KEY_PASSWORD, KafkaUserModel.KEY_SASL_JAAS_CONFIG))));
 
         String password = "aaaaaaaaaa";
-        assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_PASSWORD))), is(password));
-        assertThat(new String(Base64.getDecoder().decode(generated.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))),
+        assertThat(Util.decodeFromBase64(generated.getData().get(KafkaUserModel.KEY_PASSWORD)), is(password));
+        assertThat(Util.decodeFromBase64(generated.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)),
                 is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + ResourceUtils.NAME + "\" password=\"" + password + "\";"));
 
         // Check owner reference

--- a/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/operator/KafkaUserOperatorMockTest.java
@@ -198,9 +198,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), is(MockCertManager.userCert()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), is(MockCertManager.userKey()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), is(MockCertManager.userCert()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), is(MockCertManager.userKey()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -338,9 +338,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), is(MockCertManager.userCert()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), is(MockCertManager.userKey()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), is(MockCertManager.userCert()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), is(MockCertManager.userKey()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -400,9 +400,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(notNullValue()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))).length(), is(32));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)).length(), is(32));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)), is(notNullValue()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -467,9 +467,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(notNullValue()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))).length(), is(30));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)).length(), is(30));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)), is(notNullValue()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -555,8 +555,8 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(desiredPassword));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))), is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"12345678\";"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(desiredPassword));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)), is("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"user\" password=\"12345678\";"));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -651,9 +651,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(prefixedUserSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(prefixedUserSecret.getData().get("user.crt"))), is(MockCertManager.userCert()));
-        assertThat(new String(Base64.getDecoder().decode(prefixedUserSecret.getData().get("user.key"))), is(MockCertManager.userKey()));
+        assertThat(Util.decodeFromBase64(prefixedUserSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(prefixedUserSecret.getData().get("user.crt")), is(MockCertManager.userCert()));
+        assertThat(Util.decodeFromBase64(prefixedUserSecret.getData().get("user.key")), is(MockCertManager.userKey()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -721,9 +721,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), is("expected-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), is("expected-key"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), is("expected-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), is("expected-key"));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -794,9 +794,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), is("expected-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), is("expected-key"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), is("expected-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), is("expected-key"));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -929,9 +929,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("different-clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), is(MockCertManager.userCert()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), is(MockCertManager.userKey()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("different-clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), is(MockCertManager.userCert()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), is(MockCertManager.userKey()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -996,9 +996,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("ca.crt"))), is("clients-ca-crt"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.crt"))), startsWith("-----BEGIN CERTIFICATE-----"));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get("user.key"))), startsWith("-----BEGIN PRIVATE KEY-----"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("ca.crt")), is("clients-ca-crt"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.crt")), startsWith("-----BEGIN CERTIFICATE-----"));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get("user.key")), startsWith("-----BEGIN PRIVATE KEY-----"));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -1066,9 +1066,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(notNullValue()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))).length(), is(11));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)).length(), is(11));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)), is(notNullValue()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();
@@ -1133,9 +1133,9 @@ public class KafkaUserOperatorMockTest {
                         .withKubernetesPartOf(ResourceUtils.NAME)
                         .withKubernetesManagedBy(KafkaUserModel.KAFKA_USER_OPERATOR_NAME)
                         .toMap()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))), is(notNullValue()));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD))).length(), is(32));
-        assertThat(new String(Base64.getDecoder().decode(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG))), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)), is(notNullValue()));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_PASSWORD)).length(), is(32));
+        assertThat(Util.decodeFromBase64(userSecret.getData().get(KafkaUserModel.KEY_SASL_JAAS_CONFIG)), is(notNullValue()));
 
         // Assert the mocked Kafka ACLs
         List<String> capturedAclNames = aclNameCaptor.getAllValues();


### PR DESCRIPTION
### Type of change

Refactoring

### Description

Refactor to make use of Util.decodeFromBase64 to reduce code duplication.

Closes #9745 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

