### PR TITLE
Use a resolvable hostname for JMX RMI instead of IP

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
+++ b/docker-images/kafka-based/kafka/scripts/set_kafka_jmx_options.sh
@@ -6,7 +6,7 @@ JMX_USERNAME="$2"
 JMX_PASSWORD="$3"
 
 if [ "$JMX_ENABLED" = "true" ]; then
-  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(hostname -i) -Djava.net.preferIPv4Stack=true"
+  KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(hostname -s) -Djava.net.preferIPv4Stack=true"
 
   if [ -n "$JMX_USERNAME" ]; then
     mkdir -p /tmp/jmx/


### PR DESCRIPTION
### Type of change
- Refactoring

### Description

It is impossible to connect JMX RMI if it advertise an IP address that is non-routable outside of the kubernetes. 

https://github.com/orgs/strimzi/discussions/7469


