### PR TITLE
[ST] improve/fix waitForPods util method.

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/AdminClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/AdminClientUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils;
+
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.kafkaclients.internalClients.admin.AdminClient;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+
+public class AdminClientUtils {
+    private static final Logger LOGGER = LogManager.getLogger(AdminClientUtils.class);
+
+    private AdminClientUtils() {}
+
+    public static boolean isTopicPresent(AdminClient adminClient, String topicName) {
+        final String newLineSeparatedTopics = adminClient.listTopics();
+        LOGGER.trace("topics present in Kafka:\n{}", newLineSeparatedTopics);
+        return newLineSeparatedTopics.isEmpty() ? false : Arrays.asList(newLineSeparatedTopics.split("\n")).contains(topicName);
+    }
+
+    public static void waitForTopicPresence(AdminClient adminClient, String topicName) {
+        LOGGER.info("Waiting for topic: {} to be present in Kafka", topicName);
+        TestUtils.waitFor("Topic: " + topicName + " to be present in Kafka", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT_SHORT,
+            () -> isTopicPresent(adminClient, topicName));
+    }
+
+    public static void waitForTopicAbsence(AdminClient adminClient, String topicName) {
+        LOGGER.info("Waiting for topic: {} to be absent in Kafka", topicName);
+        TestUtils.waitFor("Topic: " + topicName + " to be absent in Kafka", TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT_SHORT,
+            () -> !isTopicPresent(adminClient, topicName));
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/DeploymentUtils.java
@@ -171,14 +171,16 @@ public class DeploymentUtils {
     /**
      * Wait until the given Deployment is ready.
      * @param namespaceName name of the namespace
-     * @param deploymentName The name of the Deployment.
+     * @param deploymentName The name of the Deployment which may also serve as filter for present Pods.
      * @param expectPods The expected number of Pods.
      */
     public static boolean waitForDeploymentAndPodsReady(String namespaceName, String deploymentName, int expectPods) {
         waitForDeploymentReady(namespaceName, deploymentName);
 
         LOGGER.info("Waiting for {} Pod(s) of Deployment: {}/{} to be ready", expectPods, namespaceName, deploymentName);
-        PodUtils.waitForPodsReady(namespaceName, kubeClient(namespaceName).getDeploymentSelectors(namespaceName, deploymentName), expectPods, true,
+        final LabelSelector deploymentPodSelector = kubeClient(namespaceName).getDeploymentSelectors(namespaceName, deploymentName);
+
+        PodUtils.waitForPodsReady(namespaceName, deploymentPodSelector, expectPods, true, deploymentName,
             () -> DeploymentUtils.logCurrentDeploymentStatus(kubeClient(namespaceName).getDeployment(namespaceName, deploymentName), namespaceName));
         LOGGER.info("Deployment: {}/{} is ready", namespaceName, deploymentName);
         return true;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/PodUtils.java
@@ -62,32 +62,57 @@ public class PodUtils {
         waitForPodsReady(namespaceName, selector, expectPods, containers, () -> { });
     }
 
+    /**
+     * Waits for a specified number of pods in a given namespace to become ready. This is an overloaded method with a
+     * default pod prefix.
+     *
+     * @param namespaceName The name of the Kubernetes namespace in which to wait for pods.
+     * @param selector The label selector to identify the pods of interest.
+     * @param expectPods The expected number of pods that should be ready.
+     * @param containers If true, checks individual container readiness within the pods.
+     * @param onTimeout The action to be executed if the pods do not become ready before the timeout.
+     */
     public static void waitForPodsReady(String namespaceName, LabelSelector selector, int expectPods, boolean containers, Runnable onTimeout) {
+        waitForPodsReady(namespaceName, selector, expectPods, containers, "", onTimeout);
+    }
+
+    /**
+     * Waits for a specified number of pods in a given namespace to become ready. This method allows specifying a pod
+     * prefix to further filter the pods of interest.
+     *
+     * @param namespace The name of the Kubernetes namespace in which to wait for pods.
+     * @param selector The label selector to identify the pods of interest.
+     * @param expectPods The expected number of pods that should be ready.
+     * @param containers If true, checks individual container readiness within the pods.
+     * @param podPrefix The prefix of the pod names to consider. Only pods whose names start with this prefix will be checked.
+     * @param onTimeout The action to be executed if the pods do not become ready before the timeout.
+     */
+    public static void waitForPodsReady(String namespace, LabelSelector selector, int expectPods, boolean containers, String podPrefix, Runnable onTimeout) {
         TestUtils.waitFor("readiness of all Pods matching: " + selector,
             TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS, ResourceOperation.timeoutForPodsOperation(expectPods),
             () -> {
-                List<Pod> pods = kubeClient(namespaceName).listPods(namespaceName, selector);
+                List<Pod> pods = kubeClient(namespace).listPods(namespace, selector).stream().filter(pod -> pod.getMetadata().getName().startsWith(podPrefix)).toList();
                 if (pods.isEmpty() && expectPods == 0) {
                     LOGGER.debug("Expected Pods are ready");
                     return true;
                 }
                 if (pods.isEmpty()) {
-                    LOGGER.debug("Pods matching: {}/{} are not ready", namespaceName, selector);
+                    LOGGER.debug("Pods matching: {}/{} are not ready", namespace, selector);
                     return false;
                 }
                 if (pods.size() != expectPods) {
-                    LOGGER.debug("Expected Pods: {}/{} are not ready", namespaceName, selector);
+                    LOGGER.debug("Expected Pods: {}/{} are not ready", namespace, selector);
                     return false;
                 }
                 for (Pod pod : pods) {
                     if (!Readiness.isPodReady(pod)) {
-                        LOGGER.debug("Pod not ready: {}/{}", namespaceName, pod.getMetadata().getName());
+                        LOGGER.debug("Pod not ready: {}/{}", namespace, pod.getMetadata().getName());
                         return false;
                     } else {
                         if (containers) {
                             for (ContainerStatus cs : pod.getStatus().getContainerStatuses()) {
                                 if (!Boolean.TRUE.equals(cs.getReady())) {
-                                    LOGGER.debug("Container: {} of Pod: {}/{} not ready", namespaceName, pod.getMetadata().getName(), cs.getName());
+                                    LOGGER.debug("Container: {} of Pod: {}/{} not ready", namespace, pod.getMetadata().getName(), cs.getName());
                                     return false;
                                 }
                             }


### PR DESCRIPTION
### Type of change

- Enhancement 

### Description

Waiting for deployment or other controllers with utils methods `waitForPodsReady` will not work if we don't have selector which are specific enough e.g. (two admin clients cannot be separated by just selector assuming they are in same namespace) with currently present labels. 
- This PR allows specification of pod prefix when looking for Pods of given deployment, with default to empty string `""` which catch all. This is done to not break previous implementation.

There are additional changes in  `AdminClientUtils`  and  `TopicST` to try validity of this change also on admin clients. 



