### PR TITLE
Update Vert.x and related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         <fasterxml.jackson-annotations.version>2.16.1</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.1</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.1</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.7</vertx.version>
-        <vertx-junit5.version>4.5.7</vertx-junit5.version>
+        <vertx.version>4.5.8</vertx.version>
+        <vertx-junit5.version>4.5.8</vertx-junit5.version>
         <kafka.version>3.7.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.4</zookeeper.version>
@@ -148,7 +148,7 @@
         <jetty.version>9.4.54.v20240208</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.110.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x to 4.5.8. It also updates Netty as the related deoendency.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally