### PR TITLE
[ST] Fix RackAwarenessST, JmxST, and file-sink image build

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -121,7 +121,7 @@ class RackAwarenessST extends AbstractST {
 
         String rackIdOut = cmdKubeClient(testStorage.getNamespaceName()).execInPod(podName, "/bin/bash", "-c", "cat /opt/kafka/init/rack.id").out().trim();
         String brokerRackOut = cmdKubeClient(testStorage.getNamespaceName()).execInPod(podName, "/bin/bash", "-c", "cat /tmp/strimzi.properties | grep broker.rack").out().trim();
-        assertThat(rackIdOut.trim(), is(hostname));
+        assertThat(rackIdOut.trim().contains(hostname), is(true));
         assertThat(brokerRackOut.contains("broker.rack=" + hostname), is(true));
 
         LOGGER.info("Producing and Consuming data in the Kafka cluster: {}/{}", testStorage.getNamespaceName(), testStorage.getClusterName());
@@ -208,7 +208,7 @@ class RackAwarenessST extends AbstractST {
         String hostname = podNodeName.contains(".") ? podNodeName.substring(0, podNodeName.indexOf(".")) : podNodeName;
         String commandOut = cmdKubeClient(testStorage.getNamespaceName()).execInPod(podName,
                 "/bin/bash", "-c", "cat /tmp/strimzi-connect.properties | grep consumer.client.rack").out().trim();
-        assertThat(commandOut.equals("consumer.client.rack=" + hostname), is(true));
+        assertThat(commandOut.contains("consumer.client.rack=" + hostname), is(true));
 
         // produce data which are to be available in the topic
         final KafkaClients kafkaClients = ClientUtils.getInstantPlainClients(testStorage);
@@ -287,7 +287,7 @@ class RackAwarenessST extends AbstractST {
         String podNodeName = pod.getSpec().getNodeName();
         String hostname = podNodeName.contains(".") ? podNodeName.substring(0, podNodeName.indexOf(".")) : podNodeName;
         String commandOut = cmdKubeClient(testStorage.getNamespaceName()).execInPod(podName, "/bin/bash", "-c", "cat /tmp/strimzi-connect.properties | grep consumer.client.rack").out().trim();
-        assertThat(commandOut.equals("consumer.client.rack=" + hostname), is(true));
+        assertThat(commandOut.contains("consumer.client.rack=" + hostname), is(true));
 
         // Mirroring messages by: Producing to the Source Kafka Cluster and consuming them from mirrored KafkaTopic in target Kafka Cluster.
 

--- a/systemtest/src/test/resources/connect-build/Dockerfile
+++ b/systemtest/src/test/resources/connect-build/Dockerfile
@@ -9,6 +9,6 @@ ARG KAFKA_VERSION
 USER root:root
 RUN mkdir -p /opt/kafka/plugins/file-sink
 
-RUN cp /opt/kafka/libs/connect-file-${KAFKA_VERSION}.jar /opt/kafka/plugins/file-sink
+RUN ls /opt/kafka/libs/* -d | grep .*connect-file-${KAFKA_VERSION}.*.jar -o | xargs cp -t /opt/kafka/plugins/file-sink
 
 USER 1001


### PR DESCRIPTION
### Type of change

- ST fixes

### Description

This PR fixes following issues:

- `RackAwarenessST` - in assertions where we are checking that the hostname is in the particular line of text, we are assuming that there will be just the hostname we are specifying, however for example on AWS, there can be also additional suffix (like region)
- `JmxST` - when running with NP default to deny, we are not able to connect to the API and get the JMX metrics, this PR adds creation of NP for Connect, so we are able to successfully collect the particular beans
- Connect image with file-sink build - when the connect plugin has additional suffix (and not just the Kafka version with `.jar`), the build simply fails, as the jar can be named differently (with different suffix)

### Checklist

- [ ] Make sure all tests pass

