### PR TITLE
Fix invalid error message when topic RF change is disabled

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -551,8 +551,8 @@ public class BatchingTopicController {
         } else {
             okStream = differentRfResults.ok().map(pair -> {
                 var reconcilableTopic = pair.getKey();
-                var specPartitions = partitions(reconcilableTopic.kt());
-                var partitions = pair.getValue().partitionsWithDifferentRfThan(specPartitions);
+                var specReplicas = replicas(reconcilableTopic.kt());
+                var partitions = pair.getValue().partitionsWithDifferentRfThan(specReplicas);
                 return pair(reconcilableTopic, Either.ofLeft(new TopicOperatorException.NotSupported(
                     "Replication factor change not supported, but required for partitions " + partitions)));
             });


### PR DESCRIPTION
When RF change is disabled, updating .spec.replicas on a KafkaTopic with 1 partiton and 1 replica fails with the following error:

```sh
Replication factor change not supported, but required for partitions
      []
```

The error message should contain the partition numbers (only 0 in this case), but we have an empty set. This is because we use partitions instead of replicas when computing the partition set.
