### PR TITLE
Compute build revision in KafkaConnectAssemblyOperatorPodSetTest

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -1343,6 +1343,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
     public void testBuildChangedCluster(VertxTestContext context)  {
         KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
                 .editSpec()
+                .withImage("my-base-image:latest")
                     .withNewBuild()
                         .withNewDockerOutput()
                             .withImage("my-image:latest")
@@ -1456,12 +1457,12 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(capturesPodSets.size(), is(1));
                     StrimziPodSet podSet = capturesPodSets.get(0);
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
-                    assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("28987d00751944b0"));
+                    assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("639b0d8b751944b0"));
                     assertThat(podSet.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_IMAGE), is("my-connect-build@sha256:blablabla"));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
 
                     for (Pod pod : PodSetUtils.podSetToPods(podSet))  {
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("28987d00751944b0"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.STRIMZI_IO_CONNECT_BUILD_REVISION), is("639b0d8b751944b0"));
                         assertThat(pod.getSpec().getContainers().get(0).getImage(), is("my-connect-build@sha256:blablabla"));
                     }
 


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
On each Kafka version change, the KafkaConnectAssemblyOperatorPodSetTest needs a manual update due to a hard-coded hash. This change updates the test to compute the expected hash, meaning that the test won't need a manual update on each version change.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

