### PR TITLE
[ST] Fix `LoggingChangeST#testDynamicallySetConnectLoggingLevels` for Kafka versions below 3.7.x

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -45,6 +45,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
+import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaBridgeUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
@@ -712,7 +713,10 @@ class LoggingChangeST extends AbstractST {
         final Pattern log4jPatternDebugLevel = Pattern.compile("^(?<date>[\\d-]+) (?<time>[\\d:,]+) DEBUG (?<message>.+)");
         final Pattern log4jPatternInfoLevel = Pattern.compile("^(?<date>[\\d-]+) (?<time>[\\d:,]+) INFO (?<message>.+)");
 
-        final KafkaConnect connect = KafkaConnectTemplates.kafkaConnect(testStorage.getClusterName(), testStorage.getNamespaceName(), 3)
+        // logging changes on multiple Connect instances are possible from Kafka 3.7.0
+        final int connectReplicas = TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0 ? 3 : 1;
+
+        final KafkaConnect connect = KafkaConnectTemplates.kafkaConnect(testStorage.getClusterName(), testStorage.getNamespaceName(), connectReplicas)
             .editSpec()
                 .withLogging(new InlineLoggingBuilder()
                     .withLoggers(Map.of("connect.root.logger.level", "OFF")).build())

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -714,6 +714,7 @@ class LoggingChangeST extends AbstractST {
         final Pattern log4jPatternInfoLevel = Pattern.compile("^(?<date>[\\d-]+) (?<time>[\\d:,]+) INFO (?<message>.+)");
 
         // logging changes on multiple Connect instances are possible from Kafka 3.7.0
+        // TODO: change once support for Kafka 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
         final int connectReplicas = TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0 ? 3 : 1;
 
         final KafkaConnect connect = KafkaConnectTemplates.kafkaConnect(testStorage.getClusterName(), testStorage.getNamespaceName(), connectReplicas)

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -691,6 +691,7 @@ public class MigrationST extends AbstractST {
     @BeforeAll
     void setup() {
         // skip if Kafka version is lower than 3.7.0
+        // TODO: remove once support for Kafka 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
         assumeTrue(TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
         assumeTrue(Environment.isKafkaNodePoolsEnabled() && Environment.isKRaftForCOEnabled());
         this.clusterOperator = this.clusterOperator


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the issue when running `LoggingChangeST#testDynamicallySetConnectLoggingLevels` with Kafka version (set in `ST_KAFKA_VERSION`) below 3.7.0, where logging change set across multiple connect instances was added.

It adds check for the Kafka version and based on that it assigns either 1 or 3 replicas, with which should be KafkaConnect deployed.

Fixes #9897 

### Checklist

- [ ] Make sure all tests pass
