### PR TITLE
Promote the UseKRaft feature gate to GA

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -17,7 +17,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -29,7 +29,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -41,7 +41,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -53,7 +53,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -65,7 +65,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -77,7 +77,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -22,7 +22,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -36,7 +36,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -50,7 +50,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -64,7 +64,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -78,7 +78,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -92,7 +92,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '-UseKRaft,+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.42.0
 
 * The `UseKRaft` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
-  To use the KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources.
+  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.
 
 ## 0.41.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## 0.42.0
+
+* The `UseKRaft` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
+  To use the KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources.
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.
 
 ## 0.41.0

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/FeatureGates.java
@@ -16,11 +16,9 @@ import static java.util.Arrays.asList;
 public class FeatureGates {
     /* test */ static final FeatureGates NONE = new FeatureGates("");
 
-    private static final String USE_KRAFT = "UseKRaft";
     private static final String CONTINUE_ON_MANUAL_RU_FAILURE = "ContinueReconciliationOnManualRollingUpdateFailure";
 
     // When adding new feature gates, do not forget to add them to allFeatureGates() and toString() methods
-    private final FeatureGate useKRaft = new FeatureGate(USE_KRAFT, true);
     private final FeatureGate continueOnManualRUFailure =
         new FeatureGate(CONTINUE_ON_MANUAL_RU_FAILURE, false);
 
@@ -44,9 +42,6 @@ public class FeatureGates {
                 featureGate = featureGate.substring(1);
 
                 switch (featureGate) {
-                    case USE_KRAFT:
-                        setValueOnlyOnce(useKRaft, value);
-                        break;
                     case CONTINUE_ON_MANUAL_RU_FAILURE:
                         setValueOnlyOnce(continueOnManualRUFailure, value);
                         break;
@@ -84,13 +79,6 @@ public class FeatureGates {
     }
 
     /**
-     * @return  Returns true when the UseKRaft feature gate is enabled
-     */
-    public boolean useKRaftEnabled() {
-        return useKRaft.isEnabled();
-    }
-
-    /**
      * @return  Returns true when the ContinueReconciliationOnManualRollingUpdateFailure feature gate is enabled
      */
     public boolean continueOnManualRUFailureEnabled() {
@@ -103,16 +91,12 @@ public class FeatureGates {
      * @return  List of all Feature Gates
      */
     /*test*/ List<FeatureGate> allFeatureGates()  {
-        return List.of(
-                useKRaft,
-            continueOnManualRUFailure
-        );
+        return List.of(continueOnManualRUFailure);
     }
 
     @Override
     public String toString() {
         return "FeatureGates(" +
-                "UseKRaft=" + useKRaft.isEnabled() +
                 "ContinueReconciliationOnManualRollingUpdateFailure=" + continueOnManualRUFailure.isEnabled() +
                 ")";
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -26,7 +26,6 @@ import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolList;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.certs.CertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
-import io.strimzi.operator.cluster.FeatureGates;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.ClusterCa;
 import io.strimzi.operator.cluster.model.KRaftUtils;
@@ -112,8 +111,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
     /* test */ final ClusterOperatorConfig config;
     /* test */ final ResourceOperatorSupplier supplier;
 
-    private final FeatureGates featureGates;
-
     private final StatefulSetOperator stsOperations;
     private final CrdOperator<KubernetesClient, Kafka, KafkaList> kafkaOperator;
     private final StrimziPodSetOperator strimziPodSetOperator;
@@ -137,7 +134,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         this.supplier = supplier;
 
         this.operationTimeoutMs = config.getOperationTimeoutMs();
-        this.featureGates = config.featureGates();
         this.stsOperations = supplier.stsOperations;
         this.kafkaOperator = supplier.kafkaOperator;
         this.nodePoolOperator = supplier.kafkaNodePoolOperator;
@@ -230,7 +226,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         if (kafkaMetadataConfigState.isPreMigrationToKRaft()) {
             // Makes sure KRaft is used only with KafkaNodePool custom resources and not with virtual node pools
             if (!nodePoolsEnabled)  {
-                throw new InvalidConfigurationException("The UseKRaft feature gate can be used only together with a Kafka cluster based on the KafkaNodePool resources.");
+                throw new InvalidConfigurationException("KRaft can be used only together with a Kafka cluster based on the KafkaNodePool resources.");
             }
 
             // Validates features which are currently not supported in KRaft mode
@@ -310,7 +306,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             this.kafkaAssembly = kafkaAssembly;
             this.namespace = kafkaAssembly.getMetadata().getNamespace();
             this.name = kafkaAssembly.getMetadata().getName();
-            this.kafkaMetadataStateManager = new KafkaMetadataStateManager(reconciliation, kafkaAssembly, featureGates.useKRaftEnabled());
+            this.kafkaMetadataStateManager = new KafkaMetadataStateManager(reconciliation, kafkaAssembly);
         }
 
         /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -226,7 +226,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         if (kafkaMetadataConfigState.isPreMigrationToKRaft()) {
             // Makes sure KRaft is used only with KafkaNodePool custom resources and not with virtual node pools
             if (!nodePoolsEnabled)  {
-                throw new InvalidConfigurationException("KRaft can be used only together with a Kafka cluster based on the KafkaNodePool resources.");
+                throw new InvalidConfigurationException("KRaft can only be used with a Kafka cluster that uses KafkaNodePool resources.");
             }
 
             // Validates features which are currently not supported in KRaft mode

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMetadataStateManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMetadataStateManager.java
@@ -55,13 +55,11 @@ public class KafkaMetadataStateManager {
      * Constructor
      *
      * @param reconciliation Reconciliation information
-     * @param kafkaCr instance of the Kafka CR
-     * @param useKRaftFeatureGateEnabled if the UseKRaft feature gate is enabled on the operator
+     * @param kafkaCr        instance of the Kafka CR
      */
     public KafkaMetadataStateManager(
             Reconciliation reconciliation,
-            Kafka kafkaCr,
-            boolean useKRaftFeatureGateEnabled) {
+            Kafka kafkaCr) {
         this.reconciliation = reconciliation;
         this.kraftAnno = kraftAnnotation(kafkaCr);
         KafkaMetadataState metadataStateFromKafkaCr = kafkaCr.getStatus() != null ? kafkaCr.getStatus().getKafkaMetadataState() : null;
@@ -71,10 +69,7 @@ public class KafkaMetadataStateManager {
         } else {
             this.metadataState = metadataStateFromKafkaCr;
         }
-        if (!useKRaftFeatureGateEnabled && (isKRaftAnnoEnabled() || isKRaftAnnoMigration())) {
-            LOGGER.errorCr(reconciliation, "Trying to reconcile a KRaft enabled cluster or migrating to KRaft without the useKRaft feature gate enabled");
-            throw new IllegalArgumentException("Failed to reconcile a KRaft enabled cluster or migration to KRaft because useKRaft feature gate is disabled");
-        }
+
         LOGGER.debugCr(reconciliation, "Loaded metadata state from the Kafka CR [{}] and strimzi.io/kraft annotation [{}]", this.metadataState, this.kraftAnno);
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -43,7 +43,7 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.OPERATOR_NAMESPACE.key(), "operator-namespace");
-        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "-UseKRaft");
+        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+ContinueReconciliationOnManualRollingUpdateFailure");
         ENV_VARS.put(ClusterOperatorConfig.DNS_CACHE_TTL.key(), "10");
         ENV_VARS.put(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key(), "my.package.CustomPodSecurityProvider");
     }
@@ -65,7 +65,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getConnectBuildTimeoutMs(), is(Long.parseLong(ClusterOperatorConfig.CONNECT_BUILD_TIMEOUT_MS.defaultValue())));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
         assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
-        assertThat(config.featureGates().useKRaftEnabled(), is(true));
+        assertThat(config.featureGates().continueOnManualRUFailureEnabled(), is(false));
         assertThat(config.isCreateClusterRoles(), is(false));
         assertThat(config.isNetworkPolicyGeneration(), is(true));
         assertThat(config.isPodSetReconciliationOnly(), is(false));
@@ -100,7 +100,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(30_000L));
         assertThat(config.getConnectBuildTimeoutMs(), is(40_000L));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
-        assertThat(config.featureGates().useKRaftEnabled(), is(false));
+        assertThat(config.featureGates().continueOnManualRUFailureEnabled(), is(true));
         assertThat(config.getDnsCacheTtlSec(), is(10));
         assertThat(config.getPodSecurityProviderClass(), is("my.package.CustomPodSecurityProvider"));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -64,7 +64,6 @@ public class ClusterOperatorTest {
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         env.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
-        env.put(ClusterOperatorConfig.FEATURE_GATES.key(), "-UseKRaft");
 
         if (podSetsOnly) {
             env.put(ClusterOperatorConfig.POD_SET_RECONCILIATION_ONLY.key(), "true");

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/FeatureGatesTest.java
@@ -22,14 +22,7 @@ public class FeatureGatesTest {
     public void testIndividualFeatureGates() {
         for (FeatureGates.FeatureGate gate : FeatureGates.NONE.allFeatureGates()) {
             FeatureGates enabled = new FeatureGates("+" + gate.getName());
-            FeatureGates disabled;
-
-            // KafkaNodePools FG can be disabled only together with UseKRaft FG
-            if (gate.getName().equals("KafkaNodePools")) {
-                disabled = new FeatureGates("-" + gate.getName() + ",-UseKRaft");
-            } else {
-                disabled = new FeatureGates("-" + gate.getName());
-            }
+            FeatureGates disabled = new FeatureGates("-" + gate.getName());
 
             assertThat(enabled.allFeatureGates().stream().filter(g -> gate.getName().equals(g.getName())).findFirst().orElseThrow().isEnabled(), is(true));
             assertThat(disabled.allFeatureGates().stream().filter(g -> gate.getName().equals(g.getName())).findFirst().orElseThrow().isEnabled(), is(false));
@@ -59,17 +52,17 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testFeatureGatesParsing() {
-        assertThat(new FeatureGates("+UseKRaft").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("-UseKRaft").useKRaftEnabled(), is(false));
-        assertThat(new FeatureGates("  -UseKRaft    ").useKRaftEnabled(), is(false));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
+        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
+        assertThat(new FeatureGates("  -ContinueReconciliationOnManualRollingUpdateFailure    ").continueOnManualRUFailureEnabled(), is(false));
         // TODO: Add more tests with various feature gate combinations once we have multiple feature gates again.
         //       The commented out code below shows the tests we used to have with multiple feature gates.
-        assertThat(new FeatureGates("-UseKRaft,-ContinueReconciliationOnManualRollingUpdateFailure").useKRaftEnabled(), is(false));
-        assertThat(new FeatureGates("-UseKRaft,-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
-        assertThat(new FeatureGates("  +UseKRaft    ,    +ContinueReconciliationOnManualRollingUpdateFailure").useKRaftEnabled(), is(true));
-        assertThat(new FeatureGates("  +UseKRaft    ,    +ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
-        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseKRaft").useKRaftEnabled(), is(false));
-        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseKRaft").continueOnManualRUFailureEnabled(), is(true));
+        //assertThat(new FeatureGates("-UseKRaft,-ContinueReconciliationOnManualRollingUpdateFailure").useKRaftEnabled(), is(false));
+        //assertThat(new FeatureGates("-UseKRaft,-ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(false));
+        //assertThat(new FeatureGates("  +UseKRaft    ,    +ContinueReconciliationOnManualRollingUpdateFailure").useKRaftEnabled(), is(true));
+        //assertThat(new FeatureGates("  +UseKRaft    ,    +ContinueReconciliationOnManualRollingUpdateFailure").continueOnManualRUFailureEnabled(), is(true));
+        //assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseKRaft").useKRaftEnabled(), is(false));
+        //assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-UseKRaft").continueOnManualRUFailureEnabled(), is(true));
     }
 
     @ParallelTest
@@ -90,20 +83,20 @@ public class FeatureGatesTest {
 
     @ParallelTest
     public void testDuplicateFeatureGateWithSameValue() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft,+UseKRaft"));
-        assertThat(e.getMessage(), containsString("Feature gate UseKRaft is configured multiple times"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,+ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(e.getMessage(), containsString("Feature gate ContinueReconciliationOnManualRollingUpdateFailure is configured multiple times"));
     }
 
     @ParallelTest
     public void testDuplicateFeatureGateWithDifferentValue() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+UseKRaft,-UseKRaft"));
-        assertThat(e.getMessage(), containsString("Feature gate UseKRaft is configured multiple times"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure,-ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(e.getMessage(), containsString("Feature gate ContinueReconciliationOnManualRollingUpdateFailure is configured multiple times"));
     }
 
     @ParallelTest
     public void testMissingSign() {
-        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("UseKRaft"));
-        assertThat(e.getMessage(), containsString("UseKRaft is not a valid feature gate configuration"));
+        InvalidConfigurationException e = assertThrows(InvalidConfigurationException.class, () -> new FeatureGates("ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(e.getMessage(), containsString("ContinueReconciliationOnManualRollingUpdateFailure is not a valid feature gate configuration"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -817,7 +817,7 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
         List<String> kafkaNodesNeedRestart = new ArrayList<>();
         private final boolean forceErrorWhenRollKafka;
         public MockKafkaReconciler(Reconciliation reconciliation, Vertx vertx, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, PlatformFeaturesAvailability pfa, Kafka kafkaAssembly, List<KafkaNodePool> nodePools, KafkaCluster kafkaCluster, ClusterCa clusterCa, ClientsCa clientsCa, boolean forceErrorWhenRollKafka) {
-            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly, config.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly));
             this.forceErrorWhenRollKafka = forceErrorWhenRollKafka;
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorPodSetTest.java
@@ -995,7 +995,7 @@ public class KafkaAssemblyOperatorPodSetTest {
         Function<Pod, RestartReasons> kafkaPodNeedsRestart = null;
 
         public MockKafkaReconciler(Reconciliation reconciliation, Vertx vertx, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, PlatformFeaturesAvailability pfa, Kafka kafkaAssembly, KafkaCluster kafkaCluster, ClusterCa clusterCa, ClientsCa clientsCa) {
-            super(reconciliation, kafkaAssembly, null, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly, config.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaAssembly, null, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly));
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
@@ -1080,7 +1080,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
                 .onComplete(context.failing(v -> context.verify(() -> {
                     assertThat(v, instanceOf(InvalidConfigurationException.class));
-                    assertThat(v.getMessage(), is("KRaft can be used only together with a Kafka cluster based on the KafkaNodePool resources."));
+                    assertThat(v.getMessage(), is("KRaft can only be used with a Kafka cluster that uses KafkaNodePool resources."));
                     async.flag();
                 })));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
@@ -1080,7 +1080,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
                 .onComplete(context.failing(v -> context.verify(() -> {
                     assertThat(v, instanceOf(InvalidConfigurationException.class));
-                    assertThat(v.getMessage(), is("The UseKRaft feature gate can be used only together with a Kafka cluster based on the KafkaNodePool resources."));
+                    assertThat(v.getMessage(), is("KRaft can be used only together with a Kafka cluster based on the KafkaNodePool resources."));
                     async.flag();
                 })));
     }
@@ -1185,7 +1185,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         Function<Pod, RestartReasons> kafkaPodNeedsRestart = null;
 
         public MockKafkaReconciler(Reconciliation reconciliation, Vertx vertx, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, PlatformFeaturesAvailability pfa, Kafka kafkaAssembly, List<KafkaNodePool> nodePools, KafkaCluster kafkaCluster, ClusterCa clusterCa, ClientsCa clientsCa) {
-            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly, config.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly));
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsTest.java
@@ -1404,7 +1404,7 @@ public class KafkaAssemblyOperatorWithPoolsTest {
         Function<Pod, RestartReasons> kafkaPodNeedsRestart = null;
 
         public MockKafkaReconciler(Reconciliation reconciliation, Vertx vertx, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, PlatformFeaturesAvailability pfa, Kafka kafkaAssembly, List<KafkaNodePool> nodePools, KafkaCluster kafkaCluster, ClusterCa clusterCa, ClientsCa clientsCa) {
-            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly, config.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaAssembly, nodePools, kafkaCluster, clusterCa, clientsCa, config, supplier, pfa, vertx, new KafkaMetadataStateManager(reconciliation, kafkaAssembly));
         }
 
         @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMetadataStateManagerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMetadataStateManagerTest.java
@@ -20,7 +20,6 @@ import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.KRaftPostMigra
 import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.PreKRaft;
 import static io.strimzi.api.kafka.model.kafka.KafkaMetadataState.ZooKeeper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -60,7 +59,7 @@ public class KafkaMetadataStateManagerTest {
                 .endMetadata()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaftMigration);
 
         // test with ZooKeeper metadata state set
@@ -73,26 +72,8 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaftMigration);
-    }
-
-    @Test
-    public void testFromZookeeperToKRaftMigrationFailsKRaftDisabled() {
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editMetadata()
-                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "migration")
-                .endMetadata()
-                .withNewStatus()
-                    .withKafkaMetadataState(ZooKeeper)
-                .endStatus()
-                .build();
-
-        var exception = assertThrows(IllegalArgumentException.class, () ->
-                new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, false));
-
-        assertEquals("Failed to reconcile a KRaft enabled cluster or migration to KRaft because useKRaft feature gate is disabled",
-                exception.getMessage());
     }
 
     @Test
@@ -106,7 +87,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         // check staying in KRaftMigration, migration is not done yet
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaftMigration);
         // set migration done and check move to KRaftDualWriting
@@ -125,7 +106,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaftPostMigration);
     }
 
@@ -140,7 +121,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), PreKRaft);
     }
 
@@ -155,7 +136,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaft);
     }
 
@@ -170,7 +151,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), KRaftDualWriting);
     }
 
@@ -185,7 +166,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         assertEquals(kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus()), ZooKeeper);
     }
 
@@ -200,7 +181,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -217,7 +198,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -237,7 +218,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -253,7 +234,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -272,7 +253,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -288,7 +269,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -307,7 +288,7 @@ public class KafkaMetadataStateManagerTest {
                 .endStatus()
                 .build();
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
         kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
         assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
         assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -328,7 +309,7 @@ public class KafkaMetadataStateManagerTest {
                     .endStatus()
                     .build();
 
-            KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+            KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
             kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
             assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
             assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),
@@ -351,7 +332,7 @@ public class KafkaMetadataStateManagerTest {
                     .endStatus()
                     .build();
 
-            KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka, true);
+            KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(Reconciliation.DUMMY_RECONCILIATION, kafka);
             kafkaMetadataStateManager.computeNextMetadataState(kafka.getStatus());
             assertTrue(kafka.getStatus().getConditions().stream().anyMatch(condition -> "KafkaMetadataStateWarning".equals(condition.getReason())));
             assertEquals(kafka.getStatus().getConditions().get(0).getMessage(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerKRaftMigrationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerKRaftMigrationTest.java
@@ -174,7 +174,7 @@ public class KafkaReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka);
 
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 
@@ -221,7 +221,7 @@ public class KafkaReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka);
 
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 
@@ -263,7 +263,7 @@ public class KafkaReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka);
 
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 
@@ -302,7 +302,7 @@ public class KafkaReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
 
