### PR TITLE
Use UBI9 instead of UBI8 as a base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * The `UseKRaft` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
   To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
+* Update the base image used by Strimzi containers from UBI8 to UBI9
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.
 
 ## 0.41.0

--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 
@@ -9,7 +9,7 @@ ARG TARGETARCH
 USER root
 
 RUN microdnf update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf reinstall -y tzdata \
     && microdnf clean all
 

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -9,7 +9,7 @@ ARG strimzi_version
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install gettext nmap-ncat net-tools unzip hostname findutils tar \
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y gettext nmap-ncat net-tools unzip hostname findutils tar \
     && microdnf clean all
 
 # Add kafka user with UID 1001

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.19
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.18
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 
@@ -8,7 +8,7 @@ USER root
 # The user is in the group 0 to have access to the mounted volumes and storage
 RUN useradd -r -m -u 1001 -g 0 strimzi
 
-RUN microdnf update \
+RUN microdnf update -y \
     && microdnf clean all
 
 USER 1001

--- a/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/security/SystemTestCertManager.java
@@ -78,7 +78,7 @@ public class SystemTestCertManager {
                 "s:O = io.strimzi, CN = " + certificateName + "\n" +
                 "   i:O = io.strimzi, CN = cluster-ca",
                 "Server certificate\n" +
-                "subject=O = io.strimzi, CN = " + certificateName + "\n\n" +
+                "subject=O = io.strimzi, CN = " + certificateName + "\n" +
                 "issuer=O = io.strimzi, CN = cluster-ca"
         ));
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As discussed on the community call on 16.5., this PR updates the base image used in Strimzi from UBI8 to UBI9. This updates only the images based on this repo. Separate PRs will be opened for Bridge and Drain Cleaner if this works.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md