### PR TITLE
Added Stopped column to the KafkaRebalance custom resource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -74,7 +74,12 @@ import java.util.function.Predicate;
                 name = "NotReady",
                 description = "There is an error on the custom resource",
                 jsonPath = ".status.conditions[?(@.type==\"NotReady\")].status",
-                type = "string")
+                type = "string"),
+            @Crd.Spec.AdditionalPrinterColumn(
+                    name = "Stopped",
+                    description = "Processing the proposal or running rebalancing was stopped",
+                    jsonPath = ".status.conditions[?(@.type==\"Stopped\")].status",
+                    type = "string")
         }
     )
 )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -51,6 +51,10 @@ spec:
           description: There is an error on the custom resource
           jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
           type: string
+        - name: Stopped
+          description: Processing the proposal or running rebalancing was stopped
+          jsonPath: ".status.conditions[?(@.type==\"Stopped\")].status"
+          type: string
       schema:
         openAPIV3Schema:
           type: object

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -50,6 +50,10 @@ spec:
       description: There is an error on the custom resource
       jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
       type: string
+    - name: Stopped
+      description: Processing the proposal or running rebalancing was stopped
+      jsonPath: ".status.conditions[?(@.type==\"Stopped\")].status"
+      type: string
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
Trivial PR to add the additional `Stopped` column to the `KafkaRebalance` custom resource output.
It's one of the possible resource states which are already in the output columns.
Useful to know that a `refresh` annotation is needed to request a rebalance proposal again.