### PR TITLE
[ST] Fix MigrationST

### DIFF
--- a/.azure/templates/jobs/system-tests/migration_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/migration_jobs.yaml
@@ -5,6 +5,6 @@ jobs:
       display_name: 'migration-bundle'
       profile: 'azp_migration'
       cluster_operator_install_type: 'bundle'
-      timeout: 180
+      timeout: 240
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceOperation.java
@@ -97,7 +97,7 @@ public class ResourceOperation {
                 timeout = Duration.ofMinutes(5).toMillis();
                 break;
             default:
-                timeout = Duration.ofMinutes(3).toMillis();
+                timeout = Duration.ofMinutes(2).toMillis();
         }
 
         return timeout;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -581,7 +581,7 @@ public class KafkaUtils {
     }
 
     public static void waitUntilKafkaStatusContainsKafkaMetadataState(String namespaceName, String clusterName, KafkaMetadataState desiredKafkaMetadataState) {
-        TestUtils.waitFor(String.join("Kafka status to be contain kafkaMetadataState: %s", desiredKafkaMetadataState.name()), TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT, () -> {
+        TestUtils.waitFor(String.join("Kafka status to be contain kafkaMetadataState: %s", desiredKafkaMetadataState.name()), TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT, () -> {
             Kafka k = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get();
             return k.getStatus().getKafkaMetadataState().equals(desiredKafkaMetadataState);
         });

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -292,6 +292,7 @@ public class MigrationST extends AbstractST {
         doSecondPartOfMigration(testStorage, deleteCoDuringProcess, zkDeleteClaim);
     }
 
+    @SuppressWarnings({"checkstyle:MethodLength"})
     private void setupMigrationTestCase(TestStorage testStorage, boolean zkDeleteClaim) {
         // we assume that users will have broker NodePool named "kafka", so we will name it completely same to follow this use-case
         String brokerPoolName = "kafka";
@@ -310,7 +311,7 @@ public class MigrationST extends AbstractST {
         brokerSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), brokerPoolName, ProcessRoles.BROKER);
         controllerSelector = KafkaNodePoolResource.getLabelSelector(testStorage.getClusterName(), testStorage.getControllerPoolName(), ProcessRoles.CONTROLLER);
 
-        String clientsAdditionConfiguration = "delivery.timeout.ms=20000\nrequest.timeout.ms=20000\nacks=all\n";
+        String clientsAdditionConfiguration = "delivery.timeout.ms=30000\nrequest.timeout.ms=30000\nacks=all\n";
 
         immediateClients = new KafkaClientsBuilder()
             .withProducerName(testStorage.getProducerName())
@@ -328,7 +329,7 @@ public class MigrationST extends AbstractST {
             .withBootstrapAddress(KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
             .withTopicName(continuousTopicName)
             .withMessageCount(continuousMessageCount)
-            .withDelayMs(1000)
+            .withDelayMs(500)
             .withConsumerGroup(continuousConsumerGroupName)
             .withUsername(continuousUserName)
             .withAdditionalConfig(clientsAdditionConfiguration)
@@ -374,6 +375,16 @@ public class MigrationST extends AbstractST {
                             .withDeleteClaim(zkDeleteClaim)
                             .endPersistentClaimStorage()
                         .endZookeeper()
+                        .editOrNewEntityOperator()
+                            .editOrNewTemplate()
+                                .editOrNewTopicOperatorContainer()
+                                    .addNewEnv()
+                                        .withName("STRIMZI_USE_FINALIZERS")
+                                        .withValue("false")
+                                    .endEnv()
+                                .endTopicOperatorContainer()
+                            .endTemplate()
+                        .endEntityOperator()
                     .endSpec()
                     .build());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes few things failing in the STs in the `MigrationST` class:

- from time to time, producer fails to send one or two messages, so I extended the `delivery.timeout.ms` (together with `request.timeout.ms`) to 30s, which should be sufficient in case of disconnection from the node
- long wait before the continuous clients are finished - changed the delay to 500 ms (from 1000ms)
- issue with deletion of KafkaTopic(s) -> the issue is only with topics from the ZK mode, when we migrated to fully KRaft, from time to time UTO wasn't able to delete the KafkaTopic(s) and because of that the clean-up of our STs was failing. For now I just turned off finalizers in UTO, but this is being investigated
- small timeout for movement of Kafka cluster state to `KRaftDualWriting` and other states -> extended to 5 minutes, however it's still not enough from time to time, depending on the KafkaRoller and when the Pods are rolled. This is being investigated as well
- small timeout for migration AZP -> increased to 240minutes.

Other than this I decreased the wait timeout for "default" resource deletion -> from 3 minutes to 2, as it should be sufficient timeout for resources like CRDs, KafkaTopic, KafkaUser, Secret, ConfigMap, etc.

### Checklist

- [x] Make sure all tests pass

