### PR TITLE
Improve the separation between the Connect and MM2 operators

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -10,10 +10,13 @@ import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watcher;
+import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ConnectTimeoutException;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
+import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
@@ -21,16 +24,21 @@ import io.strimzi.api.kafka.model.connect.KafkaConnectList;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.connect.KafkaConnectStatus;
+import io.strimzi.api.kafka.model.connector.AutoRestartStatus;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
+import io.strimzi.api.kafka.model.connector.KafkaConnectorList;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorStatus;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.KafkaConnectBuild;
 import io.strimzi.operator.cluster.model.KafkaConnectCluster;
+import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.PodSetUtils;
 import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
@@ -40,12 +48,14 @@ import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.NamespaceAndName;
 import io.strimzi.operator.common.model.OrderedProperties;
+import io.strimzi.operator.common.model.StatusDiff;
 import io.strimzi.operator.common.model.StatusUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,12 +69,16 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_RESTART_TASK;
+import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_RESTART;
+
 /**
  * <p>Assembly operator for a "Kafka Connect" assembly, which manages:</p>
  * <ul>
  *     <li>A Kafka Connect Deployment and related Services</li>
  * </ul>
  */
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<KubernetesClient, KafkaConnect, KafkaConnectList, KafkaConnectSpec, KafkaConnectStatus> {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaConnectAssemblyOperator.class.getName());
 
@@ -234,23 +248,6 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                 });
     }
 
-    /**
-     * Finds and returns the correct controller resource:
-     *     - If stable identities are enabled and PodSet exists, returns PodSet
-     *     - If stable identities are enabled and PodSet is null, we might be in the middle of migration, so it returns the Deployment (which in worst case is null which is fine)
-     *     - If stable identities are disabled and Deployment exists, returns Deployment
-     *     - If stable identities are disabled and Deployment is null, we might be in the middle of migration, so it returns the PodSet (which in worst case is null which is fine)
-     *
-     * @param deployment    Deployment resource
-     * @param podSet        PodSet resource
-     *
-     * @return  The active controller resource
-     */
-    private HasMetadata activeController(Deployment deployment, StrimziPodSet podSet)  {
-        // TODO: Do we really need this?
-        return podSet != null ? podSet : deployment;
-    }
-
     private Future<Void> reconcilePodSet(Reconciliation reconciliation,
                                          KafkaConnectCluster connect,
                                          Map<String, String> podAnnotations,
@@ -336,7 +333,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
      * @param kafkaConnectSpec   KafkaConnectSpec object
      * @return                   Future for tracking the asynchronous result of generating the TLS auth hash
      */
-    Future<Integer> generateAuthHash(String namespace, KafkaConnectSpec kafkaConnectSpec) {
+    private Future<Integer> generateAuthHash(String namespace, KafkaConnectSpec kafkaConnectSpec) {
         KafkaClientAuthentication auth = kafkaConnectSpec.getAuthentication();
         List<CertSecretSource> trustedCertificates = kafkaConnectSpec.getTls() == null ? Collections.emptyList() : kafkaConnectSpec.getTls().getTrustedCertificates();
         return VertxUtil.authTlsHash(secretOperations, namespace, auth, trustedCertificates);
@@ -416,8 +413,83 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
         });
     }
 
