### PR TITLE
Fixed KRaft detection script when broker in POST_MIGRATION

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/kraft_utils.sh
@@ -20,10 +20,10 @@ function useKRaft {
   # controller is KRaft since PRE_MIGRATION
   if [[ "$roles" =~ "controller" ]] && [ "$STRIMZI_KAFKA_METADATA_CONFIG_STATE" -ge 1 ]; then
     echo "true"
-  # starting from MIGRATION, both controller and broker are KRaft
-  elif [ "$STRIMZI_KAFKA_METADATA_CONFIG_STATE" -ge 2 ]; then
+  # broker is KRaft starting from POST_MIGRATION
+  elif [[ "$roles" =~ "broker" ]] && [ "$STRIMZI_KAFKA_METADATA_CONFIG_STATE" -ge 3 ]; then
     echo "true"
-  # we should be here in ZK state only or broker in PRE_MIGRATION	
+  # we should be here in ZK state only or broker before POST_MIGRATION
   else
     echo "false"
   fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the `kraft_utils.sh` which contains the function to detect the KRaft usage.
During migration, a broker is KRaft when in `POST_MIGRATION` and not since `MIGRATION` state.

### Checklist

- [ ] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally