### PR TITLE
Remove PKCS12 files from the server certificate secrets

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -143,13 +143,8 @@ public class CertUtils {
      * may have empty key, cert or keystore and null store password.
      */
     public static CertAndKey keyStoreCertAndKey(Secret secret, String keyCertName) {
-        return new CertAndKey(
-                decodeFromSecret(secret, Ca.SecretEntry.KEY.asKey(keyCertName)),
-                decodeFromSecret(secret, Ca.SecretEntry.CRT.asKey(keyCertName)),
-                null,
-                null,
-                null
-        );
+        return new CertAndKey(decodeFromSecret(secret, Ca.SecretEntry.KEY.asKey(keyCertName)),
+                decodeFromSecret(secret, Ca.SecretEntry.CRT.asKey(keyCertName)));
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -104,20 +104,7 @@ public class CertUtils {
 
             LOGGER.debugCr(reconciliation, "End generating certificates");
         } else {
-            CertAndKey keyStoreCertAndKey = keyStoreCertAndKey(secret, keyCertName);
-            if (keyStoreCertAndKey.keyStore().length != 0
-                    && keyStoreCertAndKey.storePassword() != null) {
-                certAndKey = keyStoreCertAndKey;
-            } else {
-                try {
-                    // coming from an older operator version, the secret exists but without keystore and password
-                    certAndKey = clusterCa.addKeyAndCertToKeyStore(commonName,
-                            keyStoreCertAndKey.key(),
-                            keyStoreCertAndKey.cert());
-                } catch (IOException e) {
-                    LOGGER.errorCr(reconciliation, "Error generating the keystore for {}", keyCertName, e);
-                }
-            }
+            certAndKey = keyStoreCertAndKey(secret, keyCertName);
         }
 
         Map<String, String> secretData = certAndKey == null ? Map.of() : buildSecretData(Map.of(keyCertName, certAndKey));
@@ -136,8 +123,6 @@ public class CertUtils {
         certificates.forEach((keyCertName, certAndKey) -> {
             data.put(Ca.SecretEntry.KEY.asKey(keyCertName), certAndKey.keyAsBase64String());
             data.put(Ca.SecretEntry.CRT.asKey(keyCertName), certAndKey.certAsBase64String());
-            data.put(Ca.SecretEntry.P12_KEYSTORE.asKey(keyCertName), certAndKey.keyStoreAsBase64String());
-            data.put(Ca.SecretEntry.P12_KEYSTORE_PASSWORD.asKey(keyCertName), certAndKey.storePasswordAsBase64String());
         });
         return data;
     }
@@ -148,10 +133,6 @@ public class CertUtils {
         } else {
             return new byte[]{};
         }
-    }
-    
-    private static String decodeStringFromSecret(Secret secret, String key) {
-        return secret.getData().get(key) == null ? null : Util.decodeFromBase64(secret.getData().get(key));
     }
 
     /**
@@ -165,9 +146,9 @@ public class CertUtils {
         return new CertAndKey(
                 decodeFromSecret(secret, Ca.SecretEntry.KEY.asKey(keyCertName)),
                 decodeFromSecret(secret, Ca.SecretEntry.CRT.asKey(keyCertName)),
-                new byte[]{},
-                decodeFromSecret(secret, Ca.SecretEntry.P12_KEYSTORE.asKey(keyCertName)),
-                decodeStringFromSecret(secret, Ca.SecretEntry.P12_KEYSTORE_PASSWORD.asKey(keyCertName))
+                null,
+                null,
+                null
         );
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -369,12 +369,7 @@ public class ClusterCa extends Ca {
             throw new RuntimeException("Certificate for node " + podName + " is missing the public key");
         }
 
-        return new CertAndKey(
-                Util.decodeBytesFromBase64(keyData),
-                Util.decodeBytesFromBase64(certData),
-                null,
-                null,
-                null);
+        return new CertAndKey(Util.decodeBytesFromBase64(keyData), Util.decodeBytesFromBase64(certData));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -80,17 +80,11 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
-                
+
         Secret initialSecret = initialSecret(initialCerts);
 
         boolean isMaintenanceTimeWindowsSatisfied = true;
@@ -126,16 +120,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(1, initialCerts);
 
@@ -172,16 +160,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -218,16 +200,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
         
@@ -242,18 +218,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod1").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
     }
 
     @ParallelTest
@@ -264,12 +234,8 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -284,18 +250,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod1").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod2").key()), is("new-key0"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod2").storePassword(), is("new-password0"));
     }
 
     @ParallelTest
@@ -305,16 +265,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -327,18 +281,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod1").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
     }
 
     @ParallelTest
@@ -348,8 +296,6 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -362,18 +308,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod1").key()), is("new-key0"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod1").storePassword(), is("new-password0"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("new-cert1"));
         assertThat(new String(newCerts.get("pod2").key()), is("new-key1"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore1"));
-        assertThat(newCerts.get("pod2").storePassword(), is("new-password1"));
     }
 
     @ParallelTest
@@ -383,12 +323,8 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -401,18 +337,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod0").storePassword(), is("old-password"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod1").key()), is("new-key0"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod1").storePassword(), is("new-password0"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod2").storePassword(), is("old-password"));
     }
 
     @ParallelTest
@@ -422,16 +352,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -446,47 +370,8 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("old-keystore"));
-        assertThat(newCerts.get("pod1").storePassword(), is("old-password"));
 
         assertThat(newCerts.get("pod2"), is(nullValue()));
-    }
-
-    @ParallelTest
-    public void oldVersionWithoutPkcs12() throws IOException {
-        MockedClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
-
-        Map<String, String> initialCerts = new HashMap<>();
-        initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
-        initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
-        initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
-        initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-
-        Secret initialSecret = initialSecret(initialCerts);
-
-        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(
-                Reconciliation.DUMMY_RECONCILIATION,
-                NODES,
-                SUBJECT_FN,
-                initialSecret,
-                true);
-
-        assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
-        assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
-
-        assertThat(new String(newCerts.get("pod1").cert()), is("old-cert"));
-        assertThat(new String(newCerts.get("pod1").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
-        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
-
-        assertThat(new String(newCerts.get("pod2").cert()), is("old-cert"));
-        assertThat(new String(newCerts.get("pod2").key()), is("old-key"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
-        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
     }
 
     @ParallelTest
@@ -497,16 +382,10 @@ public class ClusterCaRenewalTest {
         Map<String, String> initialCerts = new HashMap<>();
         initialCerts.put("pod0.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod0.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod0.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod0.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod1.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod1.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod1.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod1.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
         initialCerts.put("pod2.crt", Base64.getEncoder().encodeToString("old-cert".getBytes()));
         initialCerts.put("pod2.key", Base64.getEncoder().encodeToString("old-key".getBytes()));
-        initialCerts.put("pod2.p12", Base64.getEncoder().encodeToString("old-keystore".getBytes()));
-        initialCerts.put("pod2.password", Base64.getEncoder().encodeToString("old-password".getBytes()));
 
         Secret initialSecret = initialSecret(initialCerts);
 
@@ -521,18 +400,12 @@ public class ClusterCaRenewalTest {
 
         assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
 
         assertThat(new String(newCerts.get("pod1").cert()), is("new-cert1"));
         assertThat(new String(newCerts.get("pod1").key()), is("new-key1"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
-        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
 
         assertThat(new String(newCerts.get("pod2").cert()), is("new-cert2"));
         assertThat(new String(newCerts.get("pod2").key()), is("new-key2"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
-        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
     }
 
     public static Secret initialSecret(Map<String, String> data)   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2345,9 +2345,9 @@ public class KafkaClusterTest {
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateBrokerSecret(null, emptyMap());
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
-                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
-                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key",
+                "foo-kafka-1.crt", "foo-kafka-1.key",
+                "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
@@ -2372,9 +2372,9 @@ public class KafkaClusterTest {
 
         Secret secret = generateBrokerSecret(Collections.singleton("123.10.125.140"), externalAddresses);
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
-                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
-                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key",
+                "foo-kafka-1.crt", "foo-kafka-1.key",
+                "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
@@ -2401,9 +2401,9 @@ public class KafkaClusterTest {
 
         Secret secret = generateBrokerSecret(TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses);
         assertThat(secret.getData().keySet(), is(set(
-                "foo-kafka-0.crt",  "foo-kafka-0.key", "foo-kafka-0.p12", "foo-kafka-0.password",
-                "foo-kafka-1.crt", "foo-kafka-1.key", "foo-kafka-1.p12", "foo-kafka-1.password",
-                "foo-kafka-2.crt", "foo-kafka-2.key", "foo-kafka-2.p12", "foo-kafka-2.password")));
+                "foo-kafka-0.crt",  "foo-kafka-0.key",
+                "foo-kafka-1.crt", "foo-kafka-1.key",
+                "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -464,12 +464,12 @@ public class KafkaClusterWithKRaftTest {
 
         Secret secret = kc.generateCertificatesSecret(clusterCa, clientsCa, null, TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses, true);
         assertThat(secret.getData().keySet(), is(set(
-                "my-cluster-controllers-0.crt",  "my-cluster-controllers-0.key", "my-cluster-controllers-0.p12", "my-cluster-controllers-0.password",
-                "my-cluster-controllers-1.crt", "my-cluster-controllers-1.key", "my-cluster-controllers-1.p12", "my-cluster-controllers-1.password",
-                "my-cluster-controllers-2.crt", "my-cluster-controllers-2.key", "my-cluster-controllers-2.p12", "my-cluster-controllers-2.password",
-                "my-cluster-brokers-1000.crt",  "my-cluster-brokers-1000.key", "my-cluster-brokers-1000.p12", "my-cluster-brokers-1000.password",
-                "my-cluster-brokers-1001.crt", "my-cluster-brokers-1001.key", "my-cluster-brokers-1001.p12", "my-cluster-brokers-1001.password",
-                "my-cluster-brokers-1002.crt", "my-cluster-brokers-1002.key", "my-cluster-brokers-1002.p12", "my-cluster-brokers-1002.password")));
+                "my-cluster-controllers-0.crt",  "my-cluster-controllers-0.key",
+                "my-cluster-controllers-1.crt", "my-cluster-controllers-1.key",
+                "my-cluster-controllers-2.crt", "my-cluster-controllers-2.key",
+                "my-cluster-brokers-1000.crt",  "my-cluster-brokers-1000.key",
+                "my-cluster-brokers-1001.crt", "my-cluster-brokers-1001.key",
+                "my-cluster-brokers-1002.crt", "my-cluster-brokers-1002.key")));
 
         // Controller cert
         X509Certificate cert = Ca.cert(secret, "my-cluster-controllers-0.crt");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -413,9 +413,9 @@ public class ZookeeperClusterTest {
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateCertificatesSecret();
         assertThat(secret.getData().keySet(), is(set(
-                "foo-zookeeper-0.crt",  "foo-zookeeper-0.key", "foo-zookeeper-0.p12", "foo-zookeeper-0.password",
-                "foo-zookeeper-1.crt", "foo-zookeeper-1.key", "foo-zookeeper-1.p12", "foo-zookeeper-1.password",
-                "foo-zookeeper-2.crt", "foo-zookeeper-2.key", "foo-zookeeper-2.p12", "foo-zookeeper-2.password")));
+                "foo-zookeeper-0.crt",  "foo-zookeeper-0.key",
+                "foo-zookeeper-1.crt", "foo-zookeeper-1.key",
+                "foo-zookeeper-2.crt", "foo-zookeeper-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-zookeeper,O=io.strimzi"));
         assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -552,7 +552,7 @@ public class KafkaAssemblyOperatorMockTest {
                 // removing one pod, the related private and public keys, keystore and password (4 entries) should not be in the Secrets
                 assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get()
                                 .getData(),
-                        aMapWithSize(brokersInternalCertsCount.get() - 4));
+                        aMapWithSize(brokersInternalCertsCount.get() - 2));
 
                 // TODO assert no rolling update
                 async.flag();
@@ -597,7 +597,7 @@ public class KafkaAssemblyOperatorMockTest {
 
                 // adding one pod, the related private and public keys, keystore and password should be added to the Secrets
                 assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData(),
-                        aMapWithSize(brokersInternalCertsCount.get() + 4));
+                        aMapWithSize(brokersInternalCertsCount.get() + 2));
 
                 // TODO assert no rolling update
                 async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsMockTest.java
@@ -495,7 +495,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
 
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(20));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(10));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(5));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-a-2").get(), is(notNullValue()));
 
@@ -510,7 +510,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
             })))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(16));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(8));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(4));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-a-2").get(), is(nullValue()));
 
@@ -541,7 +541,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
 
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(20));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(10));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(5));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-a-5").get(), is(nullValue()));
 
@@ -556,7 +556,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
             })))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(24));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(12));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-a-5").get(), is(notNullValue()));
 
@@ -587,7 +587,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
 
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(20));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(10));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(5));
 
                 KafkaNodePool poolC = new KafkaNodePoolBuilder()
@@ -613,7 +613,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Assert that the new pool is added
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(28));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(14));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(7));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-c-5").get(), is(notNullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-c-6").get(), is(notNullValue()));
@@ -676,7 +676,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
         initialReconcile(context)
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Assert that the new pool is added
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(28));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(14));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(7));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-c-5").get(), is(notNullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-c-6").get(), is(notNullValue()));
@@ -710,7 +710,7 @@ public class KafkaAssemblyOperatorWithPoolsMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Assert that pool was removed
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(20));
+                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(10));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(5));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-b-3").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-pool-b-4").get(), is(nullValue()));

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -372,40 +372,6 @@ public abstract class Ca {
     }
 
     /**
-     * Returns the given {@code cert} and {@code key} values from the given {@code Secret} as a {@code CertAndKey},
-     * or null if the given {@code secret} is null.
-     * An exception is thrown if the given {@code secret} is non-null, but does not contain the given
-     * entries in its {@code data}.
-     *
-     * @param secret The secret.
-     * @param key The key.
-     * @param cert The cert.
-     * @param keyStore The keyStore.
-     * @param keyStorePassword The store password.
-     * @return The CertAndKey.
-     */
-    public static CertAndKey asCertAndKey(Secret secret, String key, String cert, String keyStore, String keyStorePassword) {
-        if (secret == null || secret.getData() == null) {
-            return null;
-        } else {
-            String keyData = secret.getData().get(key);
-            if (keyData == null) {
-                throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + key);
-            }
-            String certData = secret.getData().get(cert);
-            if (certData == null) {
-                throw new RuntimeException("The Secret " + secret.getMetadata().getNamespace() + "/" + secret.getMetadata().getName() + " is missing the key " + cert);
-            }
-            return new CertAndKey(
-                    Util.decodeBytesFromBase64(keyData),
-                    Util.decodeBytesFromBase64(certData),
-                    null,
-                    Util.decodeBytesFromBase64(secret.getData().get(keyStore)),
-                    Util.decodeFromBase64(secret.getData().get(keyStorePassword)));
-        }
-    }
-
-    /**
      * Adds a certificate into a PKCS12 keystore
      *
      * @param alias     Alias under which it should be stored in the PKCS12 store


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes the PKCS12 files from the internal secrets used by components of the Kafka cluster. This includes the server certificates of Kafka, Zoo or CC as well as the client certificates of KE, UO, TO, and CO. We added the KCS12 long time ago. But never really used them in most places. Removing them simplifies the code and its testing and makes the Secrets smaller.

This does nto impact the PKCS12 files int he CA secrets or in the User secrets. Those are expected to be used by users and we want to keep them.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally