### PR TITLE
Update Kaniko executor to 1.23.0

### DIFF
--- a/docker-images/kaniko-executor/Makefile
+++ b/docker-images/kaniko-executor/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := kaniko-executor
-KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.22.0
+KANIKO_EXECUTOR = gcr.io/kaniko-project/executor:v1.23.0
 
 docker_build:
 	# The Kaniko executor image used for building new Kafka Connect images with additional connectors is not build from


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kaniko executor to 1.23.0

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally