### PR TITLE
Fix `offset.show-all` switch in Kafka Exporter

### DIFF
--- a/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
+++ b/docker-images/kafka-based/kafka/exporter-scripts/kafka_exporter_run.sh
@@ -30,8 +30,9 @@ if [ "$KAFKA_EXPORTER_ENABLE_SARAMA" = "true" ]; then
     saramaenable="--log.enable-sarama"
 fi
 
-if [ "$KAFKA_EXPORTER_OFFSET_SHOW_ALL" = "true" ]; then
-    allgroups="--offset.show-all"
+if [ "$KAFKA_EXPORTER_OFFSET_SHOW_ALL" = "false" ]; then
+    # This is enabled by default, so we have to disable it if it is set to false
+    allgroups="--no-offset.show-all"
 fi
 
 if [ -n "$KAFKA_EXPORTER_LOGGING" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `offset.show-all` switch from #9494 does not work because it is enabled by default in Kafka Exporter. So we need to disable it when it is disabled in the Kafka CR. But today, we just enable it when it is enabled in Kafka CR, so as a result it is always on. This PR flips the condition to disable it in Kafka Exporter when set to false.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md