### PR TITLE
Avoid updating connector status again and again when Connect is scaled to 0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -836,7 +836,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
         }
 
         Map<String, Object> statusResult = null;
-        List<String> topics = new ArrayList<>();
+        List<String> topics = null;
         List<Condition> conditions = new ArrayList<>();
         AutoRestartStatus autoRestart = null;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When Kafka Connect is scaled to 0, we keep updating the status of its connectors again and again. This is because a different status is set by the `KafkaConnect` reconciliation based on the time and by the `KafkaConnector` watch. So the timer updates the connector status, that triggers the watch which updates it again. And next periodic reconciliation, the same repeats.

This PR updates the status update method used to set the _zero replicas_ status in the connector watch to set the same status as the periodical reconciliation does and that way, the status is updated only once. It also removed the default _empty list_ for the used topics and uses null instead when we actually cannot get the real list of topics.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally