### PR TITLE
[DOC] Clarify that `UseKRaft` being GA does not mean you have to use KRaft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.42.0
 
 * The `UseKRaft` feature gate moves to GA stage and is permanently enabled without the possibility to disable it.
-  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
+  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster.
 * Update the base image used by Strimzi containers from UBI8 to UBI9
 * Add support for filename patterns when configuring trusted certificates
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -24,10 +24,12 @@ Alpha and beta stage features are removed if they do not prove to be useful.
   It is now permanently enabled and cannot be disabled.
 * The `KafkaNodePools` feature gate moved to GA stage in Strimzi 0.41.
   It is now permanently enabled and cannot be disabled.
+  To use the Kafka Node Pool resources, you still need to use the `strimzi.io/node-pools: enabled` annotation on the `Kafka` custom resources.
 * The `UnidirectionalTopicOperator` feature gate moved to GA stage in Strimzi 0.41.
   It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate moved to GA stage in Strimzi 0.42.
-It is now permanently enabled and cannot be disabled.
+  It is now permanently enabled and cannot be disabled.
+  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
 * The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and is disabled by default.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -29,7 +29,7 @@ Alpha and beta stage features are removed if they do not prove to be useful.
   It is now permanently enabled and cannot be disabled.
 * The `UseKRaft` feature gate moved to GA stage in Strimzi 0.42.
   It is now permanently enabled and cannot be disabled.
-  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster using the `strimzi.io/kraft: migration` annotation.
+  To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster.
 * The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and is disabled by default.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The feature gate docs seem to be a little bit confusing for some users as they say that the `UseKRaft` feature gate is now GA and cannot be disabled which might be mistaken for KRaft being the only option. This PR tries to make it more clear that the annotation is still needed to use KRaft. It does the same also for node pools.

### Checklist

- [x] Update documentation