### PR TITLE
Add validation for unique volume IDs in JBOD storage

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -159,11 +159,12 @@ public class KafkaPool extends AbstractModel {
 
             StorageDiff diff = new StorageDiff(reconciliation, oldStorage, newStorage, idAssignment.current(), idAssignment.desired());
 
-            if (!diff.isEmpty() || diff.isTooManyKRaftMetadataVolumes()) {
+            if (diff.issuesDetected()) {
                 LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: " +
                         "changing the deleteClaim flag, " +
-                        "changing the kraftMetadata flag (but only one one volume can be marked to store the KRaft metadata log at a time) " +
+                        "changing the kraftMetadata flag (but only one one volume can be marked to store the KRaft metadata log at a time), " +
                         "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
+                        "each volume in Jbod storage should have an unique ID, " +
                         "changing overrides to nodes which do not exist yet, " +
                         "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the KafkaNodePool resource {}/{} contains changes which are not allowed. As a " +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/StorageDiffTest.java
@@ -38,12 +38,14 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
 
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod2, Set.of(0, 1, 5), Set.of(0, 1, 5));
         assertThat(diff.changesType(), is(false));
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.issuesDetected(), is(true));
     }
 
     @ParallelTest
@@ -54,10 +56,12 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(true));
     }
 
     @ParallelTest
@@ -92,14 +96,17 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent, persistent2, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(true));
 
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, persistent2, persistent3, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(true));
     }
 
     @ParallelTest
@@ -125,6 +132,7 @@ public class StorageDiffTest {
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).changesType(), is(false));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).isEmpty(), is(true));
         assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).shrinkSize(), is(false));
+        assertThat(new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, ephemeral, ephemeral, Set.of(0, 1, 5), Set.of(0, 1, 5)).issuesDetected(), is(false));
     }
 
     @ParallelTest
@@ -153,6 +161,10 @@ public class StorageDiffTest {
         assertThat(diffJbodEphemeral.isVolumesAddedOrRemoved(), is(false));
         assertThat(diffPersistentEphemeral.isVolumesAddedOrRemoved(), is(false));
         assertThat(diffJbodPersistent.isVolumesAddedOrRemoved(), is(false));
+
+        assertThat(diffJbodEphemeral.issuesDetected(), is(true));
+        assertThat(diffPersistentEphemeral.issuesDetected(), is(true));
+        assertThat(diffJbodPersistent.issuesDetected(), is(true));
     }
 
     @ParallelTest
@@ -190,6 +202,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
 
         // Volume removed
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod2, jbod, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -197,6 +210,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
 
         // Volume added with changes
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod3, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -204,6 +218,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(true));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(true));
 
         // No volume added, but with changes
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod2, jbod3, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -211,6 +226,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(true));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.issuesDetected(), is(true));
 
         // Volume removed from the beginning
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod3, jbod5, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -218,6 +234,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
 
         // Volume added to the beginning
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod5, jbod3, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -225,6 +242,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
 
         // Volume replaced with another ID and another volume which is kept changed
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod3, jbod6, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -232,6 +250,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(false));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(true));
 
         // Volume replaced with another ID in single volume broker
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod4, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -239,6 +258,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
 
         // Volume replaced with another ID without changing the volumes which are kept
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod2, jbod6, Set.of(0, 1, 5), Set.of(0, 1, 5));
@@ -246,6 +266,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(true));
+        assertThat(diff.issuesDetected(), is(false));
     }
 
     @ParallelTest
@@ -493,6 +514,7 @@ public class StorageDiffTest {
         assertThat(diff.isEmpty(), is(true));
         assertThat(diff.shrinkSize(), is(false));
         assertThat(diff.isVolumesAddedOrRemoved(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
     }
 
     @ParallelTest
@@ -509,8 +531,42 @@ public class StorageDiffTest {
 
         StorageDiff diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod, Set.of(0, 1, 5), Set.of(0, 1, 5));
         assertThat(diff.isTooManyKRaftMetadataVolumes(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
 
         diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod2, Set.of(0, 1, 5), Set.of(0, 1, 5));
         assertThat(diff.isTooManyKRaftMetadataVolumes(), is(true));
+        assertThat(diff.issuesDetected(), is(true));
+    }
+
+    @ParallelTest
+    public void testDuplicateVolumeIds()    {
+        Storage jbod = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build(),
+                        new PersistentClaimStorageBuilder().withId(1).withSize("100Gi").build())
+                .build();
+
+        Storage jbod2 = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build(),
+                        new PersistentClaimStorageBuilder().withId(5).withSize("100Gi").build(),
+                        new PersistentClaimStorageBuilder().withId(10).withSize("100Gi").build())
+                .build();
+
+        Storage jbod3 = new JbodStorageBuilder().withVolumes(
+                        new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build(),
+                        new PersistentClaimStorageBuilder().withId(1).withSize("100Gi").build(),
+                        new PersistentClaimStorageBuilder().withId(0).withSize("100Gi").build())
+                .build();
+
+        StorageDiff diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.isDuplicateVolumeIds(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod2, jbod2, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.isDuplicateVolumeIds(), is(false));
+        assertThat(diff.issuesDetected(), is(false));
+
+        diff = new StorageDiff(Reconciliation.DUMMY_RECONCILIATION, jbod, jbod3, Set.of(0, 1, 2), Set.of(0, 1, 2));
+        assertThat(diff.isDuplicateVolumeIds(), is(true));
+        assertThat(diff.issuesDetected(), is(true));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, we do not seem to have any validation that all JBOD storage IDs are unique. And when we have duplicate, we end-up breaking the first pod because we generate invalid Pod definition:

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://10.96.0.1:443/api/v1/namespaces/myproject/pods. Message: Pod "my-cluster-bodymoor-3000" is invalid: [spec.volumes[2].name: Duplicate value: "data-1", spec.containers[0].volumeMounts[2].mountPath: Invalid value: "/var/lib/kafka/data-1": must be unique]. Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=spec.volumes[2].name, message=Duplicate value: "data-1", reason=FieldValueDuplicate, additionalProperties={}), StatusCause(field=spec.containers[0].volumeMounts[2].mountPath, message=Invalid value: "/var/lib/kafka/data-1": must be unique, reason=FieldValueInvalid, additionalProperties={})], group=null, kind=Pod, name=my-cluster-bodymoor-3000, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Pod "my-cluster-bodymoor-3000" is invalid: [spec.volumes[2].name: Duplicate value: "data-1", spec.containers[0].volumeMounts[2].mountPath: Invalid value: "/var/lib/kafka/data-1": must be unique], metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:238) ~[io.fabric8.kubernetes-client-api-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:507) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:524) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleCreate(OperationSupport.java:340) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handleCreate(BaseOperation.java:754) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handleCreate(BaseOperation.java:98) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.CreateOnlyResourceOperation.create(CreateOnlyResourceOperation.java:42) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.create(BaseOperation.java:1155) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.create(BaseOperation.java:98) ~[io.fabric8.kubernetes-client-6.12.0.jar:?]
at io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController.maybeCreateOrPatchPod(StrimziPodSetController.java:470) ~[io.strimzi.cluster-operator-0.41.0-SNAPSHOT.jar:0.41.0-SNAPSHOT]
at io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController.reconcile(StrimziPodSetController.java:398) ~[io.strimzi.cluster-operator-0.41.0-SNAPSHOT.jar:0.41.0-SNAPSHOT]
at io.strimzi.operator.cluster.operator.assembly.StrimziPodSetController.run(StrimziPodSetController.java:566) ~[io.strimzi.cluster-operator-0.41.0-SNAPSHOT.jar:0.41.0-SNAPSHOT]
at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

This PR adds the validation of duplicate volume IDs to the `StorageDiff` class. That allows us to proceed with reconciliation using the old storage definition. This Pr also refactors the previously added check for multiple KRaft metadata volumes to reduce the cyclomatic complexity and adds a debug log message indicating what the actual problem is to both checks.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally