### PR TITLE
Topicoperator unalterable topic configs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityTopicOperator.java
@@ -78,6 +78,9 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
     /* test */ static final String ENV_VAR_CRUISE_CONTROL_PORT = "STRIMZI_CRUISE_CONTROL_PORT";
     /* test */ static final String ENV_VAR_CRUISE_CONTROL_SSL_ENABLED = "STRIMZI_CRUISE_CONTROL_SSL_ENABLED";
     /* test */ static final String ENV_VAR_CRUISE_CONTROL_AUTH_ENABLED = "STRIMZI_CRUISE_CONTROL_AUTH_ENABLED";
+    /* test */ static final String ENV_VAR_TOPIC_OPERATOR_UNALTERABLE_TOPIC_CONFIG = "STRIMZI_UNALTERABLE_TOPIC_CONFIG";
+
+    /* test */ static final String THROTTLED_REPLICAS_TOPIC_CONFIGS = "follower.replication.throttled.replicas,leader.replication.throttled.replicas";
 
     // Kafka bootstrap servers can't be specified in the JSON
     /* test */ final String kafkaBootstrapServers;
@@ -199,6 +202,7 @@ public class EntityTopicOperator extends AbstractModel implements SupportsLoggin
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_PORT, String.valueOf(CRUISE_CONTROL_API_PORT)));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_SSL_ENABLED, "true"));
             varList.add(ContainerUtils.createEnvVar(ENV_VAR_CRUISE_CONTROL_AUTH_ENABLED, "true"));
+            varList.add(ContainerUtils.createEnvVar(ENV_VAR_TOPIC_OPERATOR_UNALTERABLE_TOPIC_CONFIG, THROTTLED_REPLICAS_TOPIC_CONFIGS));
             // Truststore and API credentials are mounted in the container
         }
         

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.EntityTopicOperator.CRUISE_CONTROL_API_PORT;
+import static io.strimzi.operator.cluster.model.EntityTopicOperator.THROTTLED_REPLICAS_TOPIC_CONFIGS;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.API_TO_ADMIN_NAME;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.API_TO_ADMIN_NAME_KEY;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.API_TO_ADMIN_PASSWORD_KEY;
@@ -337,6 +338,7 @@ public class EntityTopicOperatorTest {
         expectedEnvVars.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_CRUISE_CONTROL_PORT).withValue(String.valueOf(CRUISE_CONTROL_API_PORT)).build());
         expectedEnvVars.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_CRUISE_CONTROL_SSL_ENABLED).withValue(Boolean.toString(true)).build());
         expectedEnvVars.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_CRUISE_CONTROL_AUTH_ENABLED).withValue(Boolean.toString(true)).build());
+        expectedEnvVars.add(new EnvVarBuilder().withName(EntityTopicOperator.ENV_VAR_TOPIC_OPERATOR_UNALTERABLE_TOPIC_CONFIG).withValue(THROTTLED_REPLICAS_TOPIC_CONFIGS).build());
         assertThat(entityTopicOperator.getEnvVars(), is(expectedEnvVars));
 
         Container container = entityTopicOperator.createContainer(null);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -67,7 +67,7 @@ import static io.strimzi.operator.common.config.ConfigParameterParser.strictlyPo
  * @param cruiseControlApiUserPath           Api admin username file path
  * @param cruiseControlApiPassPath           Api admin password file path
  * @param alterableTopicConfig               Comma separated list of the alterable Kafka topic properties
- * @param unalterableTopicConfig             Comma separated list of the unalterable Kafka topic properties
+ * @param unalterableTopicConfig             Comma separated list of Kafka topic configurations that are ignored
  * @param skipClusterConfigReview            For some managed Kafka services the Cluster config is not callable, so this skips those calls.
  */
 public record TopicOperatorConfig(

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -66,7 +66,7 @@ import static io.strimzi.operator.common.config.ConfigParameterParser.strictlyPo
  * @param cruiseControlCrtFilePath           Certificate chain to be trusted
  * @param cruiseControlApiUserPath           Api admin username file path
  * @param cruiseControlApiPassPath           Api admin password file path
- * @param alterableTopicConfig               Comma separated list of the alterable Kafka topic properties
+ * @param alterableTopicConfig               Comma separated list of Kafka topic configurations that are reconciled
  * @param unalterableTopicConfig             Comma separated list of Kafka topic configurations that are ignored
  * @param skipClusterConfigReview            For some managed Kafka services the Cluster config is not callable, so this skips those calls.
  */

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -3,7 +3,7 @@
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.operator.topic;
-    
+
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -1236,7 +1236,7 @@ class TopicControllerIT {
                 useFinalizer,
                 100, 100, 10, false, new FeatureGates(""),
                 false, false, "", 9090, false, false, "", "", "",
-                "all", false);
+                "all", "none", false);
     }
 
     @ParameterizedTest
@@ -1990,7 +1990,7 @@ class TopicControllerIT {
                 true,
                 1, 100, 5_0000, false, new FeatureGates(""),
                 false, false, "", 9090, false, false, "", "", "",
-                "all", false);
+                "all", "none", false);
 
         maybeStartOperator(config);
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature

### Description

This MR adds a new env var `STRIMZI_UNALTERABLE_TOPIC_CONFIG` to the TopicOperator, similar to the existing `STRIMZI_ALTERABLE_TOPIC_CONFIG`. It can be used to specify topic configs that should not be reconciled by the TopicOperator.

If CruiseControl is enabled in the cluster, it will automatically be set to `follower.replication.throttled.replicas,leader.replication.throttled.replicas` which are used and updated by the partition reassignment process. See [follower.replication.throttled.replicas,leader.replication.throttled.replicas](https://github.com/strimzi/strimzi-kafka-operator/issues/9972)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

