### PR TITLE
Remove serializable from API

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -41,7 +41,7 @@
             <property name="specialImportsRegExp" value="^javax\."/>
             <property name="standardPackageRegExp" value="^java\."/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="false"/>
+            <property name="separateLineBetweenGroups" value="true"/>
         </module>
 
         <!-- style -->

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
@@ -83,6 +83,7 @@ import static java.util.Collections.emptyMap;
 @Group(Constants.RESOURCE_GROUP_NAME)
 @ToString
 public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridge.java
@@ -83,7 +83,6 @@ import static java.util.Collections.emptyMap;
 @Group(Constants.RESOURCE_GROUP_NAME)
 @ToString
 public class KafkaBridge extends CustomResource<KafkaBridgeSpec, KafkaBridgeStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -23,7 +23,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
-    private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -23,7 +23,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
-
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
@@ -11,7 +11,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,9 +24,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving {
 
     protected Map<String, Object> config = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
@@ -11,7 +11,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,7 +24,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving {
-
     protected Map<String, Object> config = new HashMap<>(0);
 
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
@@ -25,8 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {
-    private static final long serialVersionUID = 1L;
-
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,9 +32,7 @@ import java.util.Map;
 @JsonPropertyOrder({"port", "cors"})
 @EqualsAndHashCode
 @ToString
-public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving {
 
     public static final int HTTP_DEFAULT_PORT = 8080;
     public static final String HTTP_DEFAULT_HOST = "0.0.0.0";

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpConfig.java
@@ -16,7 +16,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaBridgeHttpConfig implements UnknownPropertyPreserving {
-
     public static final int HTTP_DEFAULT_PORT = 8080;
     public static final String HTTP_DEFAULT_HOST = "0.0.0.0";
     private int port = HTTP_DEFAULT_PORT;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"allowedOrigins", "allowedMethods"})
 @EqualsAndHashCode
 @ToString
-public class KafkaBridgeHttpCors implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
-
+public class KafkaBridgeHttpCors implements UnknownPropertyPreserving {
     private List<String> allowedOrigins = null;
     private List<String> allowedMethods = null;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeHttpCors.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -25,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
-    private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -25,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
-
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeSpec.java
@@ -41,7 +41,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeSpec extends Spec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe {
-    private static final long serialVersionUID = 1L;
     private static final int DEFAULT_REPLICAS = 1;
 
     private int replicas = DEFAULT_REPLICAS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private String url;
     private int replicas;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaBridgeStatus extends Status {
-
     private String url;
     private int replicas;
     private String labelSelector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
@@ -19,7 +19,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeTemplate.java
@@ -19,7 +19,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,9 +34,7 @@ import java.util.Map;
 @JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "bridgeContainer", "clusterRoleBinding", "serviceAccount", "initContainer"})
 @EqualsAndHashCode
 @ToString
-public class KafkaBridgeTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
-
+public class KafkaBridgeTemplate implements UnknownPropertyPreserving {
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private InternalServiceTemplate apiService;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class CertAndKeySecretSource extends CertSecretSource {
-    private static final long serialVersionUID = 1L;
 
     protected String key;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class CertAndKeySecretSource extends CertSecretSource {
-
     protected String key;
 
     @Description("The name of the private key in the Secret.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"secretName", "certificate"})
 @EqualsAndHashCode
 @ToString
-public class CertSecretSource implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class CertSecretSource implements UnknownPropertyPreserving {
 
     protected String secretName;
     protected String certificate;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class CertSecretSource implements UnknownPropertyPreserving {
-
     protected String secretName;
     protected String certificate;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import java.util.Map;
     "renewalDays", "certificateExpirationPolicy" })
 @EqualsAndHashCode
 @ToString
-public class CertificateAuthority implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class CertificateAuthority implements UnknownPropertyPreserving {
 
     private int validityDays;
     private boolean generateCertificateAuthority = true;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertificateAuthority.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class CertificateAuthority implements UnknownPropertyPreserving {
-
     private int validityDays;
     private boolean generateCertificateAuthority = true;
     private boolean generateSecretOwnerReference = true;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class ClientTls implements UnknownPropertyPreserving {
-
     private List<CertSecretSource> trustedCertificates;
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ClientTls.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +31,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({"trustedCertificates"})
 @EqualsAndHashCode
 @ToString
-public class ClientTls implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class ClientTls implements UnknownPropertyPreserving {
 
     private List<CertSecretSource> trustedCertificates;
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Condition.java
@@ -11,7 +11,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class Condition implements UnknownPropertyPreserving {
-
     private String status;
     private String reason;
     private String message;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Condition.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Condition.java
@@ -11,7 +11,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,8 +25,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "type", "status", "lastTransitionTime", "reason", "message" })
 @EqualsAndHashCode
 @ToString
-public class Condition implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class Condition implements UnknownPropertyPreserving {
 
     private String status;
     private String reason;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"name", "value"})
 @EqualsAndHashCode
 @ToString
-public class ContainerEnvVar implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ContainerEnvVar implements UnknownPropertyPreserving {
 
     private String name;
     private String value;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ContainerEnvVar implements UnknownPropertyPreserving {
-
     private String name;
     private String value;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationReference implements UnknownPropertyPreserving {
-
     private ConfigMapKeySelector configMapKeyRef;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalConfigurationReference.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"configMapKeyRef"})
 @EqualsAndHashCode
 @ToString
-public class ExternalConfigurationReference implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class ExternalConfigurationReference implements UnknownPropertyPreserving {
 
     private ConfigMapKeySelector configMapKeyRef;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
@@ -26,7 +26,6 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public class ExternalLogging extends Logging {
 
-    private static final long serialVersionUID = 1L;
     public static final String TYPE_EXTERNAL = "external";
 
     private ExternalConfigurationReference valueFrom;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ExternalLogging.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ExternalLogging extends Logging {
-
     public static final String TYPE_EXTERNAL = "external";
 
     private ExternalConfigurationReference valueFrom;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class GenericSecretSource implements UnknownPropertyPreserving {
-
     protected String secretName;
     protected String key;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/GenericSecretSource.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"key", "secretName"})
 @EqualsAndHashCode
 @ToString
-public class GenericSecretSource implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class GenericSecretSource implements UnknownPropertyPreserving {
 
     protected String secretName;
     protected String key;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
@@ -25,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class InlineLogging extends Logging {
-
     public static final String TYPE_INLINE = "inline";
 
     private Map<String, String> loggers = null;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/InlineLogging.java
@@ -26,8 +26,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class InlineLogging extends Logging {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String TYPE_INLINE = "inline";
 
     private Map<String, String> loggers = null;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({"-XX", "-Xmx", "-Xms", "gcLoggingEnabled", "javaSystemProperties"})
 @EqualsAndHashCode
 @ToString
-public class JvmOptions implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class JvmOptions implements UnknownPropertyPreserving {
 
     /**
      * Configures the default value for the GC logging configuration. This is used in the model classes when the

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/JvmOptions.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class JvmOptions implements UnknownPropertyPreserving {
-
     /**
      * Configures the default value for the GC logging configuration. This is used in the model classes when the
      * jvmOptions section is not set at all. Storing it here ensures that the default value is the same when jvmOptions

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
@@ -11,7 +11,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Logging implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class Logging implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Logging.java
@@ -11,7 +11,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class Logging implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Logging type, must be either 'inline' or 'external'.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"valueFrom"})
 @EqualsAndHashCode
 @ToString
-public class Password implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class Password implements UnknownPropertyPreserving {
 
     private PasswordSource valueFrom;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Password.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Password implements UnknownPropertyPreserving {
-
     private PasswordSource valueFrom;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class PasswordSecretSource implements UnknownPropertyPreserving {
-
     protected String secretName;
     protected String password;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSecretSource.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"secretName", "password"})
 @EqualsAndHashCode
 @ToString
-public class PasswordSecretSource implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class PasswordSecretSource implements UnknownPropertyPreserving {
 
     protected String secretName;
     protected String password;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"secretKeyRef"})
 @EqualsAndHashCode
 @ToString
-public class PasswordSource implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class PasswordSource implements UnknownPropertyPreserving {
 
     private SecretKeySelector secretKeyRef;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/PasswordSource.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class PasswordSource implements UnknownPropertyPreserving {
-
     private SecretKeySelector secretKeyRef;
 
     private final Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Probe implements UnknownPropertyPreserving {
-
     private int initialDelaySeconds = 15;
     private int timeoutSeconds = 5;
     private Integer periodSeconds;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Probe.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"initialDelaySeconds", "timeoutSeconds", "periodSeconds", "successThreshold", "failureThreshold"})
 @EqualsAndHashCode
 @ToString
-public class Probe implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Probe implements UnknownPropertyPreserving {
 
     private int initialDelaySeconds = 15;
     private int timeoutSeconds = 5;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,9 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"topologyKey"})
 @EqualsAndHashCode
 @ToString
-public class Rack implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Rack implements UnknownPropertyPreserving {
 
     private String topologyKey;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Rack.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Rack implements UnknownPropertyPreserving {
-
     private String topologyKey;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +26,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Sidecar implements UnknownPropertyPreserving {
-
     private String image;
 
     private ResourceRequirements resources;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Sidecar.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,9 +26,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public class Sidecar implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Sidecar implements UnknownPropertyPreserving {
 
     private String image;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Spec.java
@@ -9,7 +9,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,7 +25,8 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Spec implements UnknownPropertyPreserving, Serializable {
+public abstract class Spec implements UnknownPropertyPreserving {
+
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/Spec.java
@@ -9,7 +9,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public abstract class Spec implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
@@ -12,7 +12,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class SystemProperty implements UnknownPropertyPreserving {
-
     private String name;
     private String value;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/SystemProperty.java
@@ -12,7 +12,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +27,7 @@ import java.util.Map;
 @JsonPropertyOrder({"name", "value"})
 @EqualsAndHashCode
 @ToString
-public class SystemProperty implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class SystemProperty implements UnknownPropertyPreserving {
 
     private String name;
     private String value;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
@@ -9,7 +9,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,9 +20,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public class TlsClientAuthentication implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class TlsClientAuthentication implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/TlsClientAuthentication.java
@@ -9,7 +9,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +20,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class TlsClientAuthentication implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaClientAuthentication implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthentication.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,8 +32,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaClientAuthentication implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaClientAuthentication implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -34,7 +34,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
-
     public static final String TYPE_OAUTH = "oauth";
 
     private String clientId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationOAuth.java
@@ -34,7 +34,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationOAuth extends KafkaClientAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_OAUTH = "oauth";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_PLAIN = "plain";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationPlain.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationPlain extends KafkaClientAuthentication {
-
     public static final String TYPE_PLAIN = "plain";
 
     private String username;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
@@ -18,7 +18,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class KafkaClientAuthenticationScram extends KafkaClientAuthentication {
-    private static final long serialVersionUID = 1L;
 
     @Description("Reference to the `Secret` which holds the password.")
     public abstract PasswordSecretSource getPasswordSecret();

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScram.java
@@ -18,7 +18,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class KafkaClientAuthenticationScram extends KafkaClientAuthentication {
-
     @Description("Reference to the `Secret` which holds the password.")
     public abstract PasswordSecretSource getPasswordSecret();
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {
-
     public static final String TYPE_SCRAM_SHA_256 = "scram-sha-256";
 
     private String username;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha256.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha256 extends KafkaClientAuthenticationScram {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SCRAM_SHA_256 = "scram-sha-256";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {
-
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 
     private String username;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationScramSha512.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationScramSha512 extends KafkaClientAuthenticationScram {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {
-
     public static final String TYPE_TLS = "tls";
 
     private CertAndKeySecretSource certificateAndKey;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/authentication/KafkaClientAuthenticationTls.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaClientAuthenticationTls extends KafkaClientAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TLS = "tls";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthentication.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
     @JsonSubTypes.Type(name = KafkaJmxAuthenticationPassword.TYPE_PASSWORD, value = KafkaJmxAuthenticationPassword.class)
 })
 @ToString
-public abstract class KafkaJmxAuthentication implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaJmxAuthentication implements UnknownPropertyPreserving {
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Authentication type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {
-
     public static final String TYPE_PASSWORD = "password";
 
     @Description("Must be `" + TYPE_PASSWORD + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxAuthenticationPassword.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaJmxAuthenticationPassword extends KafkaJmxAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_PASSWORD = "password";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"authentication"})
 @EqualsAndHashCode
 @ToString
-public class KafkaJmxOptions implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class KafkaJmxOptions implements UnknownPropertyPreserving {
 
     private KafkaJmxAuthentication authentication;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/jmx/KafkaJmxOptions.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaJmxOptions implements UnknownPropertyPreserving {
-
     private KafkaJmxAuthentication authentication;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JmxPrometheusExporterMetrics extends MetricsConfig {
-
     public static final String TYPE_JMX_EXPORTER = "jmxPrometheusExporter";
 
     private ExternalConfigurationReference valueFrom;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/JmxPrometheusExporterMetrics.java
@@ -30,8 +30,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class JmxPrometheusExporterMetrics extends MetricsConfig {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String TYPE_JMX_EXPORTER = "jmxPrometheusExporter";
 
     private ExternalConfigurationReference valueFrom;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class MetricsConfig implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Metrics type. Only 'jmxPrometheusExporter' supported currently.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class MetricsConfig implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class MetricsConfig implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class BuildConfigTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private String pullSecret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/BuildConfigTemplate.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "pullSecret"})
 @EqualsAndHashCode
 @ToString
-public class BuildConfigTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class BuildConfigTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private String pullSecret;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ContainerTemplate implements UnknownPropertyPreserving {
-
     private List<ContainerEnvVar> env;
     private SecurityContext securityContext;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +34,7 @@ import java.util.Map;
 @DescriptionFile
 @EqualsAndHashCode
 @ToString
-public class ContainerTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class ContainerTemplate implements UnknownPropertyPreserving {
 
     private List<ContainerEnvVar> env;
     private SecurityContext securityContext;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "deploymentStrategy"})
 @EqualsAndHashCode
 @ToString
-public class DeploymentTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class DeploymentTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private DeploymentStrategy deploymentStrategy;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/DeploymentTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class DeploymentTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private DeploymentStrategy deploymentStrategy;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class InternalServiceTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private IpFamilyPolicy ipFamilyPolicy;
     private List<IpFamily> ipFamilies;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/InternalServiceTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "ipFamilyPolicy", "ipFamilies"})
 @EqualsAndHashCode
 @ToString
-public class InternalServiceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class InternalServiceTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private IpFamilyPolicy ipFamilyPolicy;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class JmxTransTemplate implements UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ContainerTemplate container;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,8 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "deployment", "pod", "container", "serviceAccount", "additionalProperties" })
 @EqualsAndHashCode
 @ToString
-public class JmxTransTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class JmxTransTemplate implements UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +30,7 @@ import java.util.Map;
 @DescriptionFile
 @EqualsAndHashCode
 @ToString
-public class MetadataTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class MetadataTemplate implements UnknownPropertyPreserving {
 
     private Map<String, String> labels = new HashMap<>(0);
     private Map<String, String> annotations = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class MetadataTemplate implements UnknownPropertyPreserving {
-
     private Map<String, String> labels = new HashMap<>(0);
     private Map<String, String> annotations = new HashMap<>(0);
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
@@ -16,7 +16,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class PodDisruptionBudgetTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private int maxUnavailable = 1;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodDisruptionBudgetTemplate.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,8 +32,7 @@ import java.util.Map;
 @DescriptionFile
 @EqualsAndHashCode
 @ToString
-public class PodDisruptionBudgetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class PodDisruptionBudgetTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private int maxUnavailable = 1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
@@ -24,7 +24,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,8 +43,7 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 @DescriptionFile
-public class PodTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class PodTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private List<LocalObjectReference> imagePullSecrets;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/PodTemplate.java
@@ -24,7 +24,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,6 @@ import java.util.Map;
 @ToString
 @DescriptionFile
 public class PodTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private List<LocalObjectReference> imagePullSecrets;
     private PodSecurityContext securityContext;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata"})
 @EqualsAndHashCode
 @ToString
-public class ResourceTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class ResourceTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ResourceTemplate.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ResourceTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,8 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"metadata", "podManagementPolicy"})
 @EqualsAndHashCode
 @ToString
-public class StatefulSetTemplate implements HasMetadataTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class StatefulSetTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
 
     private MetadataTemplate metadata;
     private PodManagementPolicy podManagementPolicy;

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/StatefulSetTemplate.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class StatefulSetTemplate implements HasMetadataTemplate, UnknownPropertyPreserving {
-
     private MetadataTemplate metadata;
     private PodManagementPolicy podManagementPolicy;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class JaegerTracing extends Tracing {
-
     public static final String TYPE_JAEGER = "jaeger";
 
     public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentracing.contrib.kafka.TracingConsumerInterceptor";

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/JaegerTracing.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class JaegerTracing extends Tracing {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_JAEGER = "jaeger";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class OpenTelemetryTracing extends Tracing {
-
     public static final String TYPE_OPENTELEMETRY = "opentelemetry";
 
     public static final String CONSUMER_INTERCEPTOR_CLASS_NAME = "io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingConsumerInterceptor";

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/OpenTelemetryTracing.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class OpenTelemetryTracing extends Tracing {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_OPENTELEMETRY = "opentelemetry";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class Tracing implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Type of the tracing used. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/tracing/Tracing.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +30,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Tracing implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class Tracing implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -40,7 +40,6 @@ import lombok.ToString;
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
 @ToString(callSuper = true)
 public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe {
-    private static final long serialVersionUID = 1L;
 
     private Logging logging;
     private int replicas = 3;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -40,7 +40,6 @@ import lombok.ToString;
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
 @ToString(callSuper = true)
 public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe {
-
     private Logging logging;
     private int replicas = 3;
     private String version;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ConnectorPlugin implements UnknownPropertyPreserving {
-
     private String connectorClass;
     private String type;
     private String version;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ConnectorPlugin.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,8 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "class", "type", "version" })
 @EqualsAndHashCode
 @ToString
-public class ConnectorPlugin implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class ConnectorPlugin implements UnknownPropertyPreserving {
 
     private String connectorClass;
     private String type;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "env", "volumes" })
 @EqualsAndHashCode
 @ToString
-public class ExternalConfiguration implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class ExternalConfiguration implements UnknownPropertyPreserving {
 
     private List<ExternalConfigurationEnv> env;
     private List<ExternalConfigurationVolumeSource> volumes;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ExternalConfiguration implements UnknownPropertyPreserving {
-
     private List<ExternalConfigurationEnv> env;
     private List<ExternalConfigurationVolumeSource> volumes;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnv implements UnknownPropertyPreserving {
-
     private String name;
     private ExternalConfigurationEnvVarSource valueFrom;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,9 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({"name", "valueFrom"})
 @EqualsAndHashCode
 @ToString
-public class ExternalConfigurationEnv implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class ExternalConfigurationEnv implements UnknownPropertyPreserving {
 
     private String name;
     private ExternalConfigurationEnvVarSource valueFrom;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -16,7 +16,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnvVarSource implements UnknownPropertyPreserving {
-
     private SecretKeySelector secretKeyRef;
     private ConfigMapKeySelector configMapKeyRef;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,9 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({"secretKeyRef", "configMapKeyRef"})
 @EqualsAndHashCode
 @ToString
-public class ExternalConfigurationEnvVarSource implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class ExternalConfigurationEnvVarSource implements UnknownPropertyPreserving {
 
     private SecretKeySelector secretKeyRef;
     private ConfigMapKeySelector configMapKeyRef;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationVolumeSource implements UnknownPropertyPreserving {
-
     private String name;
     private SecretVolumeSource secret;
     private ConfigMapVolumeSource configMap;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,9 +32,7 @@ import java.util.Map;
 @JsonPropertyOrder({"name", "secret", "configMap"})
 @EqualsAndHashCode
 @ToString
-public class ExternalConfigurationVolumeSource implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class ExternalConfigurationVolumeSource implements UnknownPropertyPreserving {
 
     private String name;
     private SecretVolumeSource secret;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
@@ -76,7 +76,6 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnect.java
@@ -76,6 +76,7 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnect extends CustomResource<KafkaConnectSpec, KafkaConnectStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -34,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
-
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -35,8 +35,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private String url;
     private List<ConnectorPlugin> connectorPlugins;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectStatus.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectStatus extends Status {
-
     private String url;
     private List<ConnectorPlugin> connectorPlugins;
     private int replicas;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -22,7 +22,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,8 +39,7 @@ import java.util.Map;
     "buildServiceAccount", "jmxSecret"})
 @EqualsAndHashCode
 @ToString
-public class KafkaConnectTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaConnectTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private ResourceTemplate podSet;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectTemplate.java
@@ -22,7 +22,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +39,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaConnectTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private ResourceTemplate podSet;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +36,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class Artifact implements UnknownPropertyPreserving {
-
     public static final String TYPE_JAR = "jar";
     public static final String TYPE_TGZ = "tgz";
     public static final String TYPE_ZIP = "zip";

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Artifact.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,8 +36,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Artifact implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class Artifact implements UnknownPropertyPreserving {
 
     public static final String TYPE_JAR = "jar";
     public static final String TYPE_TGZ = "tgz";

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Build implements UnknownPropertyPreserving {
-
     private Output output;
     private List<Plugin> plugins;
     private ResourceRequirements resources;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Build.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +34,7 @@ import java.util.Map;
 @DescriptionFile
 @EqualsAndHashCode
 @ToString
-public class Build implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class Build implements UnknownPropertyPreserving {
 
     private Output output;
     private List<Plugin> plugins;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class DockerOutput extends Output {
-    private static final long serialVersionUID = 1L;
 
     public static final String ALLOWED_KANIKO_OPTIONS = "--customPlatform, --insecure, --insecure-pull, " +
             "--insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class DockerOutput extends Output {
-
     public static final String ALLOWED_KANIKO_OPTIONS = "--customPlatform, --insecure, --insecure-pull, " +
             "--insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, " +
             "--skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DockerOutput.java
@@ -33,7 +33,6 @@ public class DockerOutput extends Output {
             "--skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, " +
             "--use-new-run";
 
-    private String image;
     private String pushSecret;
     private List<String> additionalKanikoOptions;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
@@ -23,7 +23,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class DownloadableArtifact extends Artifact {
-
     private String url;
     private String sha512sum;
     private Boolean insecure;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/DownloadableArtifact.java
@@ -23,7 +23,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class DownloadableArtifact extends Artifact {
-    private static final long serialVersionUID = 1L;
 
     private String url;
     private String sha512sum;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ImageStreamOutput extends Output {
-    private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_IMAGESTREAM + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ImageStreamOutput.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ImageStreamOutput extends Output {
-
     @Description("Must be `" + TYPE_IMAGESTREAM + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JarArtifact extends DownloadableArtifact {
-
     @Description("Must be `" + TYPE_JAR + "`")
     @Override
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/JarArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JarArtifact extends DownloadableArtifact {
-    private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_JAR + "`")
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class MavenArtifact extends Artifact {
-
     public static final String DEFAULT_REPOSITORY = "https://repo1.maven.org/maven2/";
 
     private String group;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/MavenArtifact.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class MavenArtifact extends Artifact {
-    private static final long serialVersionUID = 1L;
+
     public static final String DEFAULT_REPOSITORY = "https://repo1.maven.org/maven2/";
 
     private String group;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class OtherArtifact extends DownloadableArtifact {
-    private static final long serialVersionUID = 1L;
 
     String fileName;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/OtherArtifact.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class OtherArtifact extends DownloadableArtifact {
-
     String fileName;
 
     @Description("Must be `" + TYPE_OTHER + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
@@ -13,7 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,8 +34,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Output implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class Output implements UnknownPropertyPreserving {
 
     public static final String TYPE_DOCKER = "docker";
     public static final String TYPE_IMAGESTREAM = "imagestream";

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Output.java
@@ -13,7 +13,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class Output implements UnknownPropertyPreserving {
-
     public static final String TYPE_DOCKER = "docker";
     public static final String TYPE_IMAGESTREAM = "imagestream";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({ "name", "artifacts" })
 @EqualsAndHashCode
 @ToString
-public class Plugin implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class Plugin implements UnknownPropertyPreserving {
 
     private String name;
     private List<Artifact> artifacts;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/Plugin.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class Plugin implements UnknownPropertyPreserving {
-
     private String name;
     private List<Artifact> artifacts;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TgzArtifact extends DownloadableArtifact {
-
     @Description("Must be `" + TYPE_TGZ + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/TgzArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TgzArtifact extends DownloadableArtifact {
-    private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_TGZ + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ZipArtifact extends DownloadableArtifact {
-    private static final long serialVersionUID = 1L;
 
     @Description("Must be `" + TYPE_ZIP + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/build/ZipArtifact.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ZipArtifact extends DownloadableArtifact {
-
     @Description("Must be `" + TYPE_ZIP + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -32,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class AbstractConnectorSpec extends Spec {
-
     /**
      * Forbidden options in the connector configuration
      */

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -32,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class AbstractConnectorSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     /**
      * Forbidden options in the connector configuration

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"enabled", "maxRestarts"})
 @EqualsAndHashCode
 @ToString
-public class AutoRestart implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class AutoRestart implements UnknownPropertyPreserving {
 
     private boolean enabled = true;
     private Integer maxRestarts;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestart.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class AutoRestart implements UnknownPropertyPreserving {
-
     private boolean enabled = true;
     private Integer maxRestarts;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +27,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "count", "connectorName", "lastRestartTimestamp"})
 @EqualsAndHashCode
 @ToString
-public class AutoRestartStatus implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class AutoRestartStatus implements UnknownPropertyPreserving {
 
     private int count;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AutoRestartStatus.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class AutoRestartStatus implements UnknownPropertyPreserving {
-
     private int count;
 
     private String connectorName;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
@@ -84,7 +84,7 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+
     public static final String V1BETA2 = Constants.V1BETA2;
     public static final String V1ALPHA1 = Constants.V1ALPHA1;
     public static final String CONSUMED_VERSION = V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnector.java
@@ -84,6 +84,7 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaConnector extends CustomResource<KafkaConnectorSpec, KafkaConnectorStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String V1BETA2 = Constants.V1BETA2;
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
@@ -11,6 +11,4 @@ import lombok.ToString;
  * A {@code DefaultKubernetesResourceList<KafkaConnector>} required for using Fabric8 CRD support.
  */
 @ToString(callSuper = true)
-public class KafkaConnectorList extends DefaultKubernetesResourceList<KafkaConnector> {
-    private static final long serialVersionUID = 1L;
-}
+public class KafkaConnectorList extends DefaultKubernetesResourceList<KafkaConnector> { }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorList.java
@@ -11,4 +11,6 @@ import lombok.ToString;
  * A {@code DefaultKubernetesResourceList<KafkaConnector>} required for using Fabric8 CRD support.
  */
 @ToString(callSuper = true)
-public class KafkaConnectorList extends DefaultKubernetesResourceList<KafkaConnector> { }
+public class KafkaConnectorList extends DefaultKubernetesResourceList<KafkaConnector> {
+    private static final long serialVersionUID = 1L;
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorSpec extends AbstractConnectorSpec {
-    private static final long serialVersionUID = 1L;
 
     private String className;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorSpec.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorSpec extends AbstractConnectorSpec {
-
     private String className;
 
     @Description("The Class for the Kafka Connector")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
@@ -28,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorStatus extends Status {
-
     private Map<String, Object> connectorStatus;
     private int tasksMax;
     private List<String> topics;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/KafkaConnectorStatus.java
@@ -28,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaConnectorStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private Map<String, Object> connectorStatus;
     private int tasksMax;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +30,7 @@ import java.util.Map;
 @JsonPropertyOrder({"outputType", "host", "port", "flushDelayInSeconds", "typeNames", "name"})
 @EqualsAndHashCode
 @ToString
-public class JmxTransOutputDefinitionTemplate implements Serializable, UnknownPropertyPreserving {
-
-    private static final long serialVersionUID = 1L;
+public class JmxTransOutputDefinitionTemplate implements UnknownPropertyPreserving {
 
     private String outputType;
     private String host;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransOutputDefinitionTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class JmxTransOutputDefinitionTemplate implements UnknownPropertyPreserving {
-
     private String outputType;
     private String host;
     private Integer port;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,12 +27,12 @@ import java.util.Map;
 @JsonPropertyOrder({"targetMBean", "attributes", "outputs"})
 @EqualsAndHashCode
 @ToString
-public class JmxTransQueryTemplate implements Serializable, UnknownPropertyPreserving {
+public class JmxTransQueryTemplate implements UnknownPropertyPreserving {
+
     private String targetMBean;
     private List<String> attributes;
     private List<String> outputs;
 
-    private static final long serialVersionUID = 1L;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @JsonProperty(required = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransQueryTemplate.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class JmxTransQueryTemplate implements UnknownPropertyPreserving {
-
     private String targetMBean;
     private List<String> attributes;
     private List<String> outputs;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
@@ -18,7 +18,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,11 +36,11 @@ import java.util.Map;
 @ToString
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
-public class JmxTransSpec implements UnknownPropertyPreserving, Serializable {
+public class JmxTransSpec implements UnknownPropertyPreserving {
+
     public static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
 
-    private static final long serialVersionUID = 1L;
     protected String image;
     private String logLevel;
     private List<JmxTransOutputDefinitionTemplate> outputDefinitions = null;

--- a/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/jmxtrans/JmxTransSpec.java
@@ -18,7 +18,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,6 @@ import java.util.Map;
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class JmxTransSpec implements UnknownPropertyPreserving {
-
     public static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     public static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
@@ -26,7 +26,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class EphemeralStorage extends SingleVolumeStorage {
-
     private String sizeLimit;
 
     @Description("Must be `" + TYPE_EPHEMERAL + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/EphemeralStorage.java
@@ -26,7 +26,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class EphemeralStorage extends SingleVolumeStorage {
-    private static final long serialVersionUID = 1L;
 
     private String sizeLimit;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
@@ -26,7 +26,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class JbodStorage extends Storage {
-
     private List<SingleVolumeStorage> volumes;
 
     @Description("Must be `" + TYPE_JBOD + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/JbodStorage.java
@@ -27,8 +27,6 @@ import java.util.List;
 @ToString(callSuper = true)
 public class JbodStorage extends Storage {
 
-    private static final long serialVersionUID = 1L;
-
     private List<SingleVolumeStorage> volumes;
 
     @Description("Must be `" + TYPE_JBOD + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -86,7 +86,6 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class Kafka extends CustomResource<KafkaSpec, KafkaStatus> implements Namespaced, UnknownPropertyPreserving {
-
     public static final String V1BETA2 = Constants.V1BETA2;
     public static final String V1BETA1 = Constants.V1BETA1;
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaAuthorization implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaAuthorization implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorization.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaAuthorization implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Authorization type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
@@ -29,7 +29,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationCustom extends KafkaAuthorization {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_CUSTOM = "custom";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationCustom.java
@@ -29,7 +29,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationCustom extends KafkaAuthorization {
-
     public static final String TYPE_CUSTOM = "custom";
 
     private String authorizerClass;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -34,7 +34,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
-
     public static final String TYPE_KEYCLOAK = "keycloak";
 
     public static final String AUTHORIZER_CLASS_NAME = "io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -34,7 +34,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_KEYCLOAK = "keycloak";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -31,7 +31,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_OPA = "opa";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationOpa.java
@@ -31,7 +31,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationOpa extends KafkaAuthorization {
-
     public static final String TYPE_OPA = "opa";
 
     public static final String AUTHORIZER_CLASS_NAME = "org.openpolicyagent.kafka.OpaAuthorizer";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
@@ -29,7 +29,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationSimple extends KafkaAuthorization {
-
     public static final String TYPE_SIMPLE = "simple";
 
     public static final String AUTHORIZER_CLASS_NAME = "kafka.security.authorizer.AclAuthorizer";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationSimple.java
@@ -29,7 +29,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationSimple extends KafkaAuthorization {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SIMPLE = "simple";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -33,7 +33,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,9 +53,7 @@ import java.util.Map;
     "logging", "template", "tieredStorage"})
 @EqualsAndHashCode
 @ToString
-public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving {
 
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., log.dir, "

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -33,7 +33,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +53,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasReadinessProbe, HasLivenessProbe, UnknownPropertyPreserving {
-
     public static final String FORBIDDEN_PREFIXES = "listeners, advertised., broker., listener., host.name, port, "
             + "inter.broker.listener.name, sasl., ssl., security., password., log.dir, "
             + "zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, "

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -21,7 +21,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,8 +40,7 @@ import java.util.Map;
     "clusterRoleBinding", "podSet"})
 @EqualsAndHashCode
 @ToString
-public class KafkaClusterTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaClusterTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
 
     private StatefulSetTemplate statefulset;
     private ResourceTemplate podSet;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterTemplate.java
@@ -21,7 +21,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,7 +40,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaClusterTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
-
     private StatefulSetTemplate statefulset;
     private ResourceTemplate podSet;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaMetadataState.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaMetadataState.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * or if a migration from ZooKeeper to KRaft is in progress and in which phase
  */
 public enum KafkaMetadataState {
-
     /**
      * The metadata are stored in ZooKeeper.
      * The strimzi.io/kraft: disabled annotation is set on the Kafka resource.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -38,7 +38,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     private KafkaClusterSpec kafka;
     private ZookeeperClusterSpec zookeeper;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -38,7 +38,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaSpec extends Spec {
-
     private KafkaClusterSpec kafka;
     private ZookeeperClusterSpec zookeeper;
     private EntityOperatorSpec entityOperator;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private List<ListenerStatus> listeners;
     private List<UsedNodePoolStatus> kafkaNodePools;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaStatus.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaStatus extends Status {
-
     private List<ListenerStatus> listeners;
     private List<UsedNodePoolStatus> kafkaNodePools;
     

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class PersistentClaimStorage extends SingleVolumeStorage {
-
     private String size;
     private String storageClass;
     private Map<String, String> selector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -30,8 +30,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class PersistentClaimStorage extends SingleVolumeStorage {
 
-    private static final long serialVersionUID = 1L;
-
     private String size;
     private String storageClass;
     private Map<String, String> selector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class PersistentClaimStorageOverride  implements UnknownPropertyPreserving {
-
     private Integer broker;
     private String storageClass;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorageOverride.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +31,7 @@ import static java.util.Collections.emptyMap;
 )
 @EqualsAndHashCode
 @ToString
-public class PersistentClaimStorageOverride  implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class PersistentClaimStorageOverride  implements UnknownPropertyPreserving {
 
     private Integer broker;
     private String storageClass;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class SingleVolumeStorage extends Storage {
-
     private Integer id;
     private KRaftMetadataStorage kraftMetadata;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/SingleVolumeStorage.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public abstract class SingleVolumeStorage extends Storage {
-    private static final long serialVersionUID = 1L;
 
     private Integer id;
     private KRaftMetadataStorage kraftMetadata;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Status.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +33,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Status implements UnknownPropertyPreserving, Serializable {
+public abstract class Status implements UnknownPropertyPreserving {
     private List<Condition> conditions;
     private long observedGeneration;
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Status.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class Storage implements UnknownPropertyPreserving {
-
     public static final String TYPE_EPHEMERAL = "ephemeral";
     public static final String TYPE_PERSISTENT_CLAIM = "persistent-claim";
     public static final String TYPE_JBOD = "jbod";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Storage.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,9 +32,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class Storage implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class Storage implements UnknownPropertyPreserving {
 
     public static final String TYPE_EPHEMERAL = "ephemeral";
     public static final String TYPE_PERSISTENT_CLAIM = "persistent-claim";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class UsedNodePoolStatus implements UnknownPropertyPreserving {
-
     private String name;
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/UsedNodePoolStatus.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +31,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "name" })
 @EqualsAndHashCode
 @ToString
-public class UsedNodePoolStatus implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class UsedNodePoolStatus implements UnknownPropertyPreserving {
 
     private String name;
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +34,7 @@ import java.util.Map;
 @JsonPropertyOrder({"disk", "cpuUtilization", "cpu", "inboundNetwork", "outboundNetwork", "overrides"})
 @EqualsAndHashCode
 @ToString
-public class BrokerCapacity implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class BrokerCapacity implements UnknownPropertyPreserving {
 
     private String disk;
     private Integer cpuUtilization;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacity.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class BrokerCapacity implements UnknownPropertyPreserving {
-
     private String disk;
     private Integer cpuUtilization;
     private String cpu;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class BrokerCapacityOverride implements UnknownPropertyPreserving {
-
     private List<Integer> brokers;
     private String cpu;
     private String inboundNetwork;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/BrokerCapacityOverride.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +32,7 @@ import java.util.Map;
 @JsonPropertyOrder({"brokers", "cpu", "inboundNetwork", "outboundNetwork"})
 @EqualsAndHashCode
 @ToString
-public class BrokerCapacityOverride implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class BrokerCapacityOverride implements UnknownPropertyPreserving {
 
     private List<Integer> brokers;
     private String cpu;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlResources.java
@@ -9,7 +9,6 @@ package io.strimzi.api.kafka.model.kafka.cruisecontrol;
  * {@code CruiseControl} cluster.
  */
 public class CruiseControlResources {
-
     /**
      * Returns the name of the Cruise Control {@code Deployment} for a {@code Kafka} cluster of the given name.
      * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -26,7 +26,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,8 +42,7 @@ import java.util.Map;
     "brokerCapacity", "config", "metricsConfig"})
 @EqualsAndHashCode
 @ToString
-public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
 
     // For the full configuration list refer to https://github.com/linkedin/cruise-control/wiki/Configurations
     public static final String FORBIDDEN_PREFIXES = "bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,"

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -26,7 +26,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +42,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
-
     // For the full configuration list refer to https://github.com/linkedin/cruise-control/wiki/Configurations
     public static final String FORBIDDEN_PREFIXES = "bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,"
         + "webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,"

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
@@ -20,7 +20,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +37,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class CruiseControlTemplate implements UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private InternalServiceTemplate apiService;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
@@ -20,7 +20,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +37,7 @@ import java.util.Map;
     "deployment", "pod", "apiService", "podDisruptionBudget", "cruiseControlContainer", "tlsSidecarContainer", "serviceAccount"})
 @EqualsAndHashCode
 @ToString
-public class CruiseControlTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class CruiseControlTemplate implements UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,9 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({"topicOperator", "userOperator", "tlsSidecar", "template"})
 @EqualsAndHashCode
 @ToString
-public class EntityOperatorSpec implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class EntityOperatorSpec implements UnknownPropertyPreserving {
 
     private EntityTopicOperatorSpec topicOperator;
     private EntityUserOperatorSpec userOperator;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class EntityOperatorSpec implements UnknownPropertyPreserving {
-
     private EntityTopicOperatorSpec topicOperator;
     private EntityUserOperatorSpec userOperator;
     private TlsSidecar tlsSidecar;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,8 +32,7 @@ import java.util.Map;
 @JsonPropertyOrder({"deployment", "pod", "topicOperatorContainer", "userOperatorContainer", "tlsSidecarContainer", "serviceAccount", "entityOperatorRole", "topicOperatorRoleBinding", "userOperatorRoleBinding"})
 @EqualsAndHashCode
 @ToString
-public class EntityOperatorTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class EntityOperatorTemplate implements UnknownPropertyPreserving {
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate entityOperatorRole;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorTemplate.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
@@ -26,7 +26,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,7 +45,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, HasStartupProbe, UnknownPropertyPreserving {
-
     public static final int DEFAULT_REPLICAS = 1;
     public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
     public static final int DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityTopicOperatorSpec.java
@@ -26,7 +26,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,9 +45,7 @@ import java.util.Map;
     "resources", "topicMetadataMaxAttempts", "logging", "jvmOptions"})
 @EqualsAndHashCode
 @ToString
-public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, HasStartupProbe, UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class EntityTopicOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, HasStartupProbe, UnknownPropertyPreserving {
 
     public static final int DEFAULT_REPLICAS = 1;
     public static final int DEFAULT_ZOOKEEPER_PORT = 2181;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
@@ -25,7 +25,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +44,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
-
     public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;
     public static final String DEFAULT_SECRET_PREFIX = "";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityUserOperatorSpec.java
@@ -25,7 +25,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,9 +44,7 @@ import java.util.Map;
     "resources", "logging", "jvmOptions"})
 @EqualsAndHashCode
 @ToString
-public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class EntityUserOperatorSpec implements HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
 
     public static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9091;
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_SECONDS = 120;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
@@ -37,7 +37,6 @@ import java.util.Map;
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class TlsSidecar extends Sidecar implements HasLivenessProbe, HasReadinessProbe {
-
     private TlsSidecarLogLevel logLevel = TlsSidecarLogLevel.NOTICE;
     private Probe livenessProbe;
     private Probe readinessProbe;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecar.java
@@ -37,7 +37,6 @@ import java.util.Map;
 @Deprecated
 @DeprecatedType(replacedWithType = void.class)
 public class TlsSidecar extends Sidecar implements HasLivenessProbe, HasReadinessProbe {
-    private static final long serialVersionUID = 1L;
 
     private TlsSidecarLogLevel logLevel = TlsSidecarLogLevel.NOTICE;
     private Probe livenessProbe;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecarLogLevel.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/TlsSidecarLogLevel.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 @Deprecated
 public enum TlsSidecarLogLevel {
-
     EMERG,
     ALERT,
     CRIT,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
@@ -18,7 +18,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +37,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
-
     private String image;
     private String groupRegex = ".*";
     private String topicRegex = ".*";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterSpec.java
@@ -18,7 +18,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +37,7 @@ import java.util.Map;
     "enableSaramaLogging", "showAllOffsets", "template"})
 @EqualsAndHashCode
 @ToString
-public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class KafkaExporterSpec implements HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
 
     private String image;
     private String groupRegex = ".*";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
@@ -19,7 +19,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaExporterTemplate implements UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private ResourceTemplate service;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/exporter/KafkaExporterTemplate.java
@@ -19,7 +19,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,8 +34,7 @@ import java.util.Map;
 @JsonPropertyOrder({"deployment", "pod", "service", "container", "serviceAccount"})
 @EqualsAndHashCode
 @ToString
-public class KafkaExporterTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaExporterTemplate implements UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
@@ -19,7 +19,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +36,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public class GenericKafkaListener implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class GenericKafkaListener implements UnknownPropertyPreserving {
 
     // maximal port name length is 15. The prefix of generic port name is 'tcp-'
     public final static String LISTENER_NAME_REGEX = "^[a-z0-9]{1,11}$";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListener.java
@@ -19,7 +19,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class GenericKafkaListener implements UnknownPropertyPreserving {
-
     // maximal port name length is 15. The prefix of generic port name is 'tcp-'
     public final static String LISTENER_NAME_REGEX = "^[a-z0-9]{1,11}$";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -20,7 +20,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,8 +41,7 @@ import static java.util.Collections.emptyMap;
 )
 @EqualsAndHashCode
 @ToString
-public class GenericKafkaListenerConfiguration implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserving {
 
     private CertAndKeySecretSource brokerCertChainAndKey;
     private String controllerClass;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -20,7 +20,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserving {
-
     private CertAndKeySecretSource brokerCertChainAndKey;
     private String controllerClass;
     private NodeAddressType preferredNodePortAddressType;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +32,8 @@ import java.util.Map;
 )
 @EqualsAndHashCode
 @ToString
-public class GenericKafkaListenerConfigurationBootstrap implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class GenericKafkaListenerConfigurationBootstrap implements UnknownPropertyPreserving {
+
 
     private List<String> alternativeNames;
     private String host;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class GenericKafkaListenerConfigurationBootstrap implements UnknownPropertyPreserving {
-
-
     private List<String> alternativeNames;
     private String host;
     private Map<String, String> annotations = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +35,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class GenericKafkaListenerConfigurationBroker implements UnknownPropertyPreserving {
-
     private Integer broker;
     private String advertisedHost;
     private Integer advertisedPort;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +35,7 @@ import static java.util.Collections.emptyMap;
 )
 @EqualsAndHashCode
 @ToString
-public class GenericKafkaListenerConfigurationBroker implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class GenericKafkaListenerConfigurationBroker implements UnknownPropertyPreserving {
 
     private Integer broker;
     private String advertisedHost;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +37,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaListenerAuthentication implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthentication.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,8 +37,7 @@ import java.util.Map;
 )
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaListenerAuthentication implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaListenerAuthentication implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -30,7 +30,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthentication {
-
     public static final String FORBIDDEN_PREFIXES = "ssl.";
 
     public static final String TYPE_CUSTOM = "custom";

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -33,8 +33,6 @@ public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthenticati
 
     public static final String FORBIDDEN_PREFIXES = "ssl.";
 
-    private static final long serialVersionUID = 1L;
-
     public static final String TYPE_CUSTOM = "custom";
 
     private Map<String, Object> listenerConfig;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -39,7 +39,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_OAUTH = "oauth";
     public static final int DEFAULT_JWKS_EXPIRY_SECONDS = 360;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationOAuth.java
@@ -39,7 +39,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationOAuth extends KafkaListenerAuthentication {
-
     public static final String TYPE_OAUTH = "oauth";
     public static final int DEFAULT_JWKS_EXPIRY_SECONDS = 360;
     public static final int DEFAULT_JWKS_REFRESH_SECONDS = 300;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthentication {
-
     public static final String SCRAM_SHA_512 = "scram-sha-512";
 
     @Description("Must be `" + SCRAM_SHA_512 + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationScramSha512.java
@@ -25,8 +25,6 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationScramSha512 extends KafkaListenerAuthentication {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String SCRAM_SHA_512 = "scram-sha-512";
 
     @Description("Must be `" + SCRAM_SHA_512 + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {
-
     public static final String TYPE_TLS = "tls";
 
     @Description("Must be `" + TYPE_TLS + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationTls.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaListenerAuthenticationTls extends KafkaListenerAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TLS = "tls";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class ListenerAddress implements UnknownPropertyPreserving {
-
     private String host;
     private Integer port;
     private Map<String, Object> additionalProperties;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +30,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "address", "host", "port" })
 @EqualsAndHashCode
 @ToString
-public class ListenerAddress implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class ListenerAddress implements UnknownPropertyPreserving {
 
     private String host;
     private Integer port;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +33,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "type", "name", "addresses", "bootstrapServers", "certificates" })
 @EqualsAndHashCode
 @ToString
-public class ListenerStatus implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class ListenerStatus implements UnknownPropertyPreserving {
 
     private String type;
     private String name;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerStatus.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class ListenerStatus implements UnknownPropertyPreserving {
-
     private String type;
     private String name;
     private List<ListenerAddress> addresses;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -14,7 +14,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,8 +29,7 @@ import java.util.Map;
 @JsonPropertyOrder({"className", "classPath", "config"})
 @EqualsAndHashCode
 @ToString
-public class RemoteStorageManager implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class RemoteStorageManager implements UnknownPropertyPreserving {
 
     private String className;
     private String classPath;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -14,7 +14,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class RemoteStorageManager implements UnknownPropertyPreserving {
-
     private String className;
     private String classPath;
     private Map<String, String> config;

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
@@ -13,7 +13,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,9 +31,8 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class TieredStorage implements UnknownPropertyPreserving, Serializable {
+public abstract class TieredStorage implements UnknownPropertyPreserving {
 
-    private static final long serialVersionUID = 1L;
     public static final String TYPE_CUSTOM = "custom";
 
     private final Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorage.java
@@ -13,7 +13,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class TieredStorage implements UnknownPropertyPreserving {
-
     public static final String TYPE_CUSTOM = "custom";
 
     private final Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class TieredStorageCustom extends TieredStorage {
-
     private RemoteStorageManager remoteStorageManager;
 
     @Description("Must be `" + TYPE_CUSTOM + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/TieredStorageCustom.java
@@ -27,7 +27,6 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class TieredStorageCustom extends TieredStorage {
-    private static final long serialVersionUID = 1L;
 
     private RemoteStorageManager remoteStorageManager;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
@@ -92,6 +92,7 @@ import static java.util.Collections.emptyMap;
 @Deprecated
 @DeprecatedType(replacedWithType = KafkaMirrorMaker2.class)
 public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMaker.java
@@ -92,7 +92,6 @@ import static java.util.Collections.emptyMap;
 @Deprecated
 @DeprecatedType(replacedWithType = KafkaMirrorMaker2.class)
 public class KafkaMirrorMaker extends CustomResource<KafkaMirrorMakerSpec, KafkaMirrorMakerStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +28,7 @@ import static java.util.Collections.emptyMap;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving {
 
     private String bootstrapServers;
     protected Map<String, Object> config = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving {
-
     private String bootstrapServers;
     protected Map<String, Object> config = new HashMap<>(0);
     private ClientTls tls;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
-    private static final long serialVersionUID = 1L;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
-
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, group.id, sasl., security., interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -25,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
-    private static final long serialVersionUID = 1L;
 
     private Boolean abortOnSendFailure;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -25,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
-
     private Boolean abortOnSendFailure;
 
     public static final String FORBIDDEN_PREFIXES = "ssl., bootstrap.servers, sasl., security., interceptor.classes";

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
@@ -43,7 +43,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe {
-    private static final long serialVersionUID = 1L;
 
     private static final int DEFAULT_REPLICAS = 3;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerSpec.java
@@ -43,7 +43,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasLivenessProbe, HasReadinessProbe {
-
     private static final int DEFAULT_REPLICAS = 3;
 
     private int replicas = DEFAULT_REPLICAS;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerStatus extends Status {
-
     private int replicas;
     private String labelSelector;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private int replicas;
     private String labelSelector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
@@ -18,7 +18,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,7 +33,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaMirrorMakerTemplate implements UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private PodDisruptionBudgetTemplate podDisruptionBudget;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerTemplate.java
@@ -18,7 +18,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,8 +33,7 @@ import java.util.Map;
 @JsonPropertyOrder({"deployment", "pod", "podDisruptionBudget", "mirrorMakerContainer", "serviceAccount"})
 @EqualsAndHashCode
 @ToString
-public class KafkaMirrorMakerTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaMirrorMakerTemplate implements UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -76,7 +76,6 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2.java
@@ -76,6 +76,7 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaMirrorMaker2 extends CustomResource<KafkaMirrorMaker2Spec, KafkaMirrorMaker2Status> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
@@ -18,7 +18,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,12 +33,10 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "alias", "bootstrapServers", "tls", "authentication", "config"})
 @EqualsAndHashCode
 @ToString
-public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving, Serializable {
+public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving {
 
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
-
-    private static final long serialVersionUID = 1L;
 
     private String alias;
     private String bootstrapServers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
@@ -18,7 +18,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,7 +33,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving {
-
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ConnectorSpec.java
@@ -20,6 +20,4 @@ import lombok.ToString;
 @JsonPropertyOrder({"tasksMax", "pause", "config", "state", "autoRestart"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec {
-    private static final long serialVersionUID = 1L;
-}
+public class KafkaMirrorMaker2ConnectorSpec extends AbstractConnectorSpec { }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
@@ -16,7 +16,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class KafkaMirrorMaker2MirrorSpec implements UnknownPropertyPreserving {
-
     private String sourceCluster;
     private String targetCluster;
     private KafkaMirrorMaker2ConnectorSpec sourceConnector;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2MirrorSpec.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +31,7 @@ import static java.util.Collections.emptyMap;
     "topicsPattern", "topicsBlacklistPattern", "topicsExcludePattern", "groupsPattern", "groupsBlacklistPattern", "groupsExcludePattern"})
 @EqualsAndHashCode
 @ToString
-public class KafkaMirrorMaker2MirrorSpec implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaMirrorMaker2MirrorSpec implements UnknownPropertyPreserving {
 
     private String sourceCluster;
     private String targetCluster;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
@@ -29,7 +29,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
-
     private List<KafkaMirrorMaker2ClusterSpec> clusters;
     private String connectCluster;
     private List<KafkaMirrorMaker2MirrorSpec> mirrors;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
@@ -30,8 +30,6 @@ import java.util.List;
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2Spec extends AbstractKafkaConnectSpec {
 
-    private static final long serialVersionUID = 1L;
-    
     private List<KafkaMirrorMaker2ClusterSpec> clusters;
     private String connectCluster;
     private List<KafkaMirrorMaker2MirrorSpec> mirrors;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
@@ -31,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
-    private static final long serialVersionUID = 1L;
 
     private List<Map<String, Object>> connectors = new ArrayList<>(3);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Status.java
@@ -31,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMaker2Status extends KafkaConnectStatus {
-
     private List<Map<String, Object>> connectors = new ArrayList<>(3);
 
     private List<AutoRestartStatus> autoRestartStatuses = new ArrayList<>();

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
@@ -20,7 +20,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,8 +35,7 @@ import java.util.Map;
 @JsonPropertyOrder({"deployment", "pod", "apiService", "podDisruptionBudget", "mirrorMaker2Container", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 @ToString
-public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, UnknownPropertyPreserving {
 
     private DeploymentTemplate deployment;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Template.java
@@ -20,7 +20,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +35,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaMirrorMaker2Template implements HasJmxSecretTemplate, UnknownPropertyPreserving {
-
     private DeploymentTemplate deployment;
     private PodTemplate pod;
     private InternalServiceTemplate apiService;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -75,6 +75,7 @@ import java.util.Map;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePoolStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -75,7 +75,6 @@ import java.util.Map;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaNodePool extends CustomResource<KafkaNodePoolSpec, KafkaNodePoolStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
@@ -33,7 +33,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolSpec extends Spec {
-
     private int replicas;
     private Storage storage;
     private List<ProcessRoles> roles;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
@@ -33,7 +33,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     private int replicas;
     private Storage storage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
@@ -28,7 +28,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private List<Integer> nodeIds;
     private String clusterId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolStatus.java
@@ -28,7 +28,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolStatus extends Status {
-
     private List<Integer> nodeIds;
     private String clusterId;
     private List<ProcessRoles> roles;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
@@ -32,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolTemplate extends Spec {
-
     private ResourceTemplate podSet;
     private PodTemplate pod;
     private ResourceTemplate perPodService;

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolTemplate.java
@@ -32,7 +32,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolTemplate extends Spec {
-    private static final long serialVersionUID = 1L;
 
     private ResourceTemplate podSet;
     private PodTemplate pod;

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
@@ -85,7 +85,6 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_CORE_GROUP_NAME)
 public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodSetStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSet.java
@@ -85,6 +85,7 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_CORE_GROUP_NAME)
 public class StrimziPodSet extends CustomResource<StrimziPodSetSpec, StrimziPodSetStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
@@ -28,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class StrimziPodSetSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     private LabelSelector selector;
     private List<Map<String, Object>> pods;

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetSpec.java
@@ -28,7 +28,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class StrimziPodSetSpec extends Spec {
-
     private LabelSelector selector;
     private List<Map<String, Object>> pods;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class StrimziPodSetStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private int pods;
     private int readyPods;

--- a/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/podset/StrimziPodSetStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class StrimziPodSetStatus extends Status {
-
     private int pods;
     private int readyPods;
     private int currentPods;

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -97,8 +97,6 @@ import java.util.function.Predicate;
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -96,6 +96,7 @@ import java.util.function.Predicate;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaRebalance extends CustomResource<KafkaRebalanceSpec, KafkaRebalanceStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1BETA2 = Constants.V1BETA2;

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaRebalanceSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     // rebalancing modes
     private KafkaRebalanceMode mode = KafkaRebalanceMode.FULL;

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceSpec.java
@@ -27,7 +27,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaRebalanceSpec extends Spec {
-
     // rebalancing modes
     private KafkaRebalanceMode mode = KafkaRebalanceMode.FULL;
     private List<Integer> brokers;

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
@@ -29,7 +29,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
-
     private String sessionId;
     private Map<String, Object> optimizationResult = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
@@ -30,8 +30,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
 
-    private static final long serialVersionUID = 1L;
-
     private String sessionId;
     private Map<String, Object> optimizationResult = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
@@ -83,6 +83,7 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopic.java
@@ -84,8 +84,6 @@ import static java.util.Collections.emptyMap;
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaTopic extends CustomResource<KafkaTopicSpec, KafkaTopicStatus> implements Namespaced, UnknownPropertyPreserving {
 
-    private static final long serialVersionUID = 1L;
-
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;
     public static final String V1BETA1 = Constants.V1BETA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
@@ -26,7 +26,6 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaTopicSpec extends Spec {
-
     private String topicName;
 
     private Integer partitions;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
@@ -27,8 +27,6 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaTopicSpec extends Spec {
 
-    private static final long serialVersionUID = 1L;
-
     private String topicName;
 
     private Integer partitions;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private String topicName;
     private String topicId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaTopicStatus extends Status {
-
     private String topicName;
     private String topicId;
     private ReplicasChangeStatus replicasChange;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
@@ -13,7 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +27,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({ "targetReplicas", "state", "userTaskId", "message", "sessionId" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
-public class ReplicasChangeStatus implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class ReplicasChangeStatus implements UnknownPropertyPreserving {
 
     private Integer targetReplicas;
     private ReplicasChangeState state;

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
@@ -13,7 +13,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class ReplicasChangeStatus implements UnknownPropertyPreserving {
-
     private Integer targetReplicas;
     private ReplicasChangeState state;
     private String sessionId;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
@@ -83,7 +83,6 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements Namespaced, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUser.java
@@ -83,6 +83,7 @@ import static java.util.Collections.emptyMap;
 @Version(Constants.V1BETA2)
 @Group(Constants.RESOURCE_GROUP_NAME)
 public class KafkaUser extends CustomResource<KafkaUserSpec, KafkaUserStatus> implements Namespaced, UnknownPropertyPreserving {
+    private static final long serialVersionUID = 1L;
 
     public static final String SCOPE = "Namespaced";
     public static final String V1ALPHA1 = Constants.V1ALPHA1;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +27,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaUserAuthentication implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaUserAuthentication implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthentication.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +27,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaUserAuthentication implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Authentication type.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaUserAuthorization implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties;
 
     @Description("Authorization type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorization.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,9 +25,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class KafkaUserAuthorization implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class KafkaUserAuthorization implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
@@ -28,7 +28,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserAuthorizationSimple extends KafkaUserAuthorization {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SIMPLE = "simple";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserAuthorizationSimple.java
@@ -28,7 +28,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserAuthorizationSimple extends KafkaUserAuthorization {
-
     public static final String TYPE_SIMPLE = "simple";
 
     private List<AclRule> acls;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
@@ -16,7 +16,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,6 @@ import static java.util.Collections.emptyMap;
 @EqualsAndHashCode
 @ToString
 public class KafkaUserQuotas implements UnknownPropertyPreserving {
-
     private Integer producerByteRate;
     private Integer consumerByteRate;
     private Integer requestPercentage;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserQuotas.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,8 +34,7 @@ import static java.util.Collections.emptyMap;
 @JsonPropertyOrder({"producerByteRate", "consumerByteRate", "requestPercentage", "controllerMutationRate"})
 @EqualsAndHashCode
 @ToString
-public class KafkaUserQuotas implements UnknownPropertyPreserving, Serializable {
-    private static final long serialVersionUID = 1L;
+public class KafkaUserQuotas implements UnknownPropertyPreserving {
 
     private Integer producerByteRate;
     private Integer consumerByteRate;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentication {
-
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 
     private Password password;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserScramSha512ClientAuthentication.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserScramSha512ClientAuthentication extends KafkaUserAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_SCRAM_SHA_512 = "scram-sha-512";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {
-
     private KafkaUserAuthentication authentication;
     private KafkaUserAuthorization authorization;
     private KafkaUserQuotas quotas;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserSpec.java
@@ -22,7 +22,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserSpec extends Spec {
-    private static final long serialVersionUID = 1L;
 
     private KafkaUserAuthentication authentication;
     private KafkaUserAuthorization authorization;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserStatus extends Status {
-    private static final long serialVersionUID = 1L;
 
     private String username;
     private String secret;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserStatus.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserStatus extends Status {
-
     private String username;
     private String secret;
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
@@ -15,7 +15,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class KafkaUserTemplate implements UnknownPropertyPreserving {
-
     private ResourceTemplate secret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTemplate.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +31,7 @@ import java.util.Map;
 @DescriptionFile
 @EqualsAndHashCode
 @ToString
-public class KafkaUserTemplate implements Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class KafkaUserTemplate implements UnknownPropertyPreserving {
 
     private ResourceTemplate secret;
     private Map<String, Object> additionalProperties = new HashMap<>(0);

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TLS = "tls";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsClientAuthentication.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsClientAuthentication extends KafkaUserAuthentication {
-
     public static final String TYPE_TLS = "tls";
 
     @Description("Must be `" + TYPE_TLS + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsExternalClientAuthentication extends KafkaUserAuthentication {
-
     public static final String TYPE_TLS_EXTERNAL = "tls-external";
 
     @Description("Must be `" + TYPE_TLS_EXTERNAL + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/KafkaUserTlsExternalClientAuthentication.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaUserTlsExternalClientAuthentication extends KafkaUserAuthentication {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TLS_EXTERNAL = "tls-external";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -17,7 +17,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class AclRule implements UnknownPropertyPreserving {
-
     private AclRuleType type = AclRuleType.ALLOW;
     private AclRuleResource resource;
     private String host = "*";

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -17,7 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +34,7 @@ import java.util.Map;
 @JsonPropertyOrder({"type", "resource", "host", "operation", "operations"})
 @EqualsAndHashCode
 @ToString
-public class AclRule implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class AclRule implements UnknownPropertyPreserving {
 
     private AclRuleType type = AclRuleType.ALLOW;
     private AclRuleResource resource;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleClusterResource extends AclRuleResource {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_CLUSTER = "cluster";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleClusterResource.java
@@ -24,7 +24,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleClusterResource extends AclRuleResource {
-
     public static final String TYPE_CLUSTER = "cluster";
 
     @Description("Must be `" + TYPE_CLUSTER + "`")

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleGroupResource extends AclRuleResource {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_GROUP = "group";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleGroupResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleGroupResource extends AclRuleResource {
-
     public static final String TYPE_GROUP = "group";
 
     private String name;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
@@ -12,7 +12,6 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class AclRuleResource implements UnknownPropertyPreserving {
-
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Resource type. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleResource.java
@@ -12,7 +12,7 @@ import io.strimzi.crdgenerator.annotations.Description;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,9 +31,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 @ToString
-public abstract class AclRuleResource implements UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class AclRuleResource implements UnknownPropertyPreserving {
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleTopicResource extends AclRuleResource {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TOPIC = "topic";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTopicResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleTopicResource extends AclRuleResource {
-
     public static final String TYPE_TOPIC = "topic";
 
     private String name;

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleTransactionalIdResource extends AclRuleResource {
-    private static final long serialVersionUID = 1L;
 
     public static final String TYPE_TRANSACTIONAL_ID = "transactionalId";
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRuleTransactionalIdResource.java
@@ -25,7 +25,6 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class AclRuleTransactionalIdResource extends AclRuleResource {
-
     public static final String TYPE_TRANSACTIONAL_ID = "transactionalId";
 
     private AclResourcePatternType patternType = AclResourcePatternType.LITERAL;

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
@@ -29,7 +29,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,9 +47,7 @@ import java.util.Map;
     "metricsConfig", "logging", "template"})
 @EqualsAndHashCode
 @ToString
-public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving, Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
 
     public static final String FORBIDDEN_PREFIXES = "server., dataDir, dataLogDir, clientPort, authProvider, " +
             "quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
@@ -29,7 +29,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,7 +47,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe, UnknownPropertyPreserving {
-
     public static final String FORBIDDEN_PREFIXES = "server., dataDir, dataLogDir, clientPort, authProvider, " +
             "quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, " +
             "reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum";

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
@@ -21,7 +21,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,8 +38,7 @@ import java.util.Map;
     "podDisruptionBudget", "zookeeperContainer", "serviceAccount", "jmxSecret"})
 @EqualsAndHashCode
 @ToString
-public class ZookeeperClusterTemplate implements HasJmxSecretTemplate, Serializable, UnknownPropertyPreserving {
-    private static final long serialVersionUID = 1L;
+public class ZookeeperClusterTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
 
     private StatefulSetTemplate statefulset;
     private ResourceTemplate podSet;

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterTemplate.java
@@ -21,7 +21,6 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,7 +38,6 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class ZookeeperClusterTemplate implements HasJmxSecretTemplate, UnknownPropertyPreserving {
-
     private StatefulSetTemplate statefulset;
     private ResourceTemplate podSet;
     private PodTemplate pod;

--- a/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/Subject.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.security.auth.x500.X500Principal;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaAgentClient.java
@@ -15,6 +15,7 @@ import io.strimzi.operator.common.auth.TlsPemIdentity;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AuthenticationUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AuthenticationUtilsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -19,6 +19,7 @@ import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
 
 import javax.security.auth.login.AppConfigurationEntry;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -647,8 +647,6 @@ class CrdGenerator {
             }
         }
 
-        checkInherits(crdClass, "java.io.Serializable");
-
         if (crdClass.getName().startsWith("io.strimzi.api.")) {
             checkInherits(crdClass, "io.strimzi.api.kafka.model.common.UnknownPropertyPreserving");
         }

--- a/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
+++ b/kafka-agent/src/main/java/io/strimzi/kafka/agent/KafkaAgent.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
+++ b/kafka-agent/src/test/java/io/strimzi/kafka/agent/KafkaAgentTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletResponse;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;

--- a/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
+++ b/mirror-maker-agent/src/main/java/io/strimzi/mirrormaker/agent/MirrorMakerAgent.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import javax.management.JMException;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -11,6 +11,7 @@ import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;

--- a/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/model/KafkaUserModel.java
@@ -32,6 +32,7 @@ import io.strimzi.operator.user.model.acl.SimpleAclRule;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR addresses an issue [1]. TLDR; Remove the `Serializable` interface because It's never serialized using Java serialization. 

[1] - https://github.com/strimzi/strimzi-kafka-operator/issues/2075

### Checklist

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging