### PR TITLE
[system test] - fix testJbodMetadataLogRelocation for >= 3.7.0 Kafka … 

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -484,7 +484,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testJbodMetadataLogRelocation() {
-        assumeTrue(Environment.isKRaftModeEnabled());
+        assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int numberOfKafkaReplicas = 3;
@@ -586,10 +586,10 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
     @BeforeAll
     void setup() {
-        this.clusterOperator = this.clusterOperator
-                .defaultInstallation()
-                .createInstallation()
-                .runInstallation();
+//        this.clusterOperator = this.clusterOperator
+//                .defaultInstallation()
+//                .createInstallation()
+//                .runInstallation();
     }
 }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -484,6 +484,9 @@ class AlternativeReconcileTriggersST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testJbodMetadataLogRelocation() {
+        // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
+        // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
+        // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
         assumeTrue(Environment.isKRaftModeEnabled() && TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -586,10 +586,10 @@ class AlternativeReconcileTriggersST extends AbstractST {
 
     @BeforeAll
     void setup() {
-//        this.clusterOperator = this.clusterOperator
-//                .defaultInstallation()
-//                .createInstallation()
-//                .runInstallation();
+        this.clusterOperator = this.clusterOperator
+                .defaultInstallation()
+                .createInstallation()
+                .runInstallation();
     }
 }
 


### PR DESCRIPTION
…version

### Type of change

- Bugfix

### Description

This PR fixes a problem when we run a release pipeline with the 3.6.2 version this test case failed because it is not intended to run on 3.6.2 because multiple JBOD volumes are not supported (expected). Thus I have updated the assumption condition here.

Should be cherry-picked to `release-0.41.x` :) if possible

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