-        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager kafkaMetadataStateManager = new KafkaMetadataStateManager(RECONCILIATION, kafka);
 
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -802,7 +802,7 @@ public class KafkaReconcilerStatusTest {
         private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(MockKafkaReconcilerStatusTasks.class.getName());
 
         public MockKafkaReconcilerStatusTasks(Reconciliation reconciliation, ResourceOperatorSupplier supplier, Kafka kafkaCr) {
-            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr, CO_CONFIG.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr));
         }
 
         private static KafkaCluster createKafkaCluster(Reconciliation reconciliation, ResourceOperatorSupplier supplier, Kafka kafkaCr)   {
@@ -813,7 +813,7 @@ public class KafkaReconcilerStatusTest {
                     Map.of(),
                     Map.of(),
                     VERSION_CHANGE,
-                    new KafkaMetadataStateManager(reconciliation, kafkaCr, CO_CONFIG.featureGates().useKRaftEnabled()).getMetadataConfigurationState(),
+                    new KafkaMetadataStateManager(reconciliation, kafkaCr).getMetadataConfigurationState(),
                     VERSIONS,
                     supplier.sharedEnvironmentProvider);
         }
@@ -853,7 +853,7 @@ public class KafkaReconcilerStatusTest {
         private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(MockKafkaReconcilerStatusTasks.class.getName());
 
         public MockKafkaReconcilerFailsWithVersionUpdate(Reconciliation reconciliation, ResourceOperatorSupplier supplier, Kafka kafkaCr) {
-            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr, CO_CONFIG.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr));
         }
 
         private static KafkaCluster createKafkaCluster(Reconciliation reconciliation, ResourceOperatorSupplier supplier, Kafka kafkaCr)   {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerUpgradeDowngradeTest.java
@@ -268,7 +268,7 @@ public class KafkaReconcilerUpgradeDowngradeTest {
 
     static class MockKafkaReconciler extends KafkaReconciler {
         public MockKafkaReconciler(Reconciliation reconciliation, ResourceOperatorSupplier supplier, Kafka kafkaCr, KafkaVersionChange versionChange) {
-            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr, versionChange), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr, CO_CONFIG.featureGates().useKRaftEnabled()));
+            super(reconciliation, kafkaCr, null, createKafkaCluster(reconciliation, supplier, kafkaCr, versionChange), CLUSTER_CA, CLIENTS_CA, CO_CONFIG, supplier, PFA, vertx, new KafkaMetadataStateManager(reconciliation, kafkaCr));
             listenerReconciliationResults = new KafkaListenersReconciler.ReconciliationResult();
         }
 
@@ -280,7 +280,7 @@ public class KafkaReconcilerUpgradeDowngradeTest {
                     Map.of(),
                     Map.of(),
                     versionChange,
-                    new KafkaMetadataStateManager(reconciliation, kafkaCr, CO_CONFIG.featureGates().useKRaftEnabled()).getMetadataConfigurationState(),
+                    new KafkaMetadataStateManager(reconciliation, kafkaCr).getMetadataConfigurationState(),
                     VERSIONS,
                     supplier.sharedEnvironmentProvider);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZookeeperReconcilerKRaftMigrationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ZookeeperReconcilerKRaftMigrationTest.java
@@ -124,7 +124,7 @@ public class ZookeeperReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 
-        KafkaMetadataStateManager stateManager = new KafkaMetadataStateManager(RECONCILIATION, patchedKafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager stateManager = new KafkaMetadataStateManager(RECONCILIATION, patchedKafka);
 
         MockZooKeeperReconciler zookeeperReconciler = spy(new MockZooKeeperReconciler(
                 RECONCILIATION,
@@ -170,7 +170,7 @@ public class ZookeeperReconcilerKRaftMigrationTest {
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.secretName(CLUSTER_NAME)))).thenReturn(Future.succeededFuture(secret));
         KafkaVersionChange versionChange = new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), VERSIONS.defaultVersion().protocolVersion(), VERSIONS.defaultVersion().messageVersion(), VERSIONS.defaultVersion().metadataVersion());
 
