### PR TITLE
fix(helm): add conditional namespace on watchAnyNamespace true

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -13,8 +13,10 @@ metadata:
   name: strimzi-cluster-operator-namespaced
   {{- else }}
   name: strimzi-cluster-operator
-  {{- end }}
+  {{- end }}  
+  {{- if not $root.Values.watchAnyNamespace }}
   namespace: {{ . }}
+  {{- end }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -14,7 +14,9 @@ metadata:
   {{- else }}
   name: strimzi-cluster-operator-watched
   {{- end }}
+  {{- if not $root.Values.watchAnyNamespace }}
   namespace: {{ . }}
+  {{- end }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -10,7 +10,9 @@ kind: RoleBinding
 {{- end }}
 metadata:
   name: strimzi-cluster-operator-entity-operator-delegation
+  {{- if not $root.Values.watchAnyNamespace }}
   namespace: {{ . }}
+  {{- end }}
   labels:
     app: {{ template "strimzi.name" $root }}
     chart: {{ template "strimzi.chart" $root }}


### PR DESCRIPTION
When the feature flag is enabled, the ClusterRoleBinding has a namespace which is not valid. In order to fix this a condition for the namespace is added to all relevant templates.

### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

