### PR TITLE
Remove last traces of ZKClient library from Strimzi

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
@@ -3,7 +3,6 @@ log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n
 kafka.root.logger.level=INFO
 log4j.rootLogger=${kafka.root.logger.level}, CONSOLE
-log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
 log4j.logger.org.apache.zookeeper=INFO
 log4j.logger.kafka=INFO
 log4j.logger.org.apache.kafka=INFO

--- a/cluster-operator/src/main/resources/default-logging/KafkaConnectCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaConnectCluster.properties
@@ -4,5 +4,4 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.cont
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR

--- a/cluster-operator/src/main/resources/default-logging/KafkaMirrorMaker2Cluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaMirrorMaker2Cluster.properties
@@ -4,5 +4,4 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.cont
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
 log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
@@ -38,7 +38,6 @@ public class LoggingModelTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 """));
@@ -65,7 +64,6 @@ public class LoggingModelTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=ERROR
                                 
                 monitorInterval=30

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
@@ -40,7 +40,6 @@ public class LoggingUtilsTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=ERROR
                 """));
     }
@@ -94,7 +93,6 @@ public class LoggingUtilsTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=ERROR
                 """));
     }
@@ -115,7 +113,6 @@ public class LoggingUtilsTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=ERROR
                 
                 monitorInterval=30
@@ -144,7 +141,6 @@ public class LoggingUtilsTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 """));
@@ -172,7 +168,6 @@ public class LoggingUtilsTest {
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
                 log4j.logger.org.apache.zookeeper=ERROR
-                log4j.logger.org.I0Itec.zkclient=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -239,7 +239,6 @@ public class KafkaConnectApiIT {
     public void testChangeLoggers(VertxTestContext context) {
         String desired = "log4j.rootLogger=TRACE, CONSOLE\n" +
                 "log4j.logger.org.apache.zookeeper=WARN\n" +
-                "log4j.logger.org.I0Itec.zkclient=INFO\n" +
                 "log4j.logger.org.reflections.Reflection=INFO\n" +
                 "log4j.logger.org.reflections=FATAL\n" +
                 "log4j.logger.foo=WARN\n" +
@@ -258,7 +257,6 @@ public class KafkaConnectApiIT {
                         .onComplete(context.succeeding(map -> context.verify(() -> {
                             assertThat(map.get("root"), is("TRACE"));
                             assertThat(map.get("org.apache.zookeeper"), is("WARN"));
-                            assertThat(map.get("org.I0Itec.zkclient"), is("INFO"));
                             assertThat(map.get("org.reflections"), is("FATAL"));
                             assertThat(map.get("org.reflections.Reflection"), is("INFO"));
                             assertThat(map.get("org.reflections.Reflection"), is("INFO"));
@@ -279,7 +277,6 @@ public class KafkaConnectApiIT {
         String rootLevel = "TRACE";
         String desired = "log4j.rootLogger=" + rootLevel + ", CONSOLE\n" +
                 "log4j.logger.oorg.apache.zookeeper=WARN\n" +
-                "log4j.logger.oorg.I0Itec.zkclient=INFO\n" +
                 "log4j.logger.oorg.reflections.Reflection=INFO\n" +
                 "log4j.logger.oorg.reflections=FATAL\n" +
                 "log4j.logger.foo=WARN\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiffTest.java
@@ -97,7 +97,6 @@ public class KafkaBrokerLoggingConfigurationDiffTest {
                 "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                 "root.logger.level=INFO\n " +
                 "log4j.rootLogger=${root.logger.level}, CONSOLE\n" +
-                "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
                 "log4j.logger.org.apache.zookeeper=INFO\n" +
                 "log4j.logger.kafka=DEBUG\n" +
                 "log4j.logger.org.apache.kafka=DEBUG\n" +
@@ -124,7 +123,6 @@ public class KafkaBrokerLoggingConfigurationDiffTest {
             newAlterConfigOp("org.apache.kafka.clients.ClientUtils", "DEBUG"),
             newAlterConfigOp("org.apache.kafka.common.security.authenticator.LoginManager", "DEBUG"),
             newAlterConfigOp("io.strimzi.kafka.oauth.common.HttpUtil", "TRACE"),
-            newAlterConfigOp("org.I0Itec.zkclient.ZkClient", "INFO"),
             newAlterConfigOp("kafka.request.logger", "WARN"),
             newAlterConfigOp("kafka.network.Processor", "FATAL"),
             newAlterConfigOp("kafka.server.KafkaApis", "FATAL"),
@@ -151,7 +149,6 @@ public class KafkaBrokerLoggingConfigurationDiffTest {
                 "# Log levels\n" +
                 // level definition is afterwards its use
                 "kafka.root.logger.level=INFO\n" +
-                "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
                 "log4j.logger.org.apache.zookeeper=INFO\n" +
                 "log4j.logger.kafka=INFO\n" +
                 "log4j.logger.org.apache.kafka=INFO\n" +

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc
@@ -156,7 +156,6 @@ If the configured image is not compatible with Strimzi images, it might not work
 
 Kafka has its own configurable loggers, which include the following:
 
-* `log4j.logger.org.I0Itec.zkclient.ZkClient`
 * `log4j.logger.org.apache.zookeeper`
 * `log4j.logger.kafka`
 * `log4j.logger.org.apache.kafka`

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <snappy.version>1.1.10.5</snappy.version>
-        <zkclient.version>0.11</zkclient.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <quartz.version>2.3.2</quartz.version>
@@ -503,11 +502,6 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper-jute</artifactId>
                 <version>${zookeeper.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.101tec</groupId>
-                <artifactId>zkclient</artifactId>
-                <version>${zkclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LogSettingST.java
@@ -106,7 +106,6 @@ class LogSettingST extends AbstractST {
         {
             put("kafka.root.logger.level", INFO);
             put("test.kafka.logger.level", INFO);
-            put("log4j.logger.org.I0Itec.zkclient.ZkClient", ERROR);
             put("log4j.logger.org.apache.zookeeper", WARN);
             put("log4j.logger.kafka", TRACE);
             put("log4j.logger.org.apache.kafka", DEBUG);
@@ -133,7 +132,6 @@ class LogSettingST extends AbstractST {
         {
             put("connect.root.logger.level", INFO);
             put("test.connect.logger.level", DEBUG);
-            put("log4j.logger.org.I0Itec.zkclient", ERROR);
             put("log4j.logger.org.reflections", WARN);
         }
     };

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -102,7 +102,6 @@ class LoggingChangeST extends AbstractST {
             "log4j.appender.CONSOLE.layout=net.logstash.log4j.JSONEventLayoutV1\n" +
             "kafka.root.logger.level=INFO\n" +
             "log4j.rootLogger=${kafka.root.logger.level}, CONSOLE\n" +
-            "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
             "log4j.logger.org.apache.zookeeper=INFO\n" +
             "log4j.logger.kafka=INFO\n" +
             "log4j.logger.org.apache.kafka=INFO\n" +
@@ -785,7 +784,6 @@ class LoggingChangeST extends AbstractST {
             log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
             log4j.rootLogger=OFF, CONSOLE
             log4j.logger.org.apache.zookeeper=ERROR
-            log4j.logger.org.I0Itec.zkclient=ERROR
             log4j.logger.org.reflections=ERROR""";
 
         final String externalCmName = "external-cm";
@@ -833,7 +831,6 @@ class LoggingChangeST extends AbstractST {
         InlineLogging ilOff = new InlineLogging();
         Map<String, String> log4jConfig = new HashMap<>();
         log4jConfig.put("kafka.root.logger.level", "OFF");
-        log4jConfig.put("log4j.logger.org.I0Itec.zkclient.ZkClient", "OFF");
         log4jConfig.put("log4j.logger.org.apache.zookeeper", "OFF");
         log4jConfig.put("log4j.logger.kafka", "OFF");
         log4jConfig.put("log4j.logger.org.apache.kafka", "OFF");
@@ -915,7 +912,6 @@ class LoggingChangeST extends AbstractST {
                 "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
                 "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                 "log4j.rootLogger=INFO, CONSOLE\n" +
-                "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
                 "log4j.logger.org.apache.zookeeper=INFO\n" +
                 "log4j.logger.kafka=INFO\n" +
                 "log4j.logger.org.apache.kafka=INFO\n" +
@@ -1038,7 +1034,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                         "log4j.rootLogger=INFO, CONSOLE\n" +
-                        "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
                         "log4j.logger.org.apache.zookeeper=INFO\n" +
                         "log4j.logger.kafka=INFO\n" +
                         "log4j.logger.org.apache.kafka=INFO\n" +
@@ -1098,7 +1093,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                         "log4j.rootLogger=INFO, CONSOLE\n" +
-                        "log4j.logger.org.I0Itec.zkclient.ZkClient=ERROR\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
                         "log4j.logger.kafka=ERROR\n" +
                         "log4j.logger.org.apache.kafka=ERROR\n" +
@@ -1130,7 +1124,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]\n" +
                         "log4j.rootLogger=INFO, CONSOLE\n" +
-                        "log4j.logger.org.I0Itec.zkclient.ZkClient=ERROR\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
                         "log4j.logger.kafka=ERROR\n" +
                         "log4j.logger.org.apache.kafka=ERROR\n" +
@@ -1164,7 +1157,6 @@ class LoggingChangeST extends AbstractST {
         Map<String, String> loggers = new HashMap<>();
         loggers.put("connect.root.logger.level", "OFF");
         loggers.put("log4j.logger.org.apache.zookeeper", "OFF");
-        loggers.put("log4j.logger.org.I0Itec.zkclient", "OFF");
         loggers.put("log4j.logger.org.reflections", "OFF");
 
         ilOff.setLoggers(loggers);
@@ -1229,7 +1221,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n\n" +
                         "log4j.rootLogger=OFF, CONSOLE\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
-                        "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
                         "log4j.logger.org.reflections=ERROR";
 
         String externalCmName = "external-cm";
@@ -1303,7 +1294,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                         "log4j.rootLogger=OFF, CONSOLE\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
-                        "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
                         "log4j.logger.org.eclipse.jetty.util.thread=FATAL\n" +
                         "log4j.logger.org.apache.kafka.connect.runtime.WorkerTask=OFF\n" +
                         "log4j.logger.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill=OFF\n" +
@@ -1356,7 +1346,6 @@ class LoggingChangeST extends AbstractST {
                         "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
                         "log4j.rootLogger=INFO, CONSOLE\n" +
                         "log4j.logger.org.apache.zookeeper=ERROR\n" +
-                        "log4j.logger.org.I0Itec.zkclient=ERROR\n" +
                         "log4j.logger.org.eclipse.jetty.util.thread=WARN\n" +
                         "log4j.logger.org.reflections=ERROR";
 
@@ -1391,7 +1380,6 @@ class LoggingChangeST extends AbstractST {
             "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +
             "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]%n\n" +
             "log4j.rootLogger=INFO, CONSOLE\n" +
-            "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
             "log4j.logger.org.apache.zookeeper=INFO\n" +
             "log4j.logger.kafka=INFO\n" +
             "log4j.logger.org.apache.kafka=INFO";
@@ -1590,7 +1578,6 @@ class LoggingChangeST extends AbstractST {
             "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %m (%c) [%t]\n" +
             "kafka.root.logger.level=INFO\n" +
             "log4j.rootLogger=${kafka.root.logger.level}, CONSOLE\n" +
-            "log4j.logger.org.I0Itec.zkclient.ZkClient=INFO\n" +
             "log4j.logger.org.apache.zookeeper=INFO\n" +
             "log4j.logger.kafka=INFO\n" +
             "log4j.logger.org.apache.kafka=INFO\n" +


### PR DESCRIPTION
### Type of change

- Task

### Description

The ZKclient library is not used anymore neither by Strimzi not by Kafka. This Pr removes the traces of it from the pom.xml files, default logging configurations etc.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally