### PR TITLE
MirrorMaker2: Add warning for dangerously invalid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added support for configuring the `externalIPs` field in node port type services.
 * The `UnidirectionalTopicOperator` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
   If the topics whose names start with `strimzi-store-topic` and `strimzi-topic-operator` still exist, you can delete them.
+* Don't allow MirrorMaker2 mirrors with target set to something else than the connect cluster. 
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -117,7 +117,7 @@ public class KafkaMirrorMaker2Connectors {
                     }
 
                     if (!mirror.getTargetCluster().equals(connectCluster)) {
-                        errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but it is not the same as the connect cluster alias " + connectCluster);
+                        errorMessages.add("Connect cluster alias (currently set to " + connectCluster + ") has to be the same as the target cluster alias " + mirror.getTargetCluster());
                     }
                 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -114,6 +114,11 @@ public class KafkaMirrorMaker2Connectors {
                     } else if (!existingClusterAliases.contains(mirror.getTargetCluster())) {
                         errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but cluster with this alias does not exist in cluster definitions");
                     }
+
+                    String connectCluster = kafkaMirrorMaker2.getSpec().getConnectCluster();
+                    if (!mirror.getTargetCluster().equals(connectCluster)) {
+                        errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but it is not the same as the connect cluster alias " + connectCluster);
+                    }
                 }
 
                 if (!errorMessages.isEmpty())   {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -101,6 +101,7 @@ public class KafkaMirrorMaker2Connectors {
             } else {
                 Set<String> existingClusterAliases = kafkaMirrorMaker2.getSpec().getClusters().stream().map(KafkaMirrorMaker2ClusterSpec::getAlias).collect(Collectors.toSet());
                 Set<String> errorMessages = new HashSet<>();
+                String connectCluster = kafkaMirrorMaker2.getSpec().getConnectCluster();
 
                 for (KafkaMirrorMaker2MirrorSpec mirror : kafkaMirrorMaker2.getSpec().getMirrors())  {
                     if (mirror.getSourceCluster() == null)  {
@@ -115,7 +116,6 @@ public class KafkaMirrorMaker2Connectors {
                         errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but cluster with this alias does not exist in cluster definitions");
                     }
 
-                    String connectCluster = kafkaMirrorMaker2.getSpec().getConnectCluster();
                     if (!mirror.getTargetCluster().equals(connectCluster)) {
                         errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but it is not the same as the connect cluster alias " + connectCluster);
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -117,7 +117,7 @@ public class KafkaMirrorMaker2ConnectorsTest {
         assertThat(ex.getMessage(), is("KafkaMirrorMaker2 resource validation failed: " +
                 "[Each MirrorMaker 2 mirror definition has to specify the source cluster alias, " +
                 "Target cluster alias wrong-target is used in a mirror definition, but cluster with this alias does not exist in cluster definitions, " +
-                "Target cluster alias wrong-target is used in a mirror definition, but it is not the same as the connect cluster alias target]"));
+                "Connect cluster alias (currently set to target) has to be the same as the target cluster alias wrong-target]"));
     }
 
     @Test
@@ -130,7 +130,7 @@ public class KafkaMirrorMaker2ConnectorsTest {
                 .build();
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2));
         assertThat(ex.getMessage(), is("KafkaMirrorMaker2 resource validation failed: " +
-                "[Target cluster alias target is used in a mirror definition, but it is not the same as the connect cluster alias source]"));
+                "[Connect cluster alias (currently set to source) has to be the same as the target cluster alias target]"));
 
         // A case where one mirror has the correct target cluster, but the other does not
         KafkaMirrorMaker2 kmm2CorrectAndIncorrectMirror = new KafkaMirrorMaker2Builder(KMM2)
@@ -146,7 +146,7 @@ public class KafkaMirrorMaker2ConnectorsTest {
                 .build();
         ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2CorrectAndIncorrectMirror));
         assertThat(ex.getMessage(), is("KafkaMirrorMaker2 resource validation failed: " +
-                "[Target cluster alias third is used in a mirror definition, but it is not the same as the connect cluster alias target]"));
+                "[Connect cluster alias (currently set to target) has to be the same as the target cluster alias third]"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -116,7 +116,8 @@ public class KafkaMirrorMaker2ConnectorsTest {
         ex = assertThrows(InvalidResourceException.class, () -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2WrongAlias));
         assertThat(ex.getMessage(), is("KafkaMirrorMaker2 resource validation failed: " +
                 "[Each MirrorMaker 2 mirror definition has to specify the source cluster alias, " +
-                "Target cluster alias wrong-target is used in a mirror definition, but cluster with this alias does not exist in cluster definitions]"));
+                "Target cluster alias wrong-target is used in a mirror definition, but cluster with this alias does not exist in cluster definitions, " +
+                "Target cluster alias wrong-target is used in a mirror definition, but it is not the same as the connect cluster alias target]"));
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -1049,6 +1049,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
                         .withBootstrapServers(targetClusterAlias + "." + targetNamespace + ".svc:9092")
                         .build();
         kmm2.getSpec().setClusters(List.of(sourceCluster, targetCluster));
+        kmm2.getSpec().setConnectCluster(targetClusterAlias);
 
         KafkaMirrorMaker2MirrorSpec deprecatedMirrorConnector = new KafkaMirrorMaker2MirrorSpecBuilder()
                 .withSourceCluster(sourceClusterAlias)
@@ -1099,6 +1100,7 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
                         .withBootstrapServers(targetClusterAlias + "." + targetNamespace + ".svc:9092")
                         .build();
         kmm2.getSpec().setClusters(List.of(sourceCluster, targetCluster));
+        kmm2.getSpec().setConnectCluster(targetClusterAlias);
 
         KafkaMirrorMaker2MirrorSpec deprecatedMirrorConnector = new KafkaMirrorMaker2MirrorSpecBuilder()
                 .withSourceCluster(sourceClusterAlias)


### PR DESCRIPTION
Fixes #9905

### Type of change

- Bugfix

### Description

In MirrorMaker2 configuration model, add check to ensure all mirrors have target set to the connect cluster. This is the only sane option anyway, but instead of raising an error message, it did start and behaved badly. See #9905.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

