### PR TITLE
Use `pattern` in `trustedCertificates` fields in examples

### DIFF
--- a/packaging/examples/connect/kafka-connect-build.yaml
+++ b/packaging/examples/connect/kafka-connect-build.yaml
@@ -14,7 +14,7 @@ spec:
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
   config:
     group.id: connect-cluster
     offset.storage.topic: connect-cluster-offsets

--- a/packaging/examples/connect/kafka-connect.yaml
+++ b/packaging/examples/connect/kafka-connect.yaml
@@ -14,7 +14,7 @@ spec:
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
   config:
     group.id: connect-cluster
     offset.storage.topic: connect-cluster-offsets

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-2-tls.yaml
@@ -12,13 +12,13 @@ spec:
     tls:
       trustedCertificates:
         - secretName: cluster-a-cluster-ca-cert
-          certificate: ca.crt
+          pattern: "*.crt"
   - alias: "cluster-b" # Target cluster
     bootstrapServers: cluster-b-kafka-bootstrap:9093
     tls:
       trustedCertificates:
         - secretName: cluster-b-cluster-ca-cert
-          certificate: ca.crt
+          pattern: "*.crt"
     config:
       # -1 means it will use the default replication factor configured in the broker
       config.storage.replication.factor: -1

--- a/packaging/examples/mirror-maker/kafka-mirror-maker-tls.yaml
+++ b/packaging/examples/mirror-maker/kafka-mirror-maker-tls.yaml
@@ -11,11 +11,11 @@ spec:
     tls:
       trustedCertificates:
         - secretName: cluster-a-cluster-ca-cert
-          certificate: ca.crt
+          pattern: "*.crt"
   producer:
     bootstrapServers: cluster-b-kafka-bootstrap:9093 # Target cluster
     tls:
       trustedCertificates:
         - secretName: cluster-b-cluster-ca-cert
-          certificate: ca.crt
+          pattern: "*.crt"
   include: ".*"

--- a/packaging/examples/security/scram-sha-512-auth/bridge.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/bridge.yaml
@@ -20,11 +20,11 @@ spec:
     - resource:
         type: topic
         name: my-topic
-        operations:
-          - Create
-          - Describe
-          - Read
-          - Write
+      operations:
+        - Create
+        - Describe
+        - Read
+        - Write
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaBridge
@@ -36,7 +36,7 @@ spec:
   tls:
     trustedCertificates:
     - secretName: my-cluster-cluster-ca-cert
-      certificate: ca.crt
+      pattern: "*.crt"
   authentication:
     type: scram-sha-512
     username: my-bridge

--- a/packaging/examples/security/scram-sha-512-auth/connect.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/connect.yaml
@@ -72,7 +72,7 @@ spec:
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
   authentication:
     type: scram-sha-512
     username: my-connect

--- a/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/scram-sha-512-auth/mirror-maker-2.yaml
@@ -227,7 +227,7 @@ spec:
       tls:
         trustedCertificates:
           - secretName: cluster-a-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication:
         type: scram-sha-512
         username: cluster-a-user
@@ -239,7 +239,7 @@ spec:
       tls:
         trustedCertificates:
           - secretName: cluster-b-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication:
         type: scram-sha-512
         username: cluster-b-user

--- a/packaging/examples/security/tls-auth/bridge.yaml
+++ b/packaging/examples/security/tls-auth/bridge.yaml
@@ -36,7 +36,7 @@ spec:
   tls:
     trustedCertificates:
     - secretName: my-cluster-cluster-ca-cert
-      certificate: ca.crt
+      pattern: "*.crt"
   authentication:
     type: tls
     certificateAndKey:

--- a/packaging/examples/security/tls-auth/connect.yaml
+++ b/packaging/examples/security/tls-auth/connect.yaml
@@ -72,7 +72,7 @@ spec:
   tls:
     trustedCertificates:
       - secretName: my-cluster-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
   authentication:
     type: tls
     certificateAndKey:

--- a/packaging/examples/security/tls-auth/mirror-maker-2.yaml
+++ b/packaging/examples/security/tls-auth/mirror-maker-2.yaml
@@ -218,7 +218,7 @@ spec:
       tls:
         trustedCertificates:
           - secretName: cluster-a-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication:
         type: tls
         certificateAndKey:
@@ -230,7 +230,7 @@ spec:
       tls:
         trustedCertificates:
           - secretName: cluster-b-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication:
         type: tls
         certificateAndKey:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As part of the [Strimzi Proposal 73](https://github.com/strimzi/proposals/blob/main/073-improve-handling-of-CA-renewals-and-replacements-in-client-based-operands.md) we are expected to use the pattern in our examples in the `trustedCertificates` fields instead of the certificate name. I forgot to do it in the original PR when adding the pattern field, so it is being added now in a separate PR.

It also fixes a misaligned YAML in one of the KAfkaUSer definitions into which I run when testing the updated examples.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally