### PR TITLE
[performance] - UserOperator capacity tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -210,3 +210,21 @@ jobs:
       test:
         tmt:
           name: performance
+  - job: tests
+    trigger: pull_request
+    identifier: "performance-capacity"
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+    skip_build: true
+    manual_trigger: true
+    env: { IP_FAMILY: ipv4 }
+    labels:
+      - performance-capacity
+    tf_extra_params:
+      settings:
+        pipeline:
+          timeout: 1440
+      test:
+        tmt:
+          name: performance-capacity

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -403,5 +403,15 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>performance-capacity</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>
+                    performance-capacity
+                </groups>
+            </properties>
+        </profile>
+
     </profiles>
 </project>

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -80,6 +80,13 @@ public class LogCollector {
     private final CollectorElement collectorElement;
     private final ExtensionContext extensionContext;
 
+    public LogCollector() throws IOException {
+        this(ResourceManager.getTestContext(), CollectorElement.createCollectorElement(
+                ResourceManager.getTestContext().getRequiredTestClass().getName(),
+                ResourceManager.getTestContext().getRequiredTestMethod().getName()),
+            KubeClusterResource.kubeClient(), Environment.TEST_LOG_DIR);
+    }
+
     public LogCollector(ExtensionContext extensionContext, CollectorElement collectorElement, KubeClient kubeClient, String logDir) throws IOException {
         this.extensionContext = extensionContext;
         this.collectorElement = collectorElement;
@@ -116,13 +123,6 @@ public class LogCollector {
         if (!logTestCaseDirExist) {
             throw new IOException("Unable to create path");
         }
-    }
-
-    public LogCollector() throws IOException {
-        this(ResourceManager.getTestContext(), CollectorElement.createCollectorElement(
-                ResourceManager.getTestContext().getRequiredTestClass().getName(),
-                ResourceManager.getTestContext().getRequiredTestMethod().getName()),
-            KubeClusterResource.kubeClient(), Environment.TEST_LOG_DIR);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -11,8 +11,10 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.ClusterOperatorInstallType;
 import io.strimzi.systemtest.resources.NamespaceManager;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.k8s.KubeClient;
+import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.logs.CollectorElement;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -114,6 +116,13 @@ public class LogCollector {
         if (!logTestCaseDirExist) {
             throw new IOException("Unable to create path");
         }
+    }
+
+    public LogCollector() throws IOException {
+        this(ResourceManager.getTestContext(), CollectorElement.createCollectorElement(
+                ResourceManager.getTestContext().getRequiredTestClass().getName(),
+                ResourceManager.getTestContext().getRequiredTestMethod().getName()),
+            KubeClusterResource.kubeClient(), Environment.TEST_LOG_DIR);
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -44,14 +44,14 @@ public class MetricsCollector {
 
     private static final Object LOCK = new Object();
 
-    private String namespaceName;
-    private String scraperPodName;
-    private ComponentType componentType;
-    private String componentName;
-    private int metricsPort;
-    private String metricsPath;
-    private LabelSelector componentLabelSelector;
-    private Map<String, String> collectedData;
+    protected String namespaceName;
+    protected String scraperPodName;
+    protected ComponentType componentType;
+    protected String componentName;
+    protected int metricsPort;
+    protected String metricsPath;
+    protected LabelSelector componentLabelSelector;
+    protected Map<String, String> collectedData;
 
     public static class Builder {
         private String namespaceName;
@@ -220,7 +220,7 @@ public class MetricsCollector {
      * @param pattern regex pattern for specific metric
      * @return list of parsed values
      */
-    public ArrayList<Double> collectSpecificMetric(Pattern pattern) {
+    public final ArrayList<Double> collectSpecificMetric(Pattern pattern) {
         ArrayList<Double> values = new ArrayList<>();
 
         if (collectedData != null && !collectedData.isEmpty()) {
@@ -240,7 +240,7 @@ public class MetricsCollector {
      * @param metricName The name of the metric to collect.
      * @return A map where each key represents the unique labels and the value is the corresponding metric value.
      */
-    public Map<String, Double> collectMetricWithLabels(String metricName) {
+    public final Map<String, Double> collectMetricWithLabels(String metricName) {
         // This pattern will match the metric name and capture the labels and value.
         Pattern pattern = Pattern.compile(metricName + "\\{([^}]+)\\}\\s(\\d+(?:\\.\\d+)?(?:E-?\\d+)?)");
         Map<String, Double> valuesWithLabels = new HashMap<>();
@@ -266,7 +266,7 @@ public class MetricsCollector {
      *
      * @return ArrayList of values collected from the metrics
      */
-    public synchronized ArrayList<Double> waitForSpecificMetricAndCollect(Pattern pattern) {
+    public final synchronized ArrayList<Double> waitForSpecificMetricAndCollect(Pattern pattern) {
         ArrayList<Double> values = collectSpecificMetric(pattern);
 
         if (values.isEmpty()) {
@@ -291,7 +291,7 @@ public class MetricsCollector {
      * Collect metrics from specific pod
      * @return collected metrics
      */
-    private String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
+    protected String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
         List<String> executableCommand = Arrays.asList(cmdKubeClient(namespaceName).toString(), "exec", scraperPodName,
             "-n", namespaceName,
             "--", "curl", metricsPodIp + ":" + metricsPort + metricsPath);
@@ -310,7 +310,7 @@ public class MetricsCollector {
      * Collect metrics from all Pods with specific selector with wait
      */
     @SuppressWarnings("unchecked")
-    public void collectMetricsFromPods() {
+    public final void collectMetricsFromPods() {
         Map<String, String>[] metricsData = (Map<String, String>[]) new HashMap[1];
         TestUtils.waitFor("metrics to contain data", GLOBAL_POLL_INTERVAL, GLOBAL_TIMEOUT,
             () -> {
@@ -332,7 +332,7 @@ public class MetricsCollector {
         collectedData = metricsData[0];
     }
 
-    public Map<String, String> collectMetricsFromPodsWithoutWait() {
+    public final Map<String, String> collectMetricsFromPodsWithoutWait() {
         Map<String, String> map = new HashMap<>();
         kubeClient(namespaceName).listPods(namespaceName, componentLabelSelector).forEach(p -> {
             try {

--- a/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/metrics/MetricsCollector.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Resources;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ComponentType;
+import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaConnectResource;
 import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -291,7 +292,7 @@ public class MetricsCollector {
      * Collect metrics from specific pod
      * @return collected metrics
      */
-    protected String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
+    private String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
         List<String> executableCommand = Arrays.asList(cmdKubeClient(namespaceName).toString(), "exec", scraperPodName,
             "-n", namespaceName,
             "--", "curl", metricsPodIp + ":" + metricsPort + metricsPath);
@@ -302,7 +303,7 @@ public class MetricsCollector {
         // 20 seconds should be enough for collect data from the pod
         int ret = exec.execute(null, executableCommand, 20_000);
 
-        LOGGER.info("Metrics collection for Pod: {}/{}({}) from Pod: {}/{} finished with return code: {}", namespaceName, podName, metricsPodIp, namespaceName, scraperPodName, ret);
+        LOGGER.log(ResourceManager.getInstance().determineLogLevel(), "Metrics collection for Pod: {}/{}({}) from Pod: {}/{} finished with return code: {}", namespaceName, podName, metricsPodIp, namespaceName, scraperPodName, ret);
         return exec.out();
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
@@ -168,4 +168,10 @@ public interface PerformanceConstants {
      */
     String TOPIC_OPERATOR_PARSER = "topic-operator";
     String USER_OPERATOR_PARSER = "user-operator";
+
+    /**
+     * Performance specific related tags
+     */
+    String PERFORMANCE_CAPACITY = "performance-capacity";
+
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
@@ -89,6 +89,7 @@ public interface PerformanceConstants {
     String USER_OPERATOR_IN_USER_OPERATIONS_THREAD_POOL_SIZE = "IN: USER_OPERATIONS_THREAD_POOL_SIZE";
     String USER_OPERATOR_OUT_CREATION_TIME = "OUT: Creation Time (ms)";
     String USER_OPERATOR_OUT_DELETION_TIME = "OUT: Deletion Time (ms)";
+    String USER_OPERATOR_OUT_SUCCESSFUL_KAFKA_USERS_CREATED = "OUT: Successful KafkaUsers Created";
 
     String METRICS_HISTORY = "Metrics History";
 
@@ -149,6 +150,7 @@ public interface PerformanceConstants {
     String TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE = "bobStreamingUseCase";
     String TOPIC_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
     String USER_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
+    String USER_OPERATOR_CAPACITY_DEFAULT_USE_CASE = "capacityDefaultUseCase";
 
     /**
      * Performance metrics file

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/PerformanceConstants.java
@@ -150,7 +150,7 @@ public interface PerformanceConstants {
     String TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE = "bobStreamingUseCase";
     String TOPIC_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
     String USER_OPERATOR_ALICE_BULK_USE_CASE = "aliceBulkUseCase";
-    String USER_OPERATOR_CAPACITY_DEFAULT_USE_CASE = "capacityDefaultUseCase";
+    String USER_OPERATOR_CAPACITY_USE_CASE = "capacityUseCase";
 
     /**
      * Performance metrics file

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/gather/collectors/BaseMetricsCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/gather/collectors/BaseMetricsCollector.java
@@ -7,18 +7,12 @@ package io.strimzi.systemtest.performance.gather.collectors;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.systemtest.metrics.MetricsCollector;
 import io.strimzi.systemtest.performance.PerformanceConstants;
-import io.strimzi.test.executor.Exec;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
-
-import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 /**
  * Abstract base class for metrics collection tailored to gather various JVM and system metrics.
@@ -38,20 +32,6 @@ public abstract class BaseMetricsCollector extends MetricsCollector {
      */
     protected BaseMetricsCollector(Builder builder) {
         super(builder);
-    }
-
-    @Override
-    protected String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
-        final List<String> executableCommand = Arrays.asList(cmdKubeClient(namespaceName).toString(), "exec", scraperPodName,
-            "-n", namespaceName,
-            "--", "curl", metricsPodIp + ":" + metricsPort + metricsPath);
-
-        final Exec exec = new Exec();
-        final int ret = exec.execute(null, executableCommand, 20_000);
-
-        LOGGER.debug("Metrics collection for Pod: {}/{}({}) from Pod: {}/{} finished with return code: {}", namespaceName, podName, metricsPodIp, namespaceName, scraperPodName, ret);
-
-        return exec.out();
     }
 
     // -----------------------------------------------------------------------------------------------------

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/utils/UserOperatorPerformanceUtils.java
@@ -66,7 +66,12 @@ public class UserOperatorPerformanceUtils {
     }
 
     public static List<KafkaUser> getListOfKafkaUsers(final TestStorage testStorage, final String userName,
-                                                final int numberOfUsers, final UserAuthType userAuthType) {
+                                                      final int numberOfUsers, final UserAuthType userAuthType) {
+        return getListOfKafkaUsers(testStorage, userName, 0, numberOfUsers, userAuthType);
+    }
+
+    public static List<KafkaUser> getListOfKafkaUsers(final TestStorage testStorage, final String userName,
+                                                      final int startPointer, final int endPointer, final UserAuthType userAuthType) {
         List<KafkaUser> usersList = new ArrayList<>();
 
         KafkaUserAuthorizationSimple usersAcl = new KafkaUserAuthorizationSimpleBuilder()
@@ -78,7 +83,8 @@ public class UserOperatorPerformanceUtils {
             .endAcl()
             .build();
 
-        for (int i = 0; i < numberOfUsers; i++) {
+        // Loop over the specific range from startPointer to endPointer
+        for (int i = startPointer; i < endPointer; i++) {
             if (userAuthType.equals(UserAuthType.Tls)) {
                 usersList.add(
                     KafkaUserTemplates.tlsUser(testStorage.getNamespaceName(), testStorage.getClusterName(), userName + "-" + i)

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static io.strimzi.systemtest.TestConstants.PERFORMANCE;
+import static io.strimzi.systemtest.performance.PerformanceConstants.PERFORMANCE_CAPACITY;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 @Tag(PERFORMANCE)
@@ -284,6 +285,7 @@ public class UserOperatorPerformanceTest extends AbstractST {
         );
     }
 
+    @Tag(PERFORMANCE_CAPACITY)
     @ParameterizedTest
     @MethodSource("provideConfigurationsForCapacity")
     void testCapacity(String controllerThreadPoolSize, String cacheRefreshIntervalMs, String batchQueueSize,
@@ -318,32 +320,32 @@ public class UserOperatorPerformanceTest extends AbstractST {
                             .editOrNewTemplate()
                                 .editOrNewUserOperatorContainer()
                                     .addNewEnv()
-                                    .withName("STRIMZI_WORK_QUEUE_SIZE")
-                                    .withValue(workerQueueSize)
+                                        .withName("STRIMZI_WORK_QUEUE_SIZE")
+                                        .withValue(workerQueueSize)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_CONTROLLER_THREAD_POOL_SIZE")
-                                    .withValue(controllerThreadPoolSize)
+                                        .withName("STRIMZI_CONTROLLER_THREAD_POOL_SIZE")
+                                        .withValue(controllerThreadPoolSize)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_CACHE_REFRESH_INTERVAL_MS")
-                                    .withValue(cacheRefreshIntervalMs)
+                                        .withName("STRIMZI_CACHE_REFRESH_INTERVAL_MS")
+                                        .withValue(cacheRefreshIntervalMs)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_BATCH_QUEUE_SIZE")
-                                    .withValue(batchQueueSize)
+                                        .withName("STRIMZI_BATCH_QUEUE_SIZE")
+                                        .withValue(batchQueueSize)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_BATCH_MAXIMUM_BLOCK_SIZE")
-                                    .withValue(batchMaximumBlockSize)
+                                        .withName("STRIMZI_BATCH_MAXIMUM_BLOCK_SIZE")
+                                        .withValue(batchMaximumBlockSize)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_BATCH_MAXIMUM_BLOCK_TIME_MS")
-                                    .withValue(batchMaximumBlockTimeMs)
+                                        .withName("STRIMZI_BATCH_MAXIMUM_BLOCK_TIME_MS")
+                                        .withValue(batchMaximumBlockTimeMs)
                                     .endEnv()
                                     .addNewEnv()
-                                    .withName("STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE")
-                                    .withValue(userOperationsThreadPoolSize)
+                                        .withName("STRIMZI_USER_OPERATIONS_THREAD_POOL_SIZE")
+                                        .withValue(userOperationsThreadPoolSize)
                                     .endEnv()
                                 .endUserOperatorContainer()
                             .endTemplate()

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
@@ -272,14 +272,14 @@ public class UserOperatorPerformanceTest extends AbstractST {
      */
     private static Stream<Arguments> provideConfigurationsForCapacity() {
         return Stream.of(
-            // Default configuration
-//            Arguments.of("50", "15000", "1024", "100", "100", "4"),     // Successfully deployed 23,900 users.
-            // Enhanced Parallel Processing
-//            Arguments.of("100", "20000", "2048", "200", "50", "10"),    // Successfully provisioned 44,100 users.
-            // Conservative Batching
-            Arguments.of("75", "15000", "1500", "150", "75", "8"),      // Managed to support 46,200 users before the machine experienced a crash.
-            // Aggressive Batching
-            Arguments.of("100", "30000", "4096", "300", "100", "12")
+            // Default configuration (Successfully deployed 23,900 users.)
+            Arguments.of("50", "15000", "1024", "100", "100", "4")
+            //  Enhanced Parallel Processing (Successfully provisioned 44,100 users.)
+//            Arguments.of("100", "20000", "2048", "200", "50", "10"),
+            // Conservative Batching (Managed to support 46,200 users before the machine experienced a crash but with stronger machine 55100 users with UO 12 GiB memory consumption )
+//            Arguments.of("75", "15000", "1500", "150", "75", "8"),
+            // Aggressive Batching (very similar to Conservative Batching)
+//            Arguments.of("100", "30000", "4096", "300", "100", "12")
         );
     }
 
@@ -299,9 +299,9 @@ public class UserOperatorPerformanceTest extends AbstractST {
                 NodePoolsConverter.convertNodePoolsIfNeeded(
                     KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), brokerReplicas)
                         .editSpec()
-                        .withNewPersistentClaimStorage()
-                        .withSize("10Gi")
-                        .endPersistentClaimStorage()
+                            .withNewPersistentClaimStorage()
+                                .withSize("10Gi")
+                            .endPersistentClaimStorage()
                         .endSpec()
                         .build(),
                     KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), controllerReplicas).build()

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
@@ -273,15 +273,13 @@ public class UserOperatorPerformanceTest extends AbstractST {
     private static Stream<Arguments> provideConfigurationsForCapacity() {
         return Stream.of(
             // Default configuration
-            Arguments.of("50", "15000", "1024", "100", "100", "4"),
+//            Arguments.of("50", "15000", "1024", "100", "100", "4"),     // Successfully deployed 23,900 users.
             // Enhanced Parallel Processing
-            Arguments.of("100", "20000", "2048", "200", "50", "10"),
+//            Arguments.of("100", "20000", "2048", "200", "50", "10"),    // Successfully provisioned 44,100 users.
             // Conservative Batching
-            Arguments.of("75", "15000", "1500", "150", "75", "8"),
+            Arguments.of("75", "15000", "1500", "150", "75", "8"),      // Managed to support 46,200 users before the machine experienced a crash.
             // Aggressive Batching
-            Arguments.of("100", "30000", "4096", "300", "100", "12"),
-            // Low-Latency Operations
-            Arguments.of("50", "10000", "512", "50", "25", "6")
+            Arguments.of("100", "30000", "4096", "300", "100", "12")
         );
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformanceTest.java
@@ -107,14 +107,15 @@ public class UserOperatorPerformanceTest extends AbstractST {
     //      beneficial in very large-scale environments to avoid timeouts and stale data.
     @ParameterizedTest
     @MethodSource("provideConfigurationsForBulkBatchUseCase")
-    public void testAliceBulkBatchUseCase(int numberOfKafkaUsersToCreate,
-                                      String operationTimeoutMs, String workQueueSize, String controllerThreadPoolSize,
+    public void testAliceBulkBatchUseCase(int numberOfKafkaUsersToCreate, String controllerThreadPoolSize,
                                       String cacheRefreshIntervalMs, String batchQueueSize, String batchMaximumBlockSize,
                                       String batchMaximumBlockTimeMs, String userOperationsThreadPoolSize) throws IOException {
         final int brokerReplicas = 3;
         final int controllerReplicas = 3;
         long creationUsersMs = 0;
         long deletionUsersMs = 0;
+        // we set worker queue size to high number as we measure performance and not memory or sizing...
+        final String workerQueueSize = "10000";
 
         try {
             resourceManager.createResourceWithWait(
@@ -145,7 +146,7 @@ public class UserOperatorPerformanceTest extends AbstractST {
                                     .endEnv()
                                     .addNewEnv()
                                         .withName("STRIMZI_WORK_QUEUE_SIZE")
-                                        .withValue(String.valueOf(Integer.MAX_VALUE))
+                                        .withValue(workerQueueSize)
                                     .endEnv()
                                     .addNewEnv()
                                         .withName("STRIMZI_CONTROLLER_THREAD_POOL_SIZE")
@@ -222,8 +223,8 @@ public class UserOperatorPerformanceTest extends AbstractST {
 
                 final Map<String, Object> performanceAttributes = new LinkedHashMap<>();
                 performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_NUMBER_OF_KAFKA_USERS, numberOfKafkaUsersToCreate);
-                performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_OPERATION_TIMEOUT_MS, operationTimeoutMs);
-                performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_WORK_QUEUE_SIZE, workQueueSize);
+                performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_OPERATION_TIMEOUT_MS, "300000");
+                performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_WORK_QUEUE_SIZE, workerQueueSize);
                 performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_CONTROLLER_THREAD_POOL_SIZE, controllerThreadPoolSize);
                 performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_CACHE_REFRESH_INTERVAL_MS, cacheRefreshIntervalMs);
                 performanceAttributes.put(PerformanceConstants.USER_OPERATOR_IN_BATCH_QUEUE_SIZE, batchQueueSize);

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -219,7 +219,7 @@ finish:
         processors: ">= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
-       - size: ">= 100 GB"
+       - size: ">= 150 GB"
   discover+:
     test:
       - performance-capacity

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -14,7 +14,7 @@ provision:
     cpu:
       processors: ">= 8"
     disk:
-      size: ">= 50 GB"
+     - size: ">= 50 GB"
 
 # Install required packages and scripts for running strimzi suite
 prepare:
@@ -219,7 +219,7 @@ finish:
         processors: ">= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
-        size: ">= 100 GB"
+       - size: ">= 100 GB"
   discover+:
     test:
       - performance-capacity

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -13,6 +13,8 @@ provision:
     memory: ">= 24 GiB"
     cpu:
       processors: ">= 8"
+    disk:
+      size: ">= 50 GB"
 
 # Install required packages and scripts for running strimzi suite
 prepare:
@@ -201,7 +203,7 @@ finish:
       memory: ">= 36 GiB"
       cpu:
         processors: ">= 8"
-     # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
+      # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
         size: ">= 100 GB"
   discover+:
@@ -215,7 +217,7 @@ finish:
       memory: ">= 36 GiB"
       cpu:
         processors: ">= 8"
-     # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
+      # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
         size: ">= 100 GB"
   discover+:

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -198,10 +198,27 @@ finish:
   summary: Run performance test suite with kraft
   provision:
     hardware:
-      memory: ">= 30 GiB"
+      memory: ">= 36 GiB"
       cpu:
         processors: ">= 8"
+     # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
+      disk:
+        size: ">= 100 GB"
   discover+:
     test:
       - performance
+
+/performance-capacity:
+  summary: Run performance test suite with kraft
+  provision:
+    hardware:
+      memory: ">= 36 GiB"
+      cpu:
+        processors: ">= 8"
+     # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
+      disk:
+        size: ">= 100 GB"
+  discover+:
+    test:
+      - performance-capacity
 

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -200,12 +200,12 @@ finish:
   summary: Run performance test suite with kraft
   provision:
     hardware:
-      memory: "= 32 GiB"
+      memory: ">= 30 GiB"
       cpu:
-        processors: "= 8"
+        processors: ">= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
-        size: ">= 100 GB"
+        size: ">= 60 GB"
   discover+:
     test:
       - performance
@@ -214,12 +214,12 @@ finish:
   summary: Run performance test suite with kraft
   provision:
     hardware:
-      memory: "= 32 GiB"
+      memory: ">= 30 GiB"
       cpu:
-        processors: "= 8"
+        processors: ">= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
-       - size: ">= 100 GB"
+       - size: ">= 60 GB"
   discover+:
     test:
       - performance-capacity

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -200,9 +200,9 @@ finish:
   summary: Run performance test suite with kraft
   provision:
     hardware:
-      memory: ">= 36 GiB"
+      memory: "= 32 GiB"
       cpu:
-        processors: ">= 8"
+        processors: "= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
         size: ">= 100 GB"
@@ -214,12 +214,12 @@ finish:
   summary: Run performance test suite with kraft
   provision:
     hardware:
-      memory: ">= 36 GiB"
+      memory: "= 32 GiB"
       cpu:
-        processors: ">= 8"
+        processors: "= 8"
       # it seems that default disk size (i.e., 50GB) is not enough for capacity tests
       disk:
-       - size: ">= 150 GB"
+       - size: ">= 100 GB"
   discover+:
     test:
       - performance-capacity

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -75,3 +75,12 @@ adjust:
   environment+:
     TEST_PROFILE: performance
     PARALLELISM_ENABLED: false
+
+/performance-capacity:
+  summary: Run performance capacity strimzi test suite
+  tags: [strimzi, kafka, kraft, performance, performance-capacity]
+  duration: 24h
+  tier: 1
+  environment+:
+    TEST_PROFILE: performance-capacity
+    PARALLELISM_ENABLED: false


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR introduces parameterized tests aimed at evaluating the capacity and performance of the system under various operational conditions. By adjusting parameters such as controller thread pool size, cache refresh intervals, batch queue size, and user operations thread pool size, the tests simulate different levels of parallel processing, batching strategies, and operational latencies. This helps in understanding how different configurations impact system performance.

We do that incrementally (pseudo-code):
```java
Initialize Test Parameters

while true:
    start = successfulCreations
    end = start + batchSize
    users = getUserBatch(testStorage, username, start, end, authType)

    try:
        createUsersAndWait(testStorage, users, username)
        successfulCreations += batchSize
        log "Batch created and verified from start to end"
    catch exception:
        log "Batch creation failed from start to end with error"
        collectLogs() // this is needed because then we could find a possible problem what is a bottleneck...
        break
```

Multi-node cluster (ZK-based)
```java
Use Case: capacityDefaultUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 4800                               | 716.524856                          | 0.23875                          |
| 2          | 300000                   | 10000               | 100                             | 20000                         | 2048                 | 200                          | 50                              | 100                                  | 4800                               | 877.894032                          | 0.2825                           |
| 3          | 300000                   | 10000               | 75                              | 15000                         | 1500                 | 150                          | 75                              | 75                                   | 4800                               | 548.884896                          | 0.2825                           |
| 4          | 300000                   | 10000               | 100                             | 30000                         | 4096                 | 300                          | 100                             | 100                                  | 4800                               | 638.626608                          | 0.243125                         |
| 5          | 300000                   | 10000               | 50                              | 10000                         | 512                  | 50                           | 25                              | 50                                   | 4800                               | 725.024336                          | 0.2375                           |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```

```java
[2024-04-28T19:39:03.891Z] | Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created |
[2024-04-28T19:39:03.891Z] | 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 4800                               |
[2024-04-28T19:39:03.891Z] +------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+
```


**Multi-node KRaft-based** (9624 s -> 2.67333333 hours):
```java
[2024-04-29T00:04:39.287Z] +------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+
[2024-04-29T00:04:39.287Z] | Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created |
[2024-04-29T00:04:39.287Z] | 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 19300                              |
[2024-04-29T00:04:39.288Z] +------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+
```

**Testing farm (i.e., KRAft-based clusters)**

Testing farm:
```java
Use Case: capacityUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 21100                              | 3326.59004                          | 0.885                            |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```
Testing farm with default configuration **ARM**:
```java
Use Case: capacityUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 26000                              | 5110.567712                         | 0.2990625                        |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```

Testing farm with default configuration **Intel**:
```java
Use Case: capacityUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 50                              | 15000                         | 1024                 | 100                          | 100                             | 50                                   | 48700                              | 10118.300232                        | 0.3009375                        |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```



Testing farm **ARM**:
```java
Use Case: capacityUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 75                              | 15000                         | 1500                 | 150                          | 75                              | 75                                   | 46500                              | 9316.4262                           | 0.4915625                        |
| 2          | 300000                   | 10000               | 100                             | 30000                         | 4096                 | 300                          | 100                             | 100                                  | 45800                              | 9347.137992                         | 0.506875                         |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```
Testing farm **INTEL**:
```java
Use Case: capacityUseCase
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
| Experiment | IN: OPERATION_TIMEOUT_MS | IN: WORK_QUEUE_SIZE | IN: CONTROLLER_THREAD_POOL_SIZE | IN: CACHE_REFRESH_INTERVAL_MS | IN: BATCH_QUEUE_SIZE | IN: BATCH_MAXIMUM_BLOCK_SIZE | IN: BATCH_MAXIMUM_BLOCK_TIME_MS | IN: USER_OPERATIONS_THREAD_POOL_SIZE | OUT: Successful KafkaUsers Created | jvm_memory_used_megabytes_total.txt | system_load_average_per_core.txt |
| 1          | 300000                   | 10000               | 75                              | 15000                         | 1500                 | 150                          | 75                              | 75                                   | 55100                              | 12310.114608                        | 0.3594791666666666               |
| 2          | 300000                   | 10000               | 100                             | 30000                         | 4096                 | 300                          | 100                             | 100                                  | 52500                              | 12179.524968                        | 0.3802083333333333               |
+------------+--------------------------+---------------------+---------------------------------+-------------------------------+----------------------+------------------------------+---------------------------------+--------------------------------------+------------------------------------+-------------------------------------+----------------------------------+
```

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass
