### PR TITLE
docs(kafka): cleans up naming of kafka clusters

### DIFF
--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -6,7 +6,7 @@
 = Accessing Kafka using an Ingress NGINX Controller for Kubernetes
 
 [role="_abstract"]
-Use an {NginxIngressController} to access a Strimzi Kafka cluster from clients outside the Kubernetes cluster. 
+Use an {NginxIngressController} to access a Kafka cluster from clients outside the Kubernetes cluster. 
 
 To be able to use an Ingress NGINX Controller for Kubernetes, add configuration for an `ingress` type listener in the `Kafka` custom resource. 
 When applied, the configuration creates a dedicated ingress and service for an external bootstrap and each broker in the cluster. 

--- a/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-loadbalancers.adoc
@@ -6,7 +6,7 @@
 = Accessing Kafka using loadbalancers
 
 [role="_abstract"]
-Use loadbalancers to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
+Use loadbalancers to access a Kafka cluster from an external client outside the Kubernetes cluster.
 
 To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the certificate used for TLS encryption.
 

--- a/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-nodeports.adoc
@@ -6,7 +6,7 @@
 = Accessing Kafka using node ports
 
 [role="_abstract"]
-Use node ports to access a Strimzi Kafka cluster from an external client outside the Kubernetes cluster.
+Use node ports to access a Kafka cluster from an external client outside the Kubernetes cluster.
 
 To connect to a broker, you specify a hostname and port number for the Kafka bootstrap address, as well as the certificate used for TLS encryption.
 

--- a/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-routes.adoc
@@ -6,7 +6,7 @@
 = Accessing Kafka using OpenShift routes
 
 [role="_abstract"]
-Use OpenShift routes to access a Strimzi Kafka cluster from clients outside the OpenShift cluster.
+Use OpenShift routes to access a Kafka cluster from clients outside the OpenShift cluster.
 
 To be able to use routes, add configuration for a `route` type listener in the `Kafka` custom resource. 
 When applied, the configuration creates a dedicated route and service for an external bootstrap and each broker in the cluster. 

--- a/documentation/modules/upgrading/proc-downgrade-kafka-kraft.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-kafka-kraft.adoc
@@ -6,8 +6,8 @@
 = Downgrading KRaft-based Kafka clusters and client applications
 
 [role="_abstract"]
-Downgrade a KRaft-based Strimzi Kafka cluster to an earlier version.
-When downgrading a KRaft-based Strimzi Kafka cluster to a lower version, like moving from {KafkaVersionHigher} to {KafkaVersionLower}, ensure that the metadata version used by the Kafka cluster is a version supported by the Kafka version you want to downgrade to. 
+Downgrade a KRaft-based Kafka cluster to an earlier version.
+When downgrading a KRaft-based Kafka cluster to a lower version, like moving from {KafkaVersionHigher} to {KafkaVersionLower}, ensure that the metadata version used by the Kafka cluster is a version supported by the Kafka version you want to downgrade to. 
 The metadata version for the Kafka version you are downgrading from must not be higher than the version you are downgrading to.
 
 NOTE: Consult the Apache Kafka documentation for information regarding the support and limitations associated with KRaft-based downgrades.
@@ -15,7 +15,7 @@ NOTE: Consult the Apache Kafka documentation for information regarding the suppo
 .Prerequisites
 
 * The Cluster Operator is up and running.
-* Before you downgrade the Strimzi Kafka cluster, check the following for the `Kafka` resource:
+* Before you downgrade the Kafka cluster, check the following for the `Kafka` resource:
 
 ** The `Kafka` custom resource does not contain options that are not supported by the Kafka version being downgraded to.
 ** `spec.kafka.metadataVersion` is set to a version that is supported by the Kafka version being downgraded to.   

--- a/documentation/modules/upgrading/proc-downgrade-kafka-zookeeper.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-kafka-zookeeper.adoc
@@ -6,8 +6,8 @@
 = Downgrading ZooKeeper-based Kafka clusters and client applications
 
 [role="_abstract"]
