### PR TITLE
Improve JBOD storage version validation in KRaft

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
@@ -233,11 +233,12 @@ public class NodePoolUtils {
         for (KafkaNodePool pool : nodePools)    {
             if (pool.getSpec().getStorage() != null
                     && pool.getSpec().getStorage() instanceof JbodStorage jbod) {
-                if (KafkaVersion.compareDottedVersions(versionChange.to().version(), "3.7.0") < 0 && jbod.getVolumes().size() > 1) {
+                if (jbod.getVolumes().size() > 1
+                        && (KafkaVersion.compareDottedVersions(versionChange.from().version(), "3.7.0") < 0 || KafkaVersion.compareDottedIVVersions(versionChange.metadataVersion(), "3.7-IV2") < 0)) {
                     // When running Kafka older than 3.7.0, JBOD storage is not supported in KRaft.
                     // This check should be removed when we remove support for Kafka 3.6.x.
                     // This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9960.
-                    errors.add("Using more than one disk in a JBOD storage in KRaft mode is supported only with Apache Kafka 3.7.0 and newer (in KafkaNodePool " + pool.getMetadata().getName() + ")");
+                    errors.add("Using more than one disk in a JBOD storage in KRaft mode is supported only with Apache Kafka 3.7.0 or newer and metadata version 3.7-IV2 or newer (in KafkaNodePool " + pool.getMetadata().getName() + ")");
                 }
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR improves the Kafka version validation when JBOD storage is used in KRaft:
* It validates the `from` version instead of the `to` version to better handle upgrades (not allow JBOD storage before the upgrade to 3.7.0 is done)
* Checks that the metadata version is set to `3.7`

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally