### PR TITLE
Assume yes when using `microdnf`

### DIFF
--- a/docker-images/base/Dockerfile
+++ b/docker-images/base/Dockerfile
@@ -8,10 +8,10 @@ ARG TARGETARCH
 
 USER root
 
-RUN microdnf update \
+RUN microdnf update -y \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf reinstall -y tzdata \
-    && microdnf clean all
+    && microdnf clean all -y
 
 ENV JAVA_HOME /usr/lib/jvm/jre-17
 

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y gettext nmap-ncat net-tools unzip hostname findutils tar \
-    && microdnf clean all
+    && microdnf clean all -y
 
 # Add kafka user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -9,6 +9,6 @@ USER root
 RUN useradd -r -m -u 1001 -g 0 strimzi
 
 RUN microdnf update -y \
-    && microdnf clean all
+    && microdnf clean all -y
 
 USER 1001


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It looks like for some reason, some of the `microdnf` commands in our Dockerfiles now require confirmation. There does not seem to be any change locally, so likely something changed either in Azure or in how `microdnf` detects interactive / non-interactive terminals. This PR adds the confirmations to avoid the CI pipelines being stuck.

