### PR TITLE
[performance] - propagate test context into metrics collecting

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/gather/schedulers/BaseMetricsCollectionScheduler.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/gather/schedulers/BaseMetricsCollectionScheduler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * of metrics collection events.</p>
  *
  * <p>Usage: Extend this class and implement the abstract methods to collect and map metrics.
- * Start the metrics collection process by calling {@link #startCollecting(ExtensionContext, long, long, TimeUnit)} with
+ * Start the metrics collection process by calling {@link #startCollecting(long, long, TimeUnit)} with
  * desired timing configurations.</p>
  *
  * <p>Note: Because it uses a TreeMap for storing metrics history, which is not thread-safe,


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This pull request resolves an issue where ExtensionContext was not being transferred correctly a `collection thread` during metrics collection, leading to potential null contexts in scheduled tasks. One hidden problem could occur in the following :
```java
/**
     * Collect metrics from specific pod
     * @return collected metrics
     */
    private String collectMetrics(String metricsPodIp, String podName) throws InterruptedException, ExecutionException, IOException {
        List<String> executableCommand = Arrays.asList(cmdKubeClient(namespaceName).toString(), "exec", scraperPodName,
            "-n", namespaceName,
            "--", "curl", metricsPodIp + ":" + metricsPort + metricsPath);

        LOGGER.debug("Executing command:{} for scrape the metrics", executableCommand);

        Exec exec = new Exec();
        // 20 seconds should be enough for collect data from the pod
        int ret = exec.execute(null, executableCommand, 20_000);

        here ->>> LOGGER.log(ResourceManager.getInstance().determineLogLevel(), "Metrics collection for Pod: {}/{}({}) from Pod: {}/{} finished with return code: {}", namespaceName, podName, metricsPodIp, namespaceName, scraperPodName, ret);
        return exec.out();
    }
```
where when we invoke `determineLogLevel` the test context was not set in another `Thread` leading to NPE. Such an issue should be solved by this fix.

### Checklist

- [x] Make sure all tests pass