### PR TITLE
Removing the inner polling to check proposal request and rebalancing

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -816,10 +816,10 @@ public class KafkaRebalanceAssemblyOperator
         Promise<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> p = Promise.promise();
 
         if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.refresh) {
-            LOGGER.infoCr(reconciliation, "Requesting a new proposal since refresh annotation is applied on the KafkaRebalance resource"); // TODO: debugCr
+            LOGGER.infoCr(reconciliation, "Requesting a new proposal since refresh annotation is applied on the KafkaRebalance resource");
             requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
         } else if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.stop) {
-            LOGGER.infoCr(reconciliation, "Stopping to request proposal or checking the status"); // TODO: debugCr
+            LOGGER.infoCr(reconciliation, "Stopping to request proposal or checking the status");
             p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, StatusUtils.validate(reconciliation, kafkaRebalance)));
         } else {
             LOGGER.infoCr(reconciliation, "Requesting a new proposal or checking the status for an already issued one");
@@ -834,9 +834,9 @@ public class KafkaRebalanceAssemblyOperator
                     rebalanceMapAndStatus.setStatus(status);
                     if (rebalanceMapAndStatus.getStatus().getOptimizationResult() != null &&
                             !rebalanceMapAndStatus.getStatus().getOptimizationResult().isEmpty()) {
-                        LOGGER.infoCr(reconciliation, "Optimization proposal ready"); // TODO: debugCr
+                        LOGGER.infoCr(reconciliation, "Optimization proposal ready");
                     } else {
-                        LOGGER.infoCr(reconciliation, "Waiting for optimization proposal to be ready"); // TODO: debugCr
+                        LOGGER.infoCr(reconciliation, "Waiting for optimization proposal to be ready");
                     }
                     p.complete(rebalanceMapAndStatus);
                 })
