### PR TITLE
[performance] Re-name perf test suites to not include in UTs

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -400,6 +400,7 @@
                 <groups>
                     performance
                 </groups>
+                <it.test>performance/**/*Performance*</it.test>
             </properties>
         </profile>
 
@@ -410,6 +411,7 @@
                 <groups>
                     performance-capacity
                 </groups>
+                <it.test>performance/**/*Performance*</it.test>
             </properties>
         </profile>
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -51,9 +51,9 @@ import static io.strimzi.systemtest.TestConstants.PERFORMANCE;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 
 @Tag(PERFORMANCE)
-public class TopicOperatorPerformanceTest extends AbstractST {
+public class TopicOperatorPerformance extends AbstractST {
 
-    private static final Logger LOGGER = LogManager.getLogger(TopicOperatorPerformanceTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(TopicOperatorPerformance.class);
     private static final int NUMBER_OF_MESSAGES = 10000;
     private static final TemporalAccessor ACTUAL_TIME = LocalDateTime.now();
 
@@ -282,7 +282,7 @@ public class TopicOperatorPerformanceTest extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.topicOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformanceTest.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }
@@ -535,7 +535,7 @@ public class TopicOperatorPerformanceTest extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_OUT_UPDATE_TIMES, bobUpdateTimerMsArr); // Array of update times
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, topicOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformanceTest.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -282,7 +282,7 @@ public class TopicOperatorPerformance extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.topicOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/TopicOperatorPerformance.java
@@ -535,7 +535,7 @@ public class TopicOperatorPerformance extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.TOPIC_OPERATOR_OUT_UPDATE_TIMES, bobUpdateTimerMsArr); // Array of update times
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, topicOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, TopicOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.topicOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.TOPIC_OPERATOR_BOBS_STREAMING_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -242,7 +242,7 @@ public class UserOperatorPerformance extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.userOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -47,9 +47,9 @@ import static io.strimzi.systemtest.performance.PerformanceConstants.PERFORMANCE
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 
 @Tag(PERFORMANCE)
-public class UserOperatorPerformanceTest extends AbstractST {
+public class UserOperatorPerformance extends AbstractST {
 
-    private static final Logger LOGGER = LogManager.getLogger(UserOperatorPerformanceTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserOperatorPerformance.class);
     private static final TemporalAccessor ACTUAL_TIME = LocalDateTime.now();
 
     private static final String REPORT_DIRECTORY = "user-operator";
@@ -242,7 +242,7 @@ public class UserOperatorPerformanceTest extends AbstractST {
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.userOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
                 // Step 3: Now, it's safe to log performance data as the collection thread has been stopped
-                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformanceTest.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_ALICE_BULK_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }
@@ -418,7 +418,7 @@ public class UserOperatorPerformanceTest extends AbstractST {
 
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.userOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
-                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformanceTest.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_CAPACITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_CAPACITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/performance/UserOperatorPerformance.java
@@ -418,7 +418,7 @@ public class UserOperatorPerformance extends AbstractST {
 
                 performanceAttributes.put(PerformanceConstants.METRICS_HISTORY, this.userOperatorMetricsGatherer.getMetricsStore()); // Map of metrics history
 
-                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, UserOperatorPerformance.REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_CAPACITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
+                this.userOperatorPerformanceReporter.logPerformanceData(this.testStorage, performanceAttributes, REPORT_DIRECTORY + "/" + PerformanceConstants.USER_OPERATOR_CAPACITY_USE_CASE, ACTUAL_TIME, Environment.PERFORMANCE_DIR);
             }
         }
     }


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR fixes a problem when we trigger a Jenkins with `mvn verify -pl systemtest -P all` it goes through two stages:
1. test = where it currently also runs performance tests because they have a suffix which ends with `Test`
2. integration test = and then our STs...

Removing this suffix solves such a problem and we should only run them via specific profiles (i.e., performance or performance-capacity). 

### Checklist

- [x] Make sure all tests pass

