### PR TITLE
Add support for Kafka 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.41.0
 
+* Add support for Apache Kafka 3.6.2
 * Provide metrics to monitor certificates expiration as well as modified `Strimzi Operators` dashboard to include certificate expiration per cluster.
 * Added support for topic replication factor change to the Unidirectional Topic Operator when Cruise Control integration is enabled.
 * The `KafkaNodePools` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.

--- a/documentation/modules/snip-images.adoc
+++ b/documentation/modules/snip-images.adoc
@@ -8,6 +8,7 @@
 a|
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.0
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.6.1
+* {DockerOrg}/kafka:{DockerTag}-kafka-3.6.2
 * {DockerOrg}/kafka:{DockerTag}-kafka-3.7.0
 
 a|

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -8,5 +8,6 @@
 |Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
 | 3.6.0 | 3.6 | 3.6 | 3.8.2
 | 3.6.1 | 3.6 | 3.6 | 3.8.3
+| 3.6.2 | 3.6 | 3.6 | 3.8.4
 | 3.7.0 | 3.7 | 3.7 | 3.8.3
 |=================

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -305,6 +305,16 @@
   third-party-libs: 3.6.x
   supported: true
   default: false
+- version: 3.6.2
+  format: 3.6
+  protocol: 3.6
+  metadata: 3.6
+  url: https://archive.apache.org/dist/kafka/3.6.2/kafka_2.13-3.6.2.tgz
+  checksum: E5D5935DF6E687898E71E583E8EA376275C6FBAC2E7872E78F7C55AB2528485582362E3778678600C5368384437C1DA6B3D612A748917F4B294C06EA160173EE
+  zookeeper: 3.8.4
+  third-party-libs: 3.6.x
+  supported: true
+  default: false
 - version: 3.7.0
   format: 3.7
   protocol: 3.7

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -15,20 +15,24 @@
               value: |                 
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.1")) }}
+                3.6.2={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.6.2")) }}
                 3.7.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.7.0")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |                 
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.1")) }}
+                3.6.2={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.6.2")) }}
                 3.7.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.7.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |                 
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.1")) }}
+                3.6.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.6.2")) }}
                 3.7.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.7.0")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |                 
                 3.6.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.0")) }}
                 3.6.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.1")) }}
+                3.6.2={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.6.2")) }}
                 3.7.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.7.0")) }}
 {{- end -}}

--- a/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/packaging/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -57,21 +57,25 @@ spec:
               value: |
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
+                3.6.2=quay.io/strimzi/kafka:latest-kafka-3.6.2
                 3.7.0=quay.io/strimzi/kafka:latest-kafka-3.7.0
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
+                3.6.2=quay.io/strimzi/kafka:latest-kafka-3.6.2
                 3.7.0=quay.io/strimzi/kafka:latest-kafka-3.7.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
+                3.6.2=quay.io/strimzi/kafka:latest-kafka-3.6.2
                 3.7.0=quay.io/strimzi/kafka:latest-kafka-3.7.0
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
                 3.6.0=quay.io/strimzi/kafka:latest-kafka-3.6.0
                 3.6.1=quay.io/strimzi/kafka:latest-kafka-3.6.1
+                3.6.2=quay.io/strimzi/kafka:latest-kafka-3.6.2
                 3.7.0=quay.io/strimzi/kafka:latest-kafka-3.7.0
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
               value: quay.io/strimzi/operator:latest


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds suport for Kafka 3.6.2.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md