### PR TITLE
Relax the KafkaConnect admin/loggers validation

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -443,14 +443,9 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                             Map<String, Map<String, String>> fetchedLoggers = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_STRINGS);
                                             Map<String, String> loggerMap = new HashMap<>(fetchedLoggers.size());
                                             for (var e : fetchedLoggers.entrySet()) {
-                                                if (Set.of("level", "last_modified").containsAll(e.getValue().keySet()))   {
-                                                    String level = e.getValue().get("level");
-                                                    if (level != null) {
-                                                        loggerMap.put(e.getKey(), level);
-                                                    }
-                                                } else {
-                                                    result.tryFail(new RuntimeException("Inner map has unexpected keys " + e.getValue().keySet()));
-                                                    break;
+                                                String level = e.getValue().get("level");
+                                                if (level != null) {
+                                                    loggerMap.put(e.getKey(), level);
                                                 }
                                             }
                                             result.tryComplete(loggerMap);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -442,10 +442,10 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                                             LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode(), path);
                                             Map<String, Map<String, String>> fetchedLoggers = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_STRINGS);
                                             Map<String, String> loggerMap = new HashMap<>(fetchedLoggers.size());
-                                            for (var e : fetchedLoggers.entrySet()) {
-                                                String level = e.getValue().get("level");
+                                            for (var loggerEntry : fetchedLoggers.entrySet()) {
+                                                String level = loggerEntry.getValue().get("level");
                                                 if (level != null) {
-                                                    loggerMap.put(e.getKey(), level);
+                                                    loggerMap.put(loggerEntry.getKey(), level);
                                                 }
                                             }
                                             result.tryComplete(loggerMap);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImplTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.strimzi.operator.common.Reconciliation;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -15,10 +16,14 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(VertxExtension.class)
@@ -32,7 +37,7 @@ public class KafkaConnectApiImplTest {
 
     @Test
     public void testFeatureCompletionWithBadlyFormattedError(Vertx vertx, VertxTestContext context) throws ExecutionException, InterruptedException {
-        HttpServer server = mockApi(vertx, "Some error message");
+        HttpServer server = mockApi(vertx, 500, "Some error message");
 
         KafkaConnectApi api = new KafkaConnectApiImpl(vertx);
 
@@ -48,7 +53,7 @@ public class KafkaConnectApiImplTest {
 
     @Test
     public void testFeatureCompletionWithWellFormattedError(Vertx vertx, VertxTestContext context) throws ExecutionException, InterruptedException {
-        HttpServer server = mockApi(vertx, "{\"message\": \"This is the error\"}");
+        HttpServer server = mockApi(vertx, 500, "{\"message\": \"This is the error\"}");
 
         KafkaConnectApi api = new KafkaConnectApiImpl(vertx);
 
@@ -62,9 +67,55 @@ public class KafkaConnectApiImplTest {
                 })));
     }
 
-    HttpServer mockApi(Vertx vertx, String error) throws InterruptedException, ExecutionException {
-        HttpServer httpServer = vertx.createHttpServer().requestHandler(request -> request.response().setStatusCode(500).end(error));
+    @Test
+    public void testListConnectLoggersWithLevel(Vertx vertx, VertxTestContext context) throws Exception {
+        final HttpServer server = mockApi(vertx, 200, new ObjectMapper().writeValueAsString(
+            Map.of(
+                "org.apache.kafka.connect",
+                Map.of(
+                    "level", "INFO"
+                )
+            )
+        ));
+        final KafkaConnectApi api = new KafkaConnectApiImpl(vertx);
+        final Checkpoint async = context.checkpoint();
+        api.listConnectLoggers(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.actualPort())
+                .onComplete(context.succeeding(res -> context.verify(() -> {
+                    assertThat(res, allOf(
+                        aMapWithSize(1),
+                        hasEntry("org.apache.kafka.connect", "INFO")
+                    ));
+                    server.close();
+                    async.flag();
+                })));
+    }
 
+    @Test
+    public void testListConnectLoggersWithLevelAndLastModified(Vertx vertx, VertxTestContext context) throws Exception {
+        final HttpServer server = mockApi(vertx, 200, new ObjectMapper().writeValueAsString(
+            Map.of(
+                "org.apache.kafka.connect",
+                Map.of(
+                    "level", "WARN",
+                    "last_modified", "2020-01-01T00:00:00.000Z"
+                )
+            )
+        ));
+        final KafkaConnectApi api = new KafkaConnectApiImpl(vertx);
+        final Checkpoint async = context.checkpoint();
+        api.listConnectLoggers(Reconciliation.DUMMY_RECONCILIATION, "127.0.0.1", server.actualPort())
+                .onComplete(context.succeeding(res -> context.verify(() -> {
+                    assertThat(res, allOf(
+                        aMapWithSize(1),
+                        hasEntry("org.apache.kafka.connect", "WARN")
+                    ));
+                    server.close();
+                    async.flag();
+                })));
+    }
+
+    HttpServer mockApi(Vertx vertx, int status, String body) throws InterruptedException, ExecutionException {
+        HttpServer httpServer = vertx.createHttpServer().requestHandler(request -> request.response().setStatusCode(status).end(body));
         return httpServer.listen(0).toCompletionStage().toCompletableFuture().get();
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This relaxes the JSON validation done when parsing the response of the `/admin/loggers` call of KafkaConnect.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