-        KafkaMetadataStateManager stateManager = new KafkaMetadataStateManager(RECONCILIATION, patchedKafka, CO_CONFIG.featureGates().useKRaftEnabled());
+        KafkaMetadataStateManager stateManager = new KafkaMetadataStateManager(RECONCILIATION, patchedKafka);
 
         MockZooKeeperReconciler zookeeperReconciler = spy(new MockZooKeeperReconciler(
                 RECONCILIATION,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -241,7 +241,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafkaWithLessVolumes, clusterOperatorConfig.featureGates().useKRaftEnabled())
+                new KafkaMetadataStateManager(reconciliation, kafkaWithLessVolumes)
         );
 
         lowerVolumes.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_HAS_OLD_REVISION, context));
@@ -291,7 +291,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_HAS_OLD_GENERATION, context));
     }
@@ -324,7 +324,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_REMOVED, context));
     }
@@ -357,7 +357,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_RENEWED, context));
     }
@@ -423,7 +423,7 @@ public class KubernetesRestartEventsMockTest {
                 supplierWithModifiedAdmin,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(CONFIG_CHANGE_REQUIRES_RESTART, context));
     }
@@ -484,7 +484,7 @@ public class KubernetesRestartEventsMockTest {
                 supplierWithModifiedAdmin,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(POD_UNRESPONSIVE, context));
     }
@@ -547,7 +547,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
         reconciler.reconcile(ks, Clock.systemUTC()).onComplete(verifyEventPublished(KAFKA_CERTIFICATES_CHANGED, context));
 
     }
@@ -591,7 +591,7 @@ public class KubernetesRestartEventsMockTest {
                 supplier,
                 PFA,
                 vertx,
-                new KafkaMetadataStateManager(reconciliation, kafka, clusterOperatorConfig.featureGates().useKRaftEnabled()));
+                new KafkaMetadataStateManager(reconciliation, kafka));
     }
 
     private ResourceOperatorSupplier supplierWithAdmin(Vertx vertx, Supplier<Admin> adminClientSupplier) {

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -22,11 +22,12 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseStrimziPodSets` feature gate moved to GA stage in Strimzi 0.35 and the support for StatefulSets is completely removed. It is now permanently enabled and cannot be disabled.
 * The `StableConnectIdentities` feature gate moved to GA stage in Strimzi 0.39.
   It is now permanently enabled and cannot be disabled.
-* The `UseKRaft` feature gate is in beta stage and is enabled by default.
 * The `KafkaNodePools` feature gate moved to GA stage in Strimzi 0.41.
   It is now permanently enabled and cannot be disabled.
 * The `UnidirectionalTopicOperator` feature gate moved to GA stage in Strimzi 0.41.
   It is now permanently enabled and cannot be disabled.
+* The `UseKRaft` feature gate moved to GA stage in Strimzi 0.42.
+It is now permanently enabled and cannot be disabled.
 * The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and is disabled by default.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
@@ -58,7 +59,7 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 ¦`UseKRaft`
 ¦0.29
 ¦0.40
-¦0.42 (planned)
+¦0.42
 
 ¦`StableConnectIdentities`
 ¦0.34

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -60,7 +60,7 @@ A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
 Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
 You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool using the `.spec.roles` property.
 When used with a ZooKeeper-based Apache Kafka cluster, it must be set to the `broker` role.
-When used with the `UseKRaft` feature gate, it can be set to `broker`, `controller`, or both.
+When used with a KRaft-based Apache Kafka cluster, it can be set to `broker`, `controller`, or both.
 
 In addition, a node pool can have its own configuration of resource requests and limits, Java JVM options, and resource templates.
 Configuration options not set in the `KafkaNodePool` resource are inherited from the `Kafka` custom resource.
@@ -84,21 +84,14 @@ With unidirectional mode, you create Kafka topics using the `KafkaTopic` resourc
 Any configuration changes to a topic outside the `KafkaTopic` resource are reverted.
 For more information on topic management, see xref:ref-operator-topic-str[].
 
-== Stable feature gates (Beta)
-
-Stable feature gates have reached a beta level of maturity, and are generally enabled by default for all users.
-Stable feature gates are production-ready, but they can still be disabled.
-
 [id='ref-operator-use-kraft-feature-gate-{context}']
 === UseKRaft feature gate
 
-The `UseKRaft` feature gate has a default state of _enabled_.
-
-The `UseKRaft` feature gate deploys a Kafka cluster in KRaft (Kafka Raft metadata) mode without ZooKeeper.
-ZooKeeper and KRaft are mechanisms used to manage metadata and coordinate operations in Kafka clusters. 
-KRaft mode eliminates the need for an external coordination service like ZooKeeper. 
-In KRaft mode, Kafka nodes take on the roles of brokers, controllers, or both. 
-They collectively manage the metadata, which is replicated across partitions. 
+The `UseKRaft` feature gate introduced the KRaft (Kafka Raft metadata) mode for running Apache Kafka clusters without ZooKeeper.
+ZooKeeper and KRaft are mechanisms used to manage metadata and coordinate operations in Kafka clusters.
+KRaft mode eliminates the need for an external coordination service like ZooKeeper.
+In KRaft mode, Kafka nodes take on the roles of brokers, controllers, or both.
+They collectively manage the metadata, which is replicated across partitions.
 Controllers are responsible for coordinating operations and maintaining the cluster's state.
 
 To deploy a Kafka cluster in KRaft mode, you must use the `KafkaNodePool` resources.
@@ -108,12 +101,15 @@ The `Kafka` custom resource using KRaft mode must also have the annotation `stri
 Currently, the KRaft mode in Strimzi has the following major limitations:
 
 * JBOD storage is supported only with Apache Kafka 3.7.0 and higher.
-  It is considered early-access in Apache Kafka 3.7.x.
-  (Storage with `type: jbod` configuration can be used also with older Kafka versions, but the JBOD array can contain only one disk.)
+It is considered early-access in Apache Kafka 3.7.x.
+(Storage with `type: jbod` configuration can be used also with older Kafka versions, but the JBOD array can contain only one disk.)
 * Scaling of KRaft controller-only nodes up or down is not supported.
 
-.Disabling the UseKRaft feature gate
-To disable the `UseKRaft` feature gate, specify `-UseKRaft` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+== Stable feature gates (Beta)
+
+Stable feature gates have reached a beta level of maturity, and are generally enabled by default for all users.
+Stable feature gates are production-ready, but they can still be disabled.
+Currently, there are no beta level feature gates.
 
 == Early access feature gates (Alpha)
 

--- a/packaging/examples/kafka/kraft/README.md
+++ b/packaging/examples/kafka/kraft/README.md
@@ -6,6 +6,5 @@ The examples in this directory demonstrate how you can use Kraft (ZooKeeper-less
 * The [`kafka-with-dual-role-nodes.yaml`](kafka-with-dual-role-nodes.yaml) deploys a Kafka cluster with one pool of KRaft nodes that share the _broker_ and _controller_ roles.
 * The [`kafka-single-node.yaml`](kafka-single-node.yaml) deploys a Kafka cluster with a single Kafka node that has both _broker_ and _controller_ roles.
 
-To use KRaft, ensure that the `UseKRaft` feature gate is not disabled.
 Please note that ZooKeeper-less Apache Kafka is still under development and has some limitations.
 For instance, scaling of controller node or JBOD storage (you can specify `type: jbod` storage in Strimzi custom resources, but it should contain only a single volume) are not supported.

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -299,11 +299,7 @@ public class Environment {
      * @return true if KRaft mode is enabled, otherwise false
      */
     public static boolean isKRaftModeEnabled() {
-        return isKRaftForCOEnabled() && STRIMZI_USE_KRAFT_IN_TESTS;
-    }
-
-    public static boolean isKRaftForCOEnabled() {
-        return !STRIMZI_FEATURE_GATES.contains(TestConstants.DONT_USE_KRAFT_MODE);
+        return STRIMZI_USE_KRAFT_IN_TESTS;
     }
 
     public static boolean isKafkaNodePoolsEnabled() {

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -206,9 +206,7 @@ public interface TestConstants {
     /**
      * Feature gate related constants
      */
-    String DONT_USE_KRAFT_MODE = "-UseKRaft";
-    // kept for upgrade/downgrade tests in KRaft
-    String USE_KRAFT_MODE = "+UseKRaft";
+    // No Feature gates kept for STs at this moment
 
     /**
      * Default value which allows execution of tests with any tags

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.strimzi.systemtest.Environment;
-import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +34,6 @@ public class VersionModificationDataLoader {
     private static final Logger LOGGER = LogManager.getLogger(VersionModificationDataLoader.class);
     private OlmVersionModificationData olmUpgradeData;
     private List<BundleVersionModificationData> bundleVersionModificationDataList;
-    private static final String KRAFT_UPGRADE_FEATURE_GATES = String.join(",", TestConstants.USE_KRAFT_MODE);
 
     public VersionModificationDataLoader(ModificationType upgradeType) {
         if (upgradeType == ModificationType.OLM_UPGRADE) {
@@ -112,7 +110,7 @@ public class VersionModificationDataLoader {
     public BundleVersionModificationData buildDataForUpgradeAcrossVersionsForKRaft() {
         BundleVersionModificationData acrossUpgradeData = buildDataForUpgradeAcrossVersions();
 
-        acrossUpgradeData = updateUpgradeDataWithFeatureGates(acrossUpgradeData, KRAFT_UPGRADE_FEATURE_GATES);
+        acrossUpgradeData = updateUpgradeDataWithFeatureGates(acrossUpgradeData, null);
 
         return acrossUpgradeData;
     }
@@ -144,7 +142,7 @@ public class VersionModificationDataLoader {
     }
 
     public BundleVersionModificationData buildDataForDowngradeUsingFirstScenarioForKRaft() {
-        return buildDataForDowngradeUsingFirstScenario(KRAFT_UPGRADE_FEATURE_GATES);
+        return buildDataForDowngradeUsingFirstScenario(null);
     }
 
     /**
@@ -165,7 +163,7 @@ public class VersionModificationDataLoader {
     }
 
     public static Stream<Arguments> loadYamlDowngradeDataForKRaft() {
-        return loadYamlDowngradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES, true);
+        return loadYamlDowngradeDataWithFeatureGates(null, true);
     }
 
     public static Stream<Arguments> loadYamlDowngradeDataWithFeatureGates(String featureGates, boolean isKRaft) {
@@ -200,7 +198,7 @@ public class VersionModificationDataLoader {
     }
 
     public static Stream<Arguments> loadYamlUpgradeDataForKRaft() {
-        return loadYamlUpgradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES, true);
+        return loadYamlUpgradeDataWithFeatureGates(null, true);
     }
 
     public static Stream<Arguments> loadYamlUpgradeDataWithFeatureGates(String featureGates, boolean isKRaft) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -365,7 +365,7 @@ public class CruiseControlST extends AbstractST {
         // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
         // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
         // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
-        assumeTrue(!Environment.isKRaftForCOEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
+        assumeTrue(!Environment.isKRaftModeEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         String diskSize = "6Gi";

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -408,7 +408,7 @@ class KafkaST extends AbstractST {
         // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
         // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
         // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
-        assumeTrue(!Environment.isKRaftForCOEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
+        assumeTrue(!Environment.isKRaftModeEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int kafkaReplicas = 2;
         final String diskSizeGi = "10";
@@ -564,7 +564,7 @@ class KafkaST extends AbstractST {
         // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
         // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
         // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
-        assumeTrue(!Environment.isKRaftForCOEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
+        assumeTrue(!Environment.isKRaftModeEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
@@ -1133,7 +1133,7 @@ class KafkaST extends AbstractST {
         // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
         // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
         // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
-        assumeTrue(!Environment.isKRaftForCOEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
+        assumeTrue(!Environment.isKRaftModeEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int numberOfKafkaReplicas = 3;

--- a/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/migration/MigrationST.java
@@ -790,7 +790,7 @@ public class MigrationST extends AbstractST {
         // skip if Kafka version is lower than 3.7.0
         // TODO: remove once support for Kafka 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
         assumeTrue(TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
-        assumeTrue(Environment.isKafkaNodePoolsEnabled() && Environment.isKRaftForCOEnabled());
+        assumeTrue(Environment.isKafkaNodePoolsEnabled() && Environment.isKRaftModeEnabled());
         this.clusterOperator = this.clusterOperator
             .defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/FeatureGatesST.java
@@ -72,8 +72,7 @@ public class FeatureGatesST extends AbstractST {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int kafkaReplicas = 3;
 
-        // as kraft is included in CO Feature gates, kafka broker can take both roles (Controller and Broker)
-        setupClusterOperatorWithFeatureGate("+UseKRaft");
+        setupClusterOperatorWithFeatureGate("");
 
         final Kafka kafkaCr = KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), kafkaReplicas)
             .editOrNewMetadata()
@@ -82,8 +81,6 @@ public class FeatureGatesST extends AbstractST {
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()
             .build();
-
-        kafkaCr.getSpec().getEntityOperator().setTopicOperator(null); // The builder cannot disable the EO. It has to be done this way.
 
         resourceManager.createResourceWithWait(
             KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), kafkaReplicas).build(),

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -340,7 +340,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         // JBOD storage in KRaft is supported only from Kafka 3.7.0 and higher.
         // So we want to run this test when KRaft is disabled or when it is with KRaft and Kafka 3.7.0+
         // TODO: remove once support for 3.6.x is removed - https://github.com/strimzi/strimzi-kafka-operator/issues/9921
-        assumeTrue(!Environment.isKRaftForCOEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
+        assumeTrue(!Environment.isKRaftModeEnabled() || TestKafkaVersion.compareDottedVersions(Environment.ST_KAFKA_VERSION, "3.7.0") >= 0);
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -4,12 +4,10 @@
  */
 package io.strimzi.systemtest.upgrade.kraft;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.Annotations;
-import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -29,7 +27,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -112,13 +109,8 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
     @BeforeAll
     void setupEnvironment() {
-        List<EnvVar> coEnvVars = new ArrayList<>();
-        coEnvVars.add(new EnvVar(Environment.STRIMZI_FEATURE_GATES_ENV, String.join(",",
-            TestConstants.USE_KRAFT_MODE), null));
-
         clusterOperator
             .defaultInstallation()
-            .withExtraEnvVars(coEnvVars)
             .createInstallation()
             .runInstallation();
     }


### PR DESCRIPTION
### Type of change

- Task

### Description

In line with the [Strimzi Proposal 62](https://github.com/strimzi/proposals/blob/main/062-UseKRaft-feature-gate-promotion.md#proposed-timeline), this PR moves the `UseKRaft` to GA. It removes it from the code and keeps it permanently enabled.

_Note: This does not mean KRaft is used by default as it still needs to be enabled with the `strimzi.io/kraft: enabled` feature gate. There is just no feature gate anymore._

There are two tasks that might be done in separate PRs as follow-ups:
* The KRaft based ST in the `FeatureGatesST` class seems useful, but not sure it makes sense to keep it in the Feature Gates tests
* The documentation might use further improvements to make KRaft moe prominent also outside of the feature gate description as the list of limitations for example might get a bit lost now.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md