-    private boolean isPaused(KafkaConnectorStatus status) {
-        return status != null && status.getConditions().stream().anyMatch(condition -> "ReconciliationPaused".equals(condition.getType()));
+    /*test*/ Future<Void> reconcileConnectorAndHandleResult(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
+                                             boolean useResources, String connectorName, KafkaConnector connector) {
+        Promise<Void> reconciliationResult = Promise.promise();
+
+        metrics().connectorsReconciliationsCounter(reconciliation.namespace()).increment();
+        Timer.Sample connectorsReconciliationsTimerSample = Timer.start(metrics().metricsProvider().meterRegistry());
+
+        if (connector != null && Annotations.isReconciliationPausedWithAnnotation(connector)) {
+            return maybeUpdateConnectorStatus(reconciliation, connector, null, null).compose(
+                i -> {
+                    connectorsReconciliationsTimerSample.stop(metrics().connectorsReconciliationsTimer(reconciliation.namespace()));
+                    metrics().connectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+                    return Future.succeededFuture();
+                }
+            );
+        }
+
+        reconcileConnector(reconciliation, host, apiClient, useResources, connectorName, connector)
+                .onComplete(result -> {
+                    if (result.succeeded() && result.result() == null)  {
+                        // The reconciliation succeeded, but there is no status to be set => we complete the reconciliation and return
+                        // This normally means that the connector was deleted and there is no status to be set
+                        metrics().connectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+                        connectorsReconciliationsTimerSample.stop(metrics().connectorsReconciliationsTimer(reconciliation.namespace()));
+                        reconciliationResult.complete();
+                    } else if (result.failed() && connector == null) {
+                        // The reconciliation failed on connector deletion, so there is nowhere for status to be set => we complete the reconciliation and return
+                        LOGGER.warnCr(reconciliation, "Error reconciling connector {}", connectorName, result.cause());
+                        metrics().connectorsFailedReconciliationsCounter(reconciliation.namespace()).increment();
+                        connectorsReconciliationsTimerSample.stop(metrics().connectorsReconciliationsTimer(reconciliation.namespace()));
+
+                        // We suppress the error to not fail Connect reconciliation just because of a failing connector
+                        reconciliationResult.complete();
+                    } else {
+                        maybeUpdateConnectorStatus(reconciliation, connector, result.result(), result.cause())
+                                .onComplete(statusResult -> {
+                                    connectorsReconciliationsTimerSample.stop(metrics().connectorsReconciliationsTimer(reconciliation.namespace()));
+
+                                    if (result.succeeded() && statusResult.succeeded()) {
+                                        metrics().connectorsSuccessfulReconciliationsCounter(reconciliation.namespace()).increment();
+                                        reconciliationResult.complete();
+                                    } else {
+                                        // Reconciliation failed if either reconciliation or status update failed
+                                        metrics().connectorsFailedReconciliationsCounter(reconciliation.namespace()).increment();
+
+                                        // We suppress the error to not fail Connect reconciliation just because of a failing connector
+                                        reconciliationResult.complete();
+                                    }
+                                });
+                    }
+                });
+
+        return reconciliationResult.future();
+    }
+
+    private Future<ConnectorStatusAndConditions> reconcileConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient,
+                                             boolean useResources, String connectorName, KafkaConnector connector) {
+        if (connector == null) {
+            if (useResources) {
+                LOGGER.infoCr(reconciliation, "deleting connector: {}", connectorName);
+                return apiClient.delete(reconciliation, host, port, connectorName).mapEmpty();
+            } else {
+                return Future.succeededFuture();
+            }
+        } else {
+            LOGGER.infoCr(reconciliation, "creating/updating connector: {}", connectorName);
+
+            if (connector.getSpec() == null) {
+                return Future.failedFuture(new InvalidResourceException("spec property is required"));
+            }
+
+            if (!useResources) {
+                return Future.failedFuture(new NoSuchResourceException(reconciliation.kind() + " " + reconciliation.name() + " is not configured with annotation " + Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES));
+            } else {
+                return maybeCreateOrUpdateConnector(reconciliation, host, apiClient, connectorName, connector.getSpec(), connector);
+            }
+        }
     }
 
     /**
@@ -498,5 +570,245 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
             default ->
                     LOGGER.errorCr(new Reconciliation("connector-watch", connectorKind, connectName, namespace), "Unknown action: {} {} in namespace {}", connectorKind, connectorName, namespace);
         }
+    }
+
+    private Future<Void> maybeUpdateConnectorStatus(Reconciliation reconciliation, KafkaConnector connector, ConnectorStatusAndConditions connectorStatus, Throwable error) {
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        if (error != null) {
+            LOGGER.warnCr(reconciliation, "Error reconciling connector {}", connector.getMetadata().getName(), error);
+        }
+
+        Map<String, Object> statusResult = null;
+        List<String> topics = null;
+        List<Condition> conditions = new ArrayList<>();
+        AutoRestartStatus autoRestart = null;
+
+        Future<Void> connectorReadiness = Future.succeededFuture();
+
+        if (connectorStatus != null) {
+            statusResult = connectorStatus.statusResult;
+            JsonObject statusResultJson = new JsonObject(statusResult);
+            List<String> failedTaskIds;
+            if (connectorHasFailed(statusResultJson)) {
+                connectorReadiness = Future.failedFuture(new Throwable("Connector has failed, see connectorStatus for more details."));
+            } else if (!(failedTaskIds = failedTaskIds(statusResultJson)).isEmpty()) {
+                connectorReadiness = Future.failedFuture(new Throwable(String.format("The following tasks have failed: %s, see connectorStatus for more details.", String.join(", ", failedTaskIds))));
+            }
+            topics = connectorStatus.topics.stream().sorted().collect(Collectors.toList());
+            conditions.addAll(connectorStatus.conditions);
+            autoRestart = connectorStatus.autoRestart;
+        }
+
+        Set<Condition> unknownAndDeprecatedConditions = validate(reconciliation, connector);
+        conditions.addAll(unknownAndDeprecatedConditions);
+
+        if (!Annotations.isReconciliationPausedWithAnnotation(connector)) {
+            StatusUtils.setStatusConditionAndObservedGeneration(connector, status, error != null ? error : connectorReadiness.cause());
+            status.setConnectorStatus(statusResult);
+            status.setTasksMax(getActualTaskCount(connector, statusResult));
+            status.setTopics(topics);
+            status.setAutoRestart(autoRestart);
+        } else {
+            status.setObservedGeneration(connector.getStatus() != null ? connector.getStatus().getObservedGeneration() : 0);
+            conditions.add(StatusUtils.getPausedCondition());
+        }
+        status.addConditions(conditions);
+
+        return maybeUpdateStatusCommon(connectorOperator, connector, reconciliation, status,
+            (connector1, status1) -> new KafkaConnectorBuilder(connector1).withStatus(status1).build());
+    }
+
+    // Methods for working with restart annotations
+
+    /**
+     * Checks whether the provided KafkaConnector resource and has the strimzi.io/restart annotation.
+     *
+     * @param resource          KafkaConnector resource instance to check
+     * @param connectorName     Connector name of the connector to check (not used in this method, but used in other implementations)
+     *
+     * @return  True if the KafkaConnector resource has the strimzi.io/restart annotation. False otherwise.
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected boolean hasRestartAnnotation(CustomResource resource, String connectorName) {
+        return Annotations.booleanAnnotation(resource, ANNO_STRIMZI_IO_RESTART, false);
+    }
+
+    /**
+     * Return the ID of the connector task to be restarted if the provided KafkaConnector resource instance has the strimzi.io/restart-task annotation
+     *
+     * @param resource          KafkaConnector resource instance to check
+     * @param connectorName     Connector name of the connector to check (not used in this method, but used in other implementations)
+     *
+     * @return  The ID of the task to be restarted if the provided KafkaConnector resource instance has the strimzi.io/restart-task annotation or -1 otherwise.
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected int getRestartTaskAnnotationTaskID(CustomResource resource, String connectorName) {
+        return Annotations.intAnnotation(resource, ANNO_STRIMZI_IO_RESTART_TASK, -1);
+    }
+
+    /**
+     * Patches the custom resource to remove the restart annotation
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaConnector resource from which the annotation should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected Future<Void> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
+        return removeAnnotation(reconciliation, (KafkaConnector) resource, ANNO_STRIMZI_IO_RESTART);
+    }
+
+    /**
+     * Patches the custom resource to remove the restart task annotation
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaConnector resource from which the annotation should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected Future<Void> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
+        return removeAnnotation(reconciliation, (KafkaConnector) resource, ANNO_STRIMZI_IO_RESTART_TASK);
+    }
+
+    /**
+     * Patches the KafkaConnector CR to remove the supplied annotation.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaConnector resource from which the annotation should be removed
+     * @param annotationKey     Annotation that should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    private Future<Void> removeAnnotation(Reconciliation reconciliation, KafkaConnector resource, String annotationKey) {
+        LOGGER.debugCr(reconciliation, "Removing annotation {}", annotationKey);
+        KafkaConnector patchedKafkaConnector = new KafkaConnectorBuilder(resource)
+                .editMetadata()
+                .removeFromAnnotations(annotationKey)
+                .endMetadata()
+                .build();
+        return connectorOperator.patchAsync(reconciliation, patchedKafkaConnector)
+                .compose(ignored -> Future.succeededFuture());
+    }
+
+    // Static utility methods and classes
+
+    /**
+     * Update the status of the Kafka Connector custom resource
+     *
+     * @param reconciliation        Reconciliation marker
+     * @param error                 Throwable indicating if any errors occurred during the reconciliation
+     * @param kafkaConnector2       Latest version of the KafkaConnector resource where the status should be updated
+     * @param connectorOperations   The KafkaConnector operations for updating the status
+     */
+    private static void updateStatus(Reconciliation reconciliation, Throwable error, KafkaConnector kafkaConnector2, CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> connectorOperations) {
+        KafkaConnectorStatus status = new KafkaConnectorStatus();
+        StatusUtils.setStatusConditionAndObservedGeneration(kafkaConnector2, status, error);
+        StatusDiff diff = new StatusDiff(kafkaConnector2.getStatus(), status);
+        if (!diff.isEmpty()) {
+            KafkaConnector copy = new KafkaConnectorBuilder(kafkaConnector2).build();
+            copy.setStatus(status);
+            connectorOperations.updateStatusAsync(reconciliation, copy);
+        }
+    }
+
+    /**
+     * Validates the KafkaConnector resource and returns any warning conditions find during the validation
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaConnector resource which should be validated
+     *
+     * @return  Set with the warning conditions. Empty set if no conditions were found.
+     */
+    private static Set<Condition> validate(Reconciliation reconciliation, KafkaConnector resource) {
+        if (resource != null) {
+            return StatusUtils.validate(reconciliation, resource);
+        }
+
+        return Collections.emptySet();
+    }
+
+    /**
+     * The tasksMax are mirrored in the KafkaConnector status section where they are used by the scale subresource.
+     * However, .spec.tasksMax is not always set and has no default value in Strimzi (only in Kafka Connect). So when
+     * it is not set, we try to count the tasks from the status. And if these are missing as well, we just set it to 0.
+     *
+     * @param connector         The KafkaConnector instance of the reconciled connector
+     * @param statusResult      The status from the Connect REST API
+     * @return                  Number of tasks which should be set in the status
+     */
+    @SuppressWarnings({ "rawtypes" })
+    private static int getActualTaskCount(KafkaConnector connector, Map<String, Object> statusResult)  {
+        if (connector.getSpec() != null
+                && connector.getSpec().getTasksMax() != null)  {
+            return connector.getSpec().getTasksMax();
+        } else if (statusResult != null
+                && statusResult.containsKey("tasks")
+                && statusResult.get("tasks") instanceof List) {
+            return ((List) statusResult.get("tasks")).size();
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Checks whether the use of KafkaConnector resources is enabled for this cluster or not
+     *
+     * @param connect   The Connect custom resource
+     *
+     * @return  True if the connector operator is enabled and KafkaConnector resources should be used. False otherwise.
+     */
+    private static boolean isUseResources(KafkaConnect connect) {
+        return Annotations.booleanAnnotation(connect, Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, false);
+    }
+
+    /**
+     * Creates an exception indicating that the KafkaConnect resource which would match given KafkaConnector resource
+     * does not exist.
+     *
+     * @param connectNamespace  Namespace where the KafkaConnect resource is missing
+     * @param connectName       Name of the missing KafkaConnect resource
+     *
+     * @return  NoSuchResourceException indicating that the Connect cluster is missing
+     */
+    private static NoSuchResourceException noConnectCluster(String connectNamespace, String connectName) {
+        return new NoSuchResourceException("KafkaConnect resource '" + connectName + "' identified by label '" + Labels.STRIMZI_CLUSTER_LABEL + "' does not exist in namespace " + connectNamespace + ".");
+    }
+
+    /**
+     * Creates an exception indicating that the connector cannot run because its Connect cluster has 0 replicas.
+     *
+     * @param connectNamespace  Namespace where the KafkaConnect resource exists
+     * @param connectName       Name of the KafkaConnect resource
+     *
+     * @return  NoSuchResourceException indicating that the Connect cluster is missing
+     */
+    private static RuntimeException zeroReplicas(String connectNamespace, String connectName) {
+        return new RuntimeException("Kafka Connect cluster '" + connectName + "' in namespace " + connectNamespace + " has 0 replicas.");
+    }
+
+    /**
+     * Finds and returns the correct controller resource:
+     *     - If stable identities are enabled and PodSet exists, returns PodSet
+     *     - If stable identities are enabled and PodSet is null, we might be in the middle of migration, so it returns the Deployment (which in worst case is null which is fine)
+     *     - If stable identities are disabled and Deployment exists, returns Deployment
+     *     - If stable identities are disabled and Deployment is null, we might be in the middle of migration, so it returns the PodSet (which in worst case is null which is fine)
+     *
+     * @param deployment    Deployment resource
+     * @param podSet        PodSet resource
+     *
+     * @return  The active controller resource
+     */
+    private static HasMetadata activeController(Deployment deployment, StrimziPodSet podSet)  {
+        return podSet != null ? podSet : deployment;
+    }
+
+    private static boolean isPaused(KafkaConnectorStatus status) {
+        return status != null && status.getConditions().stream().anyMatch(condition -> "ReconciliationPaused".equals(condition.getType()));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -181,6 +181,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                         createOrUpdatePromise.fail(new ReconciliationException(kafkaMirrorMaker2Status, reconciliationResult.cause()));
                     }
                 });
+
         return createOrUpdatePromise.future();
     }
 
@@ -221,7 +222,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * @param kafkaMirrorMaker2Spec   KafkaMirrorMaker2Spec object
      * @return                        Future for tracking the asynchronous result of generating the TLS auth hash
      */
-    Future<Integer> generateAuthHash(String namespace, KafkaMirrorMaker2Spec kafkaMirrorMaker2Spec) {
+    private Future<Integer> generateAuthHash(String namespace, KafkaMirrorMaker2Spec kafkaMirrorMaker2Spec) {
         Promise<Integer> authHash = Promise.promise();
         if (kafkaMirrorMaker2Spec.getClusters() == null) {
             authHash.complete(0);
@@ -250,9 +251,9 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
      * @param kafkaMirrorMaker2 The MirrorMaker 2
      * @return A future, failed if any of the connectors could not be reconciled.
      */
-    protected Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
+    private Future<Void> reconcileConnectors(Reconciliation reconciliation, KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2Cluster mirrorMaker2Cluster, KafkaMirrorMaker2Status mirrorMaker2Status, String desiredLogging) {
         String host = KafkaMirrorMaker2Resources.qualifiedServiceName(mirrorMaker2Cluster.getCluster(), reconciliation.namespace());
-        KafkaConnectApi apiClient = getKafkaConnectApi();
+        KafkaConnectApi apiClient = connectClientProvider.apply(vertx);
         List<KafkaConnector> desiredConnectors = mirrorMaker2Cluster.connectors().generateConnectorDefinitions();
 
         return apiClient.list(reconciliation, host, KafkaConnectCluster.REST_API_PORT).compose(currentConnectors -> {
@@ -265,7 +266,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         });
     }
 
-    private Future<Void> deleteConnectors(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, List<String> connectorsForDeletion) {
+    private static Future<Void> deleteConnectors(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, List<String> connectorsForDeletion) {
         return Future.join(connectorsForDeletion.stream()
                         .map(connectorName -> {
                             LOGGER.debugCr(reconciliation, "Deleting connector {}", connectorName);
@@ -330,6 +331,107 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
     }
 
     /**
+     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
+     *
+     * @param reconciliation    The Reconciliation identification
+     * @return                  Future indicating the result of the deletion
+     */
+    @Override
+    protected Future<Boolean> delete(Reconciliation reconciliation) {
+        return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, KafkaMirrorMaker2Resources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null)
+                .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
+    }
+
+    // Methods for working with restart annotations
+
+    /**
+     * Checks whether the provided KafkaMirrorMaker2 resource has the strimzi.io/restart-connector annotation, and
+     * whether it's value matches the supplied connectorName
+     *
+     * @param resource          KafkaMirrorMaker2 resource instance to check
+     * @param connectorName     Connector name of the MM2 connector to check
+     *
+     * @return  True if the provided resource instance has the strimzi.io/restart-connector annotation. False otherwise.
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected boolean hasRestartAnnotation(CustomResource resource, String connectorName) {
+        String restartAnnotationConnectorName = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR, null);
+        return connectorName.equals(restartAnnotationConnectorName);
+    }
+
+    /**
+     * Return the ID of the connector task to be restarted if the provided resource instance has the strimzi.io/restart-connector-task annotation
+     *
+     * @param resource          KafkaMirrorMaker2 resource instance to check
+     * @param connectorName     Connector name of the MM2 connector to check
+     *
+     * @return  The ID of the task to be restarted if the provided KafkaMirrorMaker2 resource instance has the strimzi.io/restart-connector-task annotation or -1 otherwise.
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected int getRestartTaskAnnotationTaskID(CustomResource resource, String connectorName) {
+        int taskID = -1;
+        String connectorTask = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK, "").trim();
+        Matcher connectorTaskMatcher = ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN.matcher(connectorTask);
+        if (connectorTaskMatcher.matches() && connectorTaskMatcher.group(ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_CONNECTOR).equals(connectorName)) {
+            taskID = Integer.parseInt(connectorTaskMatcher.group(ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_TASK));
+        }
+        return taskID;
+    }
+
+    /**
+     * Patches the custom resource to remove the restart annotation
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaMirrorMaker2 resource from which the annotation should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected Future<Void> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
+        return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR);
+    }
+
+
+    /**
+     * Patches the custom resource to remove the restart task annotation
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaMirrorMaker2 resource from which the annotation should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    @SuppressWarnings({ "rawtypes" })
+    @Override
+    protected Future<Void> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
+        return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK);
+    }
+
+    /**
+     * Patches the KafkaMirrorMaker2 CR to remove the supplied annotation.
+     *
+     * @param reconciliation    Reconciliation marker
+     * @param resource          KafkaMirrorMaker2 resource from which the annotation should be removed
+     * @param annotationKey     Annotation that should be removed
+     *
+     * @return  Future that indicates the operation completion
+     */
+    private Future<Void> removeAnnotation(Reconciliation reconciliation, KafkaMirrorMaker2 resource, String annotationKey) {
+        LOGGER.debugCr(reconciliation, "Removing annotation {}", annotationKey);
+        KafkaMirrorMaker2 patchedKafkaMirrorMaker2 = new KafkaMirrorMaker2Builder(resource)
+                .editMetadata()
+                .removeFromAnnotations(annotationKey)
+                .endMetadata()
+                .build();
+        return resourceOperator.patchAsync(reconciliation, patchedKafkaMirrorMaker2)
+                .compose(ignored -> Future.succeededFuture());
+    }
+
+    // Static utility methods and classes
+
+    /**
      * This comparator compares two maps where connectors' configurations are stored.
      * The comparison is done by using only one property - 'name'
      */
@@ -343,85 +445,5 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
             String name2 = m2.get("name") == null ? "" : m2.get("name").toString();
             return name1.compareTo(name2);
         }
-    }
-
-
-    /**
-     * Whether the provided resource has the strimzi.io/restart-connector annotation, and it's value matches the supplied connectorName
-     *
-     * @param resource resource instance to check
-     * @param connectorName connectorName name of the MM2 connector to check
-     * @return true if the provided resource instance has the strimzi.io/restart-connector annotation; false otherwise
-     */
-    @Override
-    @SuppressWarnings({ "rawtypes" })
-    protected boolean hasRestartAnnotation(CustomResource resource, String connectorName) {
-        String restartAnnotationConnectorName = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR, null);
-        return connectorName.equals(restartAnnotationConnectorName);
-    }
-
-    /**
-     * Return the ID of the connector task to be restarted if the provided resource instance has the strimzi.io/restart-connector-task annotation
-     *
-     * @param resource resource instance to check
-     * @param connectorName connectorName name of the MM2 connector to check
-     * @return the ID of the task to be restarted if the provided KafkaConnector resource instance has the strimzi.io/restart-connector-task annotation or -1 otherwise.
-     */
-    @SuppressWarnings({ "rawtypes" })
-    protected int getRestartTaskAnnotationTaskID(CustomResource resource, String connectorName) {
-        int taskID = -1;
-        String connectorTask = Annotations.stringAnnotation(resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK, "").trim();
-        Matcher connectorTaskMatcher = ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN.matcher(connectorTask);
-        if (connectorTaskMatcher.matches() && connectorTaskMatcher.group(ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_CONNECTOR).equals(connectorName)) {
-            taskID = Integer.parseInt(connectorTaskMatcher.group(ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK_PATTERN_TASK));
-        }
-        return taskID;
-    }
-
-    /**
-     * Patches the KafkaMirrorMaker2 CR to remove the strimzi.io/restart-connector annotation, as
-     * the restart action specified by user has been completed.
-     */
-    @Override
-    @SuppressWarnings({ "rawtypes" })
-    protected Future<Void> removeRestartAnnotation(Reconciliation reconciliation, CustomResource resource) {
-        return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR);
-    }
-
-
-    /**
-     * Patches the KafkaMirrorMaker2 CR to remove the strimzi.io/restart-connector-task annotation, as
-     * the restart action specified by user has been completed.
-     */
-    @Override
-    @SuppressWarnings({ "rawtypes" })
-    protected Future<Void> removeRestartTaskAnnotation(Reconciliation reconciliation, CustomResource resource) {
-        return removeAnnotation(reconciliation, (KafkaMirrorMaker2) resource, ANNO_STRIMZI_IO_RESTART_CONNECTOR_TASK);
-    }
-
-    /**
-     * Patches the KafkaMirrorMaker2 CR to remove the supplied annotation
-     */
-    protected Future<Void> removeAnnotation(Reconciliation reconciliation, KafkaMirrorMaker2 resource, String annotationKey) {
-        LOGGER.debugCr(reconciliation, "Removing annotation {}", annotationKey);
-        KafkaMirrorMaker2 patchedKafkaMirrorMaker2 = new KafkaMirrorMaker2Builder(resource)
-            .editMetadata()
-            .removeFromAnnotations(annotationKey)
-            .endMetadata()
-            .build();
-        return resourceOperator.patchAsync(reconciliation, patchedKafkaMirrorMaker2)
-            .compose(ignored -> Future.succeededFuture());
-    }
-
-    /**
-     * Deletes the ClusterRoleBinding which as a cluster-scoped resource cannot be deleted by the ownerReference
-     *
-     * @param reconciliation    The Reconciliation identification
-     * @return                  Future indicating the result of the deletion
-     */
-    @Override
-    protected Future<Boolean> delete(Reconciliation reconciliation) {
-        return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, KafkaMirrorMaker2Resources.initContainerClusterRoleBindingName(reconciliation.name(), reconciliation.namespace()), null), null)
-                .map(Boolean.FALSE); // Return FALSE since other resources are still deleted by garbage collection
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -126,52 +127,47 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
 
     @Test
     public void testShouldResetAutoRestartStatus(VertxTestContext context) {
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        KafkaConnectAssemblyOperator op = new KafkaConnectAssemblyOperator(vertx, new PlatformFeaturesAvailability(true, KubernetesVersion.MINIMAL_SUPPORTED_VERSION),
-                supplier, ResourceUtils.dummyClusterOperatorConfig());
-
         // Should reset after minute 2 when auto restart count is 1
         var autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(1)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(3).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
 
         // Should not reset before minute 2 when auto restart count is 1
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(1)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
 
         // Should reset after minute 12 when auto restart count is 3
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(3)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(13).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
 
         // Should not reset before minute 12 when auto restart count is 3
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(3)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
 
         // Should reset after 60 minutes when auto restart count is 25
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(25)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(61).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(true));
 
         // Should not reset after 59 minutes when auto restart count is 25
         autoRestartStatus =  new AutoRestartStatusBuilder()
                 .withCount(25)
                 .withLastRestartTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(59).format(DateTimeFormatter.ISO_INSTANT))
                 .build();
