### PR TITLE
Reorder the Azure CI Release pipeline to push Helm OCI at the end

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -68,7 +68,7 @@ stages:
   - stage: helm_as_oci_publish
     displayName: Publish Helm Chart as OCI artifact
     dependsOn:
-      - prepare_release_artifacts
+      - containers_publish
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/build/publish_helm_chart_as_oci.yaml'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the release pipeline, we push the OCI artifact with the Helm Chart to the repository before pushing all the images. That can lead to someone already trying to use the Helm Chart and running into issues as the images will be missing. This PR changes the order and pushes the Helm Chart OCI artifact only after the images are pushed.

This should resolve #10105.

### Checklist

- [x] Reference relevant issue(s) and close them after merging