### PR TITLE
Update Fabric8 Kubernetes Client to 6.13 and the API specs derived from it

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -980,6 +980,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -1684,6 +1691,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -1758,6 +1772,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -2249,6 +2270,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -2845,6 +2873,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -3435,6 +3470,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -3925,6 +3967,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -3999,6 +4048,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -4073,6 +4129,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -4542,6 +4605,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -5087,6 +5157,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -5161,6 +5238,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -5458,6 +5542,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -5948,6 +6039,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:
@@ -6182,6 +6280,13 @@ spec:
                             securityContext:
                               type: object
                               properties:
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 fsGroup:
                                   type: integer
                                 fsGroupChangePolicy:
@@ -6690,6 +6795,13 @@ spec:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  type: object
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
                                 capabilities:
                                   type: object
                                   properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -529,6 +529,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1085,6 +1092,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:
@@ -1159,6 +1173,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:
@@ -1299,6 +1320,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1789,6 +1817,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -667,6 +667,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1179,6 +1186,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -518,6 +518,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1063,6 +1070,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:
@@ -1173,6 +1187,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -674,6 +674,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1230,6 +1237,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:
@@ -1304,6 +1318,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:
@@ -1444,6 +1465,13 @@ spec:
                         securityContext:
                           type: object
                           properties:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             fsGroup:
                               type: integer
                             fsGroupChangePolicy:
@@ -1934,6 +1962,13 @@ spec:
                           properties:
                             allowPrivilegeEscalation:
                               type: boolean
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
                             capabilities:
                               type: object
                               properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -278,6 +278,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -840,6 +847,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -914,6 +928,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -979,6 +979,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -1683,6 +1690,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -1757,6 +1771,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -2248,6 +2269,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -2844,6 +2872,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -3434,6 +3469,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -3924,6 +3966,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -3998,6 +4047,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -4072,6 +4128,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -4541,6 +4604,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -5086,6 +5156,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -5160,6 +5237,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -5457,6 +5541,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -5947,6 +6038,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -6181,6 +6279,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -6689,6 +6794,13 @@ spec:
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -528,6 +528,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1084,6 +1091,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -1158,6 +1172,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -1298,6 +1319,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1788,6 +1816,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -666,6 +666,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1178,6 +1185,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -517,6 +517,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1062,6 +1069,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -1172,6 +1186,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -673,6 +673,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1229,6 +1236,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -1303,6 +1317,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -1443,6 +1464,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -1933,6 +1961,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -278,6 +278,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -840,6 +847,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -914,6 +928,13 @@ spec:
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:

--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.12.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.12.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.12.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.13.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.13.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.13.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.1</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.1</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Fabric8 to 6.13 and also updates the API specs derived from it to correspond to the new Kubernetes specifications (1.30).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally