### PR TITLE
Remove unneeded state (old certificate secrets) from the `Ca` classes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.common.CertificateAuthority;
 import io.strimzi.api.kafka.model.common.CertificateExpirationPolicy;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
-import io.strimzi.api.kafka.model.kafka.exporter.KafkaExporterResources;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.IpAndDnsValidation;
@@ -43,16 +42,6 @@ public class ClusterCa extends Ca {
      * and delete it when it is not needed anymore.
      */
     private static final Pattern OLD_CA_CERT_PATTERN = Pattern.compile("^ca-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}Z.crt$");
-
-    private final String clusterName;
-    private Secret entityTopicOperatorSecret;
-    private Secret entityUserOperatorSecret;
-    private Secret clusterOperatorSecret;
-    private Secret kafkaExporterSecret;
-    private Secret cruiseControlSecret;
-
-    private Secret brokersSecret;
-    private Secret zkNodesSecret;
 
     /**
      * Constructor
@@ -97,7 +86,6 @@ public class ClusterCa extends Ca {
                 clusterCaCert,
                 AbstractModel.clusterCaKeySecretName(clusterName),
                 clusterCaKey, validityDays, renewalDays, generateCa, policy);
-        this.clusterName = clusterName;
     }
 
     @Override
@@ -106,63 +94,36 @@ public class ClusterCa extends Ca {
     }
 
     /**
-     * Initializes the CA Secrets inside this class
+     * Prepares the Cruise Control certificate. It either reuses the existing certificate, renews it or generates new
+     * certificate if needed.
      *
-     * @param secrets   List with the secrets
+     * @param namespace                             Namespace of the Kafka cluster
+     * @param clusterName                           Name of the Kafka cluster
+     * @param existingSecret                        Existing Secret with the existing certificates (or null if it does not exist yet)
+     * @param isMaintenanceTimeWindowsSatisfied     Flag indicating whether we can do maintenance tasks or not
+     *
+     * @return  Map with CertAndKey object containing the public and private key
+     *
+     * @throws IOException  IOException is thrown when it is raised while working with the certificates
      */
-    public void initCaSecrets(List<Secret> secrets) {
-        for (Secret secret: secrets) {
-            String name = secret.getMetadata().getName();
-            if (KafkaResources.kafkaSecretName(clusterName).equals(name)) {
-                brokersSecret = secret;
-            } else if (KafkaResources.entityTopicOperatorSecretName(clusterName).equals(name)) {
-                entityTopicOperatorSecret = secret;
-            } else if (KafkaResources.entityUserOperatorSecretName(clusterName).equals(name)) {
-                entityUserOperatorSecret = secret;
-            } else if (KafkaResources.zookeeperSecretName(clusterName).equals(name)) {
-                zkNodesSecret = secret;
-            } else if (KafkaResources.secretName(clusterName).equals(name)) {
-                clusterOperatorSecret = secret;
-            } else if (KafkaExporterResources.secretName(clusterName).equals(name)) {
-                kafkaExporterSecret = secret;
-            } else if (CruiseControlResources.secretName(clusterName).equals(name)) {
-                cruiseControlSecret = secret;
-            }
-        }
-    }
-
-    protected Secret entityTopicOperatorSecret() {
-        return entityTopicOperatorSecret;
-    }
-
-    protected Secret entityUserOperatorSecret() {
-        return entityUserOperatorSecret;
-    }
-
-    /**
-     * @return  The secret with the Cluster Operator certificate
-     */
-    public Secret clusterOperatorSecret() {
-        return clusterOperatorSecret;
-    }
-
-    protected Secret kafkaExporterSecret() {
-        return kafkaExporterSecret;
-    }
-
-    protected Map<String, CertAndKey> generateCcCerts(String namespace, String kafkaName, boolean isMaintenanceTimeWindowsSatisfied) throws IOException {
-        DnsNameGenerator ccDnsGenerator = DnsNameGenerator.of(namespace, CruiseControlResources.serviceName(kafkaName));
+    protected Map<String, CertAndKey> generateCcCerts(
+            String namespace,
+            String clusterName,
+            Secret existingSecret,
+            boolean isMaintenanceTimeWindowsSatisfied
+    ) throws IOException {
+        DnsNameGenerator ccDnsGenerator = DnsNameGenerator.of(namespace, CruiseControlResources.serviceName(clusterName));
 
         Function<NodeRef, Subject> subjectFn = node -> {
             Subject.Builder subject = new Subject.Builder()
                     .withOrganizationName("io.strimzi")
-                    .withCommonName(CruiseControlResources.serviceName(kafkaName));
+                    .withCommonName(CruiseControlResources.serviceName(clusterName));
 
-            subject.addDnsName(CruiseControlResources.serviceName(kafkaName));
-            subject.addDnsName(String.format("%s.%s", CruiseControlResources.serviceName(kafkaName), namespace));
+            subject.addDnsName(CruiseControlResources.serviceName(clusterName));
+            subject.addDnsName(String.format("%s.%s", CruiseControlResources.serviceName(clusterName), namespace));
             subject.addDnsName(ccDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(ccDnsGenerator.serviceDnsName());
-            subject.addDnsName(CruiseControlResources.serviceName(kafkaName));
+            subject.addDnsName(CruiseControlResources.serviceName(clusterName));
             subject.addDnsName("localhost");
             return subject.build();
         };
@@ -172,30 +133,45 @@ public class ClusterCa extends Ca {
             reconciliation,
             Set.of(new NodeRef("cruise-control", 0, null, false, false)),
             subjectFn,
-            cruiseControlSecret,
+            existingSecret,
             isMaintenanceTimeWindowsSatisfied);
     }
 
+    /**
+     * Prepares the ZooKeeper node certificates. It either reuses the existing certificates, renews them or generates new
+     * certificates if needed.
+     *
+     * @param namespace                             Namespace of the Kafka cluster
+     * @param clusterName                           Name of the Kafka cluster
+     * @param existingSecret                        Existing Secret with the existing certificates (or null if it does not exist yet)
+     * @param nodes                                 Nodes that are part of the ZooKeeper cluster
+     * @param isMaintenanceTimeWindowsSatisfied     Flag indicating whether we can do maintenance tasks or not
+     *
+     * @return  Map with CertAndKey objects containing the public and private keys for the different nodes
+     *
+     * @throws IOException  IOException is thrown when it is raised while working with the certificates
+     */
     protected Map<String, CertAndKey> generateZkCerts(
             String namespace,
-            String crName,
+            String clusterName,
+            Secret existingSecret,
             Set<NodeRef> nodes,
             boolean isMaintenanceTimeWindowsSatisfied
     ) throws IOException {
-        DnsNameGenerator zkDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperServiceName(crName));
-        DnsNameGenerator zkHeadlessDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperHeadlessServiceName(crName));
+        DnsNameGenerator zkDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperServiceName(clusterName));
+        DnsNameGenerator zkHeadlessDnsGenerator = DnsNameGenerator.of(namespace, KafkaResources.zookeeperHeadlessServiceName(clusterName));
 
         Function<NodeRef, Subject> subjectFn = node -> {
             Subject.Builder subject = new Subject.Builder()
                     .withOrganizationName("io.strimzi")
-                    .withCommonName(KafkaResources.zookeeperComponentName(crName));
-            subject.addDnsName(KafkaResources.zookeeperServiceName(crName));
-            subject.addDnsName(String.format("%s.%s", KafkaResources.zookeeperServiceName(crName), namespace));
+                    .withCommonName(KafkaResources.zookeeperComponentName(clusterName));
+            subject.addDnsName(KafkaResources.zookeeperServiceName(clusterName));
+            subject.addDnsName(String.format("%s.%s", KafkaResources.zookeeperServiceName(clusterName), namespace));
             subject.addDnsName(zkDnsGenerator.serviceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.serviceDnsName());
             subject.addDnsName(node.podName());
-            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.zookeeperHeadlessServiceName(crName), node.podName()));
-            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.zookeeperHeadlessServiceName(crName), node.podName()));
+            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.zookeeperHeadlessServiceName(clusterName), node.podName()));
+            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.zookeeperHeadlessServiceName(clusterName), node.podName()));
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
             subject.addDnsName(zkDnsGenerator.wildcardServiceDnsName());
             subject.addDnsName(zkHeadlessDnsGenerator.wildcardServiceDnsNameWithoutClusterDomain());
@@ -203,18 +179,35 @@ public class ClusterCa extends Ca {
             return subject.build();
         };
 
-        LOGGER.debugCr(reconciliation, "{}: Reconciling zookeeper certificates", this);
+        LOGGER.debugCr(reconciliation, "{}: Reconciling ZooKeeper certificates", this);
         return maybeCopyOrGenerateCerts(
             reconciliation,
             nodes,
             subjectFn,
-            zkNodesSecret,
+            existingSecret,
             isMaintenanceTimeWindowsSatisfied);
     }
 
+    /**
+     * Prepares the Kafka broker certificates. It either reuses the existing certificates, renews them or generates new
+     * certificates if needed.
+     *
+     * @param namespace                             Namespace of the Kafka cluster
+     * @param clusterName                           Name of the Kafka cluster
+     * @param existingSecret                        Existing Secret with the existing certificates (or null if it does not exist yet)
+     * @param nodes                                 Nodes that are part of the Kafka cluster
+     * @param externalBootstrapAddresses            List of external bootstrap addresses (used for certificate SANs)
+     * @param externalAddresses                     Map with external listener addresses for the different nodes (used for certificate SANs)
+     * @param isMaintenanceTimeWindowsSatisfied     Flag indicating whether we can do maintenance tasks or not
+     *
+     * @return  Map with CertAndKey objects containing the public and private keys for the different brokers
+     *
+     * @throws IOException  IOException is thrown when it is raised while working with the certificates
+     */
     protected Map<String, CertAndKey> generateBrokerCerts(
             String namespace,
-            String crName,
+            String clusterName,
+            Secret existingSecret,
             Set<NodeRef> nodes,
             Set<String> externalBootstrapAddresses,
             Map<Integer, Set<String>> externalAddresses,
@@ -223,13 +216,13 @@ public class ClusterCa extends Ca {
         Function<NodeRef, Subject> subjectFn = node -> {
             Subject.Builder subject = new Subject.Builder()
                     .withOrganizationName("io.strimzi")
-                    .withCommonName(KafkaResources.kafkaComponentName(crName));
+                    .withCommonName(KafkaResources.kafkaComponentName(clusterName));
 
-            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.bootstrapServiceName(crName)));
-            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.brokersServiceName(crName)));
+            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.bootstrapServiceName(clusterName)));
+            subject.addDnsNames(ModelUtils.generateAllServiceDnsNames(namespace, KafkaResources.brokersServiceName(clusterName)));
 
-            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
-            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(crName), node.podName()));
+            subject.addDnsName(DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(clusterName), node.podName()));
+            subject.addDnsName(DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(clusterName), node.podName()));
 
             // Controller-only nodes do not have the SANs for external listeners.
             // That helps us to avoid unnecessary rolling updates when the SANs change
@@ -264,24 +257,13 @@ public class ClusterCa extends Ca {
             reconciliation,
             nodes,
             subjectFn,
-            brokersSecret,
+            existingSecret,
             isMaintenanceTimeWindowsSatisfied);
     }
 
     @Override
     protected String caCertGenerationAnnotation() {
         return ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION;
-    }
-
-    @SuppressWarnings("BooleanExpressionComplexity")
-    @Override
-    protected boolean hasCaCertGenerationChanged() {
-        // at least one Secret has a different cluster CA certificate thumbprint.
-        // it is useful when a renewal cluster CA certificate process needs to be recovered after an operator crash
-        return hasCaCertGenerationChanged(zkNodesSecret) || hasCaCertGenerationChanged(brokersSecret) ||
-                hasCaCertGenerationChanged(entityTopicOperatorSecret) || hasCaCertGenerationChanged(entityUserOperatorSecret) ||
-                hasCaCertGenerationChanged(kafkaExporterSecret) || hasCaCertGenerationChanged(cruiseControlSecret) ||
-                hasCaCertGenerationChanged(clusterOperatorSecret);
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -495,22 +495,22 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
 
     /**
      * Generate the Secret containing the Cruise Control certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka
-     * It also contains the related Cruise Control private key.
+     * internal communication with Kafka. It also contains the related Cruise Control private key.
      *
-     * @param namespace Namespace in which the Cruise Control cluster runs
-     * @param kafkaName Name of the Kafka cluster (it is used for the SANs in the certificate)
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
+     * @param namespace                             Namespace in which the Cruise Control cluster runs
+     * @param clusterName                           Name of the Kafka cluster (it is used for the SANs in the certificate)
+     * @param clusterCa                             The cluster CA.
+     * @param existingSecret                        The existing secret with Kafka certificates
+     * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in the maintenance window or not.
+     *                                              This is used for certificate renewals
      *
      * @return The generated Secret.
      */
-    public Secret generateCertificatesSecret(String namespace, String kafkaName, ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
+    public Secret generateCertificatesSecret(String namespace, String clusterName, ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
         Map<String, CertAndKey> ccCerts = new HashMap<>(4);
         LOGGER.debugCr(reconciliation, "Generating certificates");
         try {
-            ccCerts = clusterCa.generateCcCerts(namespace, kafkaName, isMaintenanceTimeWindowsSatisfied);
+            ccCerts = clusterCa.generateCcCerts(namespace, clusterName, existingSecret, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -251,20 +251,17 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
     }
 
     /**
-     * Generate the Secret containing the Entity Topic Operator certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka.
-     * It also contains the related Entity Topic Operator private key.
+     * Generate the Secret containing the Entity Topic Operator certificate signed by the cluster CA certificate used
+     * for TLS based internal communication with Kafka.
      *
-     * Note: This certificate will be used by both Topic Operator Container and the TLS sidecar container. The User Operator Container use a separate certificate.
-     *
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
+     * @param clusterCa                             The cluster CA.
+     * @param existingSecret                        The existing secret with Kafka certificates
+     * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in the maintenance window or not.
+     *                                              This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        Secret secret = clusterCa.entityTopicOperatorSecret();
-        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityTopicOperatorSecretName(cluster), componentName,
+    public Secret generateSecret(ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
+        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, existingSecret, namespace, KafkaResources.entityTopicOperatorSecretName(cluster), componentName,
             CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityUserOperator.java
@@ -254,18 +254,17 @@ public class EntityUserOperator extends AbstractModel implements SupportsLogging
     }
 
     /**
-     * Generate the Secret containing the Entity User Operator certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka and Zookeeper.
-     * It also contains the related Entity User Operator private key.
+     * Generate the Secret containing the Entity User Operator certificate signed by the cluster CA certificate used for
+     * TLS based internal communication with Kafka.
      *
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
+     * @param clusterCa                             The cluster CA.
+     * @param existingSecret                        The existing secret with Kafka certificates
+     * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in the maintenance window or not.
+     *                                              This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        Secret secret = clusterCa.entityUserOperatorSecret();
-        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, secret, namespace, KafkaResources.entityUserOperatorSecretName(cluster), componentName,
+    public Secret generateSecret(ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
+        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, existingSecret, namespace, KafkaResources.entityUserOperatorSecretName(cluster), componentName,
             CERT_SECRET_KEY_NAME, labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1149,18 +1149,19 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @param clusterCa                             The CA for cluster certificates
      * @param clientsCa                             The CA for clients certificates
+     * @param existingSecret                        The existing secret with Kafka certificates
      * @param externalBootstrapDnsName              Map with bootstrap DNS names which should be added to the certificate
      * @param externalDnsNames                      Map with broker DNS names  which should be added to the certificate
      * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in a maintenance window or not
      *
      * @return  The generated Secret with broker certificates
      */
-    public Secret generateCertificatesSecret(ClusterCa clusterCa, ClientsCa clientsCa, Set<String> externalBootstrapDnsName, Map<Integer, Set<String>> externalDnsNames, boolean isMaintenanceTimeWindowsSatisfied) {
+    public Secret generateCertificatesSecret(ClusterCa clusterCa, ClientsCa clientsCa, Secret existingSecret, Set<String> externalBootstrapDnsName, Map<Integer, Set<String>> externalDnsNames, boolean isMaintenanceTimeWindowsSatisfied) {
         Set<NodeRef> nodes = nodes();
         Map<String, CertAndKey> brokerCerts;
 
         try {
-            brokerCerts = clusterCa.generateBrokerCerts(namespace, cluster, nodes, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
+            brokerCerts = clusterCa.generateBrokerCerts(namespace, cluster, existingSecret, nodes, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare Kafka certificates", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaExporter.java
@@ -262,17 +262,16 @@ public class KafkaExporter extends AbstractModel {
 
     /**
      * Generate the Secret containing the Kafka Exporter certificate signed by the cluster CA certificate used for TLS based
-     * internal communication with Kafka and Zookeeper.
-     * It also contains the related Kafka Exporter private key.
+     * internal communication with Kafka and Zookeeper. It also contains the related Kafka Exporter private key.
      *
-     * @param clusterCa The cluster CA.
-     * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
-     *                                          This is used for certificate renewals
+     * @param clusterCa                             The cluster CA.
+     * @param existingSecret                        The existing secret with Kafka certificates
+     * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in the maintenance window or not.
+     *                                              This is used for certificate renewals
      * @return The generated Secret.
      */
-    public Secret generateSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
-        Secret secret = clusterCa.kafkaExporterSecret();
-        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, secret, namespace, KafkaExporterResources.secretName(cluster), componentName,
+    public Secret generateSecret(ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
+        return CertUtils.buildTrustedCertificateSecret(reconciliation, clusterCa, existingSecret, namespace, KafkaExporterResources.secretName(cluster), componentName,
                 "kafka-exporter", labels, ownerReference, isMaintenanceTimeWindowsSatisfied);
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -437,15 +437,16 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
      * based internal communication with Kafka. It contains both the public and private keys.
      *
      * @param clusterCa                         The CA for cluster certificates
+     * @param existingSecret                    The existing secret with ZooKeeper certificates
      * @param isMaintenanceTimeWindowsSatisfied Indicates whether we are in the maintenance window or not.
      *
      * @return The generated Secret with the ZooKeeper node certificates
      */
-    public Secret generateCertificatesSecret(ClusterCa clusterCa, boolean isMaintenanceTimeWindowsSatisfied) {
+    public Secret generateCertificatesSecret(ClusterCa clusterCa, Secret existingSecret, boolean isMaintenanceTimeWindowsSatisfied) {
         Map<String, CertAndKey> certs;
 
         try {
-            certs = clusterCa.generateZkCerts(namespace, cluster, nodes(), isMaintenanceTimeWindowsSatisfied);
+            certs = clusterCa.generateZkCerts(namespace, cluster, existingSecret, nodes(), isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare ZooKeeper certificates", e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -228,7 +228,7 @@ public class CruiseControlReconciler {
                     .compose(oldSecret -> {
                         return secretOperator
                                 .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.secretName(reconciliation.name()),
-                                        cruiseControl.generateCertificatesSecret(reconciliation.namespace(), reconciliation.name(), clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                        cruiseControl.generateCertificatesSecret(reconciliation.namespace(), reconciliation.name(), clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -373,7 +373,7 @@ public class EntityOperatorReconciler {
                     .compose(oldSecret -> {
                         return secretOperator
                                 .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityTopicOperatorSecretName(reconciliation.name()),
-                                        entityOperator.topicOperator().generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                        entityOperator.topicOperator().generateSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred
@@ -406,7 +406,7 @@ public class EntityOperatorReconciler {
                     .compose(oldSecret -> {
                         return secretOperator
                                 .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorSecretName(reconciliation.name()),
-                                        entityOperator.userOperator().generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                        entityOperator.userOperator().generateSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -130,7 +130,7 @@ public class KafkaExporterReconciler {
                     .compose(oldSecret -> {
                         return secretOperator
                                 .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.secretName(reconciliation.name()),
-                                        kafkaExporter.generateSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                        kafkaExporter.generateSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                                 .compose(patchResult -> {
                                     if (patchResult instanceof ReconcileResult.Patched) {
                                         // The secret is patched and some changes to the existing certificates actually occurred

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -703,7 +703,7 @@ public class KafkaReconciler {
                 .compose(oldSecret -> {
                     return secretOperator
                             .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaSecretName(reconciliation.name()),
-                                    kafka.generateCertificatesSecret(clusterCa, clientsCa, listenerReconciliationResults.bootstrapDnsNames, listenerReconciliationResults.brokerDnsNames, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                    kafka.generateCertificatesSecret(clusterCa, clientsCa, oldSecret, listenerReconciliationResults.bootstrapDnsNames, listenerReconciliationResults.brokerDnsNames, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                             .compose(patchResult -> {
                                 if (patchResult != null) {
                                     for (NodeRef node : kafka.nodes()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -431,7 +431,7 @@ public class ZooKeeperReconciler {
                 .compose(oldSecret -> {
                     return secretOperator
                             .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.zookeeperSecretName(reconciliation.name()),
-                                    zk.generateCertificatesSecret(clusterCa, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
+                                    zk.generateCertificatesSecret(clusterCa, oldSecret, Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant())))
                             .compose(patchResult -> {
                                 if (patchResult != null) {
                                     for (int podNum = 0; podNum < zk.getReplicas(); podNum++) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -40,7 +41,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
 
         // force key replacement so certificate renewal ...
@@ -55,7 +56,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(4));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(true));
 
@@ -65,7 +66,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), clusterCa.caKeySecret());
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(false));
     }
@@ -78,7 +79,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         // check certificate expiration out of the renewal period, certificate is not expiring
         instantExpected = "2023-02-15T09:00:00Z";
@@ -101,7 +102,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
 
         // force key replacement so certificate renewal ...
@@ -116,7 +117,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(4));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(true));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -205,11 +205,11 @@ public class KafkaClusterTest {
 
     private Secret generateBrokerSecret(Set<String> externalBootstrapAddress, Map<Integer, Set<String>> externalAddresses) {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         ClientsCa clientsCa = new ClientsCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), null, null, null, null, 365, 30, true, CertificateExpirationPolicy.RENEW_CERTIFICATE);
-        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
-        return KC.generateCertificatesSecret(clusterCa, clientsCa, externalBootstrapAddress, externalAddresses, true);
+        return KC.generateCertificatesSecret(clusterCa, clientsCa, null, externalBootstrapAddress, externalAddresses, true);
     }
 
     //////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -443,9 +443,9 @@ public class KafkaClusterWithKRaftTest {
     @Test
     public void testGenerateBrokerSecretExternalWithManyDNS() throws CertificateParsingException {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER_NAME, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER_NAME, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER_NAME, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         ClientsCa clientsCa = new ClientsCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), null, null, null, null, 365, 30, true, CertificateExpirationPolicy.RENEW_CERTIFICATE);
-        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER_NAME, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER_NAME, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         KafkaCluster kc = KafkaCluster.fromCrd(
                 Reconciliation.DUMMY_RECONCILIATION,
@@ -462,7 +462,7 @@ public class KafkaClusterWithKRaftTest {
         externalAddresses.put(1001, TestUtils.set("123.10.125.131", "my-broker-1001"));
         externalAddresses.put(1002, TestUtils.set("123.10.125.132", "my-broker-1002"));
 
-        Secret secret = kc.generateCertificatesSecret(clusterCa, clientsCa, TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses, true);
+        Secret secret = kc.generateCertificatesSecret(clusterCa, clientsCa, null, TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses, true);
         assertThat(secret.getData().keySet(), is(set(
                 "my-cluster-controllers-0.crt",  "my-cluster-controllers-0.key", "my-cluster-controllers-0.p12", "my-cluster-controllers-0.password",
                 "my-cluster-controllers-1.crt", "my-cluster-controllers-1.key", "my-cluster-controllers-1.p12", "my-cluster-controllers-1.password",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -149,9 +149,9 @@ public class ZookeeperClusterTest {
 
     private Secret generateCertificatesSecret() {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, true);
+        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
-        return ZC.generateCertificatesSecret(clusterCa, true);
+        return ZC.generateCertificatesSecret(clusterCa, null, true);
     }
 
     //////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -164,6 +164,7 @@ public class CaReconcilerTest {
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), c.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.noop(i.getArgument(0))));
+        when(secretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(NAME)))).thenAnswer(i -> Future.succeededFuture());
         when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.secretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
 
         when(deploymentOps.getAsync(eq(NAMESPACE), any())).thenReturn(Future.succeededFuture());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
@@ -83,6 +83,8 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -184,6 +186,8 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -301,6 +305,7 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -410,6 +415,7 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconcilerTest.java
@@ -76,6 +76,7 @@ public class KafkaExporterReconcilerTest {
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.componentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
         SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaExporterResources.secretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
 
@@ -143,6 +144,7 @@ public class KafkaExporterReconcilerTest {
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.componentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
         SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaExporterResources.secretName(NAME)))).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> secretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaExporterResources.secretName(NAME)), secretCaptor.capture())).thenReturn(Future.succeededFuture());
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ClientsCa.java
@@ -13,8 +13,6 @@ import io.strimzi.operator.common.Reconciliation;
  * Represents the Strimzi Clients CA
  */
 public class ClientsCa extends Ca {
-    private Secret brokersSecret;
-
     /**
      * Creates a ClientsCA instance
      *
@@ -39,23 +37,9 @@ public class ClientsCa extends Ca {
                 clientsCaKey, validityDays, renewalDays, generateCa, policy);
     }
 
-    /**
-     * Passes the current broker Secret during reconciliation
-     *
-     * @param secret    Kubernetes Secret
-     */
-    public void initBrokerSecret(Secret secret) {
-        this.brokersSecret = secret;
-    }
-
     @Override
     public String caCertGenerationAnnotation() {
         return ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION;
-    }
-
-    @Override
-    protected boolean hasCaCertGenerationChanged() {
-        return hasCaCertGenerationChanged(brokersSecret);
     }
 
     @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,11 +48,6 @@ class CaTest {
         protected String caCertGenerationAnnotation() {
             return "mock";
         }
-
-        @Override
-        protected boolean hasCaCertGenerationChanged() {
-            return false;
-        }
     }
 
     private Ca ca;
@@ -68,7 +64,7 @@ class CaTest {
     @Test
     @DisplayName("Should return certificate expiration date as epoch when certificate is present")
     void shouldReturnCertificateExpirationDateEpoch() {
-        ca.createRenewOrReplace("mock", "mock", emptyMap(), emptyMap(), emptyMap(), null, true);
+        ca.createRenewOrReplace("mock", "mock", emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         Instant inOneYear = Clock.offset(now, oneYear).instant();
         long expectedEpoch = inOneYear.truncatedTo(ChronoUnit.SECONDS).toEpochMilli();


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `Ca` classes currently hold the old certificate secrets as a state through the whole reconciliation. This increases memory consumption but could be also misleading as they might not be up to date and might contain old certificates. 

They seem to be used only in two places. One right after the state is set and one later in the reconciliation where we anyway query the secret again. So it seems to be easy to remove it and pass them to the methods directly as done in this PR.

This should also make it easier to split the one big Secret with all Kafka node certificates

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally