### PR TITLE
Add support for filename patterns when configuring trusted certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The `UseKRaft` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
   To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
 * Update the base image used by Strimzi containers from UBI8 to UBI9
+* Add support for filename patterns when configuring trusted certificates
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.
 
 ## 0.41.0

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertAndKeySecretSource.java
@@ -12,6 +12,9 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Represents a certificate and private key pair inside a Secret
  */
@@ -20,11 +23,35 @@ import lombok.ToString;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"key", "secretName", "certificate"})
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public class CertAndKeySecretSource extends CertSecretSource {
-    protected String key;
+@JsonPropertyOrder({"secretName", "certificate", "key"})
+@EqualsAndHashCode
+@ToString
+public class CertAndKeySecretSource implements UnknownPropertyPreserving {
+    private String secretName;
+    private String certificate;
+    private String key;
+
+    private Map<String, Object> additionalProperties;
+
+    @Description("The name of the Secret containing the certificate.")
+    @JsonProperty(required = true)
+    public String getSecretName() {
+        return secretName;
+    }
+
+    public void setSecretName(String secretName) {
+        this.secretName = secretName;
+    }
+
+    @Description("The name of the file certificate in the Secret.")
+    @JsonProperty(required = true)
+    public String getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
 
     @Description("The name of the private key in the Secret.")
     @JsonProperty(required = true)
@@ -34,5 +61,18 @@ public class CertAndKeySecretSource extends CertSecretSource {
 
     public void setKey(String key) {
         this.key = key;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(1);
+        }
+        this.additionalProperties.put(name, value);
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -45,7 +45,7 @@ public class CertSecretSource implements UnknownPropertyPreserving {
         this.secretName = secretName;
     }
 
-    @Description("The name of the file certificate in the Secret.")
+    @Description("The name of the file certificate in the secret.")
     public String getCertificate() {
         return certificate;
     }
@@ -54,9 +54,9 @@ public class CertSecretSource implements UnknownPropertyPreserving {
         this.certificate = certificate;
     }
 
-    @Description("Pattern of the certificate files in the Secret that should be used. " +
-            "The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. " +
-            "All files in the Secret matching the pattern will be used.")
+    @Description("Pattern for the certificate files in the secret. " +
+            "Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. " +
+            "All files in the secret that match the pattern are used.")
     public String getPattern() {
         return pattern;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/CertSecretSource.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.OneOf;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -23,14 +24,16 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"secretName", "certificate"})
+@JsonPropertyOrder({"secretName", "certificate", "pattern"})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("certificate")), @OneOf.Alternative(@OneOf.Alternative.Property("pattern"))})
 @EqualsAndHashCode
 @ToString
 public class CertSecretSource implements UnknownPropertyPreserving {
-    protected String secretName;
-    protected String certificate;
+    private String secretName;
+    private String certificate;
+    private String pattern;
 
-    protected Map<String, Object> additionalProperties;
+    private Map<String, Object> additionalProperties;
 
     @Description("The name of the Secret containing the certificate.")
     @JsonProperty(required = true)
@@ -43,13 +46,23 @@ public class CertSecretSource implements UnknownPropertyPreserving {
     }
 
     @Description("The name of the file certificate in the Secret.")
-    @JsonProperty(required = true)
     public String getCertificate() {
         return certificate;
     }
 
     public void setCertificate(String certificate) {
         this.certificate = certificate;
+    }
+
+    @Description("Pattern of the certificate files in the Secret that should be used. " +
+            "The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. " +
+            "All files in the Secret matching the pattern will be used.")
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -14,6 +14,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.Ca;
+import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 
 import java.io.IOException;
@@ -302,6 +303,10 @@ public class CertUtils {
             for (CertSecretSource certSecretSource : trustedCertificates) {
                 if (certSecretSource.getCertificate() != null)  {
                     paths.add(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
+                } else if (certSecretSource.getPattern() != null)   {
+                    paths.add(certSecretSource.getSecretName() + "/" + certSecretSource.getPattern());
+                } else {
+                    throw new InvalidResourceException("Certificate source does not contain the certificate or the pattern.");
                 }
             }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerCluster.java
@@ -14,7 +14,6 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
-import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.common.Probe;
 import io.strimzi.api.kafka.model.common.ProbeBuilder;
@@ -407,17 +406,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel implements SupportsMe
         if (consumer.getTls() != null) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_CONSUMER, "true"));
 
-            if (consumer.getTls().getTrustedCertificates() != null && consumer.getTls().getTrustedCertificates().size() > 0) {
-                StringBuilder sb = new StringBuilder();
-                boolean separator = false;
-                for (CertSecretSource certSecretSource : consumer.getTls().getTrustedCertificates()) {
-                    if (separator) {
-                        sb.append(";");
-                    }
-                    sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
-                    separator = true;
-                }
-                varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER, sb.toString()));
+            if (consumer.getTls().getTrustedCertificates() != null && !consumer.getTls().getTrustedCertificates().isEmpty()) {
+                varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_CONSUMER, CertUtils.trustedCertsEnvVar(consumer.getTls().getTrustedCertificates())));
             }
         }
 
@@ -433,17 +423,8 @@ public class KafkaMirrorMakerCluster extends AbstractModel implements SupportsMe
         if (producer.getTls() != null) {
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TLS_PRODUCER, "true"));
 
-            if (producer.getTls().getTrustedCertificates() != null && producer.getTls().getTrustedCertificates().size() > 0) {
-                StringBuilder sb = new StringBuilder();
-                boolean separator = false;
-                for (CertSecretSource certSecretSource : producer.getTls().getTrustedCertificates()) {
-                    if (separator) {
-                        sb.append(";");
-                    }
-                    sb.append(certSecretSource.getSecretName() + "/" + certSecretSource.getCertificate());
-                    separator = true;
-                }
-                varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER, sb.toString()));
+            if (producer.getTls().getTrustedCertificates() != null && !producer.getTls().getTrustedCertificates().isEmpty()) {
+                varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_MIRRORMAKER_TRUSTED_CERTS_PRODUCER, CertUtils.trustedCertsEnvVar(producer.getTls().getTrustedCertificates())));
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -308,7 +308,7 @@ public final class VertxUtil {
                         PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + certSecretSource.getPattern());
 
                         return validatedSecret(namespace, certSecretSource.getSecretName(), secret)
-                                .compose(validatedSecret -> Future.succeededFuture(validatedSecret.getData().entrySet().stream().filter(e -> matcher.matches(Paths.get(e.getKey()))).map(Map.Entry::getValue).collect(Collectors.joining())));
+                                .compose(validatedSecret -> Future.succeededFuture(validatedSecret.getData().entrySet().stream().filter(e -> matcher.matches(Paths.get(e.getKey()))).map(Map.Entry::getValue).sorted().collect(Collectors.joining())));
                     } else {
                         throw new InvalidResourceException("Certificate source does not contain the certificate or the pattern.");
                     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CertUtilsTest.java
@@ -239,6 +239,16 @@ public class CertUtilsTest {
                 .withCertificate("ca2.crt")
                 .build();
 
-        assertThat(CertUtils.trustedCertsEnvVar(List.of(cert1, cert2, cert3)), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt"));
+        CertSecretSource cert4 = new CertSecretSourceBuilder()
+                .withSecretName("third-certificate")
+                .withCertificate("*.crt")
+                .build();
+
+        CertSecretSource cert5 = new CertSecretSourceBuilder()
+                .withSecretName("first-certificate")
+                .withCertificate("*.pem")
+                .build();
+
+        assertThat(CertUtils.trustedCertsEnvVar(List.of(cert1, cert2, cert3, cert4, cert5)), is("first-certificate/ca.crt;second-certificate/tls.crt;first-certificate/ca2.crt;third-certificate/*.crt;first-certificate/*.pem"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.operator.cluster.model;
 
-import io.strimzi.api.kafka.model.common.CertAndKeySecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ConnectorState;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
@@ -731,7 +730,7 @@ public class KafkaMirrorMaker2ConnectorsTest {
                     .endPasswordSecret()
                 .endKafkaClientAuthenticationScramSha512()
                 .withNewTls()
-                    .withTrustedCertificates(new CertAndKeySecretSourceBuilder().withSecretName("my-tls").withCertificate("ca.crt").build())
+                    .withTrustedCertificates(new CertSecretSourceBuilder().withSecretName("my-tls").withCertificate("ca.crt").build())
                 .endTls()
                 .build();
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -366,10 +366,10 @@ Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizatio
 |The name of the Secret containing the certificate.
 |certificate
 |string
-|The name of the file certificate in the Secret.
+|The name of the file certificate in the secret.
 |pattern
 |string
-|Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used.
+|Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used.
 |====
 
 [id='type-KafkaListenerAuthenticationCustom-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -367,6 +367,9 @@ Used in: xref:type-ClientTls-{context}[`ClientTls`], xref:type-KafkaAuthorizatio
 |certificate
 |string
 |The name of the file certificate in the Secret.
+|pattern
+|string
+|Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used.
 |====
 
 [id='type-KafkaListenerAuthenticationCustom-{context}']
@@ -478,15 +481,15 @@ Used in: xref:type-GenericKafkaListenerConfiguration-{context}[`GenericKafkaList
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
-|key
-|string
-|The name of the private key in the Secret.
 |secretName
 |string
 |The name of the Secret containing the certificate.
 |certificate
 |string
 |The name of the file certificate in the Secret.
+|key
+|string
+|The name of the private key in the Secret.
 |====
 
 [id='type-GenericKafkaListenerConfigurationBootstrap-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -247,9 +247,20 @@ spec:
                                     certificate:
                                       type: string
                                       description: The name of the file certificate in the Secret.
+                                    pattern:
+                                      type: string
+                                      description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                  oneOf:
+                                    - properties:
+                                        certificate: {}
+                                      required:
+                                        - certificate
+                                    - properties:
+                                        pattern: {}
+                                      required:
+                                        - pattern
                                   required:
                                     - secretName
-                                    - certificate
                                 description: Trusted certificates for TLS connection to the OAuth server.
                               tokenEndpointUri:
                                 type: string
@@ -283,19 +294,19 @@ spec:
                               brokerCertChainAndKey:
                                 type: object
                                 properties:
-                                  key:
-                                    type: string
-                                    description: The name of the private key in the Secret.
                                   secretName:
                                     type: string
                                     description: The name of the Secret containing the certificate.
                                   certificate:
                                     type: string
                                     description: The name of the file certificate in the Secret.
+                                  key:
+                                    type: string
+                                    description: The name of the private key in the Secret.
                                 required:
-                                  - key
                                   - secretName
                                   - certificate
+                                  - key
                                 description: Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
                               class:
                                 type: string
@@ -689,9 +700,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                              - properties:
+                                  certificate: {}
+                                required:
+                                  - certificate
+                              - properties:
+                                  pattern: {}
+                                required:
+                                  - pattern
                             required:
                               - secretName
-                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -246,10 +246,10 @@ spec:
                                       description: The name of the Secret containing the certificate.
                                     certificate:
                                       type: string
-                                      description: The name of the file certificate in the Secret.
+                                      description: The name of the file certificate in the secret.
                                     pattern:
                                       type: string
-                                      description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                      description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                                   oneOf:
                                     - properties:
                                         certificate: {}
@@ -699,10 +699,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                               - properties:
                                   certificate: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -80,9 +80,20 @@ spec:
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          pattern:
+                            type: string
+                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                        oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                              - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                              - pattern
                         required:
                           - secretName
-                          - certificate
                       description: Trusted certificates for TLS connection.
                   description: TLS configuration.
                 authentication:
@@ -110,19 +121,19 @@ spec:
                     certificateAndKey:
                       type: object
                       properties:
-                        key:
-                          type: string
-                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        key:
+                          type: string
+                          description: The name of the private key in the Secret.
                       required:
-                        - key
                         - secretName
                         - certificate
+                        - key
                       description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
@@ -204,9 +215,20 @@ spec:
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          pattern:
+                            type: string
+                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                        oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                              - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                              - pattern
                         required:
                           - secretName
-                          - certificate
                       description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -79,10 +79,10 @@ spec:
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
-                            description: The name of the file certificate in the Secret.
+                            description: The name of the file certificate in the secret.
                           pattern:
                             type: string
-                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                         oneOf:
                           - properties:
                               certificate: {}
@@ -214,10 +214,10 @@ spec:
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
-                            description: The name of the file certificate in the Secret.
+                            description: The name of the file certificate in the secret.
                           pattern:
                             type: string
-                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                         oneOf:
                           - properties:
                               certificate: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -115,19 +115,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            key:
-                              type: string
-                              description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            key:
+                              type: string
+                              description: The name of the private key in the Secret.
                           required:
-                            - key
                             - secretName
                             - certificate
+                            - key
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -209,9 +209,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                              - properties:
+                                  certificate: {}
+                                required:
+                                  - certificate
+                              - properties:
+                                  pattern: {}
+                                required:
+                                  - pattern
                             required:
                               - secretName
-                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -245,9 +256,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                              - properties:
+                                  certificate: {}
+                                required:
+                                  - certificate
+                              - properties:
+                                  pattern: {}
+                                required:
+                                  - pattern
                             required:
                               - secretName
-                              - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker to the cluster.
                     config:
@@ -292,19 +314,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            key:
-                              type: string
-                              description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            key:
+                              type: string
+                              description: The name of the private key in the Secret.
                           required:
-                            - key
                             - secretName
                             - certificate
+                            - key
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -386,9 +408,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                              - properties:
+                                  certificate: {}
+                                required:
+                                  - certificate
+                              - properties:
+                                  pattern: {}
+                                required:
+                                  - pattern
                             required:
                               - secretName
-                              - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -426,9 +459,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                              - properties:
+                                  certificate: {}
+                                required:
+                                  - certificate
+                              - properties:
+                                  pattern: {}
+                                required:
+                                  - pattern
                             required:
                               - secretName
-                              - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker to the cluster.
                   required:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -208,10 +208,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                               - properties:
                                   certificate: {}
@@ -255,10 +255,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                               - properties:
                                   certificate: {}
@@ -407,10 +407,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                               - properties:
                                   certificate: {}
@@ -458,10 +458,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                               - properties:
                                   certificate: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -83,9 +83,20 @@ spec:
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          pattern:
+                            type: string
+                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                        oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                              - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                              - pattern
                         required:
                           - secretName
-                          - certificate
                       description: Trusted certificates for TLS connection.
                   description: TLS configuration for connecting Kafka Bridge to the cluster.
                 authentication:
@@ -113,19 +124,19 @@ spec:
                     certificateAndKey:
                       type: object
                       properties:
-                        key:
-                          type: string
-                          description: The name of the private key in the Secret.
                         secretName:
                           type: string
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        key:
+                          type: string
+                          description: The name of the private key in the Secret.
                       required:
-                        - key
                         - secretName
                         - certificate
+                        - key
                       description: Reference to the `Secret` which holds the certificate and private key pair.
                     clientId:
                       type: string
@@ -207,9 +218,20 @@ spec:
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          pattern:
+                            type: string
+                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                        oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                              - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                              - pattern
                         required:
                           - secretName
-                          - certificate
                       description: Trusted certificates for TLS connection to the OAuth server.
                     tokenEndpointUri:
                       type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -82,10 +82,10 @@ spec:
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
-                            description: The name of the file certificate in the Secret.
+                            description: The name of the file certificate in the secret.
                           pattern:
                             type: string
-                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                         oneOf:
                           - properties:
                               certificate: {}
@@ -217,10 +217,10 @@ spec:
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
-                            description: The name of the file certificate in the Secret.
+                            description: The name of the file certificate in the secret.
                           pattern:
                             type: string
-                            description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                         oneOf:
                           - properties:
                               certificate: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -91,10 +91,10 @@ spec:
                                   description: The name of the Secret containing the certificate.
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in the Secret.
+                                  description: The name of the file certificate in the secret.
                                 pattern:
                                   type: string
-                                  description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                  description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                               oneOf:
                                 - properties:
                                     certificate: {}
@@ -226,10 +226,10 @@ spec:
                                   description: The name of the Secret containing the certificate.
                                 certificate:
                                   type: string
-                                  description: The name of the file certificate in the Secret.
+                                  description: The name of the file certificate in the secret.
                                 pattern:
                                   type: string
-                                  description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                  description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                               oneOf:
                                 - properties:
                                     certificate: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -92,9 +92,20 @@ spec:
                                 certificate:
                                   type: string
                                   description: The name of the file certificate in the Secret.
+                                pattern:
+                                  type: string
+                                  description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              oneOf:
+                                - properties:
+                                    certificate: {}
+                                  required:
+                                    - certificate
+                                - properties:
+                                    pattern: {}
+                                  required:
+                                    - pattern
                               required:
                                 - secretName
-                                - certificate
                             description: Trusted certificates for TLS connection.
                         description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                       authentication:
@@ -122,19 +133,19 @@ spec:
                           certificateAndKey:
                             type: object
                             properties:
-                              key:
-                                type: string
-                                description: The name of the private key in the Secret.
                               secretName:
                                 type: string
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              key:
+                                type: string
+                                description: The name of the private key in the Secret.
                             required:
-                              - key
                               - secretName
                               - certificate
+                              - key
                             description: Reference to the `Secret` which holds the certificate and private key pair.
                           clientId:
                             type: string
@@ -216,9 +227,20 @@ spec:
                                 certificate:
                                   type: string
                                   description: The name of the file certificate in the Secret.
+                                pattern:
+                                  type: string
+                                  description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              oneOf:
+                                - properties:
+                                    certificate: {}
+                                  required:
+                                    - certificate
+                                - properties:
+                                    pattern: {}
+                                  required:
+                                    - pattern
                               required:
                                 - secretName
-                                - certificate
                             description: Trusted certificates for TLS connection to the OAuth server.
                           tokenEndpointUri:
                             type: string

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -245,10 +245,10 @@ spec:
                                     description: The name of the Secret containing the certificate.
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate in the Secret.
+                                    description: The name of the file certificate in the secret.
                                   pattern:
                                     type: string
-                                    description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                    description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                                 oneOf:
                                 - properties:
                                     certificate: {}
@@ -698,10 +698,10 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
                             pattern:
                               type: string
-                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                           oneOf:
                           - properties:
                               certificate: {}

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -246,9 +246,20 @@ spec:
                                   certificate:
                                     type: string
                                     description: The name of the file certificate in the Secret.
+                                  pattern:
+                                    type: string
+                                    description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                oneOf:
+                                - properties:
+                                    certificate: {}
+                                  required:
+                                  - certificate
+                                - properties:
+                                    pattern: {}
+                                  required:
+                                  - pattern
                                 required:
                                 - secretName
-                                - certificate
                               description: Trusted certificates for TLS connection to the OAuth server.
                             tokenEndpointUri:
                               type: string
@@ -282,19 +293,19 @@ spec:
                             brokerCertChainAndKey:
                               type: object
                               properties:
-                                key:
-                                  type: string
-                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
                                   description: The name of the Secret containing the certificate.
                                 certificate:
                                   type: string
                                   description: The name of the file certificate in the Secret.
+                                key:
+                                  type: string
+                                  description: The name of the private key in the Secret.
                               required:
-                              - key
                               - secretName
                               - certificate
+                              - key
                               description: Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
                             class:
                               type: string
@@ -688,9 +699,20 @@ spec:
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            pattern:
+                              type: string
+                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -79,9 +79,20 @@ spec:
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        pattern:
+                          type: string
+                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration.
               authentication:
@@ -109,19 +120,19 @@ spec:
                   certificateAndKey:
                     type: object
                     properties:
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
                       certificate:
                         type: string
                         description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
                     required:
-                    - key
                     - secretName
                     - certificate
+                    - key
                     description: Reference to the `Secret` which holds the certificate and private key pair.
                   clientId:
                     type: string
@@ -203,9 +214,20 @@ spec:
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        pattern:
+                          type: string
+                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -78,10 +78,10 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
                         pattern:
                           type: string
-                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                       oneOf:
                       - properties:
                           certificate: {}
@@ -213,10 +213,10 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
                         pattern:
                           type: string
-                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                       oneOf:
                       - properties:
                           certificate: {}

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -207,10 +207,10 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
                             pattern:
                               type: string
-                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                           oneOf:
                           - properties:
                               certificate: {}
@@ -254,10 +254,10 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
                             pattern:
                               type: string
-                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                           oneOf:
                           - properties:
                               certificate: {}
@@ -406,10 +406,10 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
                             pattern:
                               type: string
-                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                           oneOf:
                           - properties:
                               certificate: {}
@@ -457,10 +457,10 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
                             pattern:
                               type: string
-                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                           oneOf:
                           - properties:
                               certificate: {}

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -114,19 +114,19 @@ spec:
                       certificateAndKey:
                         type: object
                         properties:
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
                         required:
-                        - key
                         - secretName
                         - certificate
+                        - key
                         description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
@@ -208,9 +208,20 @@ spec:
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            pattern:
+                              type: string
+                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -244,9 +255,20 @@ spec:
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            pattern:
+                              type: string
+                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
                   config:
@@ -291,19 +313,19 @@ spec:
                       certificateAndKey:
                         type: object
                         properties:
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
                         required:
-                        - key
                         - secretName
                         - certificate
+                        - key
                         description: Reference to the `Secret` which holds the certificate and private key pair.
                       clientId:
                         type: string
@@ -385,9 +407,20 @@ spec:
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            pattern:
+                              type: string
+                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -425,9 +458,20 @@ spec:
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            pattern:
+                              type: string
+                              description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
                 required:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -82,9 +82,20 @@ spec:
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        pattern:
+                          type: string
+                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration for connecting Kafka Bridge to the cluster.
               authentication:
@@ -112,19 +123,19 @@ spec:
                   certificateAndKey:
                     type: object
                     properties:
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
                       certificate:
                         type: string
                         description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
                     required:
-                    - key
                     - secretName
                     - certificate
+                    - key
                     description: Reference to the `Secret` which holds the certificate and private key pair.
                   clientId:
                     type: string
@@ -206,9 +217,20 @@ spec:
                         certificate:
                           type: string
                           description: The name of the file certificate in the Secret.
+                        pattern:
+                          type: string
+                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -81,10 +81,10 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
                         pattern:
                           type: string
-                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                       oneOf:
                       - properties:
                           certificate: {}
@@ -216,10 +216,10 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
                         pattern:
                           type: string
-                          description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                       oneOf:
                       - properties:
                           certificate: {}

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -91,9 +91,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                            - properties:
+                                certificate: {}
+                              required:
+                              - certificate
+                            - properties:
+                                pattern: {}
+                              required:
+                              - pattern
                             required:
                             - secretName
-                            - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                     authentication:
@@ -121,19 +132,19 @@ spec:
                         certificateAndKey:
                           type: object
                           properties:
-                            key:
-                              type: string
-                              description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            key:
+                              type: string
+                              description: The name of the private key in the Secret.
                           required:
-                          - key
                           - secretName
                           - certificate
+                          - key
                           description: Reference to the `Secret` which holds the certificate and private key pair.
                         clientId:
                           type: string
@@ -215,9 +226,20 @@ spec:
                               certificate:
                                 type: string
                                 description: The name of the file certificate in the Secret.
+                              pattern:
+                                type: string
+                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                            oneOf:
+                            - properties:
+                                certificate: {}
+                              required:
+                              - certificate
+                            - properties:
+                                pattern: {}
+                              required:
+                              - pattern
                             required:
                             - secretName
-                            - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -90,10 +90,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                             - properties:
                                 certificate: {}
@@ -225,10 +225,10 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
                               pattern:
                                 type: string
-                                description: "Pattern of the certificate files in the Secret that should be used. The pattern should be specified using the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_]. All files in the Secret matching the pattern will be used."
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
                             oneOf:
                             - properties:
                                 certificate: {}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for filename pattern matching of TLS certificates in the trusted certificates secrets to allow to trust multiple certificates at once (for example based on their extension). It implements the [StrimziProposal 73](https://github.com/strimzi/proposals/blob/main/073-improve-handling-of-CA-renewals-and-replacements-in-client-based-operands.md).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md