### PR TITLE
Remove events rule from entity-operator

### DIFF
--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -88,7 +88,7 @@ rules:
   - apiGroups:
       - "events.k8s.io" # new events api, used by cluster operator
     resources:
-      # The cluster operator needs to be able to create events and delegate permissions to do so
+      # The cluster operator needs to be able to create events
       - events
     verbs:
       - create

--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -86,7 +86,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - "" # legacy core events api, used by topic operator
       - "events.k8s.io" # new events api, used by cluster operator
     resources:
       # The cluster operator needs to be able to create events and delegate permissions to do so

--- a/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/031-ClusterRole-strimzi-entity-operator.yaml
@@ -44,13 +44,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - events
-    verbs:
-      # The entity operator needs to be able to create events
-      - create
-  - apiGroups:
-      - ""
-    resources:
       # The entity operator user-operator needs to access and manage secrets to store generated credentials
       - secrets
     verbs:

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -808,11 +808,6 @@ public class EntityOperatorTest {
                 .addToApiGroups(Constants.RESOURCE_GROUP_NAME)
                 .build());
         rules.add(new PolicyRuleBuilder()
-                .addToResources("events")
-                .addToVerbs("create")
-                .addToApiGroups("")
-                .build());
-        rules.add(new PolicyRuleBuilder()
                 .addToResources("secrets")
                 .addToVerbs("get", "list", "watch", "create", "delete", "patch", "update")
                 .addToApiGroups("")

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -91,7 +91,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""   # legacy core events api, used by topic operator
   - "events.k8s.io" # new events api, used by cluster operator
   resources:
     # The cluster operator needs to be able to create events and delegate permissions to do so

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -93,7 +93,7 @@ rules:
 - apiGroups:
   - "events.k8s.io" # new events api, used by cluster operator
   resources:
-    # The cluster operator needs to be able to create events and delegate permissions to do so
+    # The cluster operator needs to be able to create events
   - events
   verbs:
   - create

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-ClusterRole-strimzi-entity-operator.yaml
@@ -49,13 +49,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-    # The entity operator needs to be able to create events
-  - create
-- apiGroups:
-  - ""
-  resources:
     # The entity operator user-operator needs to access and manage secrets to store generated credentials
   - secrets
   verbs:

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -88,7 +88,7 @@ rules:
   - apiGroups:
       - "events.k8s.io" # new events api, used by cluster operator
     resources:
-      # The cluster operator needs to be able to create events and delegate permissions to do so
+      # The cluster operator needs to be able to create events
       - events
     verbs:
       - create

--- a/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/packaging/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -86,7 +86,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - "" # legacy core events api, used by topic operator
       - "events.k8s.io" # new events api, used by cluster operator
     resources:
       # The cluster operator needs to be able to create events and delegate permissions to do so

--- a/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
+++ b/packaging/install/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml
@@ -44,13 +44,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - events
-    verbs:
-      # The entity operator needs to be able to create events
-      - create
-  - apiGroups:
-      - ""
-    resources:
       # The entity operator user-operator needs to access and manage secrets to store generated credentials
       - secrets
     verbs:

--- a/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
+++ b/packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml
@@ -25,9 +25,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create


### PR DESCRIPTION
This rule was only needed by the old implementation of the Topic Operator that has recently been removed.