@@ -917,7 +917,7 @@ public class KafkaRebalanceAssemblyOperator
 
         String sessionId = kafkaRebalance.getStatus().getSessionId();
         if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.stop) {
-            LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task"); // TODO: debugCr
+            LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task");
             apiClient.stopExecution(host, CruiseControl.REST_API_PORT)
                 .onSuccess(r -> p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, StatusUtils.validate(reconciliation, kafkaRebalance))))
                 .onFailure(e -> {
@@ -925,7 +925,7 @@ public class KafkaRebalanceAssemblyOperator
                     p.fail(e.getCause());
                 });
         } else if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.refresh) {
-            LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task since refresh annotation is applied on the KafkaRebalance resource and requesting a new proposal"); // TODO: debugCr
+            LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task since refresh annotation is applied on the KafkaRebalance resource and requesting a new proposal");
             apiClient.stopExecution(host, CruiseControl.REST_API_PORT)
                     .onSuccess(r -> {
                         requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
@@ -957,7 +957,7 @@ public class KafkaRebalanceAssemblyOperator
                             p.complete(buildRebalanceStatus(sessionId, KafkaRebalanceState.NotReady, conditions));
                             break;
                         case IN_EXECUTION: // Rebalance is still in progress
-                            LOGGER.infoCr(reconciliation, "Rebalance ({}) optimization proposal in execution", sessionId); // TODO: debugCr
+                            LOGGER.infoCr(reconciliation, "Rebalance ({}) optimization proposal in execution", sessionId);
                             // We need to check that the status has been updated with the ongoing optimisation proposal
                             // The proposal field can be empty if a rebalance(dryrun=false) was called and the optimisation
                             // proposal was still being prepared (in progress). In that case the rebalance will start when

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -187,6 +187,7 @@ public class ResourceUtils {
                         .withImage(image + "-zk")
                         .withLivenessProbe(probe)
                         .withReadinessProbe(probe)
+                        .withStorage(new EphemeralStorage())
                     .endZookeeper()
                 .endSpec()
                 .build();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -210,20 +210,40 @@ public class KafkaRebalanceStateMachineTest {
         }
     }
 
+    /**
+     * Tests the transition from 'New' to 'ProposalReady'
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the New state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'ProposalReady' state
+     */
     @Test
-    public void testNewToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNewToProposalReadyRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krNewToProposalReady(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krNewToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testNewToProposalReadyAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNewToProposalReady(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testNewToProposalReadyRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNewToProposalReady(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krNewToProposalReady(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.ProposalReady,
@@ -231,15 +251,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'New' to 'PendingProposal' because of not enough data to compute an optimization proposal
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the New state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
+     */
     @Test
-    public void testNewWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNewWithNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewWithNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testNewWithNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewWithNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testNewWithNotEnoughDataRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krNewWithNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -254,20 +294,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'New' to 'PendingProposal' because of the optimization proposal not available yet on Cruise Control
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the New state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
+     */
     @Test
-    public void testNewToProposalPending(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNewToPendingProposalRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNewToProposalPending(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krNewToPendingProposal(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krNewToProposalPending(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testNewToPendingProposalAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNewToPendingProposal(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testNewToPendingProposalRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNewToPendingProposal(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krNewToPendingProposal(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.New, KafkaRebalanceState.PendingProposal,
@@ -275,8 +335,16 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'New' to 'NotReady' due to "missing hard goals" error
+     *
+     * 1. A new KafkaRebalance resource is created with some specified not hard goals; it is in the New state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is not ready because of a "missing hard goals" error
+     * 4. The KafkaRebalance resource moves to the 'NotReady' state
+     */
     @Test
-    public void testNewBadGoalsError(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNewBadGoalsErrorRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         List<String> customGoals = new ArrayList<>();
         customGoals.add("Goal.one");
         customGoals.add("Goal.two");
@@ -285,21 +353,43 @@ public class KafkaRebalanceStateMachineTest {
         KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder().addAllToGoals(customGoals).build();
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        rebalanceSpec = new KafkaRebalanceSpecBuilder()
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewBadGoalsErrorRebalance} for description
+     */
+    @Test
+    public void testNewBadGoalsErrorAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        List<String> customGoals = new ArrayList<>();
+        customGoals.add("Goal.one");
+        customGoals.add("Goal.two");
+        customGoals.add("Goal.three");
+
+        KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withMode(KafkaRebalanceMode.ADD_BROKERS)
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        rebalanceSpec = new KafkaRebalanceSpecBuilder()
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewBadGoalsErrorRebalance} for description
+     */
+    @Test
+    public void testNewBadGoalsErrorRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        List<String> customGoals = new ArrayList<>();
+        customGoals.add("Goal.one");
+        customGoals.add("Goal.two");
+        customGoals.add("Goal.three");
+
+        KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withMode(KafkaRebalanceMode.REMOVE_BROKERS)
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
         this.krNewBadGoalsError(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -320,8 +410,16 @@ public class KafkaRebalanceStateMachineTest {
                 }));
     }
 
+    /**
+     * Tests the transition from 'New' to 'ProposalReady' skipping the hard goals check
+     *
+     * 1. A new KafkaRebalance resource is created with some specified not hard goals but with flag to skip the check; it is in the New state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'ProposalReady' state
+     */
     @Test
-    public void testNewBadGoalsErrorWithSkipHGCheck(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNewBadGoalsErrorWithSkipHardGoalsRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         List<String> customGoals = new ArrayList<>();
         customGoals.add("Goal.one");
         customGoals.add("Goal.two");
@@ -329,28 +427,50 @@ public class KafkaRebalanceStateMachineTest {
 
         KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder().addAllToGoals(customGoals).withSkipHardGoalCheck(true).build();
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
-        this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+        this.krNewBadGoalsErrorWithSkipHardGoals(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        rebalanceSpec = new KafkaRebalanceSpecBuilder()
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewBadGoalsErrorWithSkipHardGoalsRebalance} for description
+     */
+    @Test
+    public void testNewBadGoalsErrorWithSkipHardGoalsAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        List<String> customGoals = new ArrayList<>();
+        customGoals.add("Goal.one");
+        customGoals.add("Goal.two");
+        customGoals.add("Goal.three");
+
+        KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withMode(KafkaRebalanceMode.ADD_BROKERS)
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .withSkipHardGoalCheck(true)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
-        this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
+        this.krNewBadGoalsErrorWithSkipHardGoals(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        rebalanceSpec = new KafkaRebalanceSpecBuilder()
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNewBadGoalsErrorWithSkipHardGoalsRebalance} for description
+     */
+    @Test
+    public void testNewBadGoalsErrorWithSkipHardGoalsRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        List<String> customGoals = new ArrayList<>();
+        customGoals.add("Goal.one");
+        customGoals.add("Goal.two");
+        customGoals.add("Goal.three");
+
+        KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder()
                 .withMode(KafkaRebalanceMode.REMOVE_BROKERS)
                 .withBrokers(3)
                 .addAllToGoals(customGoals)
                 .withSkipHardGoalCheck(true)
                 .build();
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
-        this.krNewBadGoalsErrorWithSkipHGCheck(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.New, null, null, rebalanceSpec, null, false);
+        this.krNewBadGoalsErrorWithSkipHardGoals(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
-    private void krNewBadGoalsErrorWithSkipHGCheck(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+    private void krNewBadGoalsErrorWithSkipHardGoals(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         // Test the case where the user asks for a rebalance with custom goals which do not contain all the configured hard goals
         // But we have set skip hard goals check to true
         ccServer.setupCCRebalanceBadGoalsError(endpoint);
@@ -361,20 +481,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'PendingProposal' to 'ProposalReady'
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the PendingProposal state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'ProposalReady' state
+     */
     @Test
-    public void testProposalPendingToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testPendingProposalToProposalReadyRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krPendingProposalToProposalReady(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalPendingToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToProposalReadyAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToProposalReady(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToProposalReadyRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToProposalReady(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krPendingProposalToProposalReady(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.PendingProposal, KafkaRebalanceState.ProposalReady,
@@ -382,41 +522,91 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'PendingProposal' to 'ProposalReady' but after several pending calls
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the PendingProposal state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is still pending for several calls (Cruise Control is computing it) and finally it's ready
+     * 4. The KafkaRebalance resource moves to the 'ProposalReady' state
+     */
     @Test
-    public void testProposalPendingToProposalReadyWithDelay(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testPendingProposalToProposalReadyWithDelayRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToProposalReadyWithDelay(vertx, context, 3, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krPendingProposalToProposalReadyWithDelay(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalPendingToProposalReadyWithDelay(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToProposalReadyWithDelayRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToProposalReadyWithDelayAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToProposalReadyWithDelay(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToProposalReadyWithDelayRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToProposalReadyWithDelayRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToProposalReadyWithDelay(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krPendingProposalToProposalReadyWithDelay(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(3, endpoint);
 
         checkTransition(vertx, context,
-                KafkaRebalanceState.PendingProposal, KafkaRebalanceState.ProposalReady,
+                KafkaRebalanceState.PendingProposal, KafkaRebalanceState.PendingProposal,
                 KafkaRebalanceAnnotation.none, kcRebalance)
+                .compose(v -> checkTransition(vertx, context,
+                        KafkaRebalanceState.PendingProposal, KafkaRebalanceState.PendingProposal,
+                        KafkaRebalanceAnnotation.none, kcRebalance))
+                .compose(v -> checkTransition(vertx, context,
+                        KafkaRebalanceState.PendingProposal, KafkaRebalanceState.PendingProposal,
+                        KafkaRebalanceAnnotation.none, kcRebalance))
+                .compose(v -> checkTransition(vertx, context,
+                        KafkaRebalanceState.PendingProposal, KafkaRebalanceState.ProposalReady,
+                        KafkaRebalanceAnnotation.none, kcRebalance))
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'PendingProposal' to 'Stopped'
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=stop; it is in the PendingProposal state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource moves to the 'Stopped' state
+     */
     @Test
-    public void testProposalPendingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testPendingProposalToStoppedRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalPendingToStopped(vertx, context, 3, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krPendingProposalToStopped(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalPendingToStopped(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToStoppedRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToStoppedAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToStopped(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testPendingProposalToStoppedRebalance} for description
+     */
+    @Test
+    public void testPendingProposalToStoppedRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.PendingProposal, null, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krPendingProposalToStopped(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krPendingProposalToStopped(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        // the number of pending calls doesn't have a real impact
+        // the stop annotation is evaluated on the next step computation so the rebalance request will be stopped immediately
+        ccServer.setupCCRebalanceResponse(3, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.PendingProposal, KafkaRebalanceState.Stopped,
@@ -424,20 +614,39 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the stay on `ProposalReady` when there are no changes
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource stays in the 'ProposalReady' state
+     */
     @Test
-    public void testProposalReadyNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyNoChangeRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyNoChange(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krProposalReadyNoChange(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalReadyNoChange(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyNoChangeRebalance} for description
+     */
+    @Test
+    public void testProposalReadyNoChangeAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyNoChange(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyNoChangeRebalance} for description
+     */
+    @Test
+    public void testProposalReadyNoChangeRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyNoChange(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krProposalReadyNoChange(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.ProposalReady,
@@ -445,19 +654,39 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> defaultStatusHandler(result, context));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'PendingProposal' because of not enough data
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=approve; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
+     */
     @Test
-    public void testProposalReadyToRebalancingWithNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyToPendingProposalWithNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krProposalReadyToPendingProposalWithNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalReadyToRebalancingWithNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToPendingProposalWithNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToPendingProposalWithNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyToPendingProposalWithNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToPendingProposalWithNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToPendingProposalWithNotEnoughDataRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyToPendingProposalWithNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krProposalReadyToPendingProposalWithNotEnoughData(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         ccServer.setupCCRebalanceNotEnoughDataError(endpoint);
 
         checkTransition(vertx, context,
@@ -466,20 +695,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'Rebalancing' because of the pending call
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=approve; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance resource moves to the 'Rebalancing' state
+     */
     @Test
-    public void testProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyToRebalancingWithPendingSummaryRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToRebalancingWithPendingSummaryRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToRebalancingWithPendingSummaryAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToRebalancingWithPendingSummaryRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToRebalancingWithPendingSummaryRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyToRebalancingWithPendingSummary(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krProposalReadyToRebalancingWithPendingSummary(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.Rebalancing,
@@ -487,15 +736,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'Rebalancing' with manual approval
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=approve; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'Rebalancing' state
+     */
     @Test
-    public void testProposalReadyToRebalancing(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyToRebalancingRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToRebalancingRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToRebalancingAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyToRebalancingRebalance} for description
+     */
+    @Test
+    public void testProposalReadyToRebalancingRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -508,20 +777,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'Rebalancing' with auto-approval
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance-auto-approval=true; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'Rebalancing' state
+     */
     @Test
-    public void testAutoApprovalProposalReadyToRebalancing(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testAutoApprovalProposalReadyToRebalancingRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, true);
-        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, true);
-        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, true);
-        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krAutoApprovalProposalReadyToRebalancing(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testAutoApprovalProposalReadyToRebalancingRebalance} for description
+     */
+    @Test
+    public void testAutoApprovalProposalReadyToRebalancingAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, true);
+        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testAutoApprovalProposalReadyToRebalancingRebalance} for description
+     */
+    @Test
+    public void testAutoApprovalProposalReadyToRebalancingRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, true);
+        this.krAutoApprovalProposalReadyToRebalancing(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krAutoApprovalProposalReadyToRebalancing(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.Rebalancing,
@@ -529,20 +818,39 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the stay on `ProposalReady` when there are no changes on refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource stays in the 'ProposalReady' state
+     */
     @Test
-    public void testProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyRefreshNoChangeRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshNoChange(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krProposalReadyRefreshNoChange(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshNoChangeRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshNoChangeAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyRefreshNoChange(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshNoChangeRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshNoChangeRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyRefreshNoChange(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krProposalReadyRefreshNoChange(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.ProposalReady,
@@ -550,20 +858,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'PendingProposal' because of the pending call when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
+     */
     @Test
-    public void testProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyRefreshToPendingProposalRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krProposalReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krProposalReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshToPendingProposalAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshToPendingProposalRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krProposalReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krProposalReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.ProposalReady, KafkaRebalanceState.PendingProposal,
@@ -571,15 +899,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'ProposalReady' to 'PendingProposal' because of not enough data when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance resource moves to the 'PendingProposal' state
+     */
     @Test
-    public void testProposalReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyRefreshToPendingProposalNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshToPendingProposalNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testProposalReadyRefreshToPendingProposalNotEnoughDataRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krProposalReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -592,20 +940,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Rebalancing' to 'Ready'
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the Rebalancing state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance resource moves to the 'Ready' state
+     */
     @Test
-    public void testRebalancingCompleted(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testRebalancingCompletedRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingCompleted(vertx, context, 0, 0, kcRebalance);
+        this.krRebalancingCompleted(vertx, context, kcRebalance);
     }
 
-    private void krRebalancingCompleted(Vertx vertx, VertxTestContext context, int activeCalls, int inExecutionCalls, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingCompletedRebalance} for description
+     */
+    @Test
+    public void testRebalancingCompletedAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingCompleted(vertx, context, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingCompletedRebalance} for description
+     */
+    @Test
+    public void testRebalancingCompletedRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingCompleted(vertx, context, kcRebalance);
+    }
+
+    private void krRebalancingCompleted(Vertx vertx, VertxTestContext context, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCUserTasksResponseNoGoals(0, 0);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Ready,
@@ -613,15 +981,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the staying on 'Rebalancing' across multiple calls
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the Rebalancing state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is rebalancing for several calls (Cruise Control is computing it)
+     * 4. The KafkaRebalance stays in 'Rebalancing' state
+     */
     @Test
-    public void testRebalancingPendingThenExecution(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testRebalancingPendingThenExecutionRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingPendingThenExecutionRebalance} for description
+     */
+    @Test
+    public void testRebalancingPendingThenExecutionAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingPendingThenExecutionRebalance} for description
+     */
+    @Test
+    public void testRebalancingPendingThenExecutionRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krRebalancingPendingThenExecution(vertx, context, 1, 1, kcRebalance);
     }
 
@@ -634,23 +1022,45 @@ public class KafkaRebalanceStateMachineTest {
         checkTransition(vertx, context,
                 KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Rebalancing,
                 KafkaRebalanceAnnotation.none, kcRebalance)
+                .compose(v -> checkTransition(vertx, context,
+                        KafkaRebalanceState.Rebalancing, KafkaRebalanceState.Rebalancing,
+                        KafkaRebalanceAnnotation.none, kcRebalance))
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'Rebalancing' to 'Stopped'
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=stop; it is in the Rebalancing state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource moves to the 'Stopped' state
+     */
     @Test
-    public void testRebalancingToStopped(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testRebalancingToStoppedRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, 0, 0, kcRebalance);
+        this.krRebalancingToStopped(vertx, context, kcRebalance);
     }
 
-    private void krRebalancingToStopped(Vertx vertx, VertxTestContext context, int activeCalls, int inExecutionCalls, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCUserTasksResponseNoGoals(activeCalls, inExecutionCalls);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingToStoppedRebalance} for description
+     */
+    @Test
+    public void testRebalancingToStoppedAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingToStopped(vertx, context, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingToStoppedRebalance} for description
+     */
+    @Test
+    public void testRebalancingToStoppedRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, "stop", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingToStopped(vertx, context, kcRebalance);
+    }
+
+    private void krRebalancingToStopped(Vertx vertx, VertxTestContext context, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCUserTasksResponseNoGoals(0, 0);
         ccServer.setupCCStopResponse();
 
         checkTransition(vertx, context,
@@ -659,19 +1069,39 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Rebalancing' to 'NotReady'
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the Rebalancing state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal has errors
+     * 4. The KafkaRebalance moves to the 'NotReady' state
+     */
     @Test
-    public void testRebalancingCompletedWithError(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testRebalancingCompletedWithErrorRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krRebalancingToStopped(vertx, context, kcRebalance);
+        this.krRebalancingCompletedWithError(vertx, context, kcRebalance);
     }
 
-    private void krRebalancingToStopped(Vertx vertx, VertxTestContext context, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingCompletedWithErrorRebalance} for description
+     */
+    @Test
+    public void testRebalancingCompletedWithErrorAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingCompletedWithError(vertx, context, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testRebalancingCompletedWithErrorRebalance} for description
+     */
+    @Test
+    public void testRebalancingCompletedWithErrorRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krRebalancingCompletedWithError(vertx, context, kcRebalance);
+    }
+
+    private void krRebalancingCompletedWithError(Vertx vertx, VertxTestContext context, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
         ccServer.setupCCUserTasksCompletedWithError();
 
         checkTransition(vertx, context,
@@ -680,20 +1110,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Stopped' to 'PendingProposal' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Stopped state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testStoppedRefreshToPendingProposalRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krStoppedRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToPendingProposalAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krStoppedRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToPendingProposalRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krStoppedRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krStoppedRefreshToPendingProposal(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Stopped, KafkaRebalanceState.PendingProposal,
@@ -701,20 +1151,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Stopped' to 'ProposalReady' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Stopped state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance moves to the 'ProposalReady' state
+     */
     @Test
-    public void testStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testStoppedRefreshToProposalReadyRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krStoppedRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krStoppedRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToProposalReadyAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krStoppedRefreshToProposalReady(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToProposalReadyRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krStoppedRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krStoppedRefreshToProposalReady(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Stopped, KafkaRebalanceState.ProposalReady,
@@ -722,15 +1192,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'Stopped' to 'PendingProposal' because of not enough data when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Stopped state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testStoppedRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testStoppedRefreshToPendingProposalNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToPendingProposalNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testStoppedRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testStoppedRefreshToPendingProposalNotEnoughDataRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Stopped, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krStoppedRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -743,20 +1233,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Ready' to 'PendingProposal' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Ready state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testReadyRefreshToPendingProposalRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToPendingProposalAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToPendingProposalRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Ready, KafkaRebalanceState.PendingProposal,
@@ -764,20 +1274,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'Ready' to 'ProposalReady' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Ready state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance moves to the 'ProposalReady' state
+     */
     @Test
-    public void testReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testReadyRefreshToProposalReadyRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToProposalReadyAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToProposalReadyRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.Ready, KafkaRebalanceState.ProposalReady,
@@ -785,15 +1315,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'Ready' to 'PendingProposal' because of not enough data when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Ready state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testReadyRefreshToPendingProposalNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToPendingProposalNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -806,20 +1356,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'NotReady' to 'PendingProposal' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the NotReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not ready yet
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNotReadyRefreshToPendingProposalRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToPendingProposal(vertx, context, 1, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krNotReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToPendingProposalAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNotReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToPendingProposalRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToPendingProposalRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNotReadyRefreshToPendingProposal(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krNotReadyRefreshToPendingProposal(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(1, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.NotReady, KafkaRebalanceState.PendingProposal,
@@ -827,20 +1397,40 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the transition from 'NotReady' to 'ProposalReady' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the NotReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready on the first call
+     * 4. The KafkaRebalance moves to the 'ProposalReady' state
+     */
     @Test
-    public void testNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNotReadyRefreshToProposalReadyRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
-
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
-        this.krNotReadyRefreshToProposalReady(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+        this.krNotReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
     }
 
-    private void krNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, int pendingCalls, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
-        ccServer.setupCCRebalanceResponse(pendingCalls, endpoint);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToProposalReadyAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNotReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
+
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToProposalReadyRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToProposalReadyRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        this.krNotReadyRefreshToProposalReady(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
+    }
+
+    private void krNotReadyRefreshToProposalReady(Vertx vertx, VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kcRebalance) throws IOException, URISyntaxException {
+        ccServer.setupCCRebalanceResponse(0, endpoint);
 
         checkTransition(vertx, context,
                 KafkaRebalanceState.NotReady, KafkaRebalanceState.ProposalReady,
@@ -848,15 +1438,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, false));
     }
 
+    /**
+     * Tests the transition from 'NotReady' to 'PendingProposal' because of not enough data when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the NotReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is pending because not enough data
+     * 4. The KafkaRebalance moves to the 'PendingProposal' state
+     */
     @Test
-    public void testNotReadyRefreshToPendingProposalNotEnoughData(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testNotReadyRefreshToPendingProposalNotEnoughDataRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REBALANCE, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToPendingProposalNotEnoughDataAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.ADD_BROKER, kcRebalance);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testNotReadyRefreshToPendingProposalNotEnoughDataRebalance} for description
+     */
+    @Test
+    public void testNotReadyRefreshToPendingProposalNotEnoughDataRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.krNotReadyRefreshToPendingProposalNotEnoughData(vertx, context, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance);
     }
 
@@ -869,27 +1479,65 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> checkOptimizationResults(result, context, true));
     }
 
+    /**
+     * Tests the stay on `ProposalReady` when there is a wrong annotation
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with an "unknown" annotation; it is in the ProposalReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource stays in the 'ProposalReady' state
+     */
     @Test
-    public void testProposalReadyWithWrongAnnotation(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testProposalReadyWithWrongAnnotationRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.ProposalReady,  KafkaRebalanceAnnotation.unknown);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyWithWrongAnnotationRebalance} for description
+     */
+    @Test
+    public void testProposalReadyWithWrongAnnotationAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.ProposalReady, KafkaRebalanceAnnotation.unknown);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testProposalReadyWithWrongAnnotationRebalance} for description
+     */
+    @Test
+    public void testProposalReadyWithWrongAnnotation(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.ProposalReady, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.ProposalReady, KafkaRebalanceAnnotation.unknown);
     }
 
+    /**
+     * Tests the stay on `Ready` when there is a wrong annotation
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with an "unknown" annotation; it is in the Ready state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The KafkaRebalance resource stays in the 'Ready' state
+     */
     @Test
-    public void testReadyWithWrongAnnotation(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testReadyWithWrongAnnotationRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, EMPTY_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyWithWrongAnnotationRebalance} for description
+     */
+    @Test
+    public void testReadyWithWrongAnnotationAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyWithWrongAnnotationRebalance} for description
+     */
+    @Test
+    public void testReadyWithWrongAnnotationRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         this.testStateWithWrongAnnotation(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.Ready, KafkaRebalanceAnnotation.approve);
     }
 
@@ -905,15 +1553,35 @@ public class KafkaRebalanceStateMachineTest {
                 .onComplete(result -> defaultStatusHandler(result, context));
     }
 
+    /**
+     * Tests the transition from 'NotReady' to 'ProposalReady' after recovering a retriable exception on Cruise Control
+     *
+     * 1. A new KafkaRebalance resource is created; it is in the NotReady state
+     * 2. The operator computes the next state on the rebalance proposal via the Cruise Control REST API
+     * 3. The rebalance proposal is ready after a retriable exception on Cruise Control
+     * 4. The KafkaRebalance moves to the 'ProposalReady' state
+     */
     @Test
-    public void testReadyAfterCruiseControlRetriableConnectionException(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+    public void testReadyAfterCruiseControlRetriableConnectionExceptionRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.NotReady, null, null, EMPTY_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION, false);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REBALANCE, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyAfterCruiseControlRetriableConnectionExceptionRebalance} for description
+     */
+    @Test
+    public void testReadyAfterCruiseControlRetriableConnectionExceptionAddBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, ADD_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION, false);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.ADD_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
+    }
 
-        kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION, false);
+    /**
+     * See the {@link KafkaRebalanceStateMachineTest#testReadyAfterCruiseControlRetriableConnectionExceptionRebalance} for description
+     */
+    @Test
+    public void testReadyAfterCruiseControlRetriableConnectionExceptionRemoveBroker(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Ready, null, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, CRUISE_CONTROL_RETRIABLE_CONNECTION_EXCEPTION, false);
         this.testStateWithException(vertx, context, 0, CruiseControlEndpoints.REMOVE_BROKER, kcRebalance, KafkaRebalanceState.NotReady, KafkaRebalanceAnnotation.none);
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the inner polling loop when checking the status of a rebalance proposal request and the current rebalancing. It refactors the code in order to rely on the operator periodic reconcile loop to run the checks.
Due to this change, the PR has a big refactoring on tests as well because of the logic is now depending on the reconciliation loop and not hidden inside a short periodic internal polling anymore.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
