### PR TITLE
Fixed validation minimum Kafka version for migration

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -152,7 +152,7 @@ public class KRaftUtils {
 
         MetadataVersion kafkaVersion = MetadataVersion.fromVersionString(kafkaVersionFromCr);
         // this should check that spec.kafka.version is >= 3.7.0
-        boolean isMigrationSupported = kafkaVersion.isMigrationSupported();
+        boolean isMigrationSupported = kafkaVersion.isAtLeast(MetadataVersion.IBP_3_7_IV0);
 
         MetadataVersion metadataVersion = MetadataVersion.fromVersionString(metadataVersionFromCr);
         MetadataVersion interBrokerProtocolVersion = MetadataVersion.fromVersionString(interBrokerProtocolVersionFromCr);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsTest.java
@@ -281,7 +281,7 @@ public class KRaftUtilsTest {
     @ParallelTest
     public void testsVersionsForKRaftMigrationValidation() {
         // Valid values
-        assertDoesNotThrow(() -> KRaftUtils.validateVersionsForKRaftMigration("3.6.1", "3.6-IV2", "3.6", "3.6"));
+        assertDoesNotThrow(() -> KRaftUtils.validateVersionsForKRaftMigration("3.7.0", "3.7-IV4", "3.7", "3.7"));
 
         // Invalid Values
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateVersionsForKRaftMigration("3.6.1", "3.6-IV2", "3.5", "3.5"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -3990,13 +3990,13 @@ public class KafkaClusterTest {
     public void testInvalidInterBrokerProtocolAndLogMessageFormatOnKRaftMigration() {
         // invalid values ... metadata missing (it gets the Kafka version), inter broker protocol and log message format lower than Kafka version
         Map<String, Object> config = new HashMap<>();
-        config.put("inter.broker.protocol.version", "3.5");
-        config.put("log.message.format.version", "3.5");
+        config.put("inter.broker.protocol.version", "3.6");
+        config.put("log.message.format.version", "3.6");
 
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.6.1")
+                        .withVersion("3.7.0")
                         .withConfig(config)
                     .endKafka()
                 .endSpec()
@@ -4009,14 +4009,14 @@ public class KafkaClusterTest {
             KafkaVersionChange kafkaVersionChange = new KafkaVersionChange(
                     kafkaVersion,
                     kafkaVersion,
-                    VERSIONS.version("3.5.0").protocolVersion(),
-                    VERSIONS.version("3.5.0").messageVersion(),
+                    VERSIONS.version("3.6.0").protocolVersion(),
+                    VERSIONS.version("3.6.0").messageVersion(),
                     // as per ZooKeeperVersionChangeCreator, when migration, we set missing metadata version to the Kafka version
                     kafkaVersion.metadataVersion());
             KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, kafkaVersionChange, KafkaMetadataConfigurationState.PRE_MIGRATION, null, SHARED_ENV_PROVIDER);
         });
 
-        assertThat(ex.getMessage(), containsString("Migration cannot be performed with Kafka version 3.6-IV2, metadata version 3.6-IV2, inter.broker.protocol.version 3.5-IV2, log.message.format.version 3.5-IV2."));
+        assertThat(ex.getMessage(), containsString("Migration cannot be performed with Kafka version 3.7-IV4, metadata version 3.7-IV4, inter.broker.protocol.version 3.6-IV2, log.message.format.version 3.6-IV2."));
     }
 
     @ParallelTest
@@ -4025,8 +4025,8 @@ public class KafkaClusterTest {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.6.1")
-                        .withMetadataVersion("3.5-IV2")
+                        .withVersion("3.7.0")
+                        .withMetadataVersion("3.6-IV2")
                         .withConfig(Map.of())
                     .endKafka()
                 .endSpec()
@@ -4046,20 +4046,20 @@ public class KafkaClusterTest {
             KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, kafkaVersionChange, KafkaMetadataConfigurationState.PRE_MIGRATION, null, SHARED_ENV_PROVIDER);
         });
 
-        assertThat(ex.getMessage(), containsString("Migration cannot be performed with Kafka version 3.6-IV2, metadata version 3.5-IV2, inter.broker.protocol.version 3.6-IV2, log.message.format.version 3.6-IV2."));
+        assertThat(ex.getMessage(), containsString("Migration cannot be performed with Kafka version 3.7-IV4, metadata version 3.6-IV2, inter.broker.protocol.version 3.7-IV4, log.message.format.version 3.7-IV4."));
     }
 
     @ParallelTest
     public void testValidVersionsOnKRaftMigration() {
         Map<String, Object> config = new HashMap<>();
-        config.put("inter.broker.protocol.version", "3.6");
-        config.put("log.message.format.version", "3.6");
+        config.put("inter.broker.protocol.version", "3.7");
+        config.put("log.message.format.version", "3.7");
 
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.6.1")
-                        .withMetadataVersion("3.6-IV2")
+                        .withVersion("3.7.0")
+                        .withMetadataVersion("3.7-IV4")
                         .withConfig(config)
                 .endKafka()
                 .endSpec()


### PR DESCRIPTION
Trivial PR to fix the minimum Kafka version to validate the possibility of migrating the cluster to KRaft.
We were aiming for 3.7.0 as the minimum (as by the comments) but current code was leveraging the default `MetadataVersion.isMigrationSupported()` method which is validating against 3.4.0 (it just does `return this.isAtLeast(IBP_3_4_IV0);`).