### PR TITLE
docs(otel): updates dependencies for Initializing tracing

### DIFF
--- a/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
+++ b/documentation/modules/tracing/proc-configuring-tracers-kafka-clients.adoc
@@ -21,19 +21,52 @@ In each client application add the dependencies for the tracer:
 [source,xml,subs="attributes+"]
 ----
 <dependency>
+    <groupId>io.opentelemetry.semconv</groupId>
+    <artifactId>opentelemetry-semconv</artifactId>
+    <version>{OpenTelemetrySemConvVersion}</version>
+</dependency>
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-otlp</artifactId>
+    <version>{OpenTelemetryVersion}</version>
+    <exclusions>
+        <exclusion>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-sender-okhttp</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-sender-grpc-managed-channel</artifactId>
+    <version>{OpenTelemetryVersion}</version>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
     <version>{OpenTelemetryVersion}</version>
 </dependency>
 <dependency>
-  <groupId>io.opentelemetry.instrumentation</groupId>
-  <artifactId>opentelemetry-kafka-clients-{OpenTelemetryKafkaClientVersion}</artifactId>
-  <version>{OpenTelemetryAlphaVersion}</version>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-kafka-clients-{OpenTelemetryKafkaClientVersion}</artifactId>
+    <version>{OpenTelemetryInstrumentationVersion}</version>
 </dependency>
 <dependency>
-  <groupId>io.opentelemetry</groupId>
-  <artifactId>opentelemetry-exporter-otlp</artifactId>
-  <version>{OpenTelemetryVersion}</version>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-sdk</artifactId>
+    <version>{OpenTelemetryVersion}</version>
+</dependency>
+<dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+    <version>{OpenTelemetryAlphaVersion}</version>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-netty-shaded</artifactId>
+    <version>{GRPCVersion}</version>
 </dependency>
 ----
 

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -119,9 +119,12 @@
 :HelmCustomResourceDefinitions: link:https://helm.sh/docs/chart_best_practices/custom_resource_definitions/[Custom Resource Definitions for Helm^]
 
 //distributed tracing versions and links
-:OpenTelemetryAlphaVersion: 1.19.0-alpha
-:OpenTelemetryVersion: 1.19.0
+:OpenTelemetryAlphaVersion: 1.34.1-alpha
+:OpenTelemetryVersion: 1.34.1
+:OpenTelemetryInstrumentationVersion: 1.32.0-alpha
+:OpenTelemetrySemConvVersion: 1.21.0-alpha
 :OpenTelemetryKafkaClientVersion: 2.6
+:GRPCVersion: 1.61.0
 
 :OpenTelemetryDocs: link:https://opentelemetry.io/docs/[OpenTelemetry documentation^]
 :JaegerDocs: link:https://www.jaegertracing.io/docs/[Jaeger documentation^]


### PR DESCRIPTION
**Documentation**

Due to a Kotlin issue, the okhttp-based client was replaced with one based on the JDK HTTP client, adding gRPC support.
This PR updates the OpenTelemetry documentation with the dependencies for instrumenting clients to avoid users inadvertently using okhttp instead of the JDK HTTP client. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

