### PR TITLE
Refactor handing and preparatin of trusted certificates

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AuthenticationUtils.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthentication;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth;
@@ -149,7 +148,7 @@ public class AuthenticationUtils {
             } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
                 addNewVolume(volumeList, volumeNamePrefix, scramAuth.getPasswordSecret().getSecretName(), isOpenShift);
             } else if (authentication instanceof KafkaClientAuthenticationOAuth oauth) {
-                volumeList.addAll(configureOauthCertificateVolumes(oauthVolumeNamePrefix, oauth.getTlsTrustedCertificates(), isOpenShift));
+                CertUtils.createTrustedCertificatesVolumes(volumeList, oauth.getTlsTrustedCertificates(), isOpenShift, oauthVolumeNamePrefix);
 
                 if (createOAuthSecretVolumes) {
                     if (oauth.getClientSecret() != null) {
@@ -219,7 +218,7 @@ public class AuthenticationUtils {
             } else if (authentication instanceof KafkaClientAuthenticationScram scramAuth) {
                 volumeMountList.add(VolumeUtils.createVolumeMount(volumeNamePrefix + scramAuth.getPasswordSecret().getSecretName(), passwordVolumeMount + scramAuth.getPasswordSecret().getSecretName()));
             } else if (authentication instanceof KafkaClientAuthenticationOAuth oauth) {
-                volumeMountList.addAll(configureOauthCertificateVolumeMounts(oauthVolumeNamePrefix, oauth.getTlsTrustedCertificates(), oauthCertsVolumeMount));
+                CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, oauth.getTlsTrustedCertificates(), oauthCertsVolumeMount, oauthVolumeNamePrefix);
             
                 if (mountOAuthSecretVolumes) {
                     if (oauth.getClientSecret() != null) {
@@ -277,6 +276,10 @@ public class AuthenticationUtils {
                 if (oauth.getPasswordSecret() != null) {
                     varList.add(ContainerUtils.createEnvVarFromSecret(envVarNamer.apply("OAUTH_PASSWORD_GRANT_PASSWORD"), oauth.getPasswordSecret().getSecretName(), oauth.getPasswordSecret().getPassword()));
                 }
+
+                if (oauth.getTlsTrustedCertificates() != null && !oauth.getTlsTrustedCertificates().isEmpty()) {
+                    varList.add(ContainerUtils.createEnvVar(envVarNamer.apply("OAUTH_TRUSTED_CERTS"), CertUtils.trustedCertsEnvVar(oauth.getTlsTrustedCertificates())));
+                }
             }
         }
     }
@@ -325,34 +328,6 @@ public class AuthenticationUtils {
     }
 
     /**
-     * Generates volumes needed for certificates needed to connect to OAuth server.
-     * This is used in both OAuth servers and clients.
-     *
-     * @param volumeNamePrefix    Prefix for naming the secret volumes
-     * @param trustedCertificates   List of certificates which should be mounted
-     * @param isOpenShift   Flag whether we are on OpenShift or not
-     *
-     * @return List of new Volumes
-     */
-    public static List<Volume> configureOauthCertificateVolumes(String volumeNamePrefix, List<CertSecretSource> trustedCertificates, boolean isOpenShift)   {
-        List<Volume> newVolumes = new ArrayList<>();
-
-        if (trustedCertificates != null && trustedCertificates.size() > 0) {
-            int i = 0;
-
-            for (CertSecretSource certSecretSource : trustedCertificates) {
-                Map<String, String> items = Collections.singletonMap(certSecretSource.getCertificate(), "tls.crt");
-                String volumeName = String.format("%s-%d", volumeNamePrefix, i);
-                Volume vol = VolumeUtils.createSecretVolume(volumeName, certSecretSource.getSecretName(), items, isOpenShift);
-                newVolumes.add(vol);
-                i++;
-            }
-        }
-
-        return newVolumes;
-    }
-
-    /**
      * Generates volumes needed for generic secrets needed for custom authentication.
      *
      * @param volumeNamePrefix    Prefix for naming the secret volumes
@@ -377,32 +352,6 @@ public class AuthenticationUtils {
         }
 
         return newVolumes;
-    }
-
-    /**
-     * Generates volume mounts needed for certificates needed to connect to OAuth server.
-     * This is used in both OAuth servers and clients.
-     *
-     * @param volumeNamePrefix   Prefix which was used to name the secret volumes
-     * @param trustedCertificates   List of certificates which should be mounted
-     * @param baseVolumeMount   The Base volume into which the certificates should be mounted
-     *
-     * @return List of new VolumeMounts
-     */
-    public static List<VolumeMount> configureOauthCertificateVolumeMounts(String volumeNamePrefix, List<CertSecretSource> trustedCertificates, String baseVolumeMount)   {
-        List<VolumeMount> newVolumeMounts = new ArrayList<>();
-
-        if (trustedCertificates != null && trustedCertificates.size() > 0) {
-            int i = 0;
-
-            for (CertSecretSource certSecretSource : trustedCertificates) {
-                String volumeName = String.format("%s-%d", volumeNamePrefix, i);
-                newVolumeMounts.add(VolumeUtils.createVolumeMount(volumeName, String.format("%s/%s-%d", baseVolumeMount, certSecretSource.getSecretName(), i)));
-                i++;
-            }
-        }
-
-        return newVolumeMounts;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -220,7 +220,7 @@ public class CertUtils {
      * @param prefix            Prefix used to generate the volume name
      */
     private static void maybeAddTrustedCertificateVolume(List<Volume> volumeList, CertSecretSource certSecretSource, boolean isOpenShift, String prefix) {
-        String volumeName = prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
+        String volumeName = trustedCertificateVolumeName(certSecretSource, prefix);
 
         // skipping if a volume with same name was already added
         if (volumeList.stream().noneMatch(v -> v.getName().equals(volumeName))) {
@@ -267,12 +267,24 @@ public class CertUtils {
      * @param prefix                Prefix used to generate the volume name
      */
     private static void maybeAddTrustedCertificateVolumeMount(List<VolumeMount> volumeMountList, CertSecretSource certSecretSource, String tlsVolumeMountPath, String prefix) {
-        String volumeName = prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
+        String volumeName = trustedCertificateVolumeName(certSecretSource, prefix);
 
         // skipping if a volume mount with same Secret name was already added
         if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(volumeName))) {
             volumeMountList.add(VolumeUtils.createVolumeMount(volumeName, tlsVolumeMountPath + certSecretSource.getSecretName()));
         }
+    }
+
+    /**
+     * Generates the volume name that is used in the Volume definition and in the Volume mounts
+     *
+     * @param certSecretSource      Represents a certificate inside a Secret
+     * @param prefix                Prefix used to generate the volume name
+
+     * @return  The generated volume name
+     */
+    private static String trustedCertificateVolumeName(CertSecretSource certSecretSource, String prefix)    {
+        return prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -211,7 +211,7 @@ public class CertUtils {
 
     /**
      * Creates the Volume used for trusted certificates and adds it to the list. It checks if the Secret where the
-     * certificate is stored has been already used or not and makes sure to mount it only once to avid duplicates and
+     * certificate is stored has been already used or not and makes sure to mount it only once to avoid duplicates and
      * naming conflicts.
      *
      * @param volumeList        List where the volume will be added
@@ -258,7 +258,7 @@ public class CertUtils {
 
     /**
      * Creates the VolumeMount used for trusted TLS certificates and adds it to the list. It checks if the Secret where
-     * the certificate is stored has been already used or not and makes sure to mount it only once to avid duplicates
+     * the certificate is stored has been already used or not and makes sure to mount it only once to avoid duplicates
      * and naming conflicts.
      *
      * @param volumeMountList       List where the volume mount will be added

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -6,6 +6,9 @@ package io.strimzi.operator.cluster.model;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.certs.CertAndKey;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
@@ -176,5 +179,123 @@ public class CertUtils {
         }
 
         return false;
+    }
+
+    /**
+     * Creates the Secret Volumes for trusted TLS certificates
+     *
+     * @param volumeList            List where the volumes will be added
+     * @param trustedCertificates   List of trusted certificates for TLS connection
+     * @param isOpenShift           Indicates whether we run on OpenShift or not
+     */
+    public static void createTrustedCertificatesVolumes(List<Volume> volumeList, List<CertSecretSource> trustedCertificates, boolean isOpenShift) {
+        createTrustedCertificatesVolumes(volumeList, trustedCertificates, isOpenShift, null);
+    }
+
+    /**
+     * Creates the Secret Volumes for trusted TLS certificates
+     *
+     * @param volumeList            List where the volumes will be added
+     * @param trustedCertificates   List of trusted certificates for TLS connection
+     * @param isOpenShift           Indicates whether we run on OpenShift or not
+     * @param prefix                Prefix used for the volume names to distinguish when the same Secret is mounted for
+     *                              different purposes (e.g. different cluster connections in MM2)
+     */
+    public static void createTrustedCertificatesVolumes(List<Volume> volumeList, List<CertSecretSource> trustedCertificates, boolean isOpenShift, String prefix) {
+        if (trustedCertificates != null && !trustedCertificates.isEmpty()) {
+            for (CertSecretSource certSecretSource : trustedCertificates) {
+                maybeAddTrustedCertificateVolume(volumeList, certSecretSource, isOpenShift, prefix);
+            }
+        }
+    }
+
+    /**
+     * Creates the Volume used for trusted certificates and adds it to the list. It checks if the Secret where the
+     * certificate is stored has been already used or not and makes sure to mount it only once to avid duplicates and
+     * naming conflicts.
+     *
+     * @param volumeList        List where the volume will be added
+     * @param certSecretSource  Represents a certificate inside a Secret
+     * @param isOpenShift       Indicates whether we run on OpenShift or not
+     * @param prefix            Prefix used to generate the volume name
+     */
+    private static void maybeAddTrustedCertificateVolume(List<Volume> volumeList, CertSecretSource certSecretSource, boolean isOpenShift, String prefix) {
+        String volumeName = prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
+
+        // skipping if a volume with same name was already added
+        if (volumeList.stream().noneMatch(v -> v.getName().equals(volumeName))) {
+            volumeList.add(VolumeUtils.createSecretVolume(volumeName, certSecretSource.getSecretName(), isOpenShift));
+        }
+    }
+
+    /**
+     * Creates the volume mounts for Secrets with trusted TLS certificates
+     *
+     * @param volumeMountList       List where the volume mounts will be added
+     * @param trustedCertificates   Trusted certificates for TLS connection
+     * @param tlsVolumeMountPath    Path where the TLS certs should be mounted
+     */
+    public static void createTrustedCertificatesVolumeMounts(List<VolumeMount> volumeMountList, List<CertSecretSource> trustedCertificates, String tlsVolumeMountPath) {
+        createTrustedCertificatesVolumeMounts(volumeMountList, trustedCertificates, tlsVolumeMountPath, null);
+    }
+
+    /**
+     * Creates the volume mounts for Secrets with trusted TLS certificates
+     *
+     * @param volumeMountList       List where the volume mounts will be added
+     * @param trustedCertificates   Trusted certificates for TLS connection
+     * @param tlsVolumeMountPath    Path where the TLS certs should be mounted
+     * @param prefix                Prefix used for the volume names to distinguish when the same Secret is mounted for
+     *                              different purposes (e.g. different cluster connections in MM2)
+     */
+    public static void createTrustedCertificatesVolumeMounts(List<VolumeMount> volumeMountList, List<CertSecretSource> trustedCertificates, String tlsVolumeMountPath, String prefix) {
+        if (trustedCertificates != null && !trustedCertificates.isEmpty()) {
+            for (CertSecretSource certSecretSource : trustedCertificates) {
+                maybeAddTrustedCertificateVolumeMount(volumeMountList, certSecretSource, tlsVolumeMountPath, prefix);
+            }
+        }
+    }
+
+    /**
+     * Creates the VolumeMount used for trusted TLS certificates and adds it to the list. It checks if the Secret where
+     * the certificate is stored has been already used or not and makes sure to mount it only once to avid duplicates
+     * and naming conflicts.
+     *
+     * @param volumeMountList       List where the volume mount will be added
+     * @param certSecretSource      Represents a certificate inside a Secret
+     * @param tlsVolumeMountPath    Path where the TLS certs should be mounted
+     * @param prefix                Prefix used to generate the volume name
+     */
+    private static void maybeAddTrustedCertificateVolumeMount(List<VolumeMount> volumeMountList, CertSecretSource certSecretSource, String tlsVolumeMountPath, String prefix) {
+        String volumeName = prefix != null ? prefix + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
+
+        // skipping if a volume mount with same Secret name was already added
+        if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(volumeName))) {
+            volumeMountList.add(VolumeUtils.createVolumeMount(volumeName, tlsVolumeMountPath + certSecretSource.getSecretName()));
+        }
+    }
+
+    /**
+     * Process the list of trusted certificates into an environment variable that will be used by the container images.
+     * The environment variable has the format `secretName/filenameOrPattern;secretName/filenameOrPattern;...`.
+     *
+     * @param trustedCertificates   List of trusted certificates
+     *
+     * @return  String to be used in the environment variable
+     */
+    public static String trustedCertsEnvVar(List<CertSecretSource> trustedCertificates)   {
+        if (trustedCertificates != null && !trustedCertificates.isEmpty()) {
+            List<String> paths = new ArrayList<>();
+
+            for (CertSecretSource certSecretSource : trustedCertificates) {
+                if (certSecretSource.getCertificate() != null)  {
+                    paths.add(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
+                }
+            }
+
+            return String.join(";", paths);
+        } else {
+            return null;
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -32,7 +32,6 @@ import io.fabric8.kubernetes.api.model.rbac.RoleRef;
 import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
-import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.ClientTls;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Probe;
@@ -374,7 +373,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         }
 
         if (tls != null) {
-            VolumeUtils.createSecretVolume(volumeList, tls.getTrustedCertificates(), isOpenShift);
+            CertUtils.createTrustedCertificatesVolumes(volumeList, tls.getTrustedCertificates(), isOpenShift);
         }
         AuthenticationUtils.configureClientAuthenticationVolumes(authentication, volumeList, "oauth-certs", isOpenShift);
         volumeList.addAll(getExternalConfigurationVolumes(isOpenShift));
@@ -435,7 +434,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         }
 
         if (tls != null) {
-            VolumeUtils.createSecretVolumeMount(volumeMountList, tls.getTrustedCertificates(), TLS_CERTS_BASE_VOLUME_MOUNT);
+            CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, tls.getTrustedCertificates(), TLS_CERTS_BASE_VOLUME_MOUNT);
         }
         AuthenticationUtils.configureClientAuthenticationVolumeMounts(authentication, volumeMountList, TLS_CERTS_BASE_VOLUME_MOUNT, PASSWORD_VOLUME_MOUNT, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT, "oauth-certs");
         volumeMountList.addAll(getExternalConfigurationVolumeMounts());
@@ -633,19 +632,8 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     private void populateTLSEnvVars(final List<EnvVar> varList) {
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_CONNECT_TLS, "true"));
 
-        List<CertSecretSource> trustedCertificates = tls.getTrustedCertificates();
-
-        if (trustedCertificates != null && trustedCertificates.size() > 0) {
-            StringBuilder sb = new StringBuilder();
-            boolean separator = false;
-            for (CertSecretSource certSecretSource : trustedCertificates) {
-                if (separator) {
-                    sb.append(";");
-                }
-                sb.append(certSecretSource.getSecretName()).append("/").append(certSecretSource.getCertificate());
-                separator = true;
-            }
-            varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS, sb.toString()));
+        if (tls.getTrustedCertificates() != null && !tls.getTrustedCertificates().isEmpty()) {
+            varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_CONNECT_TRUSTED_CERTS, CertUtils.trustedCertsEnvVar(tls.getTrustedCertificates())));
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -48,7 +48,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_AUTH_CERTS_CLUSTERS = "KAFKA_MIRRORMAKER_2_TLS_AUTH_CERTS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_TLS_AUTH_KEYS_CLUSTERS = "KAFKA_MIRRORMAKER_2_TLS_AUTH_KEYS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_SASL_PASSWORD_FILES_CLUSTERS = "KAFKA_MIRRORMAKER_2_SASL_PASSWORD_FILES_CLUSTERS";
-    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS = "KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS";
+    protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS = "KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_CLIENT_SECRETS_CLUSTERS = "KAFKA_MIRRORMAKER_2_OAUTH_CLIENT_SECRETS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_ACCESS_TOKENS_CLUSTERS = "KAFKA_MIRRORMAKER_2_OAUTH_OAUTH_ACCESS_TOKENS_CLUSTERS";
     protected static final String ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_REFRESH_TOKENS_CLUSTERS = "KAFKA_MIRRORMAKER_2_OAUTH_REFRESH_TOKENS_CLUSTERS";
@@ -279,7 +279,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         }
 
         if (clustersOauthTrustedCerts.length() > 0) {
-            varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS, clustersOauthTrustedCerts.toString()));
+            varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS, clustersOauthTrustedCerts.toString()));
         }
 
         if (clustersOauthClientSecrets.length() > 0) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -234,12 +234,12 @@ public class KafkaMirrorMakerCluster extends AbstractModel implements SupportsMe
         volumeList.add(VolumeUtils.createConfigMapVolume(LOG_AND_METRICS_CONFIG_VOLUME_NAME, KafkaMirrorMakerResources.metricsAndLogConfigMapName(cluster)));
 
         if (producer.getTls() != null) {
-            VolumeUtils.createSecretVolume(volumeList, producer.getTls().getTrustedCertificates(), isOpenShift);
+            CertUtils.createTrustedCertificatesVolumes(volumeList, producer.getTls().getTrustedCertificates(), isOpenShift);
         }
         AuthenticationUtils.configureClientAuthenticationVolumes(producer.getAuthentication(), volumeList, "producer-oauth-certs", isOpenShift);
 
         if (consumer.getTls() != null) {
-            VolumeUtils.createSecretVolume(volumeList, consumer.getTls().getTrustedCertificates(), isOpenShift);
+            CertUtils.createTrustedCertificatesVolumes(volumeList, consumer.getTls().getTrustedCertificates(), isOpenShift);
         }
         AuthenticationUtils.configureClientAuthenticationVolumes(consumer.getAuthentication(), volumeList, "consumer-oauth-certs", isOpenShift);
 
@@ -253,13 +253,13 @@ public class KafkaMirrorMakerCluster extends AbstractModel implements SupportsMe
         volumeMountList.add(VolumeUtils.createVolumeMount(LOG_AND_METRICS_CONFIG_VOLUME_NAME, LOG_AND_METRICS_CONFIG_VOLUME_MOUNT));
         /* producer auth*/
         if (producer.getTls() != null) {
-            VolumeUtils.createSecretVolumeMount(volumeMountList, producer.getTls().getTrustedCertificates(), TLS_CERTS_VOLUME_MOUNT_PRODUCER);
+            CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, producer.getTls().getTrustedCertificates(), TLS_CERTS_VOLUME_MOUNT_PRODUCER);
         }
         AuthenticationUtils.configureClientAuthenticationVolumeMounts(producer.getAuthentication(), volumeMountList, TLS_CERTS_VOLUME_MOUNT_PRODUCER, PASSWORD_VOLUME_MOUNT_PRODUCER, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT_PRODUCER, "producer-oauth-certs");
 
         /* consumer auth*/
         if (consumer.getTls() != null) {
-            VolumeUtils.createSecretVolumeMount(volumeMountList, consumer.getTls().getTrustedCertificates(), TLS_CERTS_VOLUME_MOUNT_CONSUMER);
+            CertUtils.createTrustedCertificatesVolumeMounts(volumeMountList, consumer.getTls().getTrustedCertificates(), TLS_CERTS_VOLUME_MOUNT_CONSUMER);
         }
         AuthenticationUtils.configureClientAuthenticationVolumeMounts(consumer.getAuthentication(), volumeMountList, TLS_CERTS_VOLUME_MOUNT_CONSUMER, PASSWORD_VOLUME_MOUNT_CONSUMER, OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT_CONSUMER, "consumer-oauth-certs");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/VolumeUtils.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorage;
 import io.strimzi.api.kafka.model.kafka.JbodStorage;
@@ -432,94 +431,6 @@ public class VolumeUtils {
 
         // Returned new fixed name with the hash at the end
         return newName.substring(0, i) + "-" + digestStub;
-    }
-
-    /**
-     * Creates the Client Secret Volume
-     * @param volumeList    List where the volumes will be added
-     * @param trustedCertificates   Trusted certificates for TLS connection
-     * @param isOpenShift   Indicates whether we run on OpenShift or not
-     */
-    public static void createSecretVolume(List<Volume> volumeList, List<CertSecretSource> trustedCertificates, boolean isOpenShift) {
-        createSecretVolume(volumeList, trustedCertificates, isOpenShift, null);
-    }
-
-    /**
-     * Creates the Client Secret Volume
-     * @param volumeList    List where the volumes will be added
-     * @param trustedCertificates   Trusted certificates for TLS connection
-     * @param isOpenShift   Indicates whether we run on OpenShift or not
-     * @param alias   Alias to reference the Kafka Cluster
-     */
-    public static void createSecretVolume(List<Volume> volumeList, List<CertSecretSource> trustedCertificates, boolean isOpenShift, String alias) {
-
-        if (trustedCertificates != null && trustedCertificates.size() > 0) {
-            for (CertSecretSource certSecretSource : trustedCertificates) {
-                addSecretVolume(volumeList, certSecretSource, isOpenShift, alias);
-            }
-        }
-    }
-
-    /**
-     * Creates the Volumes used for authentication of Kafka client based components, checking that the named volume has not already been
-     * created.
-     *
-     * @param volumeList    List where the volume will be added
-     * @param certSecretSource   Represents a certificate inside a Secret
-     * @param isOpenShift   Indicates whether we run on OpenShift or not
-     * @param alias   Alias to reference the Kafka Cluster
-     */
-    private static void addSecretVolume(List<Volume> volumeList, CertSecretSource certSecretSource, boolean isOpenShift, String alias) {
-        String volumeName = alias != null ? alias + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
-        // skipping if a volume with same name was already added
-        if (volumeList.stream().noneMatch(v -> v.getName().equals(volumeName))) {
-            volumeList.add(VolumeUtils.createSecretVolume(volumeName, certSecretSource.getSecretName(), isOpenShift));
-        }
-    }
-
-    /**
-     * Creates the Client tls encrypted Volume Mounts
-     *  @param volumeMountList    List where the volume mounts will be added
-     * @param trustedCertificates   Trusted certificates for TLS connection
-     * @param tlsVolumeMountPath   Path where the TLS certs should be mounted
-     */
-    public static void createSecretVolumeMount(List<VolumeMount> volumeMountList, List<CertSecretSource> trustedCertificates, String tlsVolumeMountPath) {
-        createSecretVolumeMount(volumeMountList, trustedCertificates, tlsVolumeMountPath, null);
-    }
-
-    /**
-     * Creates the Client Tls encrypted Volume Mount
-     *
-     * @param volumeMountList    List where the volume mounts will be added
-     * @param trustedCertificates  Trusted certificates for TLS connection
-     * @param tlsVolumeMountPath  Path where the TLS certs should be mounted
-     * @param alias   Alias to reference the Kafka Cluster
-     */
-    public static void createSecretVolumeMount(List<VolumeMount> volumeMountList, List<CertSecretSource> trustedCertificates, String tlsVolumeMountPath, String alias) {
-
-        if (trustedCertificates != null && trustedCertificates.size() > 0) {
-            for (CertSecretSource certSecretSource : trustedCertificates) {
-                addSecretVolumeMount(volumeMountList, certSecretSource, tlsVolumeMountPath, alias);
-            }
-        }
-    }
-
-    /**
-     * Creates the VolumeMount used for authentication of Kafka client based components, checking that the named volume mount has not already been
-     * created.
-     *
-     * @param volumeMountList    List where the volume mount will be added
-     * @param certSecretSource   Represents a certificate inside a Secret
-     * @param tlsVolumeMountPath   Path where the TLS certs should be mounted
-     * @param alias   Alias to reference the Kafka Cluster
-     */
-    private static void addSecretVolumeMount(List<VolumeMount> volumeMountList,  CertSecretSource certSecretSource, String tlsVolumeMountPath, String alias) {
-        String volumeMountName = alias != null ? alias + '-' + certSecretSource.getSecretName() : certSecretSource.getSecretName();
-        // skipping if a volume mount with same Secret name was already added
-        if (volumeMountList.stream().noneMatch(vm -> vm.getName().equals(volumeMountName))) {
-            volumeMountList.add(createVolumeMount(volumeMountName,
-                    tlsVolumeMountPath + certSecretSource.getSecretName()));
-        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.KeyToPath;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
@@ -1118,26 +1117,15 @@ public class KafkaBridgeClusterTest {
                 is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ServerConfig.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "")));
 
         // Volume mounts
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaBridgeCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-0"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaBridgeCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/second-certificate-1"));
-        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaBridgeCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-2"));
-
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaBridgeCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "first-certificate"));
+        assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaBridgeCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "second-certificate"));
 
         // Volumes
