### PR TITLE
ST: Add system test for tiered-storage with Aiven plugin

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -84,46 +84,6 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "kraft-operators"
-    targets:
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-    skip_build: true
-    manual_trigger: true
-    env: { IP_FAMILY: ipv4 }
-    labels:
-      - kraft
-      - operators
-      - kraft-operators
-      - ko
-    tf_extra_params:
-      test:
-        tmt:
-          name: kraft-operators
-  ###############################################################################################
-
-  - job: tests
-    trigger: pull_request
-    identifier: "kraft-components"
-    targets:
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-    skip_build: true
-    manual_trigger: true
-    env: { IP_FAMILY: ipv4 }
-    labels:
-      - kraft
-      - components
-      - kraft-components
-      - kc
-    tf_extra_params:
-      test:
-        tmt:
-          name: kraft-components
-  ###############################################################################################
-
-  - job: tests
-    trigger: pull_request
     identifier: "acceptance"
     targets:
       - centos-stream-9-x86_64

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -180,6 +180,11 @@ public class Environment {
     public static final String CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN = getOrDefault(CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN_ENV, "");
 
     /**
+     * Env var for specify base image for building Kafka with tiered storage in system tests
+     */
+    public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE_ENV = "KAFKA_TIERED_STORAGE_BASE_IMAGE";
+
+    /**
      * Defaults
      */
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
@@ -210,6 +215,8 @@ public class Environment {
     public static final String IP_FAMILY_DEFAULT = "ipv4";
     public static final String IP_FAMILY_VERSION_6 = "ipv6";
     public static final String IP_FAMILY_DUAL_STACK = "dual";
+
+    public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka:latest-kafka-" + ST_KAFKA_VERSION_DEFAULT;
 
     /**
      * Set values
@@ -265,6 +272,8 @@ public class Environment {
     public static final String TEST_SUITE_NAMESPACE = Environment.isNamespaceRbacScope() ? TestConstants.CO_NAMESPACE : "test-suite-namespace";
 
     public static final String IP_FAMILY = getOrDefault(IP_FAMILY_ENV, IP_FAMILY_DEFAULT);
+
+    public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE = getOrDefault(KAFKA_TIERED_STORAGE_BASE_IMAGE_ENV, KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT);
 
 
     private Environment() { }

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -26,6 +26,7 @@ public interface TestConstants {
     long TIMEOUT_TEARDOWN = Duration.ofSeconds(10).toMillis();
     long GLOBAL_TIMEOUT = Duration.ofMinutes(5).toMillis();
     long GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(2).toMillis();
+    long GLOBAL_TIMEOUT_LONG = Duration.ofMinutes(10).toMillis();
     long GLOBAL_CMD_CLIENT_TIMEOUT = Duration.ofMinutes(5).toMillis();
     long GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3).toMillis();
     long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
@@ -164,6 +165,8 @@ public interface TestConstants {
     String REPLICA_SET = "ReplicaSet";
     String SUBSCRIPTION = "Subscription";
     String OPERATOR_GROUP = "OperatorGroup";
+    String BUILD_CONFIG = "BuildConfig";
+    String IMAGE_STREAM = "ImageStream";
 
     /**
      * KafkaBridge JSON encoding with JSON embedded format

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -409,7 +409,7 @@ public interface TestConstants {
     /**
      * Tag for tests that covers Tiered Storage integration
      */
-    String TIERED_STORAGE = "tiered-storage";
+    String TIERED_STORAGE = "tieredstorage";
 
     /**
      * Tag for tests, without ARM,AARCH64 support

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -407,6 +407,11 @@ public interface TestConstants {
     String QUOTAS_PLUGIN = "quotasplugin";
 
     /**
+     * Tag for tests that covers Tiered Storage integration
+     */
+    String TIERED_STORAGE = "tiered-storage";
+
+    /**
      * Tag for tests, without ARM,AARCH64 support
      */
     String ARM64_UNSUPPORTED = "arm64unsupported";

--- a/systemtest/src/main/java/io/strimzi/systemtest/enums/DeploymentTypes.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/enums/DeploymentTypes.java
@@ -13,4 +13,5 @@ public enum DeploymentTypes {
     DrainCleaner,
     Scraper,
     AdminClient,
+    Minio,
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -55,6 +55,8 @@ import io.strimzi.systemtest.resources.kubernetes.SecretResource;
 import io.strimzi.systemtest.resources.kubernetes.ServiceAccountResource;
 import io.strimzi.systemtest.resources.kubernetes.ServiceResource;
 import io.strimzi.systemtest.resources.kubernetes.ValidatingWebhookConfigurationResource;
+import io.strimzi.systemtest.resources.openshift.BuildConfigResource;
+import io.strimzi.systemtest.resources.openshift.ImageStreamResource;
 import io.strimzi.systemtest.resources.openshift.OperatorGroupResource;
 import io.strimzi.systemtest.resources.openshift.SubscriptionResource;
 import io.strimzi.systemtest.resources.operator.BundleResource;
@@ -157,7 +159,9 @@ public class ResourceManager {
         new ValidatingWebhookConfigurationResource(),
         new SubscriptionResource(),
         new OperatorGroupResource(),
-        new KafkaNodePoolResource()
+        new KafkaNodePoolResource(),
+        new BuildConfigResource(),
+        new ImageStreamResource()
     };
     @SafeVarargs
     public final <T extends HasMetadata> void createResourceWithoutWait(T... resources) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
@@ -18,6 +18,7 @@ import io.fabric8.openshift.api.model.BuildRequestBuilder;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
 import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.openshift.BuildConfigResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
@@ -107,8 +108,8 @@ public class ImageBuild {
             .endSpec()
             .build();
 
-        ResourceManager.getInstance().createResourceWithoutWait(kanikoJob);
-        JobUtils.waitForJobSuccess(name, namespace, 120_000);
+        ResourceManager.getInstance().createResourceWithWait(kanikoJob);
+        JobUtils.waitForJobSuccess(name, namespace, TestConstants.GLOBAL_TIMEOUT);
     }
 
     /**
@@ -144,7 +145,7 @@ public class ImageBuild {
                     .withType("Docker")
                     .withNewDockerStrategy()
                         .addToBuildArgs(new EnvVar("BASE_IMAGE", baseImage, null))
-                .endDockerStrategy()
+                    .endDockerStrategy()
                 .endStrategy()
             .endSpec()
             .build();
@@ -153,7 +154,8 @@ public class ImageBuild {
                 .withNewMetadata()
                     .withName(name)
                     .withNamespace(namespace)
-                .endMetadata().build();
+                .endMetadata()
+                .build();
 
         BuildRequest buildRequest = new BuildRequestBuilder()
             .withNewMetadata()
@@ -180,13 +182,13 @@ public class ImageBuild {
         String dockerfileContent = Files.readString(Paths.get(dockerfilePath), StandardCharsets.UTF_8);
 
         ConfigMap configMap = new ConfigMapBuilder()
-                .withNewMetadata()
+            .withNewMetadata()
                 .withName(configMapName)
                 .withNamespace(namespace)
-                .endMetadata()
-                .addToData("Dockerfile", dockerfileContent)
-                .build();
+            .endMetadata()
+            .addToData("Dockerfile", dockerfileContent)
+            .build();
 
-        ResourceManager.getInstance().createResourceWithoutWait(configMap);
+        ResourceManager.getInstance().createResourceWithWait(configMap);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.imageBuild;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigBuilder;
+import io.fabric8.openshift.api.model.BuildRequest;
+import io.fabric8.openshift.api.model.BuildRequestBuilder;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.openshift.BuildConfigResource;
+import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import io.strimzi.systemtest.utils.kubeUtils.objects.BuildUtils;
+import io.strimzi.test.k8s.KubeClusterResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+public class ImageBuild {
+    private static final Logger LOGGER = LogManager.getLogger(ImageBuild.class);
+    private static final String KANIKO_IMAGE = "gcr.io/kaniko-project/executor:latest";
+
+    /**
+     * Build a specific image from passed Dockerfile and push it into internal registry.
+     * It will use OpenShift build on OpenShift like clusters and Kaniko on other distributions.
+     * @param name Image name (it is also used as a name for all needed resources)
+     * @param namespace location where the build will happen
+     * @param dockerfilePath path to Dockerfile
+     * @param imageTag tag of the final image that will be pushed into internal registries
+     * @param baseImage used base image for the build
+     * @throws IOException
+     */
+    public static void buildImage(String name, String namespace, String dockerfilePath, String imageTag, String baseImage) throws IOException {
+        if (KubeClusterResource.getInstance().isOpenShiftLikeCluster()) {
+            buildImageOpenshift(name, namespace, dockerfilePath, imageTag, baseImage);
+        } else {
+            buildImageKaniko(name, namespace, dockerfilePath, imageTag, baseImage);
+        }
+    }
+
+    /**
+     * Build a specific image from passed Dockerfile and push it into internal registry.
+     * @param name Image name (it is also used as a name for all needed resources)
+     * @param namespace location where the build will happen
+     * @param dockerfilePath path to Dockerfile
+     * @param imageTag tag of the final image that will be pushed into internal registries
+     * @param baseImage used base image for the build
+     * @throws IOException
+     */
+    public static void buildImageKaniko(String name, String namespace, String dockerfilePath, String imageTag, String baseImage) throws IOException {
+        createDockerfileConfigMap(namespace, name, dockerfilePath);
+
+        SecurityContext securityContext = new SecurityContextBuilder()
+                .withNewCapabilities()
+                .addAllToAdd(Arrays.asList("CHOWN", "DAC_OVERRIDE", "FOWNER", "SETFCAP", "SETGID", "SETUID", "NET_ADMIN", "SYS_TIME"))
+                .endCapabilities()
+                .build();
+
+        String secretName = ResourceManager.kubeClient().getServiceAccount(namespace, "builder").getSecrets().stream()
+                .filter(secretReference -> secretReference.getName().contains("dockercfg") || secretReference.getName().contains("dockerconfigjson"))
+                .findFirst()
+                .map(it -> it.getName())
+                .orElse(null);
+
+        Job kanikoJob = new JobBuilder()
+            .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace) // Change this to your namespace
+            .endMetadata()
+            .withNewSpec()
+                .withNewTemplate()
+                    .withNewMetadata()
+                        .withName(name)
+                    .endMetadata()
+                    .withNewSpec()
+                        .withServiceAccount("builder")
+                        .withServiceAccountName("builder")
+
+                        .withRestartPolicy("Never")
+                        .withVolumes(
+//                        new VolumeBuilder()
+//                                .withName("kaniko-secret")
+//                                .withNewSecret()
+//                                    .withSecretName(secretName)
+//                                    .addNewItem(".dockercfg", 0440, "config.json")
+//                                .endSecret()
+//                                .build(),
+                            new VolumeBuilder()
+                                    .withName(name)
+                                    .withNewConfigMap()
+                                        .withName(name)
+                                    .endConfigMap()
+                                    .build()
+                        )
+                        .addNewContainer()
+                            .withName(name)
+                            .withImage(KANIKO_IMAGE)
+    //                        .withSecurityContext(securityContext)
+                            .withArgs(
+                                "--dockerfile=/workspace/Dockerfile",
+                                "--destination=" + Environment.getImageOutputRegistry(namespace, name, imageTag),
+                                "--build-arg=BASE_IMAGE=" + baseImage,
+                                "--skip-tls-verify",
+                                "-v=debug")
+                            .withVolumeMounts(
+    //                        new VolumeMountBuilder()
+    //                                .withName("kaniko-secret")
+    //                                .withMountPath("/kaniko/.docker")
+    //                                .build(),
+                                new VolumeMountBuilder()
+                                        .withName(name)
+                                        .withSubPath("Dockerfile")
+                                        .withMountPath("/workspace/Dockerfile")
+                                        .build()
+                            )
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+
+        ResourceManager.getInstance().createResourceWithoutWait(kanikoJob);
+        JobUtils.waitForJobSuccess(name, namespace, 120_000);
+    }
+
+    /**
+     * Build a specific image from passed Dockerfile and push it into internal registry.
+     * @param name Image name (it is also used as a name for all needed resources)
+     * @param namespace location where the build will happen
+     * @param dockerfilePath path to Dockerfile
+     * @param imageTag tag of the final image that will be pushed into internal registries
+     * @param baseImage used base image for the build
+     * @throws IOException
+     */
+    public static void buildImageOpenshift(String name, String namespace, String dockerfilePath, String imageTag, String baseImage) throws IOException {
+        String dockerfileContent = new String(Files.readAllBytes(Paths.get(dockerfilePath)));
+
+        BuildConfig buildConfig = new BuildConfigBuilder()
+            .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+            .endMetadata()
+            .withNewSpec()
+                .withNewOutput()
+                    .withNewTo()
+                        .withName(name + ":" + imageTag)
+                        .withNamespace(namespace)
+                        .withKind("ImageStreamTag")
+                    .endTo()
+                .endOutput()
+                .withNewSource()
+                    .withType("Dockerfile")
+                    .withDockerfile(dockerfileContent)
+                .endSource()
+                .withNewStrategy()
+                    .withType("Docker")
+                    .withNewDockerStrategy()
+                        .addToBuildArgs(new EnvVar("BASE_IMAGE", baseImage, null))
+                .endDockerStrategy()
+                .endStrategy()
+            .endSpec()
+            .build();
+
+        ImageStream imageStream = new ImageStreamBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(namespace)
+                .endMetadata().build();
+
+        BuildRequest buildRequest = new BuildRequestBuilder()
+            .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+            .endMetadata()
+            .build();
+
+        ResourceManager.getInstance().createResourceWithoutWait(imageStream);
+        ResourceManager.getInstance().createResourceWithoutWait(buildConfig);
+        BuildConfigResource.buildConfigClient().inNamespace(namespace).withName(name).instantiate(buildRequest);
+
+        BuildUtils.waitForBuildComplete(name, namespace);
+    }
+
+    /**
+     * Create config map with Dockerfile loaded by Kaniko
+     * @param namespace location of the config map
+     * @param configMapName name of the config map
+     * @param dockerfilePath path to the Dockerfile
+     * @throws IOException
+     */
+    private static void createDockerfileConfigMap(String namespace, String configMapName, String dockerfilePath) throws IOException {
+        String dockerfileContent = new String(Files.readAllBytes(Paths.get(dockerfilePath)));
+
+        ConfigMap configMap = new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(configMapName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .addToData("Dockerfile", dockerfileContent)
+                .build();
+
+        ResourceManager.getInstance().createResourceWithoutWait(configMap);
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -120,7 +121,7 @@ public class ImageBuild {
      * @throws IOException
      */
     public static void buildImageOpenshift(String name, String namespace, String dockerfilePath, String imageTag, String baseImage) throws IOException {
-        String dockerfileContent = new String(Files.readAllBytes(Paths.get(dockerfilePath)));
+        String dockerfileContent = Files.readString(Paths.get(dockerfilePath), StandardCharsets.UTF_8);
 
         BuildConfig buildConfig = new BuildConfigBuilder()
             .withNewMetadata()
@@ -176,7 +177,7 @@ public class ImageBuild {
      * @throws IOException
      */
     private static void createDockerfileConfigMap(String namespace, String configMapName, String dockerfilePath) throws IOException {
-        String dockerfileContent = new String(Files.readAllBytes(Paths.get(dockerfilePath)));
+        String dockerfileContent = Files.readString(Paths.get(dockerfilePath), StandardCharsets.UTF_8);
 
         ConfigMap configMap = new ConfigMapBuilder()
                 .withNewMetadata()

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.minio;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.enums.DeploymentTypes;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SetupMinio {
+    private static final Logger LOGGER = LogManager.getLogger(SetupMinio.class);
+
+    public static final String MINIO = "minio";
+    public static final String ADMIN_CREDS = "minioadmin";
+    public static final String MINIO_STORAGE_ALIAS = "local";
+    public static final int MINIO_PORT = 9000;
+
+    /**
+     * Deploy minio to a specific namespace, creates service for it and init client inside the Minio pod
+     * @param namespace where Minio will be installed to
+     */
+    public static void deployMinio(String namespace) {
+        // Create a Minio deployment
+        Deployment minioDeployment = new DeploymentBuilder()
+            .withNewMetadata()
+                .withName(MINIO)
+                .withNamespace(namespace)
+                .withLabels(Map.of(TestConstants.DEPLOYMENT_TYPE, DeploymentTypes.Minio.name()))
+            .endMetadata()
+            .withNewSpec()
+                .withReplicas(1)
+                .withNewSelector()
+                    .withMatchLabels(Map.of(TestConstants.APP_POD_LABEL, MINIO))
+                .endSelector()
+                .withNewTemplate()
+                    .withNewMetadata()
+                        .withLabels(Map.of(TestConstants.APP_POD_LABEL, MINIO))
+                    .endMetadata()
+                    .withNewSpec()
+                        .addNewContainer()
+                            .withName("minio")
+                                .withImage("minio/minio:latest")
+                                .withArgs("server", "/data")
+                                .addToEnv(new EnvVar("MINIO_ACCESS_KEY", ADMIN_CREDS, null))
+                                .addToEnv(new EnvVar("MINIO_SECRET_KEY", ADMIN_CREDS, null))
+                                .addNewPort()
+                                    .withContainerPort(MINIO_PORT)
+                                .endPort()
+                                .withVolumeMounts(new VolumeMountBuilder()
+                                    .withName("minio-storage")
+                                    .withMountPath("/data")
+                                    .build())
+                        .endContainer()
+                        .withVolumes(new VolumeBuilder()
+                            .withName("minio-storage")
+                            .withNewEmptyDir()
+                            .endEmptyDir()
+                            .build())
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+
+        // Create the deployment
+        ResourceManager.getInstance().createResourceWithWait(minioDeployment);
+
+        // Create a service to expose Minio
+        Service minioService = new ServiceBuilder()
+            .withNewMetadata()
+                .withName(MINIO)
+                .withNamespace(namespace)
+            .endMetadata()
+            .withNewSpec()
+                .withSelector(Map.of(TestConstants.APP_POD_LABEL, MINIO))
+                .addNewPort()
+                    .withPort(MINIO_PORT)
+                    .withTargetPort(new IntOrString(MINIO_PORT))
+                .endPort()
+            .endSpec()
+            .build();
+
+        ResourceManager.getInstance().createResourceWithoutWait(minioService);
+        NetworkPolicyResource.allowNetworkPolicyAllIngressForMatchingLabel(namespace, MINIO, Map.of(TestConstants.APP_POD_LABEL, MINIO));
+
+        initMinioClient(namespace);
+    }
+
+    /**
+     * Init client inside the Minio pod. This allows other commands to be executed during the tests.
+     * @param namespace where Minio is installed
+     */
+    private static void initMinioClient(String namespace) {
+        final String minioPod = ResourceManager.kubeClient().listPods(namespace, Map.of(TestConstants.APP_POD_LABEL, MINIO)).get(0).getMetadata().getName();
+
+        ResourceManager.cmdKubeClient().namespace(namespace).execInPod(minioPod,
+            "mc",
+            "config",
+            "host",
+            "add",
+            MINIO_STORAGE_ALIAS,
+            "http://localhost:" + MINIO_PORT,
+            ADMIN_CREDS, ADMIN_CREDS);
+    }
+
+    /**
+     * Create bucket in Minio instance in specific namespace.
+     * @param namespace Minio location
+     * @param bucketName name of the bucket that will be created and used within the tests
+     */
+    public static void createBucket(String namespace, String bucketName) {
+        final String minioPod = ResourceManager.kubeClient().listPods(namespace, Map.of(TestConstants.APP_POD_LABEL, MINIO)).get(0).getMetadata().getName();
+
+        ResourceManager.cmdKubeClient().namespace(namespace).execInPod(minioPod,
+            "mc",
+            "mb",
+            MINIO_STORAGE_ALIAS + "/" + bucketName);
+    }
+
+    /**
+     * Collect data from Minio about usage of a specific bucket
+     * @param namespace
+     * @param bucketName
+     * @return Overall statistics about the bucket in String format
+     */
+    public static String getBucketSizeInfo(String namespace, String bucketName) {
+        final String minioPod = ResourceManager.kubeClient().listPods(namespace, Map.of(TestConstants.APP_POD_LABEL, MINIO)).get(0).getMetadata().getName();
+
+        return ResourceManager.cmdKubeClient().namespace(namespace).execInPod(minioPod,
+            "mc",
+            "stat",
+            "local/" + bucketName).out();
+
+    }
+
+    /**
+     * Parse out total size of bucket from the information about usage.
+     * @param bucketInfo String containing all stat info about bucket
+     * @return Map consists of parsed size and it's unit
+     */
+    private static Map<String, Object> parseTotalSize(String bucketInfo) {
+        Pattern pattern = Pattern.compile("Total size:\\s*(?<size>[\\d.]+)\\s*(?<unit>.*)");
+        Matcher matcher = pattern.matcher(bucketInfo);
+
+        if (matcher.find()) {
+            return Map.of("size", Double.parseDouble(matcher.group("size")), "unit", matcher.group("unit"));
+        } else {
+            throw new IllegalArgumentException("Total size not found in the provided string");
+        }
+    }
+
+    /**
+     * Wait until size of the bucket is not 0 B.
+     * @param namespace Minio location
+     * @param bucketName bucket name
+     */
+    public static void waitForDataInMinio(String namespace, String bucketName) {
+        TestUtils.waitFor("data sync from Kafka to Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
+            String bucketSizeInfo = SetupMinio.getBucketSizeInfo(namespace, bucketName);
+            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
+            double bucketSize = (Double) parsedSize.get("size");
+            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
+            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
+
+            return bucketSize > 0;
+        });
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -56,7 +56,7 @@ public class SetupMinio {
                     .endMetadata()
                     .withNewSpec()
                         .addNewContainer()
-                            .withName("minio")
+                            .withName(MINIO)
                                 .withImage(MINIO_IMAGE)
                                 .withArgs("server", "/data")
                                 .addToEnv(new EnvVar("MINIO_ACCESS_KEY", ADMIN_CREDS, null))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -56,7 +56,7 @@ public class SetupMinio {
                     .withNewSpec()
                         .addNewContainer()
                             .withName("minio")
-                                .withImage("minio/minio:latest")
+                                .withImage("quay.io/minio/minio:latest")
                                 .withArgs("server", "/data")
                                 .addToEnv(new EnvVar("MINIO_ACCESS_KEY", ADMIN_CREDS, null))
                                 .addToEnv(new EnvVar("MINIO_SECRET_KEY", ADMIN_CREDS, null))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -31,6 +31,7 @@ public class SetupMinio {
     public static final String ADMIN_CREDS = "minioadmin";
     public static final String MINIO_STORAGE_ALIAS = "local";
     public static final int MINIO_PORT = 9000;
+    private static final String MINIO_IMAGE = "quay.io/minio/minio:latest";
 
     /**
      * Deploy minio to a specific namespace, creates service for it and init client inside the Minio pod
@@ -56,7 +57,7 @@ public class SetupMinio {
                     .withNewSpec()
                         .addNewContainer()
                             .withName("minio")
-                                .withImage("quay.io/minio/minio:latest")
+                                .withImage(MINIO_IMAGE)
                                 .withArgs("server", "/data")
                                 .addToEnv(new EnvVar("MINIO_ACCESS_KEY", ADMIN_CREDS, null))
                                 .addToEnv(new EnvVar("MINIO_SECRET_KEY", ADMIN_CREDS, null))

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/BuildConfigResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/BuildConfigResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.openshift;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.BuildConfigList;
+import io.fabric8.openshift.api.model.BuildList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.dsl.BuildResource;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.ResourceType;
+
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+public class BuildConfigResource implements ResourceType<BuildConfig> {
+
+    @Override
+    public String getKind() {
+        return TestConstants.BUILD_CONFIG;
+    }
+
+    @Override
+    public BuildConfig get(String namespace, String name) {
+        return buildConfigClient().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void create(BuildConfig resource) {
+        buildConfigClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
+    }
+
+    @Override
+    public void delete(BuildConfig resource) {
+        buildConfigClient().inNamespace(resource.getMetadata().getNamespace())
+            .withName(resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    }
+
+    @Override
+    public void update(BuildConfig resource) {
+        buildConfigClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
+    public boolean waitForReadiness(BuildConfig resource) {
+        return resource != null;
+    }
+
+    public static MixedOperation<BuildConfig, BuildConfigList, io.fabric8.openshift.client.dsl.BuildConfigResource<BuildConfig, Void, Build>> buildConfigClient() {
+        return kubeClient().getClient().adapt(OpenShiftClient.class).buildConfigs();
+    }
+
+    public static MixedOperation<Build, BuildList, BuildResource> buildsClient() {
+        return kubeClient().getClient().adapt(OpenShiftClient.class).builds();
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/ImageStreamResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/openshift/ImageStreamResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.resources.openshift;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.ResourceType;
+
+import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
+
+public class ImageStreamResource implements ResourceType<ImageStream> {
+
+    @Override
+    public String getKind() {
+        return TestConstants.IMAGE_STREAM;
+    }
+
+    @Override
+    public ImageStream get(String namespace, String name) {
+        return imageStreamsClient().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void create(ImageStream resource) {
+        imageStreamsClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
+    }
+
+    @Override
+    public void delete(ImageStream resource) {
+        imageStreamsClient().inNamespace(resource.getMetadata().getNamespace())
+            .withName(resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    }
+
+    @Override
+    public void update(ImageStream resource) {
+        imageStreamsClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
+    public boolean waitForReadiness(ImageStream resource) {
+        return resource != null;
+    }
+
+    public static MixedOperation<ImageStream, ImageStreamList, Resource<ImageStream>> imageStreamsClient() {
+        return kubeClient().getClient().adapt(OpenShiftClient.class).imageStreams();
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/controllers/JobUtils.java
@@ -70,6 +70,17 @@ public class JobUtils {
     }
 
     /**
+     * Wait for specific Job success
+     * @param jobName job name
+     * @param timeout timeout in ms after which we assume that job failed
+     */
+    public static void waitForJobSuccess(String jobName, String namespace, long timeout) {
+        LOGGER.info("Waiting for Job: {}/{} to success", namespace, jobName);
+        TestUtils.waitFor("success of Job: " + namespace + "/" + jobName, TestConstants.GLOBAL_POLL_INTERVAL, timeout,
+                () -> kubeClient().checkSucceededJobStatus(namespace, jobName, 1));
+    }
+
+    /**
      * Wait for specific Job failure
      * @param jobName job name
      * @param timeout timeout in ms after which we assume that job failed

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
@@ -39,11 +39,7 @@ public class BuildUtils {
 
             LOGGER.info("Build status of {} is '{}'", buildName, buildStatus.getPhase());
 
-            if (buildStatus.getPhase().equals("Complete")) {
-                return true;
-            }
-
-            return false;
+            return buildStatus.getPhase().equals("Complete");
         });
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
@@ -15,6 +15,8 @@ public class BuildUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(BuildUtils.class);
 
+    private BuildUtils() { }
+
     /**
      * Gets OpenShift build name based on name and version
      * @param name

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.kubeUtils.objects;
+
+import io.fabric8.openshift.api.model.BuildStatus;
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.openshift.BuildConfigResource;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class BuildUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(BuildUtils.class);
+
+    /**
+     * Gets OpenShift build name based on name and version
+     * @param name
+     * @param version
+     * @return
+     */
+    public static String getBuildName(String name, Long version) {
+        return name + "-" + version;
+    }
+
+    /**
+     * Waits for build status to be complete which indicates successful build.
+     * @param buildConfigName name of the corresponding BuildConfig resource
+     * @param namespace namespace where the resources are deployed
+     */
+    public static void waitForBuildComplete(String buildConfigName, String namespace) {
+        TestUtils.waitFor("build " + buildConfigName + " complete", TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS, TestConstants.GLOBAL_TIMEOUT_SHORT, () -> {
+            Long buildLatestVersion = BuildConfigResource.buildConfigClient().inNamespace(namespace).withName(buildConfigName).get().getStatus().getLastVersion();
+            String buildName = getBuildName(buildConfigName, buildLatestVersion);
+
+            BuildStatus buildStatus = BuildConfigResource.buildsClient().inNamespace(namespace).withName(buildName).get().getStatus();
+
+            LOGGER.info("Build status of {} is '{}'", buildName, buildStatus.getPhase());
+
+            if (buildStatus.getPhase().equals("Complete")) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -80,7 +80,7 @@ public class TieredStorageST extends AbstractST {
                             .withDeleteClaim(true)
                         .endPersistentClaimStorage()
                     .endSpec()
-                        .build(),
+                    .build(),
                 KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 1).build()
             )
         );
@@ -92,22 +92,22 @@ public class TieredStorageST extends AbstractST {
             .editSpec()
                 .editKafka()
                     .withImage(Environment.getImageOutputRegistry(testStorage.getNamespaceName(), IMAGE_NAME, BUILT_IMAGE_TAG))
-                        .withNewTieredStorageCustomTiered()
-                            .withNewRemoteStorageManager()
-                                .withClassName("io.aiven.kafka.tieredstorage.RemoteStorageManager")
-                                .withClassPath("/opt/kafka/plugins/tiered-storage/*")
-                                .addToConfig("storage.backend.class", "io.aiven.kafka.tieredstorage.storage.s3.S3Storage")
-                                .addToConfig("chunk.size", "4194304")
-                                // s3 config
-                                .addToConfig("storage.s3.endpoint.url",
-                                        "http://" + SetupMinio.MINIO + "." + testStorage.getNamespaceName() + ".svc.cluster.local:" + SetupMinio.MINIO_PORT)
-                                .addToConfig("storage.s3.bucket.name", BUCKET_NAME)
-                                .addToConfig("storage.s3.region", "us-east-1")
-                                .addToConfig("storage.s3.path.style.access.enabled", "true")
-                                .addToConfig("storage.aws.access.key.id", SetupMinio.ADMIN_CREDS)
-                                .addToConfig("storage.aws.secret.access.key", SetupMinio.ADMIN_CREDS)
-                            .endRemoteStorageManager()
-                        .endTieredStorageCustomTiered()
+                    .withNewTieredStorageCustomTiered()
+                        .withNewRemoteStorageManager()
+                            .withClassName("io.aiven.kafka.tieredstorage.RemoteStorageManager")
+                            .withClassPath("/opt/kafka/plugins/tiered-storage/*")
+                            .addToConfig("storage.backend.class", "io.aiven.kafka.tieredstorage.storage.s3.S3Storage")
+                            .addToConfig("chunk.size", "4194304")
+                            // s3 config
+                            .addToConfig("storage.s3.endpoint.url",
+                                    "http://" + SetupMinio.MINIO + "." + testStorage.getNamespaceName() + ".svc.cluster.local:" + SetupMinio.MINIO_PORT)
+                            .addToConfig("storage.s3.bucket.name", BUCKET_NAME)
+                            .addToConfig("storage.s3.region", "us-east-1")
+                            .addToConfig("storage.s3.path.style.access.enabled", "true")
+                            .addToConfig("storage.aws.access.key.id", SetupMinio.ADMIN_CREDS)
+                            .addToConfig("storage.aws.secret.access.key", SetupMinio.ADMIN_CREDS)
+                        .endRemoteStorageManager()
+                    .endTieredStorageCustomTiered()
                 .endKafka()
             .endSpec()
             .build());

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.kafka;
+
+import io.strimzi.systemtest.AbstractST;
+import io.strimzi.systemtest.Environment;
+import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.resources.NamespaceManager;
+import io.strimzi.systemtest.resources.NodePoolsConverter;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.imageBuild.ImageBuild;
+import io.strimzi.systemtest.resources.minio.SetupMinio;
+import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTemplates;
+import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
+import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static io.strimzi.systemtest.TestConstants.REGRESSION;
+
+/**
+ * @description This test suite covers scenarios for Tiered Storage integration implemented within Strimzi.
+ *
+ * @steps
+ *  1. - Create test namespace
+ *  2. - Build Kafka image based on passed parameters like image full name, base image, Dockerfile path (via Kaniko or OpenShift build)
+ *  3. - Deploy Minio in test namespace and init the client inside the Minio pod
+ *  4. - Init bucket in Minio for purposes of these tests
+ *  5. - Deploy Strimzi Cluster Operator
+ *
+ * @usecase
+ *  - tiered-storage-integration
+ */
+@Tag(REGRESSION)
+public class TieredStorageST extends AbstractST {
+    private static final Logger LOGGER = LogManager.getLogger(TieredStorageST.class);
+
+    private static final String IMAGE_NAME = "kafka-tiered-storage";
+    private static final String TIERED_STORAGE_DOCKERFILE = TestUtils.USER_PATH + "/../systemtest/src/test/resources/tiered-storage/Dockerfile";
+    private static final String BUCKET_NAME = "test-bucket";
+    private static final String BUILT_IMAGE_TAG = "latest";
+
+    /**
+     * @description This testcase is focused on testing of Tiered Storage integration implemented within Strimzi.
+     * The tests use Aiven Tiered Storage plugin - <a href="https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/tree/main">...</a>
+     *
+     * @steps
+     *  1. - Deploys KafkaNodePool resource with Broker NodePool with PV of size 10Gi
+     *  2. - Deploys Kafka resource with configuration of Tiered Storage for Aiven plugin, pointing to Minio S3, and with image built in beforeAll
+     *  3. - Creates topic with enabled Tiered Storage sync with size of segments set to 10mb (this is needed for speedup the sync)
+     *  4. - Starts continuous producer to send data to Kafka
+     *  5. - Wait until Minio size is not empty (contains data from Kafka)
+     *
+     * @usecase
+     *  - tiered-storage-integration
+     */
+    @ParallelTest
+    void testTieredStorageWithAivenPlugin() {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
+
+        resourceManager.createResourceWithWait(
+            NodePoolsConverter.convertNodePoolsIfNeeded(
+                KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getBrokerPoolName(), testStorage.getClusterName(), 3)
+                    .editSpec()
+                        .withNewPersistentClaimStorage()
+                            .withSize("10Gi")
+                            .withDeleteClaim(true)
+                        .endPersistentClaimStorage()
+                    .endSpec()
+                        .build(),
+                KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 1).build()
+            )
+        );
+
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1)
+            .editMetadata()
+                .withNamespace(testStorage.getNamespaceName())
+            .endMetadata()
+            .editSpec()
+                .editKafka()
+                    .withImage(Environment.getImageOutputRegistry(testStorage.getNamespaceName(), IMAGE_NAME, BUILT_IMAGE_TAG))
+                        .withNewTieredStorageCustomTiered()
+                            .withNewRemoteStorageManager()
+                                .withClassName("io.aiven.kafka.tieredstorage.RemoteStorageManager")
+                                .withClassPath("/opt/kafka/plugins/tiered-storage/*")
+                                .addToConfig("storage.backend.class", "io.aiven.kafka.tieredstorage.storage.s3.S3Storage")
+                                .addToConfig("chunk.size", "4194304")
+                                // s3 config
+                                .addToConfig("storage.s3.endpoint.url",
+                                        "http://" + SetupMinio.MINIO + "." + testStorage.getNamespaceName() + ".svc.cluster.local:" + SetupMinio.MINIO_PORT)
+                                .addToConfig("storage.s3.bucket.name", BUCKET_NAME)
+                                .addToConfig("storage.s3.region", "us-east-1")
+                                .addToConfig("storage.s3.path.style.access.enabled", "true")
+                                .addToConfig("storage.aws.access.key.id", SetupMinio.ADMIN_CREDS)
+                                .addToConfig("storage.aws.secret.access.key", SetupMinio.ADMIN_CREDS)
+                            .endRemoteStorageManager()
+                        .endTieredStorageCustomTiered()
+                .endKafka()
+            .endSpec()
+            .build());
+
+        resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getClusterName(), testStorage.getTopicName(), testStorage.getNamespaceName())
+            .editSpec()
+                .addToConfig("file.delete.delay.ms", 1000)
+                .addToConfig("local.retention.ms", 1000)
+                // Allow tiered storage sync
+                .addToConfig("remote.storage.enable", true)
+                // Bytes retention set to 1024mb
+                .addToConfig("retention.bytes", 1073741824)
+                .addToConfig("retention.ms", 86400000)
+                // Segment size is set to 10mb to make it quickier to sync data to Minio
+                .addToConfig("segment.bytes", 1048576)
+            .endSpec()
+            .build());
+
+        final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
+            .withMessageCount(10000000)
+            .withDelayMs(1)
+            .withMessage(String.join("", Collections.nCopies(5000, "#")))
+            .build();
+
+        resourceManager.createResourceWithWait(clients.producerStrimzi());
+
+        SetupMinio.waitForDataInMinio(testStorage.getNamespaceName(), BUCKET_NAME);
+    }
+
+    @BeforeAll
+    void setup() throws IOException {
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
+        NamespaceManager.getInstance().createNamespaceAndPrepare(testStorage.getNamespaceName());
+
+        ImageBuild.buildImage(IMAGE_NAME, testStorage.getNamespaceName(), TIERED_STORAGE_DOCKERFILE, BUILT_IMAGE_TAG, Environment.KAFKA_TIERED_STORAGE_BASE_IMAGE);
+
+        SetupMinio.deployMinio(testStorage.getNamespaceName());
+        SetupMinio.createBucket(testStorage.getNamespaceName(), BUCKET_NAME);
+
+        this.clusterOperator = this.clusterOperator
+            .defaultInstallation()
+            .createInstallation()
+            .runInstallation();
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -125,7 +125,7 @@ public class TieredStorageST extends AbstractST {
             .build());
 
         final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
-            .withMessageCount(10000000)
+            .withMessageCount(10000)
             .withDelayMs(1)
             .withMessage(String.join("", Collections.nCopies(5000, "#")))
             .build();
@@ -133,6 +133,10 @@ public class TieredStorageST extends AbstractST {
         resourceManager.createResourceWithWait(clients.producerStrimzi());
 
         SetupMinio.waitForDataInMinio(testStorage.getNamespaceName(), BUCKET_NAME);
+        ClientUtils.waitForInstantProducerClientSuccess(testStorage);
+
+        resourceManager.createResourceWithWait(clients.consumerStrimzi());
+        ClientUtils.waitForInstantConsumerClientSuccess(testStorage);
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
+import static io.strimzi.systemtest.TestConstants.TIERED_STORAGE;
 
 /**
  * @description This test suite covers scenarios for Tiered Storage integration implemented within Strimzi.
@@ -43,6 +44,7 @@ import static io.strimzi.systemtest.TestConstants.REGRESSION;
  *  - tiered-storage-integration
  */
 @Tag(REGRESSION)
+@Tag(TIERED_STORAGE)
 public class TieredStorageST extends AbstractST {
     private static final Logger LOGGER = LogManager.getLogger(TieredStorageST.class);
 

--- a/systemtest/src/test/resources/tiered-storage/Dockerfile
+++ b/systemtest/src/test/resources/tiered-storage/Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+ARG AIVEN_PLUGIN_VERSION="2024-04-02-1712056402"
+ARG TIERED_STORAGE_URL="https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/download/"
+
+USER root:root
+RUN mkdir -p /opt/kafka/plugins/tiered-storage
+
+RUN curl -sL "$TIERED_STORAGE_URL/$AIVEN_PLUGIN_VERSION/s3-0.0.1-SNAPSHOT.tgz" | tar -xz  --strip-components=1 -C "/opt/kafka/plugins/tiered-storage"
+RUN curl -sL "$TIERED_STORAGE_URL/$AIVEN_PLUGIN_VERSION/core-0.0.1-SNAPSHOT.tgz" | tar -xz  --strip-components=1 -C "/opt/kafka/plugins/tiered-storage"
+
+RUN rm -rf /tmp/tiered-storage
+
+USER 1001


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds system test with tiered storage configuration for Kafka together with Aiven plugin. The tests deals with building an image with Aiven plugin inside using Kaniko or OpenShift build and also deploys Minio as S3 compatible storage.

Manually verified on OCP 4.15 and Minikube (azp setup script)

Packit changes are needed for removal the legacy jobs that are not exists anymore. It resulted into execution of the jobs that immediately failed due to missing config. 

### Checklist

- [x] Make sure all tests pass

