### PR TITLE
Improve the role change reversal and properly revert them

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterCreator.java
@@ -249,7 +249,7 @@ public class KafkaClusterCreator {
                         newNodePools.add(
                                 new KafkaNodePoolBuilder(nodePool)
                                         .editSpec()
-                                        .withReplicas(newReplicasCount)
+                                            .withReplicas(newReplicasCount)
                                         .endSpec()
                                         .build());
                     } else {
@@ -281,12 +281,12 @@ public class KafkaClusterCreator {
                 if (nodePool.getStatus() != null
                         && nodePool.getStatus().getRoles().contains(ProcessRoles.BROKER)
                         && !nodePool.getSpec().getRoles().contains(ProcessRoles.BROKER)) {
-                    warningConditions.add(StatusUtils.buildWarningCondition("ScaleDownPreventionCheck", "Reverting role change of KafkaNodePool " + nodePool.getMetadata().getName() + " by adding the broker role to it"));
-                    LOGGER.warnCr(reconciliation, "Reverting role change of KafkaNodePool {} by adding the broker role to it", nodePool.getMetadata().getName());
+                    warningConditions.add(StatusUtils.buildWarningCondition("ScaleDownPreventionCheck", "Reverting role change of KafkaNodePool " + nodePool.getMetadata().getName() + " (setting roles to " + nodePool.getStatus().getRoles() + ")"));
+                    LOGGER.warnCr(reconciliation, "Reverting role change of KafkaNodePool {} (setting roles to {})", nodePool.getMetadata().getName(), nodePool.getStatus().getRoles());
                     newNodePools.add(
                             new KafkaNodePoolBuilder(nodePool)
                                     .editSpec()
-                                    .addToRoles(ProcessRoles.BROKER)
+                                        .withRoles(nodePool.getStatus().getRoles())
                                     .endSpec()
                                     .build());
                 } else {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The current way how the reversal of the role change when a broker role is removed from a node that is not empty is implemented as simply adding the broker role back. But that is not the reversal in case the role is changed from `broker` to `controller`. That leads the operator into a strange _in the middle_ state where the controller role is applied but the broker role is not removed. This PR fixes it by reverting the roles to the original state before this change and maintaining the current state.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally