### PR TITLE
docs(node pools): reversing the migration to node pools

### DIFF
--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -98,7 +98,7 @@ When the `KafkaNodePool` resource is in use, you can remove the properties that 
 
 To revert to managing Kafka nodes using only `Kafka` custom resources:
 
-. Move all brokers (and partition replicas) to a single `KafkaNodePool` named `kafka` with node IDs from 0 to N (where N is the number of replicas).
+. If you have multiple node pools, consolidate them into a single `KafkaNodePool` named `kafka` with node IDs from 0 to N (where N is the number of replicas).
 . Ensure that the `.spec.kafka` configuration in the `Kafka` resource matches the `KafkaNodePool` configuration, including storage, resources, and replicas.
 . Disable support for node pools in the `Kafka` resource using the `strimzi.io/node-pools: disabled` annotation.
 . Delete the Kafka node pool named `kafka`.

--- a/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
+++ b/documentation/modules/configuring/proc-migrating-clusters-node-pools.adoc
@@ -48,7 +48,7 @@ spec:
         deleteClaim: false
 ----
 +
-WARNING: To migrate a cluster while preserving its data along with the names of its nodes and resources, the node pool name must be `kafka`, and the `strimzi.io/cluster` label must use the name of the Kafka resource. 
+WARNING: To preserve cluster data and the names of its nodes and resources, the node pool name must be `kafka`, and the `strimzi.io/cluster` label matches the Kafka resource name. 
 Otherwise, nodes and resources are created with new names, including the persistent volume storage used by the nodes. 
 Consequently, your previous data may not be available.       
 
@@ -93,3 +93,12 @@ The resources remain identical to how they were before.
 
 . Remove the replicated properties from the `Kafka` custom resource.
 When the `KafkaNodePool` resource is in use, you can remove the properties that you copied to the `KafkaNodePool` resource, such as the `.spec.kafka.replicas` and `.spec.kafka.storage` properties.
+
+.Reversing the migration
+
+To revert to managing Kafka nodes using only `Kafka` custom resources:
+
+. Move all brokers (and partition replicas) to a single `KafkaNodePool` named `kafka` with node IDs from 0 to N (where N is the number of replicas).
+. Ensure that the `.spec.kafka` configuration in the `Kafka` resource matches the `KafkaNodePool` configuration, including storage, resources, and replicas.
+. Disable support for node pools in the `Kafka` resource using the `strimzi.io/node-pools: disabled` annotation.
+. Delete the Kafka node pool named `kafka`.


### PR DESCRIPTION
**Documentation**

Adds an overview of the steps required to reverse the process for migrating to using node pools.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

