### PR TITLE
Raise warning when `kraftMetadata` is used in storage configuration for ZooKeeper-based clusters

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaSpecCheckerTest.java
@@ -7,9 +7,13 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorage;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.kafka.JbodStorage;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
+import io.strimzi.api.kafka.model.kafka.KRaftMetadataStorage;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -326,5 +330,102 @@ public class KafkaSpecCheckerTest {
         assertThat(warnings, hasSize(2));
         assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR)), is(true));
         assertThat(warnings.stream().anyMatch(w -> w.getMessage().contains(KafkaConfiguration.MIN_INSYNC_REPLICAS)), is(true));
+    }
+
+    @Test
+    public void checkKRaftMetadataConfigInZooKeeperMode() {
+        // Set to avoid unrelated warnings being raised here
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        // Kafka with ephemeral storage
+        EphemeralStorage ephemeralStorage = new EphemeralStorageBuilder()
+                .withKraftMetadata(KRaftMetadataStorage.SHARED)
+                .build();
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(), ephemeralStorage, new EphemeralStorage(), null, null, null, null);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        List<Condition> warnings = checker.run(false);
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0).getReason(), is("KRaftMetadataStorageConfiguredWithoutKRaft"));
+        assertThat(warnings.get(0).getMessage(), is("The Kafka custom resource or one or more of the KafkaNodePool custom resources contain the kraftMetadata configuration. This configuration is supported only for KRaft-based Kafka clusters."));
+
+        // Check Persistent storage
+        PersistentClaimStorage persistentStorage = new PersistentClaimStorageBuilder()
+                .withSize("100Gi")
+                .withKraftMetadata(KRaftMetadataStorage.SHARED)
+                .build();
+        kafka.getSpec().getKafka().setStorage(persistentStorage);
+        checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        warnings = checker.run(false);
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0).getReason(), is("KRaftMetadataStorageConfiguredWithoutKRaft"));
+        assertThat(warnings.get(0).getMessage(), is("The Kafka custom resource or one or more of the KafkaNodePool custom resources contain the kraftMetadata configuration. This configuration is supported only for KRaft-based Kafka clusters."));
+
+        // Check JBOD storage
+        JbodStorage jbodStorage = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                                .withId(0)
+                                .withSize("100Gi")
+                                .build(),
+                        new PersistentClaimStorageBuilder()
+                                .withId(1)
+                                .withSize("100Gi")
+                                .withKraftMetadata(KRaftMetadataStorage.SHARED)
+                                .build())
+                .build();
+        kafka.getSpec().getKafka().setStorage(jbodStorage);
+        checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        warnings = checker.run(false);
+        assertThat(warnings, hasSize(1));
+        assertThat(warnings.get(0).getReason(), is("KRaftMetadataStorageConfiguredWithoutKRaft"));
+        assertThat(warnings.get(0).getMessage(), is("The Kafka custom resource or one or more of the KafkaNodePool custom resources contain the kraftMetadata configuration. This configuration is supported only for KRaft-based Kafka clusters."));
+    }
+
+    @Test
+    public void checkKRaftMetadataConfigNotUsedInZooKeeperMode() {
+        // Set to avoid unrelated warnings being raised here
+        Map<String, Object> kafkaOptions = new HashMap<>();
+        kafkaOptions.put(KafkaConfiguration.DEFAULT_REPLICATION_FACTOR, 3);
+        kafkaOptions.put(KafkaConfiguration.MIN_INSYNC_REPLICAS, 2);
+
+        // Kafka with ephemeral storage
+        Kafka kafka = ResourceUtils.createKafka(NAMESPACE, NAME, 3, IMAGE, HEALTH_DELAY, HEALTH_TIMEOUT,
+                null, kafkaOptions, emptyMap(), new EphemeralStorage(), new EphemeralStorage(), null, null, null, null);
+        KafkaSpecChecker checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        List<Condition> warnings = checker.run(false);
+        assertThat(warnings, hasSize(0));
+
+        // Check Persistent storage
+        PersistentClaimStorage persistentStorage = new PersistentClaimStorageBuilder()
+                .withSize("100Gi")
+                .build();
+        kafka.getSpec().getKafka().setStorage(persistentStorage);
+        checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        warnings = checker.run(false);
+        assertThat(warnings, hasSize(0));
+
+        // Check JBOD storage
+        JbodStorage jbodStorage = new JbodStorageBuilder()
+                .withVolumes(new PersistentClaimStorageBuilder()
+                                .withId(0)
+                                .withSize("100Gi")
+                                .build(),
+                        new PersistentClaimStorageBuilder()
+                                .withId(1)
+                                .withSize("100Gi")
+                                .build())
+                .build();
+        kafka.getSpec().getKafka().setStorage(jbodStorage);
+        checker = generateChecker(kafka, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE);
+
+        warnings = checker.run(false);
+        assertThat(warnings, hasSize(0));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds a warning when the `kraftMetadata` option in the storage configuration is used in ZooKeeper-based cluster.

To simplify the code, the warning message is generic without mentioning the exact resource(s) (Kafka or KafkaNodePool) where the issue is. Creating the warning including such a detailed message would significantly increase the complexity as it would require several things:
* Information about the KRaft state (enabled, disabled, etc.)
* Detailed information about the original resources configuration
* The warnings to be passed to the custom resource status

These three are not available in one place and the effort to bring them together does not seem to be worth the effort.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally