### PR TITLE
Add publishNotReadyAddresses to GenericKafkaListenerConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for filename patterns when configuring trusted certificates
 * Enhance `KafkaBridge` resource with consumer inactivity timeout and HTTP consumer/producer enablement.
 * Add support for feature gates to User and Topic Operators
+* Add support for setting `publishNotReadyAddresses` on services for listener types other than internal.
 
 ## 0.41.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -32,7 +32,7 @@ import static java.util.Collections.emptyMap;
 @DescriptionFile
 @JsonPropertyOrder({"brokerCertChainAndKey", "class", "preferredAddressType", "externalTrafficPolicy",
     "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService",
-    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType"})
+    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType", "publishNotReadyAddresses"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -55,6 +55,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private IpFamilyPolicy ipFamilyPolicy;
     private List<IpFamily> ipFamilies;
     private Boolean createBootstrapService = true;
+    private Boolean publishNotReadyAddresses;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -238,6 +239,17 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
 
     public void setCreateBootstrapService(Boolean createBootstrapService) {
         this.createBootstrapService = createBootstrapService;
+    }
+    
+    @Description("Configures whether the service endpoints are considered \"ready\" even if the Pods themselves are not. " +
+            "Defaults to `false`.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getPublishNotReadyAddresses() {
+        return publishNotReadyAddresses;
+    }
+
+    public void setPublishNotReadyAddresses(Boolean publishNotReadyAddresses) {
+        this.publishNotReadyAddresses = publishNotReadyAddresses;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -242,7 +242,8 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     }
     
     @Description("Configures whether the service endpoints are considered \"ready\" even if the Pods themselves are not. " +
-            "Defaults to `false`.")
+            "Defaults to `false`. " +
+            "This field can not be used with `internal` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getPublishNotReadyAddresses() {
         return publishNotReadyAddresses;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -687,7 +687,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     ListenersUtils.bootstrapLabels(listener),
                     ListenersUtils.bootstrapAnnotations(listener),
                     ListenersUtils.ipFamilyPolicy(listener),
-                    ListenersUtils.ipFamilies(listener)
+                    ListenersUtils.ipFamilies(listener),
+                    ListenersUtils.publishNotReadyAddresses(listener)
             );
 
             if (KafkaListenerType.LOADBALANCER == listener.getType()) {
@@ -772,7 +773,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                                 ListenersUtils.brokerLabels(listener, node.nodeId()),
                                 ListenersUtils.brokerAnnotations(listener, node.nodeId()),
                                 ListenersUtils.ipFamilyPolicy(listener),
-                                ListenersUtils.ipFamilies(listener)
+                                ListenersUtils.ipFamilies(listener),
+                                ListenersUtils.publishNotReadyAddresses(listener)
                         );
 
                         if (KafkaListenerType.LOADBALANCER == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -583,11 +583,7 @@ public class ListenersUtils {
      * @return          publish not ready addresses value or null if not specified
      */
     public static Boolean publishNotReadyAddresses(GenericKafkaListener listener)    {
-        if (listener.getConfiguration() != null) {
-            return listener.getConfiguration().getPublishNotReadyAddresses();
-        } else {
-            return null;
-        }
+        return listener.getConfiguration() == null ? null : listener.getConfiguration().getPublishNotReadyAddresses();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -575,6 +575,20 @@ public class ListenersUtils {
             return null;
         }
     }
+    
+    /**
+     * Finds publish not ready addresses configuration
+     *
+     * @param listener  Listener for which the publish not ready addresses value should be found
+     * @return          publish not ready addresses value or null if not specified
+     */
+    public static Boolean publishNotReadyAddresses(GenericKafkaListener listener)    {
+        if (listener.getConfiguration() != null) {
+            return listener.getConfiguration().getPublishNotReadyAddresses();
+        } else {
+            return null;
+        }
+    }
 
     /**
      * Finds IP family policy

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -82,6 +82,7 @@ public class ListenersValidator {
                 validateLoadBalancerSourceRanges(errors, listener);
                 validateFinalizers(errors, listener);
                 validatePreferredAddressType(errors, listener);
+                validatePublishNotReadyAddresses(errors, listener);
                 validateCreateBootstrapService(errors, listener);
 
 
@@ -264,6 +265,19 @@ public class ListenersValidator {
         if (!KafkaListenerType.NODEPORT.equals(listener.getType())
                 && listener.getConfiguration().getPreferredNodePortAddressType() != null)    {
             errors.add("listener " + listener.getName() + " cannot configure preferredAddressType because it is not NodePort based listener");
+        }
+    }
+    
+    /**
+     * Validates that publishNotReadyAddresses is not used with internal type listener
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validatePublishNotReadyAddresses(Set<String> errors, GenericKafkaListener listener) {
+        if (KafkaListenerType.INTERNAL.equals(listener.getType())
+                && listener.getConfiguration().getPublishNotReadyAddresses() != null)    {
+            errors.add("listener " + listener.getName() + " cannot configure publishNotReadyAddresses because it is internal listener");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ServiceUtils.java
@@ -56,7 +56,8 @@ public class ServiceUtils {
                 null,
                 null,
                 ipFamilyPolicy(template),
-                ipFamilies(template)
+                ipFamilies(template),
+                null
         );
     }
 
@@ -99,25 +100,27 @@ public class ServiceUtils {
                 discoveryLabels,
                 discoveryAnnotations,
                 ipFamilyPolicy(template),
-                ipFamilies(template)
+                ipFamilies(template),
+                null
         );
     }
 
     /**
      * Creates a service
      *
-     * @param name                  Name of the Service
-     * @param namespace             Namespace of the Service
-     * @param labels                Labels of the Service
-     * @param ownerReference        OwnerReference of the Service
-     * @param template              Template with user's custom metadata for this service
-     * @param ports                 List of service ports
-     * @param selector              Selector for selecting the Pods to route the traffic to
-     * @param type                  Type of the service
-     * @param additionalLabels      Additional labels
-     * @param additionalAnnotations Additional annotations
-     * @param ipFamilyPolicy        IP Family Policy configuration
-     * @param ipFamilies            List of IP families
+     * @param name                      Name of the Service
+     * @param namespace                 Namespace of the Service
+     * @param labels                    Labels of the Service
+     * @param ownerReference            OwnerReference of the Service
+     * @param template                  Template with user's custom metadata for this service
+     * @param ports                     List of service ports
+     * @param selector                  Selector for selecting the Pods to route the traffic to
+     * @param type                      Type of the service
+     * @param additionalLabels          Additional labels
+     * @param additionalAnnotations     Additional annotations
+     * @param ipFamilyPolicy            IP Family Policy configuration
+     * @param ipFamilies                List of IP families
+     * @param publishNotReadyAddresses  Publish Not Ready Addresses configuration
      *
      * @return  New Service
      */
@@ -133,7 +136,8 @@ public class ServiceUtils {
             Map<String, String> additionalLabels,
             Map<String, String> additionalAnnotations,
             IpFamilyPolicy ipFamilyPolicy,
-            List<IpFamily> ipFamilies
+            List<IpFamily> ipFamilies,
+            Boolean publishNotReadyAddresses
     )   {
         return new ServiceBuilder()
                 .withNewMetadata()
@@ -149,6 +153,7 @@ public class ServiceUtils {
                     .withPorts(ports)
                     .withIpFamilyPolicy(ipFamilyPolicyToString(ipFamilyPolicy))
                     .withIpFamilies(ipFamiliesToListOfStrings(ipFamilies))
+                    .withPublishNotReadyAddresses(publishNotReadyAddresses)
                 .endSpec()
                 .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -151,6 +151,7 @@ public class ListenersUtilsTest {
                 .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                 .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                 .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
+                .withPublishNotReadyAddresses(true)
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-np-1", "my-np-2"))
                     .withNodePort(32189)
@@ -201,6 +202,7 @@ public class ListenersUtilsTest {
                 .withIpFamilies(IpFamily.IPV6, IpFamily.IPV4)
                 .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                 .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                .withPublishNotReadyAddresses(false)
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-lb-1", "my-lb-2"))
                     .withLoadBalancerIP("130.211.204.1")
@@ -640,6 +642,19 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.preferredNodeAddressType(newNodePort), is(nullValue()));
         assertThat(ListenersUtils.preferredNodeAddressType(newNodePort2), is(NodeAddressType.INTERNAL_DNS));
         assertThat(ListenersUtils.preferredNodeAddressType(newNodePort3), is(nullValue()));
+    }
+    
+    @ParallelTest
+    public void testPublishNotReadyAddresses() {
+        assertThat(ListenersUtils.publishNotReadyAddresses(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(oldExternal), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newLoadBalancer), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newLoadBalancer2), is(false));
+        assertThat(ListenersUtils.publishNotReadyAddresses(oldPlain), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newTls), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newNodePort), is(nullValue()));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newNodePort2), is(true));
+        assertThat(ListenersUtils.publishNotReadyAddresses(newNodePort3), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -236,6 +236,7 @@ public class ListenersValidatorTest {
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -286,7 +287,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].annotations because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
                 "listener " + name + " cannot configure brokers[].labels because it is not LoadBalancer, NodePort, Route, Ingress or ClusterIP based listener",
                 "listener " + name + " cannot configure ipFamilyPolicy because it is internal listener",
-                "listener " + name + " cannot configure ipFamilies because it is internal listener"
+                "listener " + name + " cannot configure ipFamilies because it is internal listener",
+                "listener " + name + " cannot configure publishNotReadyAddresses because it is internal listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -309,6 +311,7 @@ public class ListenersValidatorTest {
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -386,6 +389,7 @@ public class ListenersValidatorTest {
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -468,6 +472,7 @@ public class ListenersValidatorTest {
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -568,6 +573,7 @@ public class ListenersValidatorTest {
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                    .withPublishNotReadyAddresses(true)
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                         .withLoadBalancerIP("130.211.204.1")
@@ -795,6 +801,7 @@ public class ListenersValidatorTest {
                 .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                 .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                 .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
+                .withPublishNotReadyAddresses(true)
                 .withNewBootstrap()
                 .withAlternativeNames(List.of("my-name-1", "my-name-2"))
                 .withLoadBalancerIP("130.211.204.1")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ServiceUtilsTest.java
@@ -250,7 +250,7 @@ public class ServiceUtilsTest {
 
     @ParallelTest
     public void testCreateServiceWithNullTemplate() {
-        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6));
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, null, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), true);
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
@@ -265,11 +265,12 @@ public class ServiceUtilsTest {
         assertThat(svc.getSpec().getPorts().get(0), is(PORT));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("RequireDualStack"));
         assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv6")));
+        assertThat(svc.getSpec().getPublishNotReadyAddresses(), is(true));
     }
 
     @ParallelTest
     public void testCreateServiceWithTemplate() {
-        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6));
+        Service svc = ServiceUtils.createService(NAME, NAMESPACE, LABELS, OWNER_REFERENCE, TEMPLATE, List.of(PORT), Labels.fromMap(Map.of("selector-label", "selector-value")), "NodePort", Map.of("label", "label-value"), Map.of("anno", "anno-value"), IpFamilyPolicy.REQUIRE_DUAL_STACK, List.of(IpFamily.IPV6), false);
 
         assertThat(svc.getMetadata().getName(), is(NAME));
         assertThat(svc.getMetadata().getNamespace(), is(NAMESPACE));
@@ -284,5 +285,6 @@ public class ServiceUtilsTest {
         assertThat(svc.getSpec().getPorts().get(0), is(PORT));
         assertThat(svc.getSpec().getIpFamilyPolicy(), is("RequireDualStack"));
         assertThat(svc.getSpec().getIpFamilies(), is(List.of("IPv6")));
+        assertThat(svc.getSpec().getPublishNotReadyAddresses(), is(false));
     }
 }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -472,7 +472,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
 |publishNotReadyAddresses
 |boolean
-|Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`.
+|Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` type listeners.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -470,6 +470,9 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 * `Hostname`
 
 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
+|publishNotReadyAddresses
+|boolean
+|Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -446,6 +446,9 @@ spec:
                                   * `Hostname`
 
                                   This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
+                              publishNotReadyAddresses:
+                                type: boolean
+                                description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` type listeners.
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -445,6 +445,9 @@ spec:
                                 * `Hostname`
 
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
+                            publishNotReadyAddresses:
+                              type: boolean
+                              description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -447,7 +447,7 @@ spec:
                                 This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
                             publishNotReadyAddresses:
                               type: boolean
-                              description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`.
+                              description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` type listeners.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array


### PR DESCRIPTION
### Type of change

Enhancement / new feature


### Description

Adds new boolean property to GenericKafkaListenerConfiguration in the Kafka CRD to enable the setting of 'publishNotReadyAddresses' on the created services.

Closes #10148 

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

