### PR TITLE
Fix incorrect path in custom authroizer docs and improve them

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaAuthorizationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaAuthorizationCustom.adoc
@@ -10,14 +10,20 @@ IMPORTANT: The custom authorizer must implement the `org.apache.kafka.server.aut
 
 [id='property-custom-authorization-authorizerclass-{context}']
 = `authorizerClass`
-(Required) Java class that implements the `org.apache.kafka.server.authorizer.Authorizer` interface to support custom ACLs.
 
+(Required) Java class that implements the `org.apache.kafka.server.authorizer.Authorizer` interface to support custom ACLs.
 
 [id='property-custom-authorization-superusers-{context}']
 = `superUsers`
 A list of user principals treated as super users, so that they are always allowed without querying ACL rules.
 
-You can add configuration for initializing the custom authorizer using `Kafka.spec.kafka.config`.
+NOTE: The `super.user` configuration option in the `config` property in `Kafka.spec.kafka` is ignored.
+Designate super users in the `authorization` property instead.
+For more information, see xref:type-KafkaClusterSpec-reference[Kafka broker configuration].
+
+= Additional configuration options
+
+You can add additional configuration for initializing the custom authorizer using `Kafka.spec.kafka.config`.
 
 .An example of custom authorization configuration under `Kafka.spec`
 [source,yaml,subs="attributes+"]
@@ -44,15 +50,29 @@ spec:
     # ...
 ----
 
-In addition to the `Kafka` custom resource configuration, the JAR file containing the custom authorizer class along with its dependencies must be available on the classpath of the Kafka broker.
+= Adding the custom authorizer JAR file(s) to the container image
 
-The Strimzi Maven build process provides a mechanism to add custom third-party libraries to the generated Kafka broker container image by adding them as dependencies in the `pom.xml` file under the `docker-images/kafka/kafka-thirdparty-libs` directory. The directory contains different folders for different Kafka versions. Choose the appropriate folder. Before modifying the `pom.xml` file, the third-party library must be available in a Maven repository, and that Maven repository must be accessible to the Strimzi build process.
+In addition to the `Kafka` custom resource configuration, the JAR file(s) containing the custom authorizer class along with its dependencies must be available on the classpath of the Kafka broker.
 
-NOTE: The `super.user` configuration option in the `config` property in `Kafka.spec.kafka` is ignored.
-Designate super users in the `authorization` property instead.
-For more information, see xref:type-KafkaClusterSpec-reference[Kafka broker configuration].
+You can add them by building Strimzi from the source-code.
+The Strimzi build process provides a mechanism to add custom third-party libraries to the generated Kafka broker container image by adding them as dependencies in the `pom.xml` file under the `docker-images/artifacts/kafka-thirdparty-libs` directory.
+The directory contains different folders for different Kafka versions. Choose the appropriate folder.
+Before modifying the `pom.xml` file, the third-party library must be available in a Maven repository, and that Maven repository must be accessible to the Strimzi build process.
 
-Custom authorization can make use of group membership information extracted from the JWT token during authentication when using `oauth` authentication and configuring `groupsClaim` configuration attribute. Groups are available on the `OAuthKafkaPrincipal` object during authorize() call as follows:
+Or by adding the JARs to an existing Strimzi container image:
+
+[source,subs="+quotes,attributes"]
+----
+FROM {DockerKafka}
+USER root:root
+COPY ./_my-authorizer_/ /opt/kafka/libs/
+USER {DockerImageUser}
+----
+
+= Using custom authorizer with OAuth authentication
+
+Custom authorization can make use of group membership information extracted from the JWT token during authentication when using `oauth` authentication and configuring `groupsClaim` configuration attribute.
+Groups are available on the `OAuthKafkaPrincipal` object during authorize() call as follows:
 
 [source, subs="attributes+"]
 ----


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixed an incorrect path to the 3rd party libs that changed since the docs were written. It also does some additional improvements:
* Adds an option to add the file using a Dockerfile
* Tries to create a better structure to the chapter that seems to mix subchapters followed by a general content

### Checklist

- [x] Update documentation