### PR TITLE
Address some trivial warnings and deprecations in two model test classes

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -89,7 +89,6 @@ import java.io.IOException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays; 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -4084,7 +4083,7 @@ public class KafkaClusterTest {
         // set externalIP
         GenericKafkaListenerConfigurationBootstrap bootstrapConfig = new GenericKafkaListenerConfigurationBootstrapBuilder()
                 .withNodePort(32100)
-                .withExternalIPs(Arrays.asList("10.0.0.1"))
+                .withExternalIPs(List.of("10.0.0.1"))
                 .build();
         
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
@@ -4107,7 +4106,7 @@ public class KafkaClusterTest {
        
         List<Service> services = kc.generateExternalBootstrapServices();
         assertThat(services.get(0).getSpec().getType(), is("NodePort"));
-        assertEquals(services.get(0).getSpec().getExternalIPs(), Arrays.asList("10.0.0.1"));
+        assertEquals(services.get(0).getSpec().getExternalIPs(), List.of("10.0.0.1"));
     }
     
     @ParallelTest
@@ -4117,7 +4116,7 @@ public class KafkaClusterTest {
         nodePortListenerBrokerConfig.setBroker(0);
         nodePortListenerBrokerConfig.setNodePort(32000);
         nodePortListenerBrokerConfig.setAdvertisedHost("advertised.host");
-        nodePortListenerBrokerConfig.setExternalIPs(Arrays.asList("10.0.0.1"));
+        nodePortListenerBrokerConfig.setExternalIPs(List.of("10.0.0.1"));
         
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -4139,6 +4138,6 @@ public class KafkaClusterTest {
        
         List<Service> services = kc.generatePerPodServices();
         assertThat(services.get(0).getSpec().getType(), is("NodePort"));
-        assertEquals(services.get(0).getSpec().getExternalIPs(), Arrays.asList("10.0.0.1"));
+        assertEquals(services.get(0).getSpec().getExternalIPs(), List.of("10.0.0.1"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -417,7 +417,7 @@ public class ZookeeperClusterTest {
                 "foo-zookeeper-1.crt", "foo-zookeeper-1.key", "foo-zookeeper-1.p12", "foo-zookeeper-1.password",
                 "foo-zookeeper-2.crt", "foo-zookeeper-2.key", "foo-zookeeper-2.p12", "foo-zookeeper-2.password")));
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
-        assertThat(cert.getSubjectDN().getName(), is("CN=foo-zookeeper, O=io.strimzi"));
+        assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-zookeeper,O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
                 asList(2, "foo-zookeeper-0"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc"),


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This Pr addresses some trivial warnings and deprecations in the `KafkaCluster` and `ZooKeeperCluster` tests.

### Checklist

- [x] Make sure all tests pass