-        List<KeyToPath> cert1Items = dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems();
-        assertThat(cert1Items.size(), is(1));
-        assertThat(cert1Items.get(0).getKey(), is("ca.crt"));
-        assertThat(cert1Items.get(0).getPath(), is("tls.crt"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
+        assertThat(dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
 
-        List<KeyToPath> cert2Items = dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems();
-        assertThat(cert2Items.size(), is(1));
-        assertThat(cert2Items.get(0).getKey(), is("tls.crt"));
-        assertThat(cert2Items.get(0).getPath(), is("tls.crt"));
-
-        List<KeyToPath> cert3Items = dep.getSpec().getTemplate().getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems();
-        assertThat(cert3Items.size(), is(1));
-        assertThat(cert3Items.get(0).getKey(), is("ca2.crt"));
-        assertThat(cert3Items.get(0).getPath(), is("tls.crt"));
+        // Environment variable
+        assertThat(cont.getEnv().stream().filter(e -> "KAFKA_BRIDGE_OAUTH_TRUSTED_CERTS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -1760,22 +1760,15 @@ public class KafkaConnectClusterTest {
                     is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ServerConfig.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "")));
 
             // Volume mounts
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-0"));
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/second-certificate-1"));
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-2"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "first-certificate"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "second-certificate"));
 
             // Volumes
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("ca.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
 
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("tls.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
-
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("ca2.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
+            // Environment variable
+            assertThat(cont.getEnv().stream().filter(e -> "KAFKA_CONNECT_OAUTH_TRUSTED_CERTS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1843,13 +1843,18 @@ public class KafkaMirrorMaker2ClusterTest {
             // Volume mounts
             assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "first-certificate"));
             assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "second-certificate"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "target-oauth-certs-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaMirrorMaker2Cluster.MIRRORMAKER_2_OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "target/first-certificate"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "target-oauth-certs-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaMirrorMaker2Cluster.MIRRORMAKER_2_OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "target/second-certificate"));
 
             // Volumes
             assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
             assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "target-oauth-certs-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "target-oauth-certs-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
 
             // Environment variable
             assertThat(cont.getEnv().stream().filter(e -> "KAFKA_CONNECT_OAUTH_TRUSTED_CERTS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
+            assertThat(cont.getEnv().stream().filter(e -> "KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("target=first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1841,22 +1841,15 @@ public class KafkaMirrorMaker2ClusterTest {
                     is(String.format("%s=\"%s\" %s=\"%s\" %s=\"%s\"", ClientConfig.OAUTH_CLIENT_ID, "my-client-id", ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, "http://my-oauth-server", ServerConfig.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "")));
 
             // Volume mounts
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-0"));
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/second-certificate-1"));
-            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-2".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "/first-certificate-2"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-first-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "first-certificate"));
+            assertThat(cont.getVolumeMounts().stream().filter(mount -> "oauth-certs-second-certificate".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaConnectCluster.OAUTH_TLS_CERTS_BASE_VOLUME_MOUNT + "second-certificate"));
 
             // Volumes
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("ca.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-first-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
+            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-second-certificate".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().isEmpty(), is(true));
 
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("tls.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
-
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("ca2.crt"));
-            assertThat(pod.getSpec().getVolumes().stream().filter(vol -> "oauth-certs-2".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("tls.crt"));
+            // Environment variable
+            assertThat(cont.getEnv().stream().filter(e -> "KAFKA_CONNECT_OAUTH_TRUSTED_CERTS".equals(e.getName())).findFirst().orElseThrow().getValue(), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
         });
     }
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_connector_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_connector_config_generator.sh
@@ -39,7 +39,7 @@ EOF
     done
 fi
 
-if [ -n "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS" ]; then
+if [ -n "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS" ]; then
     OAUTH_TRUSTED_CERTS_CONFIGURATION=$(cat <<EOF
 # OAuth trusted certs
 oauth.ssl.truststore.password=${CERTS_STORE_PASSWORD}

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -47,7 +47,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS" ]; then
     IFS=$'\n' read -rd '' -a OAUTH_TRUSTED_CERTS_CLUSTERS <<< "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS" || true
     for cluster in "${OAUTH_TRUSTED_CERTS_CLUSTERS[@]}"
     do
-        IFS='=' read -ra TRUSTED_CERTS_CLUSTER <<< "${cluster}" || true
+        IFS='=' read -ra OAUTH_TRUSTED_CERTS_CLUSTERS <<< "${cluster}" || true
         OAUTH_TRUSTED_CERTS["${OAUTH_TRUSTED_CERTS_CLUSTERS[0]}"]="${OAUTH_TRUSTED_CERTS_CLUSTERS[1]}"
     done
 fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -42,6 +42,16 @@ if [ -n "$KAFKA_MIRRORMAKER_2_TRUSTED_CERTS_CLUSTERS" ]; then
     done
 fi
 
+declare -A OAUTH_TRUSTED_CERTS
+if [ -n "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS" ]; then
+    IFS=$'\n' read -rd '' -a OAUTH_TRUSTED_CERTS_CLUSTERS <<< "$KAFKA_MIRRORMAKER_2_OAUTH_TRUSTED_CERTS_CLUSTERS" || true
+    for cluster in "${OAUTH_TRUSTED_CERTS_CLUSTERS[@]}"
+    do
+        IFS='=' read -ra TRUSTED_CERTS_CLUSTER <<< "${cluster}" || true
+        OAUTH_TRUSTED_CERTS["${OAUTH_TRUSTED_CERTS_CLUSTERS[0]}"]="${OAUTH_TRUSTED_CERTS_CLUSTERS[1]}"
+    done
+fi
+
 if [ -n "$KAFKA_MIRRORMAKER_2_CLUSTERS" ]; then
     IFS=';' read -ra CLUSTERS <<< "$KAFKA_MIRRORMAKER_2_CLUSTERS" || true
     for clusterAlias in "${CLUSTERS[@]}"
@@ -58,6 +68,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_CLUSTERS" ]; then
             "/tmp/kafka/clusters/${clusterAlias}.truststore.p12" \
             "/tmp/kafka/clusters/${clusterAlias}.keystore.p12" \
             "/opt/kafka/mm2-certs/${clusterAlias}" \
+            "${OAUTH_TRUSTED_CERTS["${clusterAlias}"]}" \
             "/opt/kafka/mm2-oauth-certs/${clusterAlias}" \
             "/tmp/kafka/clusters/${clusterAlias}-oauth.truststore.p12"
     done

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_2_run.sh
@@ -60,6 +60,7 @@ if [ -n "$KAFKA_MIRRORMAKER_2_CLUSTERS" ]; then
         echo "  with trusted certs ${TRUSTED_CERTS["${clusterAlias}"]}"
         echo "  with tls auth certs ${TLS_AUTH_CERTS["${clusterAlias}"]}"
         echo "  with tls auth keys ${TLS_AUTH_KEYS["${clusterAlias}"]}"
+        echo "  with OAuth trusted certs ${OAUTH_TRUSTED_CERTS["${clusterAlias}"]}"
         # $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
         ./kafka_mirror_maker_tls_prepare_certificates.sh \
             "${TRUSTED_CERTS["${clusterAlias}"]}" \

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -18,6 +18,7 @@ mkdir -p /tmp/kafka
     "/tmp/kafka/consumer.truststore.p12" \
     "/tmp/kafka/consumer.keystore.p12" \
     "/opt/kafka/consumer-certs" \
+    "$KAFKA_MIRRORMAKER_OAUTH_TRUSTED_CERTS_CONSUMER" \
     "/opt/kafka/consumer-oauth-certs" \
     "/tmp/kafka/consumer-oauth.keystore.p12"
 
@@ -28,6 +29,7 @@ mkdir -p /tmp/kafka
     "/tmp/kafka/producer.truststore.p12" \
     "/tmp/kafka/producer.keystore.p12" \
     "/opt/kafka/producer-certs" \
+    "$KAFKA_MIRRORMAKER_OAUTH_TRUSTED_CERTS_PRODUCER" \
     "/opt/kafka/producer-oauth-certs" \
     "/tmp/kafka/producer-oauth.keystore.p12"
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_tls_prepare_certificates.sh
@@ -11,18 +11,13 @@ tls_auth_key="$3"
 truststore_path="$4"
 keystore_path="$5"
 certs_key_path="$6"
-oauth_certs_path="$7"
-oauth_keystore_path="$8"
+oauth_trusted_certs="$7"
+oauth_certs_path="$8"
+oauth_truststore_path="$9"
 
 if [ -n "$trusted_certs" ]; then
-    echo "Preparing truststore"
-    rm -f "$truststore_path"
-    IFS=';' read -ra CERTS <<< "${trusted_certs}"
-    for cert in "${CERTS[@]}"
-    do
-        create_truststore "$truststore_path" "$CERTS_STORE_PASSWORD" "$certs_key_path/$cert" "$cert"
-    done
-    echo "Preparing truststore is complete"
+    echo "Preparing $truststore_path truststore"
+    prepare_truststore "$truststore_path" "$CERTS_STORE_PASSWORD" "$certs_key_path" "$trusted_certs"
 fi
 
 if [ -n "$tls_auth_cert" ] && [ -n "$tls_auth_key" ]; then
@@ -32,16 +27,7 @@ if [ -n "$tls_auth_cert" ] && [ -n "$tls_auth_key" ]; then
     echo "Preparing keystore is complete"
 fi
 
-if [ -d "$oauth_certs_path" ]; then
-  echo "Preparing truststore for OAuth"
-  rm -f "$oauth_keystore_path"
-  # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$oauth_certs_path"/**/*; do
-    ALIAS="oauth-${INDEX}"
-    echo "Adding $CRT to truststore $oauth_keystore_path with alias $ALIAS"
-    create_truststore "$oauth_keystore_path" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for OAuth is complete"
+if [ -n "$oauth_trusted_certs" ]; then
+    echo "Preparing $oauth_truststore_path truststore for OAuth"
+    prepare_truststore "$oauth_truststore_path" "$CERTS_STORE_PASSWORD" "$oauth_certs_path" "$oauth_trusted_certs"
 fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -71,5 +71,5 @@ fi
 
 if [ -n "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS" ]; then
   echo "Preparing Keycloak authorization truststore"
-  prepare_truststore "/opt/kafka/certificates/authz-keycloak-certs" "$CERTS_STORE_PASSWORD" "/opt/kafka/certificates/authz-keycloak-certs" "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS"
+  prepare_truststore "/tmp/kafka/authz-keycloak.truststore.p12" "$CERTS_STORE_PASSWORD" "/opt/kafka/certificates/authz-keycloak-certs" "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS"
 fi

--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -44,16 +44,10 @@ for CERT_DIR in /opt/kafka/certificates/*; do
       rm -f /tmp/kafka/"$listener".keystore.p12
       create_keystore_without_ca_file /tmp/kafka/"$listener".keystore.p12 "$CERTS_STORE_PASSWORD" "${CERT_DIR}/tls.crt" "${CERT_DIR}/tls.key" custom-key
     elif [[ ${BASH_REMATCH[1]} == "oauth"  ]]; then
-      OAUTH_STORE="/tmp/kafka/$listener.truststore.p12"
-      rm -f "$OAUTH_STORE"
-      # Add each certificate to the trust store
-      declare -i INDEX=0
-      for CRT in "$CERT_DIR"/**/*; do
-        ALIAS="oauth-${INDEX}"
-        echo "Adding $CRT to truststore $OAUTH_STORE with alias $ALIAS"
-        create_truststore "$OAUTH_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-        INDEX+=1
-      done
+      trusted_certs="STRIMZI_${BASH_REMATCH[2]^^}_${BASH_REMATCH[3]}_OAUTH_TRUSTED_CERTS"
+      if [ -n "${!trusted_certs}" ]; then
+        prepare_truststore "/tmp/kafka/$listener.truststore.p12" "$CERTS_STORE_PASSWORD" "$CERT_DIR" "${!trusted_certs}"
+      fi
     fi
     echo "Preparing store for ${BASH_REMATCH[1]} ${BASH_REMATCH[2]} listener is complete"  
   fi
@@ -70,36 +64,12 @@ for CRT in /opt/kafka/client-ca-certs/*.crt; do
 done
 echo "Preparing truststore for client authentication is complete"
 
-AUTHZ_OPA_DIR="/opt/kafka/certificates/authz-opa-certs"
-AUTHZ_OPA_STORE="/tmp/kafka/authz-opa.truststore.p12"
-rm -f "$AUTHZ_OPA_STORE"
-if [ -d "$AUTHZ_OPA_DIR" ]; then
-  echo "Preparing truststore for Authorization with OPA"
-
-  # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$AUTHZ_OPA_DIR"/**/*; do
-    ALIAS="authz-opa-${INDEX}"
-    echo "Adding $CRT to truststore $AUTHZ_OPA_STORE with alias $ALIAS"
-    create_truststore "$AUTHZ_OPA_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for Authorization with OPA is complete"
+if [ -n "$STRIMZI_OPA_AUTHZ_TRUSTED_CERTS" ]; then
+  echo "Preparing Open Policy Agent authorization truststore"
+  prepare_truststore "/tmp/kafka/authz-opa.truststore.p12" "$CERTS_STORE_PASSWORD" "/opt/kafka/certificates/authz-opa-certs" "$STRIMZI_OPA_AUTHZ_TRUSTED_CERTS"
 fi
 
-AUTHZ_KEYCLOAK_DIR="/opt/kafka/certificates/authz-keycloak-certs"
-AUTHZ_KEYCLOAK_STORE="/tmp/kafka/authz-keycloak.truststore.p12"
-rm -f "$AUTHZ_KEYCLOAK_STORE"
-if [ -d "$AUTHZ_KEYCLOAK_DIR" ]; then
-  echo "Preparing truststore for Authorization with Keycloak"
-
-  # Add each certificate to the trust store
-  declare -i INDEX=0
-  for CRT in "$AUTHZ_KEYCLOAK_DIR"/**/*; do
-    ALIAS="authz-keycloak-${INDEX}"
-    echo "Adding $CRT to truststore $AUTHZ_KEYCLOAK_STORE with alias $ALIAS"
-    create_truststore "$AUTHZ_KEYCLOAK_STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
-    INDEX+=1
-  done
-  echo "Preparing truststore for Authorization with Keycloak is complete"
+if [ -n "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS" ]; then
+  echo "Preparing Keycloak authorization truststore"
+  prepare_truststore "/opt/kafka/certificates/authz-keycloak-certs" "$CERTS_STORE_PASSWORD" "/opt/kafka/certificates/authz-keycloak-certs" "$STRIMZI_KEYCLOAK_AUTHZ_TRUSTED_CERTS"
 fi

--- a/docker-images/kafka-based/kafka/scripts/tls_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/tls_utils.sh
@@ -63,12 +63,12 @@ function find_ca {
 # $3: Base path where the certificates are mounted
 # $4: Environment variable defining the certs that should be loaded
 function prepare_truststore {
-    STORE=$1
+    TRUSTSTORE=$1
     PASSWORD=$2
     BASEPATH=$3
     TRUSTED_CERTS=$4
 
-    rm -f "$STORE"
+    rm -f "$TRUSTSTORE"
 
     IFS=';' read -ra CERTS <<< "${TRUSTED_CERTS}"
     for cert in "${CERTS[@]}"
@@ -76,8 +76,8 @@ function prepare_truststore {
         for file in $BASEPATH/$cert
         do
             if [ -f "$file" ]; then
-                echo "Adding $file to truststore $STORE with alias $file"
-                create_truststore "$STORE" "$PASSWORD" "$file" "$file"
+                echo "Adding $file to truststore $TRUSTSTORE with alias $file"
+                create_truststore "$TRUSTSTORE" "$PASSWORD" "$file" "$file"
             fi
         done
     done

--- a/docker-images/kafka-based/kafka/scripts/tls_utils.sh
+++ b/docker-images/kafka-based/kafka/scripts/tls_utils.sh
@@ -56,3 +56,29 @@ function find_ca {
         fi
     done
 }
+
+# Parameters:
+# $1: Path to the new truststore
+# $2: Truststore password
+# $3: Base path where the certificates are mounted
+# $4: Environment variable defining the certs that should be loaded
+function prepare_truststore {
+    STORE=$1
+    PASSWORD=$2
+    BASEPATH=$3
+    TRUSTED_CERTS=$4
+
+    rm -f "$STORE"
+
+    IFS=';' read -ra CERTS <<< "${TRUSTED_CERTS}"
+    for cert in "${CERTS[@]}"
+    do
+        for file in $BASEPATH/$cert
+        do
+            if [ -f "$file" ]; then
+                echo "Adding $file to truststore $STORE with alias $file"
+                create_truststore "$STORE" "$PASSWORD" "$file" "$file"
+            fi
+        done
+    done
+}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently, we configure trusted certificates in several places:
* For Kafka clients in Connect, Bridge, MM2, ...
* For OPA authorization
* For OAuth authentication and Keycloak authorization

But in each place we handle them a bit differently. This PR unifies that to use the same code and mechanism in all those places. This is in preparation for implementation of the [Strimz Proposal 72](https://github.com/strimzi/proposals/blob/main/073-improve-handling-of-CA-renewals-and-replacements-in-client-based-operands.md) -> after this refactoring, the implementation will be easier and will need to be done only in one place.

This is also accompanied by the https://github.com/strimzi/strimzi-kafka-bridge/pull/901 PR in the Bridge repo.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging