### PR TITLE
Refactor InitWriterConfig

### DIFF
--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.init;
 
+import io.strimzi.operator.common.InvalidConfigurationException;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -15,11 +16,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InitWriterConfigTest {
-
     private static final Map<String, String> ENV_VARS = Map.of(
-            InitWriterConfig.NODE_NAME, "localhost",
-            InitWriterConfig.RACK_TOPOLOGY_KEY, "failure-domain.beta.kubernetes.io/zone",
-            InitWriterConfig.EXTERNAL_ADDRESS, "TRUE"
+        InitWriterConfig.NODE_NAME.key(), "localhost",
+        InitWriterConfig.RACK_TOPOLOGY_KEY.key(), "failure-domain.beta.kubernetes.io/zone",
+        InitWriterConfig.EXTERNAL_ADDRESS.key(), "true"
     );
 
     @Test
@@ -35,7 +35,7 @@ public class InitWriterConfigTest {
     @Test
     public void testFromMapWithAddressTypeEnvVar() {
         Map<String, String> envs = new HashMap<>(ENV_VARS);
-        envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE, "InternalDNS");
+        envs.put(InitWriterConfig.EXTERNAL_ADDRESS_TYPE.key(), "InternalDNS");
 
         InitWriterConfig config = InitWriterConfig.fromMap(envs);
         assertThat(config.getAddressType(), is("InternalDNS"));
@@ -43,14 +43,14 @@ public class InitWriterConfigTest {
 
     @Test
     public void testFromMapEmptyEnvVarsThrows() {
-        assertThrows(IllegalArgumentException.class, () -> InitWriterConfig.fromMap(Map.of()));
+        assertThrows(InvalidConfigurationException.class, () -> InitWriterConfig.fromMap(Map.of()));
     }
 
     @Test
     public void testFromMapMissingNodeNameThrows() {
         Map<String, String> envVars = new HashMap<>(ENV_VARS);
-        envVars.remove(InitWriterConfig.NODE_NAME);
+        envVars.remove(InitWriterConfig.NODE_NAME.key());
 
-        assertThrows(IllegalArgumentException.class, () -> InitWriterConfig.fromMap(envVars));
+        assertThrows(InvalidConfigurationException.class, () -> InitWriterConfig.fromMap(envVars));
     }
 }

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterConfigTest.java
@@ -19,7 +19,7 @@ public class InitWriterConfigTest {
     private static final Map<String, String> ENV_VARS = Map.of(
         InitWriterConfig.NODE_NAME.key(), "localhost",
         InitWriterConfig.RACK_TOPOLOGY_KEY.key(), "failure-domain.beta.kubernetes.io/zone",
-        InitWriterConfig.EXTERNAL_ADDRESS.key(), "true"
+        InitWriterConfig.EXTERNAL_ADDRESS.key(), "TRUE"
     );
 
     @Test

--- a/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
+++ b/kafka-init/src/test/java/io/strimzi/kafka/init/InitWriterTest.java
@@ -34,9 +34,9 @@ public class InitWriterTest {
     public File tempDir;
 
     private static final Map<String, String> ENV_VARS = Map.of(
-            InitWriterConfig.NODE_NAME, "localhost",
-            InitWriterConfig.RACK_TOPOLOGY_KEY, "failure-domain.beta.kubernetes.io/zone",
-            InitWriterConfig.EXTERNAL_ADDRESS, "true"
+            InitWriterConfig.NODE_NAME.key(), "localhost",
+            InitWriterConfig.RACK_TOPOLOGY_KEY.key(), "failure-domain.beta.kubernetes.io/zone",
+            InitWriterConfig.EXTERNAL_ADDRESS.key(), "true"
     );
     // metadata labels related to the Kubernetes cluster node
     private static final Map<String, String> LABELS = Map.of(
@@ -60,7 +60,7 @@ public class InitWriterTest {
         new File(rackFolder).mkdirs();
 
         Map<String, String> envVars = new HashMap<>(ENV_VARS);
-        envVars.put(InitWriterConfig.INIT_FOLDER, rackFolder);
+        envVars.put(InitWriterConfig.INIT_FOLDER.key(), rackFolder);
 
         InitWriterConfig config = InitWriterConfig.fromMap(envVars);
 
@@ -80,7 +80,7 @@ public class InitWriterTest {
         new File(addressFolder).mkdirs();
 
         Map<String, String> envVars = new HashMap<>(ENV_VARS);
-        envVars.put(InitWriterConfig.INIT_FOLDER, addressFolder);
+        envVars.put(InitWriterConfig.INIT_FOLDER.key(), addressFolder);
 
         InitWriterConfig config = InitWriterConfig.fromMap(envVars);
 
@@ -116,7 +116,7 @@ public class InitWriterTest {
 
         // specify a not existing folder for emulating IOException in the rack writer
         Map<String, String> envVars = new HashMap<>(ENV_VARS);
-        envVars.put(InitWriterConfig.INIT_FOLDER, "/no-folder");
+        envVars.put(InitWriterConfig.INIT_FOLDER.key(), "/no-folder");
 
         InitWriterConfig config = InitWriterConfig.fromMap(envVars);
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
@@ -134,7 +134,7 @@ public interface ConfigParameterParser<T> {
      * A Java Boolean
      */
     ConfigParameterParser<Boolean> BOOLEAN = configValue -> {
-        if (configValue.equals("true") || configValue.equals("false")) {
+        if (configValue.equalsIgnoreCase("true") || configValue.equalsIgnoreCase("false")) {
             return Boolean.parseBoolean(configValue);
         } else {
             throw new InvalidConfigurationException("Failed to parse. Value " + configValue + " is not valid");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Refactor the InitWriterConfig in the kafka-init module to use the shared classes, fix https://github.com/strimzi/strimzi-kafka-operator/issues/9881

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

