### PR TITLE
docs(bridge): cleans up naming of kafka bridge

### DIFF
--- a/documentation/assemblies/deploying/assembly-deploy-intro.adoc
+++ b/documentation/assemblies/deploying/assembly-deploy-intro.adoc
@@ -40,4 +40,4 @@ include::../../shared/ref-document-conventions.adoc[leveloffset=+1]
 
 * link:{BookURLOverview}[Strimzi Overview^]
 * link:{BookURLConfiguring}[Strimzi Custom Resource API Reference^]
-* link:{BookURLBridge}[Using the Strimzi Kafka Bridge^]
+* link:{BookURLBridge}[Using the Kafka Bridge^]

--- a/documentation/contributing/introduction.adoc
+++ b/documentation/contributing/introduction.adoc
@@ -30,7 +30,7 @@ Strimzi uses public GitHub repositories to host files.
 The following repositories contain source documentation files.
 
 https://github.com/strimzi/strimzi-kafka-operator[`strimzi-kafka-operator`^] (GitHub):: Strimzi operators code and related documentation.
-https://github.com/strimzi/strimzi-kafka-bridge[`strimzi-kafka-bridge`^] (GitHub):: Strimzi Kafka Bridge code and related documentation.
+https://github.com/strimzi/strimzi-kafka-bridge[`strimzi-kafka-bridge`^] (GitHub):: Kafka Bridge code and related documentation.
 https://github.com/strimzi/strimzi.github.io[`strimzi.github.io`^] (GitHub):: Strimzi web site code and quick start documentation.
 
 == Strimzi operators documentation
@@ -125,8 +125,8 @@ If you change anything in the `api` module of the Java code, you must rebuild th
 
 The Kafka Bridge documentation shows how to get started using the Kafka Bridge to make HTTP requests to a Kafka cluster.
 
-The Kafka Bridge documentation is maintained in the https://github.com/strimzi/strimzi-kafka-bridge[Strimzi Kafka Bridge project in GitHub].
-For information on contributing to the Kafka Bridge documentation, see the https://github.com/strimzi/strimzi-kafka-bridge/blob/main/README.md[`readme`]  in the Strimzi Kafka Bridge project.
+The Kafka Bridge documentation is maintained in the https://github.com/strimzi/strimzi-kafka-bridge[Kafka Bridge project in GitHub].
+For information on contributing to the Kafka Bridge documentation, see the https://github.com/strimzi/strimzi-kafka-bridge/blob/main/README.md[`readme`]  in the Kafka Bridge project.
 
 == Quick start documentation
 

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -456,7 +456,7 @@ The following Strimzi components run inside a Java Virtual Machine (JVM):
 * Apache ZooKeeper
 * Apache Kafka Connect
 * Apache Kafka MirrorMaker
-* Strimzi Kafka Bridge
+* Kafka Bridge
 
 To optimize their performance on different platforms and architectures, you configure the `jvmOptions` property in the following resources:
 

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -114,4 +114,4 @@ By default, the Kafka Bridge connects to Kafka brokers without authentication.
 [role="_additional-resources"]
 .Additional resources
 
-* link:{BookURLBridge}[Using the Strimzi Kafka Bridge^]
+* link:{BookURLBridge}[Using the Kafka Bridge^]

--- a/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
+++ b/documentation/modules/configuring/proc-generating-reassignment-json-files.adoc
@@ -127,7 +127,7 @@ Replace _<cluster_name>_ with the name of the Kafka cluster.
 When you deploy Kafka using the `Kafka` resource, a secret with the cluster CA certificate is created with the Kafka cluster name (`_<cluster_name>_-cluster-ca-cert`).
 For example, `my-cluster-cluster-ca-cert`.
 
-. Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.
+. Run a new interactive pod container using the Kafka image to connect to a running Kafka broker.
 +
 [source,shell,subs="+quotes,attributes"]
 ----

--- a/documentation/modules/deploying/con-accessing-kafka-bridge-from-outside.adoc
+++ b/documentation/modules/deploying/con-accessing-kafka-bridge-from-outside.adoc
@@ -6,7 +6,7 @@
 
 = Accessing the Kafka Bridge outside of Kubernetes
 
-After deployment, the Strimzi Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster.
+After deployment, the Kafka Bridge can only be accessed by applications running in the same Kubernetes cluster.
 These applications use the `_<kafka_bridge_name>_-bridge-service` service to access the API.
 
 If you want to make the Kafka Bridge accessible to applications running outside of the Kubernetes cluster, you can expose it manually by creating one of the following features:

--- a/documentation/modules/deploying/con-kafka-bridge-concepts.adoc
+++ b/documentation/modules/deploying/con-kafka-bridge-concepts.adoc
@@ -6,7 +6,7 @@
 = Using the Kafka Bridge to connect with a Kafka cluster
 
 [role="_abstract"]
-You can use the Strimzi Kafka Bridge API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
+You can use the Kafka Bridge API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
 
 When you set up the Kafka Bridge you configure HTTP access to the Kafka cluster.
 You can then use the Kafka Bridge to produce and consume messages from the cluster, as well as performing other operations through its REST interface.
@@ -14,4 +14,4 @@ You can then use the Kafka Bridge to produce and consume messages from the clust
 [role="_additional-resources"]
 .Additional resources
 
