### PR TITLE
Fixed deletion of cluster metadata on rollback after JBOD in KRaft support

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -77,7 +77,7 @@ if [ "$USE_KRAFT" == "true" ]; then
 
   # Manage the metadata log file changes
   KRAFT_METADATA_LOG_DIR=$(grep "metadata\.log\.dir=" /tmp/strimzi.properties | sed "s/metadata\.log\.dir=*//")
-  CURRENT_KRAFT_METADATA_LOG_DIR=$(ls -d /var/lib/kafka/data*/kafka-log"$STRIMZI_BROKER_ID"/__cluster_metadata-0 2> /dev/null || true)
+  CURRENT_KRAFT_METADATA_LOG_DIR=$(ls -d /var/lib/kafka/data-*/kafka-log"$STRIMZI_BROKER_ID"/__cluster_metadata-0 2> /dev/null || true)
   if [[ -d "$CURRENT_KRAFT_METADATA_LOG_DIR" && "$CURRENT_KRAFT_METADATA_LOG_DIR" != $KRAFT_METADATA_LOG_DIR* ]]; then
     echo "The desired KRaft metadata log directory ($KRAFT_METADATA_LOG_DIR) and the current one ($CURRENT_KRAFT_METADATA_LOG_DIR) differ. The current directory will be deleted."
     rm -rf "$CURRENT_KRAFT_METADATA_LOG_DIR"

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -77,7 +77,7 @@ if [ "$USE_KRAFT" == "true" ]; then
 
   # Manage the metadata log file changes
   KRAFT_METADATA_LOG_DIR=$(grep "metadata\.log\.dir=" /tmp/strimzi.properties | sed "s/metadata\.log\.dir=*//")
-  CURRENT_KRAFT_METADATA_LOG_DIR=$(ls -d /var/lib/kafka/data-*/kafka-log"$STRIMZI_BROKER_ID"/__cluster_metadata-0 2> /dev/null || true)
+  CURRENT_KRAFT_METADATA_LOG_DIR=$(ls -d /var/lib/kafka/data*/kafka-log"$STRIMZI_BROKER_ID"/__cluster_metadata-0 2> /dev/null || true)
   if [[ -d "$CURRENT_KRAFT_METADATA_LOG_DIR" && "$CURRENT_KRAFT_METADATA_LOG_DIR" != $KRAFT_METADATA_LOG_DIR* ]]; then
     echo "The desired KRaft metadata log directory ($KRAFT_METADATA_LOG_DIR) and the current one ($CURRENT_KRAFT_METADATA_LOG_DIR) differ. The current directory will be deleted."
     rm -rf "$CURRENT_KRAFT_METADATA_LOG_DIR"
@@ -93,13 +93,13 @@ if [ "$USE_KRAFT" == "true" ]; then
   KAFKA_READY=
   ZK_CONNECTED=
 else
-  KRAFT_LOG_DIR=$(grep "log\.dirs=" /tmp/strimzi.properties | sed "s/log\.dirs=*//")
-
   # when in ZooKeeper mode, the __cluster_metadata folder should not exist.
   # if it does, it means a KRaft migration rollback is ongoing and it has to be removed.
-  if [ -d "$KRAFT_LOG_DIR/__cluster_metadata-0" ]; then
+  # also checking that metadata state is ZK (0), because if it's MIGRATION (2) it means we are rolling back but not finalized yet and KRaft quorum is still in place.
+  CURRENT_KRAFT_METADATA_LOG_DIR=$(ls -d /var/lib/kafka/data*/kafka-log"$STRIMZI_BROKER_ID"/__cluster_metadata-0 2> /dev/null || true)
+  if [[ -d "$CURRENT_KRAFT_METADATA_LOG_DIR" ]] && [ "$STRIMZI_KAFKA_METADATA_CONFIG_STATE" -eq 0 ]; then
     echo "Removing __cluster_metadata folder"
-    rm -rf "$KRAFT_LOG_DIR/__cluster_metadata-0"
+    rm -rf "$CURRENT_KRAFT_METADATA_LOG_DIR"
   fi
 
   # when in ZooKeeper mode, the Kafka ready and ZooKeeper connected file paths are defined because used by the agent


### PR DESCRIPTION
This PR fixes the deletion of cluster metadata when doing the migration rollback, by taking into account that now there is support for multiple JBOD disks in KRaft as well so there is the need to identify in which `data` folder they are stored to be correctly deleted.

This PR doesn't add any new migration STs with a cluster having multiple JBOD disks. I tested it manually but a new PR will be opened for new STs.