### PR TITLE
Add early-access warning about JBOD in KRaft to CHANGELOG and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for Apache Kafka 3.6.2
 * Provide metrics to monitor certificates expiration as well as modified `Strimzi Operators` dashboard to include certificate expiration per cluster.
 * Add support for JBOD storage in KRaft mode.
+  (Note: JBOD support in KRaft mode is considered early-access in Apache Kafka 3.7.x)
 * Added support for topic replication factor change to the Unidirectional Topic Operator when Cruise Control integration is enabled.
 * The `KafkaNodePools` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
   To use the Kafka Node Pool resources, you still need to use the `strimzi.io/node-pools: enabled` annotation on the `Kafka` custom resources.

--- a/documentation/modules/configuring/ref-storage-jbod.adoc
+++ b/documentation/modules/configuring/ref-storage-jbod.adoc
@@ -72,6 +72,8 @@ When running a Kafka cluster in a KRaft mode, each node must store the KRaft met
 By default, the KRaft metadata log is stored on the volume with the lowest ID.
 However, you can specify another volume using the `kraftMetadata` property.
 
+NOTE: JBOD storage in KRaft mode is considered early-access in Apache Kafka 3.7.x.
+
 .Example JBOD storage configuration using volume with ID 1 to store the KRaft metadata
 [source,yaml,subs="attributes+"]
 ----

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -107,6 +107,7 @@ The `Kafka` custom resource using KRaft mode must also have the annotation `stri
 Currently, the KRaft mode in Strimzi has the following major limitations:
 
 * JBOD storage is supported only with Apache Kafka 3.7.0 and higher.
+  It is considered early-access in Apache Kafka 3.7.x.
   (Storage with `type: jbod` configuration can be used also with older Kafka versions, but the JBOD array can contain only one disk.)
 * Scaling of KRaft controller-only nodes up or down is not supported.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As JBOD support in KRaft is still considered early access in Apache Kafka 3.7.x, we should warn about it in the CHANGELOG (release ntoes) and in our docs.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md