-        assertThat(op.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
+        assertThat(AbstractConnectOperator.shouldResetAutoRestartStatus(autoRestartStatus), is(false));
 
         context.completeNow();
     }
@@ -180,7 +176,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
     public void testAutoRestartWhenDisabled(VertxTestContext context) {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of(), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -214,7 +210,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of(), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -257,7 +253,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
         when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -302,7 +298,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
         when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -351,7 +347,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")));
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -400,7 +396,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of(), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")
@@ -446,7 +442,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of());
+        AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of(), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
                     .withName("my-connector")


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `AbstractConnectOperator`, `KafkaConnectAssemblyOperator` and `KafkaMirrorMaker2AssemblyOperator` classes are currently badly designed in how they separate the functionality specific to Connect and MM2. The `AbstractConnectOperator` does not really contain only the abstract and shared parts. But it seems to contain also many parts related only to Connect. This applies specifically for the parts related to the `KafkaConnector` management and operations -> `KafkaConnector` resources are used only with Connect as MM2 has the connector configuration directly inside the `KafkaMirrorMaker2` CR. These parts are then later overridden in the `KafkaMirrorMaker2AssemblyOperator`. This makes it very hard to see:
* What methods are really shared
* What should be the access modifiers for the different methods

This PR refactors these classes to improve the separation between them. The `AbstractConnectOperator` now contains only the parts that are really shared and does not contain any parts unique to either Connect or MM2. The other parts were moved to the corresponding assembly operator, in most cases to `KafkaConnectAssemblyOperator`. This refactoring should help us to better understand what is shared and what is not shared. And in the future it should allow us to follow up with another refactoring that will try to reuse more code between `KafkaConnectAssemblyOperator` and `KafkaMirrorMaker2AssemblyOperator` => these classes have now each its own reconciliation flow. But they really differ only in how the connectors are managed. So there should be space to further improve this. But this is not done in this PR to keep the PR scope under review and keep the reviews easier. Where possible, this PR also makes methods private or static.

_Note: While this PR moves a lot of methods around, it usually only changes their placement, access modifiers etc. It doesn't change any content inside these methods with the exception of few places where very simple methods were inlined._

This contributes to #8158.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally