### PR TITLE
Add Topic Operator's Cruise Control additional metrics

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReconcilableTopic.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReconcilableTopic.java
@@ -4,23 +4,23 @@
  */
 package io.strimzi.operator.topic;
 
-import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
 
+import java.util.Objects;
+
 /**
- * A topic to be reconciled
+ * A topic to be reconciled.
  */
 public class ReconcilableTopic {
     private Reconciliation reconciliation;
     private KafkaTopic kt;
     private String topicName;
-    private Timer.Sample sample;
 
     /**
-     * @param reconciliation The reconciliation
-     * @param kt The topic
-     * @param topicName The name of the topic in Kafka (spec.topicName, or metadata.name)
+     * @param reconciliation The reconciliation.
+     * @param kt The topic.
+     * @param topicName The name of the topic in Kafka (spec.topicName, or metadata.name).
      */
     public ReconcilableTopic(Reconciliation reconciliation, KafkaTopic kt, String topicName) {
         this.reconciliation = reconciliation;
@@ -29,7 +29,6 @@ public class ReconcilableTopic {
     }
 
     /**
-     * Returns the reconciliation.
      * @return Reconciliation.
      */
     public Reconciliation reconciliation() {
@@ -37,7 +36,6 @@ public class ReconcilableTopic {
     }
 
     /**
-     * Returns the Kafka topic.
      * @return Kafka topic.
      */
     public KafkaTopic kt() {
@@ -45,26 +43,23 @@ public class ReconcilableTopic {
     }
 
     /**
-     * Returns the topic name.
-     * @return Topic name
+     * @return Topic name.
      */
     public String topicName() {
         return topicName;
     }
 
-    /**
-     * @return The timer sample
-     */
-    public Timer.Sample reconciliationTimerSample() {
-        return sample;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReconcilableTopic that = (ReconcilableTopic) o;
+        return Objects.equals(reconciliation, that.reconciliation) && Objects.equals(topicName, that.topicName);
     }
 
-    /**
-     * Store the timer sample
-     * @param sample The timer sample
-     */
-    public void reconciliationTimerSample(Timer.Sample sample) {
-        this.sample = sample;
+    @Override
+    public int hashCode() {
+        return Objects.hash(reconciliation, topicName);
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.topic;
 
+import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.topic.KafkaTopicStatusBuilder;
 import io.strimzi.api.kafka.model.topic.ReplicasChangeStatusBuilder;
@@ -12,6 +13,7 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient.TaskState;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient.UserTasksResponse;
+import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,15 +44,13 @@ import static org.apache.logging.log4j.core.util.Throwables.getRootCause;
 public class ReplicasChangeHandler {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(ReplicasChangeHandler.class);
     
+    private final TopicOperatorConfig config;
+    private final TopicOperatorMetricsHolder metrics;
     private final CruiseControlClient cruiseControlClient;
     
-    /**
-     * Create a new replicas change handler instance.
-     * 
-     * @param config Topic Operator configuration.
-     */
-    public ReplicasChangeHandler(TopicOperatorConfig config) {
-        this.cruiseControlClient = CruiseControlClient.create(
+    ReplicasChangeHandler(TopicOperatorConfig config,
+                          TopicOperatorMetricsHolder metrics) {
+        this(config, metrics, CruiseControlClient.create(
             config.cruiseControlHostname(),
             config.cruiseControlPort(),
             config.cruiseControlRackEnabled(),
@@ -59,7 +59,15 @@ public class ReplicasChangeHandler {
             config.cruiseControlAuthEnabled(),
             config.cruiseControlAuthEnabled() ? new String(getFileContent(config.cruiseControlApiUserPath()), UTF_8) : null,
             config.cruiseControlAuthEnabled() ? new String(getFileContent(config.cruiseControlApiPassPath()), UTF_8) : null
-        );
+        ));
+    }
+    
+    ReplicasChangeHandler(TopicOperatorConfig config,
+                          TopicOperatorMetricsHolder metrics, 
+                          CruiseControlClient cruiseControlClient) {
+        this.config = config;
+        this.metrics = metrics;
+        this.cruiseControlClient = cruiseControlClient;
     }
 
     /**
@@ -92,7 +100,9 @@ public class ReplicasChangeHandler {
         try {
             LOGGER.debugOp("Sending topic configuration request, topics {}", topicNames(reconcilableTopics));
             List<KafkaTopic> kafkaTopics = reconcilableTopics.stream().map(rt -> rt.kt()).collect(Collectors.toList());
+            Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
             String userTaskId = cruiseControlClient.topicConfiguration(kafkaTopics);
+            TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlTopicConfig, config.enableAdditionalMetrics(), config.namespace());
             updateToOngoing(result, "Replicas change ongoing", userTaskId);
         } catch (Throwable t) {
             updateToFailed(result, format("Replicas change failed, %s", getRootCause(t).getMessage()));
@@ -122,8 +132,9 @@ public class ReplicasChangeHandler {
 
         try {
             LOGGER.debugOp("Sending user tasks request, Tasks {}", groupByUserTaskId.keySet());
+            Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
             UserTasksResponse utr = cruiseControlClient.userTasks(groupByUserTaskId.keySet());
-
+            TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlUserTasks, config.enableAdditionalMetrics(), config.namespace());
             if (utr.userTasks().isEmpty()) {
                 // Cruise Control restarted: reset the state because the tasks queue is not persisted
                 updateToPending(result, "Task not found, Resetting the state");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
@@ -96,17 +96,17 @@ public class ReplicasChangeHandler {
         }
         updateToPending(reconcilableTopics, "Replicas change pending");
         result.addAll(reconcilableTopics);
-        
+
+        Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
         try {
             LOGGER.debugOp("Sending topic configuration request, topics {}", topicNames(reconcilableTopics));
             List<KafkaTopic> kafkaTopics = reconcilableTopics.stream().map(rt -> rt.kt()).collect(Collectors.toList());
-            Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
             String userTaskId = cruiseControlClient.topicConfiguration(kafkaTopics);
-            TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlTopicConfig, config.enableAdditionalMetrics(), config.namespace());
             updateToOngoing(result, "Replicas change ongoing", userTaskId);
         } catch (Throwable t) {
             updateToFailed(result, format("Replicas change failed, %s", getRootCause(t).getMessage()));
         }
+        TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlTopicConfig, config.enableAdditionalMetrics(), config.namespace());
         return result;
     }
 
@@ -130,11 +130,10 @@ public class ReplicasChangeHandler {
             .map(rt -> new ReconcilableTopic(new Reconciliation("", KafkaTopic.RESOURCE_KIND, "", ""), rt.kt(), rt.topicName()))
             .collect(Collectors.groupingBy(rt -> rt.kt().getStatus().getReplicasChange().getSessionId(), HashMap::new, Collectors.toList()));
 
+        Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
         try {
             LOGGER.debugOp("Sending user tasks request, Tasks {}", groupByUserTaskId.keySet());
-            Timer.Sample timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, config.enableAdditionalMetrics());
             UserTasksResponse utr = cruiseControlClient.userTasks(groupByUserTaskId.keySet());
-            TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlUserTasks, config.enableAdditionalMetrics(), config.namespace());
             if (utr.userTasks().isEmpty()) {
                 // Cruise Control restarted: reset the state because the tasks queue is not persisted
                 updateToPending(result, "Task not found, Resetting the state");
@@ -159,6 +158,7 @@ public class ReplicasChangeHandler {
         } catch (Throwable t) {
             updateToFailed(result, format("Replicas change failed, %s", getRootCause(t).getMessage()));
         }
+        TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::cruiseControlUserTasks, config.enableAdditionalMetrics(), config.namespace());
         return result;
     }
     

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -67,7 +67,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
         this.admin = admin;
         TopicOperatorMetricsProvider metricsProvider = createMetricsProvider();
         TopicOperatorMetricsHolder metrics = new TopicOperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);
-        this.replicasChangeHandler = new ReplicasChangeHandler(config);
+        this.replicasChangeHandler = new ReplicasChangeHandler(config, metrics);
         this.controller = new BatchingTopicController(config, selector, admin, kubeClient, metrics, replicasChangeHandler);
         this.itemStore = new BasicItemStore<>(Cache::metaNamespaceKeyFunc);
         this.queue = new BatchingLoop(config.maxQueueSize(), controller, 1, config.maxBatchSize(), config.maxBatchLingerMs(), itemStore, this::stop, metrics, namespace);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -59,62 +59,53 @@ public class TopicOperatorUtil {
 
     /**
      * Start the reconciliation timer.
-     * 
-     * @param reconcilableTopic Reconcilable topic.
+     *
      * @param metrics Metrics holder.
+     * @return Timer sample.
      */
-    public static void startReconciliationTimer(ReconcilableTopic reconcilableTopic,
-                                                TopicOperatorMetricsHolder metrics) {
-        if (reconcilableTopic.reconciliationTimerSample() == null) {
-            reconcilableTopic.reconciliationTimerSample(Timer.start(metrics.metricsProvider().meterRegistry()));
-        }
+    public static Timer.Sample startReconciliationTimer(TopicOperatorMetricsHolder metrics) {
+        return Timer.start(metrics.metricsProvider().meterRegistry());
     }
 
     /**
      * Stop the reconciliation timer.
-     * 
-     * @param reconcilableTopic Reconcilable topic.
-     * @param metrics Metrics holder.
-     * @param namespace Namespace.
-     */
-    public static void stopReconciliationTimer(ReconcilableTopic reconcilableTopic,
-                                               TopicOperatorMetricsHolder metrics,
-                                               String namespace) {
-        if (reconcilableTopic.reconciliationTimerSample() != null) {
-            reconcilableTopic.reconciliationTimerSample().stop(metrics.reconciliationsTimer(namespace));
-        }
-    }
-
-    /**
-     * Start the operation timer.
-     * 
-     * @param enableAdditionalMetrics Whether to enable additional metrics.
-     * @param metrics Metrics holder.
-     * @return The timer sample.
-     */
-    public static Timer.Sample startOperationTimer(boolean enableAdditionalMetrics,
-                                                   TopicOperatorMetricsHolder metrics) {
-        if (enableAdditionalMetrics) {
-            return Timer.start(metrics.metricsProvider().meterRegistry());
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Stop the operation timer.
      *
-     * @param timerSample The timer sample.
-     * @param opTimer Operation timer.
-     * @param enableAdditionalMetrics Whether to enable additional metrics.
+     * @param metrics Metrics holder.
+     * @param timerSample Timer sample.
      * @param namespace Namespace.
      */
-    public static void stopOperationTimer(Timer.Sample timerSample, 
-                                          Function<String, Timer> opTimer,
-                                          boolean enableAdditionalMetrics,
-                                          String namespace) {
-        if (timerSample != null && enableAdditionalMetrics) {
-            timerSample.stop(opTimer.apply(namespace));
+    public static void stopReconciliationTimer(TopicOperatorMetricsHolder metrics,
+                                               Timer.Sample timerSample,
+                                               String namespace) {
+        timerSample.stop(metrics.reconciliationsTimer(namespace));
+    }
+
+    /**
+     * Start the external request timer.
+     *
+     * @param metrics Metrics holder.
+     * @param enabled Whether additional metrics are enabled.
+     * @return Timer sample.
+     */
+    public static Timer.Sample startExternalRequestTimer(TopicOperatorMetricsHolder metrics,
+                                                         boolean enabled) {
+        return enabled ? Timer.start(metrics.metricsProvider().meterRegistry()) : null;
+    }
+
+    /**
+     * Stop the external request timer.
+     *
+     * @param timerSample Timer sample.
+     * @param requestTimer Request timer.
+     * @param enabled Whether additional metrics are enabled.
+     * @param namespace Namespace.
+     */
+    public static void stopExternalRequestTimer(Timer.Sample timerSample,
+                                                Function<String, Timer> requestTimer,
+                                                boolean enabled,
+                                                String namespace) {
+        if (enabled) {
+            timerSample.stop(requestTimer.apply(namespace));
         }
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/metrics/TopicOperatorMetricsHolder.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/metrics/TopicOperatorMetricsHolder.java
@@ -66,6 +66,14 @@ public class TopicOperatorMetricsHolder extends MetricsHolder {
      * Metric name for Kafka delete topics duration.
      */
     public static final String METRICS_DELETE_TOPICS_DURATION = METRICS_PREFIX + "delete.topics.duration";
+    /**
+     * Metric name for Cruise Control topic_configuration duration.
+     */
+    public static final String METRICS_CC_TOPIC_CONFIG_DURATION = METRICS_PREFIX + "cruisecontrol.topic.config.duration";
+    /**
+     * Metric name for Cruise Control user_tasks duration.
+     */
+    public static final String METRICS_CC_USER_TASKS_DURATION = METRICS_PREFIX + "cruisecontrol.user.tasks.duration";
 
     private final Map<MetricKey, AtomicInteger> reconciliationsMaxQueueMap = new ConcurrentHashMap<>(1);
     private final Map<MetricKey, AtomicInteger> reconciliationsMaxBatchMap = new ConcurrentHashMap<>(1);
@@ -81,6 +89,8 @@ public class TopicOperatorMetricsHolder extends MetricsHolder {
     private final Map<MetricKey, Timer> describeTopicsTimerMap = new ConcurrentHashMap<>(1);
     private final Map<MetricKey, Timer> describeConfigsTimerMap = new ConcurrentHashMap<>(1);
     private final Map<MetricKey, Timer> deleteTopicsTimerMap = new ConcurrentHashMap<>(1);
+    private final Map<MetricKey, Timer> ccTopicConfigTimerMap = new ConcurrentHashMap<>(1);
+    private final Map<MetricKey, Timer> ccUserTasksTimerMap = new ConcurrentHashMap<>(1);
 
     /**
      * Constructs the operator metrics holder.
@@ -106,7 +116,10 @@ public class TopicOperatorMetricsHolder extends MetricsHolder {
      * @param timerMap          Map with timers.
      * @return  Timer metric.
      */
-    private Timer getFineGrainedTimer(String namespace, String metricName, String metricHelp, Optional<String> selectorLabels,
+    private Timer getFineGrainedTimer(String namespace, 
+                                      String metricName, 
+                                      String metricHelp, 
+                                      Optional<String> selectorLabels,
                                       Map<MetricKey, Timer> timerMap) {
         return metric(new MetricKey(kind, namespace), selectorLabels, timerMap,
                 tags -> ((TopicOperatorMetricsProvider) metricsProvider).fineGrainedTimer(metricName, metricHelp, tags));
@@ -254,5 +267,29 @@ public class TopicOperatorMetricsHolder extends MetricsHolder {
         return getFineGrainedTimer(namespace, METRICS_DELETE_TOPICS_DURATION,
             "The time Kafka deleteTopics request takes to complete",
                 Optional.of(getLabelSelectorValues()), deleteTopicsTimerMap);
+    }
+    
+    /**
+     * Timer which measures how long the Cruise Control topic_configuration request takes to complete.
+     *
+     * @param namespace Namespace of the resources being reconciled.
+     * @return Metrics timer.
+     */
+    public Timer cruiseControlTopicConfig(String namespace) {
+        return getFineGrainedTimer(namespace, METRICS_CC_TOPIC_CONFIG_DURATION,
+            "The time Cruise Control topic_configuration request takes to complete",
+                Optional.of(getLabelSelectorValues()), ccTopicConfigTimerMap);
+    }
+
+    /**
+     * Timer which measures how long the Cruise Control user_tasks request takes to complete.
+     *
+     * @param namespace Namespace of the resources being reconciled.
+     * @return Metrics timer.
+     */
+    public Timer cruiseControlUserTasks(String namespace) {
+        return getFineGrainedTimer(namespace, METRICS_CC_USER_TASKS_DURATION,
+            "The time Cruise Control user_tasks request takes to complete",
+                Optional.of(getLabelSelectorValues()), ccUserTasksTimerMap);
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMetricsTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorMetricsTest.java
@@ -179,12 +179,28 @@ public class TopicOperatorMetricsTest {
         var t3 = createTopic("t3", 2, 1);
         controller.onUpdate(List.of(reconcilableTopic(t1), reconcilableTopic(t2), reconcilableTopic(t3)));
         
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(3.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(3.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CREATE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_ADD_FINALIZER_DURATION, "timer", greaterThan(0.0));
+        
         // config change, 1 reconciliation, success
         var t1ConfigChanged = updateTopic("t1", kt -> {
             kt.getSpec().setConfig(Map.of("retention.ms", "86400000"));
             return kt;
         });
         controller.onUpdate(List.of(reconcilableTopic(t1ConfigChanged)));
+        
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(4.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(4.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_ALTER_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_UPDATE_TOPICS_DURATION, "timer", greaterThan(0.0));
         
         // increase partitions, 1 reconciliation, success
         var t2PartIncreased = updateTopic("t2", kt -> {
@@ -193,12 +209,26 @@ public class TopicOperatorMetricsTest {
         });
         controller.onUpdate(List.of(reconcilableTopic(t2PartIncreased)));
 
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(5.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(5.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CREATE_PARTITIONS_DURATION, "timer", greaterThan(0.0));
+
         // decrease partitions, 1 reconciliation, fail
         var t2PartDecreased = updateTopic("t2", kt -> {
             kt.getSpec().setPartitions(4);
             return kt;
         });
         controller.onUpdate(List.of(reconcilableTopic(t2PartDecreased)));
+
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(6.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(5.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_FAILED, "counter", is(1.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
 
         // increase replicas, 1 reconciliation, success
         var t3ReplIncreased = updateTopic("t3", kt -> {
@@ -207,15 +237,40 @@ public class TopicOperatorMetricsTest {
         });
         controller.onUpdate(List.of(reconcilableTopic(t3ReplIncreased)));
 
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(7.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(6.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_FAILED, "counter", is(1.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_LIST_REASSIGNMENTS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CC_TOPIC_CONFIG_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CC_USER_TASKS_DURATION, "timer", greaterThan(0.0));
+
         // unmanage topic, 1 reconciliation, success
         var t1Unmanaged = updateTopic("t1", kt -> {
             kt.getMetadata().setAnnotations(Map.of(TopicOperatorUtil.MANAGED, "false"));
             return kt;
         });
         controller.onUpdate(List.of(reconcilableTopic(t1Unmanaged)));
+
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(8.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(7.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_FAILED, "counter", is(1.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
         
         // delete managed topics, 1 reconciliation, success
         controller.onDelete(List.of(reconcilableTopic(t2)));
+
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(9.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(8.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_FAILED, "counter", is(1.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DELETE_TOPICS_DURATION, "timer", greaterThan(0.0));
 
         // delete unmanaged topic, 1 reconciliation, success
         var t3Unmanaged = updateTopic("t3", kt -> {
@@ -224,25 +279,13 @@ public class TopicOperatorMetricsTest {
         });
         controller.onDelete(List.of(reconcilableTopic(t3Unmanaged)));
 
-        // check standard metrics
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS, "counter", is(10.0));
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_SUCCESSFUL, "counter", is(9.0));
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_FAILED, "counter", is(1.0));
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_RECONCILIATIONS_DURATION, "timer", greaterThan(0.0));
-        
-        // check additional metrics
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_ADD_FINALIZER_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_REMOVE_FINALIZER_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CREATE_TOPICS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_UPDATE_TOPICS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_LIST_REASSIGNMENTS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_ALTER_CONFIGS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CREATE_PARTITIONS_DURATION, "timer", greaterThan(0.0));
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_TOPICS_DURATION, "timer", greaterThan(0.0));
         assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DESCRIBE_CONFIGS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_DELETE_TOPICS_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CC_TOPIC_CONFIG_DURATION, "timer", greaterThan(0.0));
-        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_CC_USER_TASKS_DURATION, "timer", greaterThan(0.0));
+        assertMetricMatches(TopicOperatorMetricsHolder.METRICS_REMOVE_FINALIZER_DURATION, "timer", greaterThan(0.0));
     }
     
     private KafkaTopic createTopic(String name, int partitions, int replicas) {


### PR DESCRIPTION
This change adds missing timers for Cruise Control's requests to the Topic Operator.

Should close #10124.
