### PR TITLE
docs(connectors): annotation to rebuild container image

### DIFF
--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -66,7 +66,9 @@ $ kubectl apply -f <kafka_connect_configuration_file>
 
 .Rebuilding the container image with new artifacts
 
-To update a base image and download the latest connector plugin artifacts, you can trigger a rebuild of the container image associated with the Kafka Connect cluster by applying the annotation `strimzi.io/force-rebuild=true` to the Kafka Connect `StrimziPodSet` resource.
+A new container image is built automatically when you change the base image (`.spec.image`) or change the connector plugin artifacts configuration (`.spec.build.plugins`).
+
+To pull an upgraded base image or to download the latest connector plugin artifacts without changing the `KafkaConnect` resource, you can trigger a rebuild of the container image associated with the Kafka Connect cluster by applying the annotation `strimzi.io/force-rebuild=true` to the Kafka Connect `StrimziPodSet` resource.
 
 The annotation triggers the rebuilding process, fetching any new artifacts for plugins specified in the `KafkaConnect` custom resource and incorporating them into the container image.
 The rebuild includes downloads of new plugin artifacts without versions. 

--- a/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-connect-using-kafka-connect-build.adoc
@@ -64,6 +64,13 @@ $ kubectl apply -f <kafka_connect_configuration_file>
 
 . Use the Kafka Connect REST API or `KafkaConnector` custom resources to use the connector plugins you added.
 
+.Rebuilding the container image with new artifacts
+
+To update a base image and download the latest connector plugin artifacts, you can trigger a rebuild of the container image associated with the Kafka Connect cluster by applying the annotation `strimzi.io/force-rebuild=true` to the Kafka Connect `StrimziPodSet` resource.
+
+The annotation triggers the rebuilding process, fetching any new artifacts for plugins specified in the `KafkaConnect` custom resource and incorporating them into the container image.
+The rebuild includes downloads of new plugin artifacts without versions. 
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
**Documentation**

Adds instructions to the  [Building a new container image with connector plugins automatically](https://strimzi.io/docs/operators/in-development/deploying#creating-new-image-using-kafka-connect-build-str) for rebuilding the Kafka Connect container image to update connector plugins using the `strimzi.io/force-rebuild=true` annotation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