-* For information on installing and using the Kafka Bridge, see link:{BookURLBridge}[Using the Strimzi Kafka Bridge^].
+* For information on installing and using the Kafka Bridge, see link:{BookURLBridge}[Using the Kafka Bridge^].

--- a/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
+++ b/documentation/modules/deploying/proc-deploy-kafka-bridge.adoc
@@ -55,4 +55,4 @@ The deployment is successful when the `STATUS` displays as `Running`.
 .Additional resources
 
 * xref:con-config-kafka-bridge-str[Kafka Bridge cluster configuration]
-* link:{BookURLBridge}[Using the Strimzi Kafka Bridge^]
+* link:{BookURLBridge}[Using the Kafka Bridge^]

--- a/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
+++ b/documentation/modules/deploying/proc-exposing-kafka-bridge-service-local-machine.adoc
@@ -6,7 +6,7 @@
 = Exposing the Kafka Bridge service to your local machine
 
 [role="_abstract"]
-Use port forwarding to expose the Strimzi Kafka Bridge service to your local machine on http://localhost:8080.
+Use port forwarding to expose the Kafka Bridge service to your local machine on http://localhost:8080.
 
 NOTE: Port forwarding is only suitable for development and testing purposes.
 

--- a/documentation/modules/managing/con-custom-resources-status.adoc
+++ b/documentation/modules/managing/con-custom-resources-status.adoc
@@ -54,7 +54,7 @@ m¦KafkaMirrorMaker
 
 m¦KafkaBridge
 ¦`KafkaBridgeStatus` schema reference
-¦The Strimzi Kafka Bridge
+¦The Kafka Bridge
 
 m¦KafkaRebalance
 ¦`KafkaRebalance` schema reference

--- a/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
@@ -227,7 +227,7 @@ In the Keycloak Admin Console, check the roles assigned to the clients are displ
 
 .Procedure
 
-. Run a new interactive pod container using the Strimzi Kafka image to connect to a running Kafka broker.
+. Run a new interactive pod container using the Kafka image to connect to a running Kafka broker.
 +
 [source,shell,subs="attributes"]
 ----
@@ -320,7 +320,7 @@ Apply the checks using Kafka's example producer and consumer clients to create t
 Use the `team-a-client` and `team-b-client` clients to check the authorization rules.
 Use the `alice` admin user to perform additional administrative tasks on Kafka.
 
-The Strimzi Kafka image used in this example contains Kafka producer and consumer binaries.
+The Kafka image used in this example contains Kafka producer and consumer binaries.
 
 .Prerequisites
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -123,6 +123,7 @@ The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate has a defa
 
 The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate allows the Cluster Operator to continue a reconciliation if the manual rolling update of the operands fails.
 It applies to the following operands that support manual rolling updates using the `strimzi.io/manual-rolling-update` annotation:
+
 * ZooKeeper
 * Kafka
 * Kafka Connect

--- a/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
+++ b/documentation/modules/overview/con-overview-components-kafka-bridge.adoc
@@ -30,4 +30,4 @@ Messages can be sent in JSON or binary formats.
 
 [role="_additional-resources"]
 .Additional resources
-* To view the API documentation, including example requests and responses, see link:{BookURLBridge}[Using the Strimzi Kafka Bridge^].
+* To view the API documentation, including example requests and responses, see link:{BookURLBridge}[Using the Kafka Bridge^].

--- a/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-in-connect-mirror-maker-bridge-resources.adoc
@@ -6,7 +6,7 @@
 = Enabling tracing in MirrorMaker, Kafka Connect, and Kafka Bridge resources
 
 [role="_abstract"]
-Distributed tracing is supported for MirrorMaker, MirrorMaker 2, Kafka Connect, and the Strimzi Kafka Bridge.
+Distributed tracing is supported for MirrorMaker, MirrorMaker 2, Kafka Connect, and the Kafka Bridge.
 Configure the custom resource of the component to specify and enable a tracer service. 
 
 Enabling tracing in a resource triggers the following events:

--- a/documentation/modules/tracing/proc-enabling-tracing-type.adoc
+++ b/documentation/modules/tracing/proc-enabling-tracing-type.adoc
@@ -15,7 +15,7 @@ This procedure shows how to implement Zipkin tracing.
 
 .Procedure
 
-. Add the tracing artifacts to the `/opt/kafka/libs/` directory of the Strimzi Kafka image.
+. Add the tracing artifacts to the `/opt/kafka/libs/` directory of the Kafka image.
 +
 You can use the Kafka container image on the {DockerRepository} as a base image for creating a new custom image.
 +

--- a/documentation/snip-images.sh
+++ b/documentation/snip-images.sh
@@ -53,7 +53,7 @@ a|
 * {DockerOrg}/kafka-bridge:{BridgeDockerTag}
 
 a|
-Strimzi image for running the Strimzi kafka Bridge
+Strimzi image for running the Kafka Bridge
 
 |Strimzi Drain Cleaner
 a|


### PR DESCRIPTION
**Documentation**

In a few places in the docs we say "Strimzi Kafka Bridge" without needing to make this distinction. These instances have been updated to say just "Kafka Bridge"

Few similar changes for "Strimzi Kafka image"



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

