### PR TITLE
[ST] Bump version of test-clients to 0.8.0 and Jaeger's all-in-one image to `1.56`

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -203,7 +203,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.7.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.7.0";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.40.0";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -203,7 +203,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.7.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "latest";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.8.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.40.0";
 

--- a/systemtest/src/test/resources/tracing/jaeger-instance.yaml
+++ b/systemtest/src/test/resources/tracing/jaeger-instance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   strategy: allInOne
   allInOne:
-    image: 'quay.io/jaegertracing/all-in-one:1.35'
+    image: 'quay.io/jaegertracing/all-in-one:1.56'
     options:
       log-level: debug
       query:


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates the test-clients version to newly released `0.8.0`, which brings few enhancements (mainly to admin-client) and fixes, that will be used to fix issues we have in the STs.

Together with that, I'm updating the version of Jaeger's `all-in-one` image, to fix issue with gRPC port. This is needed for the new test-clients, which are using gRPC for OTel.

### Checklist

- [ ] Make sure all tests pass
