### PR TITLE
Include only broker nodes in the NodePort bootstrap address

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -989,7 +989,9 @@ public class KafkaReconciler {
                                 String hostIP = broker.getStatus().getHostIP();
                                 allNodes.stream()
                                         .filter(node -> {
-                                            if (node.getStatus() != null && node.getStatus().getAddresses() != null) {
+                                            if (Labels.booleanLabel(broker, Labels.STRIMZI_BROKER_ROLE_LABEL, false)
+                                                    && node.getStatus() != null
+                                                    && node.getStatus().getAddresses() != null) {
                                                 return node.getStatus().getAddresses().stream().anyMatch(address -> hostIP.equals(address.getAddress()));
                                             } else {
                                                 return false;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.resource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
@@ -461,8 +460,8 @@ public class KafkaRoller {
 
         // We try to detect the current roles. If we fail to do so, we optimistically assume the roles did not
         // change and the desired roles still apply.
-        boolean isBroker = isCurrentlyBroker(pod).orElse(nodeRef.broker());
-        boolean isController = isCurrentlyController(pod).orElse(nodeRef.controller());
+        boolean isBroker = Labels.booleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL, nodeRef.broker());
+        boolean isController = Labels.booleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL, nodeRef.controller());
 
         try {
             checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext);
@@ -1051,50 +1050,6 @@ public class KafkaRoller {
                 LOGGER.warnCr(reconciliation, "Error waiting for pod {}/{} to become ready: {}", namespace, podName, error);
                 return Future.failedFuture(error);
             });
-    }
-
-    /**
-     * Checks from the Pod labels if the Kafka node is currently a broker or not.
-     *
-     * @param pod   Current Pod
-     *
-     * @return  Optional with true if the pod is currently a broker, false if it is not broker or empty optional
-     * if the label is not present.
-     */
-    /* test */ static Optional<Boolean> isCurrentlyBroker(Pod pod)    {
-        return checkBooleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL);
-    }
-
-    /**
-     * Checks from the Pod labels if the Kafka node is currently a controller or not.
-     *
-     * @param pod   Current Pod
-     *
-     * @return  Optional with true if the pod is currently a controller, false if it is not controller or empty optional
-     * if the label is not present.
-     */
-    /* test */ static Optional<Boolean> isCurrentlyController(Pod pod)    {
-        return checkBooleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL);
-    }
-
-    /**
-     * Generic method to extract a boolean value from Kubernetes resource labels
-     *
-     * @param pod       Kube resource with metadata
-     * @param label     Name of the label for which we want to extract the boolean value
-     *
-     * @return  Optional with true if the label is present and is set to `true`, false if it is present and not set to
-     * `true` or empty optional if the label is not present.
-     */
-    private static Optional<Boolean> checkBooleanLabel(HasMetadata pod, String label)    {
-        if (pod != null
-                && pod.getMetadata() != null
-                && pod.getMetadata().getLabels() != null
-                && pod.getMetadata().getLabels().containsKey(label))  {
-            return Optional.of("true".equalsIgnoreCase(pod.getMetadata().getLabels().get(label)));
-        } else {
-            return Optional.empty();
-        }
     }
 }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -466,7 +466,7 @@ public class KafkaReconcilerStatusTest {
         Pod pod5 = new PodBuilder()
                 .withNewMetadata()
                     .withName(CLUSTER_NAME + "-controller-" + 5)
-                    .withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "tfalserue", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true"))
+                    .withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "false", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true"))
                 .endMetadata()
                 .withNewStatus()
                     .withHostIP("10.0.0.13")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -19,7 +19,6 @@ import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.DefaultAdminClientProvider;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
-import io.strimzi.operator.common.model.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -53,7 +52,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -708,33 +706,6 @@ public class KafkaRollerTest {
         doSuccessfulRollingRestart(testContext, kafkaRoller,
                 asList(0, 1, 2, 3, 4, 5, 6, 7, 8), // brokers, combined, controllers
                 asList(7, 4, 3, 5, 6, 8, 1, 0, 2)); //Rolls in order: unready controllers, ready controllers, unready brokers, ready brokers
-    }
-
-    @Test
-    public void testExistingRoles() {
-        // No pod
-        assertThat(KafkaRoller.isCurrentlyBroker(null), is(Optional.empty()));
-        assertThat(KafkaRoller.isCurrentlyController(null), is(Optional.empty()));
-
-        // No annotation
-        Pod pod = new PodBuilder().withNewMetadata().withName("my-pod").endMetadata().build();
-        assertThat(KafkaRoller.isCurrentlyBroker(pod), is(Optional.empty()));
-        assertThat(KafkaRoller.isCurrentlyController(pod), is(Optional.empty()));
-
-        // Annotation set to wrong value
-        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "grr", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "meh")).endMetadata().build();
-        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(false));
-        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(false));
-
-        // Annotation set to false
-        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "false", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "false")).endMetadata().build();
-        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(false));
-        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(false));
-
-        // Annotation set to true
-        pod = new PodBuilder().withNewMetadata().withName("my-pod").withLabels(Map.of(Labels.STRIMZI_BROKER_ROLE_LABEL, "true", Labels.STRIMZI_CONTROLLER_ROLE_LABEL, "true")).endMetadata().build();
-        assertThat(KafkaRoller.isCurrentlyBroker(pod).orElseThrow(), is(true));
-        assertThat(KafkaRoller.isCurrentlyController(pod).orElseThrow(), is(true));
     }
 
     private TestingKafkaRoller rollerWithControllers(PodOperator podOps, int... controllers) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
@@ -500,5 +501,29 @@ public class Labels extends ResourceLabels {
                 .withKubernetesInstance(customResourceName)
                 .withKubernetesPartOf(customResourceName)
                 .withKubernetesManagedBy(managedBy);
+    }
+
+    /*
+     * Static methods for working with Labels
+     */
+
+    /**
+     * Gets a boolean value of an label from a Kubernetes resource
+     *
+     * @param resource      Resource from which the label should be extracted
+     * @param label         Label key for which we want the value
+     * @param defaultValue  Default value if the label is not present or the resource doesn't exist / doesn't have labels
+     *
+     * @return  Boolean value form the labels or the default value
+     */
+    public static boolean booleanLabel(HasMetadata resource, String label, boolean defaultValue) {
+        if (resource != null
+                && resource.getMetadata() != null
+                && resource.getMetadata().getLabels() != null)  {
+            String value = resource.getMetadata().getLabels().get(label);
+            return value != null ? parseBoolean(value) : defaultValue;
+        } else {
+            return defaultValue;
+        }
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -331,5 +332,19 @@ public class LabelsTest {
         assertThat(Labels.getOrValidInstanceLabelValue("too-long-012345678901234567890123456789012345678901234567890123456789"), is("too-long-012345678901234567890123456789012345678901234567890123"));
         assertThat(Labels.getOrValidInstanceLabelValue("too-long-01234567890123456789012345678901234567890123456789012-456789"), is("too-long-01234567890123456789012345678901234567890123456789012"));
         assertThat(Labels.getOrValidInstanceLabelValue("too-long-01234567890123456789012345678901234567890123456789.---456789"), is("too-long-01234567890123456789012345678901234567890123456789"));
+    }
+
+    @Test
+    public void testBooleanLabel()  {
+        final String label = "my-label";
+
+        assertThat(Labels.booleanLabel(null, label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().build(), label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").endMetadata().build(), label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").addToLabels("not-my-label", "false").endMetadata().build(), label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").addToLabels(label, null).endMetadata().build(), label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").addToLabels(label, "true").endMetadata().build(), label, true), is(true));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").addToLabels(label, "potato").endMetadata().build(), label, true), is(false));
+        assertThat(Labels.booleanLabel(new PodBuilder().withNewMetadata().withName("my-pod").addToLabels(label, "false").endMetadata().build(), label, true), is(false));
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When preparing the bootstrap address for the `.status` section of the Kafka CR for `type: nodeport` listeners, we include there the node addresses of all nodes that host some Kafka nodes. But right now, this includes the controller nodes as well when running in Kraft. Technically, that works as Kubernetes will forward the connection. But it is not optimal. This PR filters out the controller-only nodes and uses only broker nodes for the address.

To avoid code duplication, this PR creates a new method `booleanLabel` in the `Labels` class to check labels with boolean values. This is similar to the methods in the `Annotations` class, but currently uses onl the one method for booleans that we need right now. This method is shared also with the `KafkaRoller` code.

This should resolve #10169.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging