### PR TITLE
Rebuild the Kafka Connect image only when the rebuild annotation is set to true

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -118,7 +118,7 @@ public class ConnectBuildOperator {
             // Extract information from the current controllerResource. This is used to figure out if new build needs to be run or not.
             currentBuildRevision = Annotations.stringAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION, null);
             currentImage = Annotations.stringAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE, null);
-            forceRebuild = Annotations.hasAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD);
+            forceRebuild = Annotations.booleanAnnotation(controllerResource, Annotations.STRIMZI_IO_CONNECT_FORCE_REBUILD, false);
         }
 
         KafkaConnectDockerfile dockerfile = connectBuild.generateDockerfile();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Rebuild of the Kafka Connect image (when using the Kafka Connect Build feature) can be triggered using the `strimzi.io/force-rebuild` annotation. But right now, we only check if this annotation is present and not its value. So we trigger the rebuild even when the annotation is for example set to `false`. This PR fixes it and checks the actual value of the annotation and does the rebuild only when it is set to `true`.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally