### PR TITLE
docs(kraft): makes the migration rollback situation clear

### DIFF
--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -18,6 +18,7 @@ Note also, the following:
 
 * Migration is only supported on dedicated controller nodes, not on nodes with dual roles as brokers and controllers.
 * Throughout the migration process, ZooKeeper and controller nodes operate in parallel for a period, requiring sufficient compute resources in the cluster.
+* *Once KRaft mode is enabled, rollback to ZooKeeper is not possible. Consider this carefully before proceeding with the migration.*
 
 .Prerequisites
 


### PR DESCRIPTION
**Documentation**

Updates [Migrating to KRaft mode](https://strimzi.io/docs/operators/in-development/deploying#proc-deploy-migrate-kraft-str) procedure to make it clear that the migration can't be rolled back once KRaft is enabled.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