-Downgrade a ZooKeeper-based Strimzi Kafka cluster to an earlier version.
-When downgrading a ZooKeeper-based Strimzi Kafka cluster to a lower version, like moving from {KafkaVersionHigher} to {KafkaVersionLower}, ensure that the inter-broker protocol version used by the Kafka cluster is a version supported by the Kafka version you want to downgrade to.  
+Downgrade a ZooKeeper-based Kafka cluster to an earlier version.
+When downgrading a ZooKeeper-based Kafka cluster to a lower version, like moving from {KafkaVersionHigher} to {KafkaVersionLower}, ensure that the inter-broker protocol version used by the Kafka cluster is a version supported by the Kafka version you want to downgrade to.  
 The inter-broker protocol version for the Kafka version you are downgrading from must not be higher than the version you are downgrading to.
 
 NOTE: Consult the Apache Kafka documentation for information regarding the support and limitations associated with ZooKeeper-based downgrades.
@@ -15,7 +15,7 @@ NOTE: Consult the Apache Kafka documentation for information regarding the suppo
 .Prerequisites
 
 * The Cluster Operator is up and running.
-* Before you downgrade the Strimzi Kafka cluster, check the following for the `Kafka` resource:
+* Before you downgrade the Kafka cluster, check the following for the `Kafka` resource:
 
 ** IMPORTANT: xref:con-target-downgrade-version-{context}[Compatibility of Kafka versions].
 ** The `Kafka` custom resource does not contain options that are not supported by the Kafka version being downgraded to.

--- a/documentation/modules/upgrading/proc-upgrade-kafka-kraft.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-kraft.adoc
@@ -6,7 +6,7 @@
 = Upgrading KRaft-based Kafka clusters and client applications
 
 [role="_abstract"]
-Upgrade a KRaft-based Strimzi Kafka cluster to a newer supported Kafka version and KRaft metadata version.
+Upgrade a KRaft-based Kafka cluster to a newer supported Kafka version and KRaft metadata version.
 
 You should also choose a xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients].
 Kafka clients are upgraded in step 6 of this procedure.
@@ -16,7 +16,7 @@ NOTE: Refer to the Apache Kafka documentation for the latest on support for KRaf
 .Prerequisites
 
 * The Cluster Operator is up and running.
-* Before you upgrade the Strimzi Kafka cluster, check that the properties of the `Kafka` resource do _not_ contain configuration options that are not supported in the new Kafka version.
+* Before you upgrade the Kafka cluster, check that the properties of the `Kafka` resource do _not_ contain configuration options that are not supported in the new Kafka version.
 
 .Procedure
 

--- a/documentation/modules/upgrading/proc-upgrade-kafka-zookeeper.adoc
+++ b/documentation/modules/upgrading/proc-upgrade-kafka-zookeeper.adoc
@@ -6,7 +6,7 @@
 = Upgrading ZooKeeper-based Kafka clusters and client applications
 
 [role="_abstract"]
-Upgrade a ZooKeeper-based Strimzi Kafka cluster to a newer supported Kafka version and inter-broker protocol version.
+Upgrade a ZooKeeper-based Kafka cluster to a newer supported Kafka version and inter-broker protocol version.
 
 You should also choose a xref:con-strategies-for-upgrading-clients-{context}[strategy for upgrading clients].
 Kafka clients are upgraded in step 6 of this procedure.
@@ -14,7 +14,7 @@ Kafka clients are upgraded in step 6 of this procedure.
 .Prerequisites
 
 * The Cluster Operator is up and running.
-* Before you upgrade the Strimzi Kafka cluster, check that the properties of the `Kafka` resource do _not_ contain configuration options that are not supported in the new Kafka version.
+* Before you upgrade the Kafka cluster, check that the properties of the `Kafka` resource do _not_ contain configuration options that are not supported in the new Kafka version.
 
 .Procedure
 


### PR DESCRIPTION
**Documentation**

In a few places in the docs we say "Strimzi Kafka cluster" without needing to make this distinction. These instances have been updated to say just "Kafka cluster"

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

