### PR TITLE
Add ContinueReconciliationOnManualRollingUpdateFailure to CHANGELOG and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Don't allow MirrorMaker2 mirrors with target set to something else than the connect cluster. 
 * Added support for custom SASL config in standalone Topic Operator deployment to support alternate access controllers (i.e. `AWS_MSK_IAM`)
 * Remove Angular dependent plugins from Grafana example dashboard. This makes our dashboard compatible with Grafana 7.4.5 and higher.
+* Continue reconciliation after failed manual rolling update using the `strimzi.io/manual-rolling-update` annotation (when the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is enabled).
 
 ### Changes, deprecations and removals
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -27,6 +27,7 @@ Alpha and beta stage features are removed if they do not prove to be useful.
   It is now permanently enabled and cannot be disabled.
 * The `UnidirectionalTopicOperator` feature gate moved to GA stage in Strimzi 0.41.
   It is now permanently enabled and cannot be disabled.
+* The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and is disabled by default.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -73,6 +74,11 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦0.36
 ¦0.39
 ¦0.41
+
+¦`ContinueReconciliationOnManualRollingUpdateFailure`
+¦0.41
+¦0.43 (planned)
+¦n/a
 
 |===
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -124,17 +124,17 @@ An early access feature gate provides an opportunity for assessment before its f
 
 The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate has a default state of _disabled_.
 
-The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate allows the Strimzi Cluster Operator to continue the reconciliation if the manual rolling update of the operands fails.
+The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate allows the Cluster Operator to continue a reconciliation if the manual rolling update of the operands fails.
 It applies to the following operands that support manual rolling updates using the `strimzi.io/manual-rolling-update` annotation:
 * ZooKeeper
-* Kafka brokers
+* Kafka
 * Kafka Connect
 * Kafka MirrorMaker 2
 
-Continuing the reconciliation after the manual rolling update failure allows the operator to recover from various situations that might prevent the manual rolling update to succeed.
-For example, a missing Persistent Volume Claim (PVC) / Persistent Volume (PV) might cause the manual rolling update to fail.
-But the PVCs / PVs are created only in a later stage of the reconciliation.
-Continuing the reconciliation after the failure would allow to recreate the missing PVC / PV and recover from the failure.
+Continuing the reconciliation after the manual rolling update failure allows the operator to recover from various situations that might prevent the manual rolling update from succeeding.
+For example, a missing Persistent Volume Claim (PVC) or Persistent Volume (PV) might cause the manual rolling update to fail.
+But the PVCs and PVs are created only in a later stage of the reconciliation.
+Continuing the reconciliation after the failure would allow to recreate the missing PVC or PV and recover from the failure.
 
 .Enabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
 To enable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `+ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -119,7 +119,25 @@ To disable the `UseKRaft` feature gate, specify `-UseKRaft` in the `STRIMZI_FEAT
 Early access feature gates have not yet reached the beta stage, and are disabled by default. 
 An early access feature gate provides an opportunity for assessment before its functionality is permanently incorporated into Strimzi.
 
-Currently, there are no feature gates in alpha stage.
+[id='ref-operator-continue-reconciliation-on-manual-ru-failure-feature-gate-{context}']
+=== ContinueReconciliationOnManualRollingUpdateFailure feature gate
+
+The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate has a default state of _disabled_.
+
+The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate allows the Strimzi Cluster Operator to continue the reconciliation if the manual rolling update of the operands fails.
+It applies to the following operands that support manual rolling updates using the `strimzi.io/manual-rolling-update` annotation:
+* ZooKeeper
+* Kafka brokers
+* Kafka Connect
+* Kafka MirrorMaker 2
+
+Continuing the reconciliation after the manual rolling update failure allows the operator to recover from various situations that might prevent the manual rolling update to succeed.
+For example, a missing Persistent Volume Claim (PVC) / Persistent Volume (PV) might cause the manual rolling update to fail.
+But the PVCs / PVs are created only in a later stage of the reconciliation.
+Continuing the reconciliation after the failure would allow to recreate the missing PVC / PV and recover from the failure.
+
+.Enabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
+To enable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `+ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 == Enabling feature gates
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the feature gate `ContinueReconciliationOnManualRollingUpdateFailure` to the CHANGELOG and to the docs as that was missed in the original PR.

This should be backported into the 0.41.0 release branch.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md