### PR TITLE
[DOC] Improve the host field description to make the default value more clear

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -75,7 +75,8 @@ public class AclRule implements UnknownPropertyPreserving {
         this.resource = resource;
     }
 
-    @Description("The host from which the action described in the ACL rule is allowed or denied.")
+    @Description("The host from which the action described in the ACL rule is allowed or denied. " +
+            "If not set, it defaults to `*` and the action will be allowed or denied from any host.")
     @JsonProperty(defaultValue = "*")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public String getHost() {

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3141,7 +3141,7 @@ include::../api/io.strimzi.api.kafka.model.user.acl.AclRule.adoc[leveloffset=+1]
 |Indicates the resource for which given ACL rule applies.
 |host
 |string
-|The host from which the action described in the ACL rule is allowed or denied.
+|The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host.
 |operation
 |string (one of [Read, Write, Delete, Alter, Describe, All, IdempotentWrite, ClusterAction, Create, AlterConfigs, DescribeConfigs])
 |**The `operation` property has been deprecated, and should now be configured using `spec.authorization.acls[*].operations`.** Operation which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -130,7 +130,7 @@ spec:
                             description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
-                            description: The host from which the action described in the ACL rule is allowed or denied.
+                            description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                           operation:
                             type: string
                             enum:
@@ -361,7 +361,7 @@ spec:
                             description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
-                            description: The host from which the action described in the ACL rule is allowed or denied.
+                            description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                           operation:
                             type: string
                             enum:
@@ -592,7 +592,7 @@ spec:
                             description: Indicates the resource for which given ACL rule applies.
                           host:
                             type: string
-                            description: The host from which the action described in the ACL rule is allowed or denied.
+                            description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                           operation:
                             type: string
                             enum:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -129,7 +129,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:
@@ -360,7 +360,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:
@@ -591,7 +591,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -129,7 +129,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:
@@ -360,7 +360,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:
@@ -591,7 +591,7 @@ spec:
                           description: Indicates the resource for which given ACL rule applies.
                         host:
                           type: string
-                          description: The host from which the action described in the ACL rule is allowed or denied.
+                          description: "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*` and the action will be allowed or denied from any host."
                         operation:
                           type: string
                           enum:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR updates the description for the ACL `host` field in the `KafkaUser` resource to make it more clear what the default value is and what does it mean.

### Checklist

- [x] Update documentation