### PR TITLE
Allow KafkaRoller talk to controller directly

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -124,7 +124,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final String REPLICATION_PORT_NAME = "tcp-replication";
     protected static final int KAFKA_AGENT_PORT = 8443;
     protected static final String KAFKA_AGENT_PORT_NAME = "tcp-kafkaagent";
-    protected static final int CONTROLPLANE_PORT = 9090;
+    /**
+     * Port number used for control plane
+     */
+    public static final int CONTROLPLANE_PORT = 9090;
     protected static final String CONTROLPLANE_PORT_NAME = "tcp-ctrlplane"; // port name is up to 15 characters
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -35,10 +35,8 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 
@@ -111,7 +109,6 @@ public class KafkaRoller {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaRoller.class);
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME = "controller.quorum.fetch.timeout.ms";
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
-
     private final PodOperator podOperations;
     private final long pollingIntervalMs;
     protected final long operationTimeoutMs;
@@ -198,7 +195,7 @@ public class KafkaRoller {
     private boolean maybeInitBrokerAdminClient() {
         if (this.brokerAdminClient == null) {
             try {
-                this.brokerAdminClient = adminClient(nodes.stream().filter(NodeRef::broker).collect(Collectors.toSet()), false);
+                this.brokerAdminClient = brokerAdminClient(nodes);
             } catch (ForceableProblem | FatalProblem e) {
                 LOGGER.warnCr(reconciliation, "Failed to create brokerAdminClient.", e);
                 return false;
@@ -213,14 +210,17 @@ public class KafkaRoller {
      */
     private boolean maybeInitControllerAdminClient() {
         if (this.controllerAdminClient == null) {
+            // Prior to 3.9.0, Kafka did not support directly connecting to controllers nodes
+            // via Kafka Admin API when running in KRaft mode.
+            // Therefore, use brokers to initialise adminClient for quorum health check
+            // when the version is older than 3.9.0.
             try {
-                // TODO: Currently, when running in KRaft mode Kafka does not support using Kafka Admin API with controller
-                //       nodes. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9692.
-                //       Therefore use broker nodes of the cluster to initialise adminClient for quorum health check.
-                //       Once Kafka Admin API is supported for controllers, nodes.stream().filter(NodeRef:controller)
-                //       can be used here. Until then pass an empty set of nodes so the client is initialized with
-                //       the brokers service.
-                this.controllerAdminClient = adminClient(Set.of(), false);
+                if (KafkaVersion.compareDottedVersions(kafkaVersion.version(), "3.9.0") >= 0) {
+                    this.controllerAdminClient = controllerAdminClient(nodes);
+                } else {
+                    this.controllerAdminClient = brokerAdminClient(Set.of());
+
+                }
             } catch (ForceableProblem | FatalProblem e) {
                 LOGGER.warnCr(reconciliation, "Failed to create controllerAdminClient.", e);
                 return false;
@@ -607,35 +607,13 @@ public class KafkaRoller {
         KafkaBrokerLoggingConfigurationDiff brokerLoggingDiff = null;
         boolean needsReconfig = false;
 
-        if (isController) {
-            if (maybeInitControllerAdminClient()) {
-                String controllerQuorumFetchTimeout = CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT;
-                String desiredConfig = kafkaConfigProvider.apply(nodeRef.nodeId());
-
-                if (desiredConfig != null) {
-                    OrderedProperties orderedProperties = new OrderedProperties();
-                    controllerQuorumFetchTimeout = orderedProperties.addStringPairs(desiredConfig).asMap().getOrDefault(CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT);
-                }
-
-                restartContext.quorumCheck = quorumCheck(controllerAdminClient, Long.parseLong(controllerQuorumFetchTimeout));
-            } else {
-                //TODO When https://github.com/strimzi/strimzi-kafka-operator/issues/9692 is complete
-                // we should change this logic to immediately restart this pod because we cannot connect to it.
-                if (isBroker) {
-                    // If it is a combined node (controller and broker) and the admin client cannot be initialised,
-                    // restart this pod. There is no reason to continue as we won't be able to
-                    // connect an admin client to this pod for other checks later.
-                    LOGGER.infoCr(reconciliation, "KafkaQuorumCheck cannot be initialised for {} because none of the brokers do not seem to responding to connection attempts. " +
-                            "Restarting pod because it is a combined node so it is one of the brokers that is not responding.", nodeRef);
-                    reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
-                    markRestartContextWithForceRestart(restartContext);
-                    return;
-                } else {
-                    // If it is a controller only node throw an UnforceableProblem, so we try again until the backOff
-                    // is finished, then it will move on to the next controller and eventually the brokers.
-                    throw new UnforceableProblem("KafkaQuorumCheck cannot be initialised for " + nodeRef + " because none of the brokers do not seem to responding to connection attempts");
-                }
+        // if it is a pure controller, initialise the admin client specifically for controllers
+        if (isController && !isBroker) {
+            if (!maybeInitControllerAdminClient()) {
+                handleFailedAdminClientForController(nodeRef, restartContext, reasonToRestartPod);
+                return;
             }
+            restartContext.quorumCheck = quorumCheck(controllerAdminClient, nodeRef);
         }
 
         if (isBroker) {
@@ -644,6 +622,11 @@ public class KafkaRoller {
                 reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
                 markRestartContextWithForceRestart(restartContext);
                 return;
+            }
+
+            // If it is a mixed node, initialise quorum check with the broker admin client
+            if (isController) {
+                restartContext.quorumCheck = quorumCheck(brokerAdminClient, nodeRef);
             }
 
             // Always get the broker config. This request gets sent to that specific broker, so it's a proof that we can
@@ -689,6 +672,21 @@ public class KafkaRoller {
         restartContext.forceRestart = false;
         restartContext.brokerConfigDiff = brokerConfigDiff;
         restartContext.brokerLoggingDiff = brokerLoggingDiff;
+    }
+
+    private void handleFailedAdminClientForController(NodeRef nodeRef, RestartContext restartContext, RestartReasons reasonToRestartPod) throws UnforceableProblem {
+        if (KafkaVersion.compareDottedVersions(kafkaVersion.version(), "3.9.0") >= 0) {
+            // If the version supports talking to controllers, force restart this pod when the admin client cannot be initialised.
+            // There is no reason to continue as we won't be able to connect an admin client to this pod for other checks later.
+            LOGGER.infoCr(reconciliation, "KafkaQuorumCheck cannot be initialised for {} because none of the controllers do not seem to responding to connection attempts.", nodeRef);
+            reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
+            markRestartContextWithForceRestart(restartContext);
+        } else {
+            // If the version does not support talking to controllers, the admin client should be connecting to the broker nodes.
+            // Since connection to the brokers failed, throw an UnforceableProblem so that broker nodes can be checked later
+            // which may potentially resolve the connection issue.
+            throw new UnforceableProblem("KafkaQuorumCheck cannot be initialised for " + nodeRef + " because none of the brokers do not seem to responding to connection attempts");
+        }
     }
 
     /**
@@ -905,34 +903,48 @@ public class KafkaRoller {
      * Returns an AdminClient instance bootstrapped from the given nodes. If nodes is an
      * empty set, use the brokers service to bootstrap the client.
      */
-    /* test */ Admin adminClient(Set<NodeRef> nodes, boolean ceShouldBeFatal) throws ForceableProblem, FatalProblem {
-        // If no nodes are passed initialize the admin client using the brokers service
-        // TODO when https://github.com/strimzi/strimzi-kafka-operator/issues/9692 is completed review whether
-        //      this function can be reverted to expect nodes to be non empty
+    /* test */ Admin brokerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
+        // If no nodes are passed, initialize the admin client using the bootstrap service
+        // This is still needed for versions older than 3.9.0, so that when only controller nodes being rolled,
+        // it can use brokers to get quorum information via AdminClient.
         String bootstrapHostnames;
         if (nodes.isEmpty()) {
             bootstrapHostnames = String.format("%s:%s", DnsNameGenerator.of(namespace, KafkaResources.bootstrapServiceName(cluster)).serviceDnsName(), KafkaCluster.REPLICATION_PORT);
         } else {
-            bootstrapHostnames = nodes.stream().map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.REPLICATION_PORT).collect(Collectors.joining(","));
+            bootstrapHostnames = nodes.stream().filter(NodeRef::broker).map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.REPLICATION_PORT).collect(Collectors.joining(","));
         }
 
         try {
             LOGGER.debugCr(reconciliation, "Creating AdminClient for {}", bootstrapHostnames);
             return adminClientProvider.createAdminClient(bootstrapHostnames, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
-        } catch (KafkaException e) {
-            if (ceShouldBeFatal && (e instanceof ConfigException
-                    || e.getCause() instanceof ConfigException)) {
-                throw new FatalProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
-            } else {
-                throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
-            }
         } catch (RuntimeException e) {
             throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
         }
     }
 
-    /* test */ KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
-        return new KafkaQuorumCheck(reconciliation, ac, vertx, controllerQuorumFetchTimeoutMs);
+    /**
+     * Returns an AdminClient instance bootstrapped from the given controller nodes.
+     */
+    /* test */ Admin controllerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
+        String bootstrapHostnames = nodes.stream().filter(NodeRef::controller).map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.CONTROLPLANE_PORT).collect(Collectors.joining(","));
+
+        try {
+            LOGGER.debugCr(reconciliation, "Creating AdminClient for {}", bootstrapHostnames);
+            return adminClientProvider.createControllerAdminClient(bootstrapHostnames, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
+        } catch (RuntimeException e) {
+            throw new ForceableProblem("An error while try to create an admin client with bootstrap controllers " + bootstrapHostnames, e);
+        }
+    }
+
+    /* test */ KafkaQuorumCheck quorumCheck(Admin ac, NodeRef nodeRef) {
+        String controllerQuorumFetchTimeout = CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT;
+        String desiredConfig = kafkaConfigProvider.apply(nodeRef.nodeId());
+
+        if (desiredConfig != null) {
+            OrderedProperties orderedProperties = new OrderedProperties();
+            controllerQuorumFetchTimeout = orderedProperties.addStringPairs(desiredConfig).asMap().getOrDefault(CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT);
+        }
+        return new KafkaQuorumCheck(reconciliation, ac, vertx, Long.parseLong(controllerQuorumFetchTimeout));
     }
 
     /* test */ KafkaAvailability availability(Admin ac) {
@@ -975,7 +987,7 @@ public class KafkaRoller {
             //      This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9373.
             // Use admin client connected directly to this broker here, then any exception or timeout trying to connect to
             // the current node will be caught and handled from this method, rather than appearing elsewhere.
-            try (Admin ac = adminClient(Set.of(nodeRef), false)) {
+            try (Admin ac = brokerAdminClient(Set.of(nodeRef))) {
                 Node controllerNode = null;
 
                 try {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -216,7 +216,7 @@ public class KafkaRoller {
             // Therefore, use brokers to initialise adminClient for quorum health check
             // when the version is older than 3.9.0.
             try {
-                if (currentVersion != null && KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
+                if (KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
                     this.controllerAdminClient = controllerAdminClient(nodes);
                 } else {
                     this.controllerAdminClient = brokerAdminClient(Set.of());
@@ -456,7 +456,7 @@ public class KafkaRoller {
         boolean isBroker = Labels.booleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL, nodeRef.broker());
         boolean isController = Labels.booleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL, nodeRef.controller());
         // This is relevant when creating admin client for controllers
-        String currentVersion = pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_KAFKA_VERSION);
+        String currentVersion = Annotations.stringAnnotation(pod, KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION, "0.0.0", null);
 
         try {
             checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext, currentVersion);
@@ -678,7 +678,7 @@ public class KafkaRoller {
     }
 
     private void handleFailedAdminClientForController(NodeRef nodeRef, RestartContext restartContext, RestartReasons reasonToRestartPod, String currentVersion) throws UnforceableProblem {
-        if (currentVersion != null && KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
+        if (KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
             // If the version supports talking to controllers, force restart this pod when the admin client cannot be initialised.
             // There is no reason to continue as we won't be able to connect an admin client to this pod for other checks later.
             LOGGER.infoCr(reconciliation, "KafkaQuorumCheck cannot be initialised for {} because none of the controllers do not seem to responding to connection attempts.", nodeRef);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -519,7 +519,17 @@ public class ResourceUtils {
             }
 
             @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+                return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
+            }
+
+            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+                return mockAdminClient;
+            }
+
+            @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return mockAdminClient;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -9,13 +9,13 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
+import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.RestartReason;
 import io.strimzi.operator.cluster.model.RestartReasons;
 import io.strimzi.operator.cluster.operator.resource.events.KubernetesRestartEventPublisher;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.common.AdminClientProvider;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
@@ -845,7 +845,7 @@ public class KafkaRollerTest {
                         .withNewMetadata()
                         .withNamespace(invocation.getArgument(0))
                         .withName(invocation.getArgument(1))
-                        .addToAnnotations(Annotations.ANNO_STRIMZI_KAFKA_VERSION, version)
+                        .addToAnnotations(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION, version)
                         .endMetadata()
                         .build()
         );

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -171,6 +171,7 @@ public class KafkaRollerTest {
                 brokerId -> succeededFuture(true),
                 true, mock, mockKafkaAgentClientProvider(), true, null, -1);
 
+        // When admin client cannot be created for a controller node, we expect it to be force restarted.
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0),
                 asList(0));
@@ -188,6 +189,8 @@ public class KafkaRollerTest {
                 brokerId -> succeededFuture(true),
                 true, mock, mockKafkaAgentClientProvider(), true, null, -1);
 
+        // If the controller has older version (< 3.9.0), we should only be creating admin client for brokers
+        // and when the operator cannot connect to brokers, we expect to fail initialising KafkaQuorumCheck
         doFailingRollingRestart(testContext, kafkaRoller,
                 asList(0),
                 KafkaRoller.UnforceableProblem.class, "KafkaQuorumCheck cannot be initialised for c-kafka-0/0 because none of the brokers do not seem to responding to connection attempts",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -167,8 +167,7 @@ public class KafkaRollerTest {
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createControllerAdminClient(anyString(), any(), any())).thenThrow(new RuntimeException("An error while try to create an admin client with bootstrap controllers"));
 
-        KafkaVersion versionSupportsTalkingToControllers = new KafkaVersion("3.9.0", "", "", "", "", false, false, "");
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps, versionSupportsTalkingToControllers,
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps, KafkaVersionTestUtils.getLatestVersion(),
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
                 true, mock, mockKafkaAgentClientProvider(), true, null, -1);
@@ -185,7 +184,8 @@ public class KafkaRollerTest {
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenThrow(new RuntimeException("An error while try to create an admin client with bootstrap brokers"));
 
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps, KafkaVersionTestUtils.getLatestVersion(),
+        KafkaVersion oldKafkaVersion = new KafkaVersion("3.8.1", "", "", "", "", false, false, "");
+        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps, oldKafkaVersion,
                 noException(), null, noException(), noException(), noException(),
                 brokerId -> succeededFuture(true),
                 true, mock, mockKafkaAgentClientProvider(), true, null, -1);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -617,7 +617,17 @@ public class KubernetesRestartEventsMockTest {
             }
 
             @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+                return adminClientSupplier.get();
+            }
+
+            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+                return adminClientSupplier.get();
+            }
+
+            @Override
+            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return adminClientSupplier.get();
             }
         };

--- a/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 public interface AdminClientProvider {
 
     /**
-     * Create a Kafka Admin interface instance
+     * Create a Kafka Admin interface instance for brokers
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -26,7 +26,17 @@ public interface AdminClientProvider {
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
 
     /**
-     * Create a Kafka Admin interface instance
+     * Create a Kafka Admin interface instance for controllers
+     *
+     * @param controllerBootstrapHostnames Kafka controller hostname to connect to for administration operations
+     * @param kafkaCaTrustSet Trust set for connecting to Kafka
+     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
+     * @return Instance of Kafka Admin interface
+     */
+    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
+
+    /**
+     * Create a Kafka Admin interface instance for brokers
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -36,4 +46,16 @@ public interface AdminClientProvider {
      * @return Instance of Kafka Admin interface
      */
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
+
+    /**
+     * Create a Kafka Admin interface instance for controllers
+     *
+     * @param controllerBootstrapHostnames Kafka hostname to connect to for administration operations
+     * @param kafkaCaTrustSet Trust set for connecting to Kafka
+     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
+     * @param config Additional configuration for the Kafka Admin Client
+     *
+     * @return Instance of Kafka Admin interface
+     */
+    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -34,10 +34,6 @@ public class Annotations extends ResourceAnnotations {
      * annotation we force a restart of the pods managed by StrimziPodSets or Deployments.
      */
     public static final String ANNO_STRIMZI_LOGGING_HASH = STRIMZI_DOMAIN + "logging-hash";
-    /**
-     * Annotation for current Kafka Version
-     */
-    public static final String ANNO_STRIMZI_KAFKA_VERSION = STRIMZI_DOMAIN + "kafka-version";
 
     /**
      * Annotation for tracking authentication changes

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -34,6 +34,10 @@ public class Annotations extends ResourceAnnotations {
      * annotation we force a restart of the pods managed by StrimziPodSets or Deployments.
      */
     public static final String ANNO_STRIMZI_LOGGING_HASH = STRIMZI_DOMAIN + "logging-hash";
+    /**
+     * Annotation for current Kafka Version
+     */
+    public static final String ANNO_STRIMZI_KAFKA_VERSION = STRIMZI_DOMAIN + "kafka-version";
 
     /**
      * Annotation for tracking authentication changes

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -68,7 +68,7 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      *
      * @return  Admin client configuration
      */
-    /* test */ static Properties adminClientConfiguration(PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
+    /* test */ Properties adminClientConfiguration(PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
         if (config == null) {
             throw new InvalidConfigurationException("The config parameter should not be null");
         }

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -21,6 +21,11 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
         return createAdminClient(bootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
     }
 
+    @Override
+    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
+        return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
+    }
+
     /**
      * Create a Kafka Admin interface instance handling the following different scenarios:
      *
@@ -44,25 +49,29 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      */
     @Override
     public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-        return Admin.create(adminClientConfiguration(bootstrapHostnames, kafkaCaTrustSet, authIdentity, config));
+        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
+        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
+    }
+
+    @Override
+    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
+        config.setProperty(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, controllerBootstrapHostnames);
+        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
     }
 
     /**
      * Utility method for preparing the Admin client configuration
      *
-     * @param bootstrapHostnames    Kafka bootstrap address
      * @param kafkaCaTrustSet       Trust set for connecting to Kafka
      * @param authIdentity          Identity for TLS client authentication for connecting to Kafka
      * @param config                Custom Admin client configuration or empty properties instance
      *
      * @return  Admin client configuration
      */
-    /* test */ static Properties adminClientConfiguration(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
+    /* test */ static Properties adminClientConfiguration(PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
         if (config == null) {
             throw new InvalidConfigurationException("The config parameter should not be null");
         }
-
-        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
 
         // configuring TLS encryption if requested
         if (kafkaCaTrustSet != null) {

--- a/operator-common/src/test/java/io/strimzi/operator/common/DefaultAdminClientProviderTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/DefaultAdminClientProviderTest.java
@@ -26,7 +26,6 @@ public class DefaultAdminClientProviderTest {
     private static final String USER_KEY = "user-key";
 
     private void assertDefaultConfigs(Properties config) {
-        assertThat(config.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), is("my-kafka:9092"));
         assertThat(config.get(AdminClientConfig.METADATA_MAX_AGE_CONFIG), is("30000"));
         assertThat(config.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG), is("10000"));
         assertThat(config.get(AdminClientConfig.RETRIES_CONFIG), is("3"));
@@ -35,9 +34,9 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testPlainConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, null, new Properties());
+        Properties config = DefaultAdminClientProvider.adminClientConfiguration(null, null, new Properties());
 
-        assertThat(config.size(), is(5));
+        assertThat(config.size(), is(4));
         assertDefaultConfigs(config);
     }
 
@@ -47,10 +46,9 @@ public class DefaultAdminClientProviderTest {
         customConfig.setProperty(AdminClientConfig.RETRIES_CONFIG, "5"); // Override a value we have default for
         customConfig.setProperty(AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG, "13000"); // Override a value we do not use
 
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, null, customConfig);
+        Properties config = DefaultAdminClientProvider.adminClientConfiguration(null, null, customConfig);
 
-        assertThat(config.size(), is(6));
-        assertThat(config.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), is("my-kafka:9092"));
+        assertThat(config.size(), is(5));
         assertThat(config.get(AdminClientConfig.METADATA_MAX_AGE_CONFIG), is("30000"));
         assertThat(config.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG), is("10000"));
         assertThat(config.get(AdminClientConfig.RETRIES_CONFIG), is("5"));
@@ -60,9 +58,9 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testTlsConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", mockPemTrustSet(), null, new Properties());
+        Properties config = DefaultAdminClientProvider.adminClientConfiguration(mockPemTrustSet(), null, new Properties());
 
-        assertThat(config.size(), is(8));
+        assertThat(config.size(), is(7));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), is("PEM"));
@@ -72,9 +70,9 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testMTlsConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", mockPemTrustSet(), mockPemAuthIdentity(), new Properties());
+        Properties config = DefaultAdminClientProvider.adminClientConfiguration(mockPemTrustSet(), mockPemAuthIdentity(), new Properties());
 
-        assertThat(config.size(), is(11));
+        assertThat(config.size(), is(10));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), is("PEM"));
@@ -87,9 +85,9 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testMTlsWithPublicCAConnection() {
-        Properties config = DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, mockPemAuthIdentity(), new Properties());
+        Properties config = DefaultAdminClientProvider.adminClientConfiguration(null, mockPemAuthIdentity(), new Properties());
 
-        assertThat(config.size(), is(9));
+        assertThat(config.size(), is(8));
         assertDefaultConfigs(config);
         assertThat(config.get(AdminClientConfig.SECURITY_PROTOCOL_CONFIG), is("SSL"));
         assertThat(config.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG).toString(), is("PEM"));
@@ -99,7 +97,7 @@ public class DefaultAdminClientProviderTest {
 
     @Test
     public void testNullConfig() {
-        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> DefaultAdminClientProvider.adminClientConfiguration("my-kafka:9092", null, mockPemAuthIdentity(), null));
+        InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> DefaultAdminClientProvider.adminClientConfiguration(null, mockPemAuthIdentity(), null));
         assertThat(ex.getMessage(), is("The config parameter should not be null"));
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

- Add a method for creating admin client for controllers with BOOTSTRAP_CONTROLLERS_CONFIG set. 
- Make KafkaRoller create admin client against controllers nodes, if they are running 3.9.0 or later. 
- Tidy up: remove ceShouldBeFatal option as it's never set to true.

There will be a follow up PR to dynamically apply configurations for controllers (with version 3.9.0 or later) using the admin client instead of how we currently restart controllers when any config changes. 

Closes https://github.com/strimzi/strimzi-kafka-operator/issues/9692 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

