### PR TITLE
Highlight migration doesn't work with one KRaft controller ephemeral storage

### DIFF
--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -25,6 +25,7 @@ Note also, the following:
 * You must be using Strimzi 0.40 or newer with Kafka 3.7.0 or newer. If you are using an earlier version of Strimzi or Apache Kafka, upgrade before migrating to KRaft mode.
 * Verify that the ZooKeeper-based deployment is operating without the following, as they are not supported in KRaft mode:
 ** JBOD storage. While the `jbod` storage type can be used, the JBOD array must contain only one disk.
+* The current running brokers and the controllers to be deployed are not configured with `ephemeral` storage which is not supported for migration purposes.
 * The Cluster Operator that manages the Kafka cluster is running.
 * The Kafka cluster deployment uses Kafka node pools.
 +

--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -25,7 +25,6 @@ Note also, the following:
 * You must be using Strimzi 0.40 or newer with Kafka 3.7.0 or newer. If you are using an earlier version of Strimzi or Apache Kafka, upgrade before migrating to KRaft mode.
 * Verify that the ZooKeeper-based deployment is operating without the following, as they are not supported in KRaft mode:
 ** JBOD storage. While the `jbod` storage type can be used, the JBOD array must contain only one disk.
-* The current running brokers and the controllers to be deployed are not configured with `ephemeral` storage which is not supported for migration purposes.
 * The Cluster Operator that manages the Kafka cluster is running.
 * The Kafka cluster deployment uses Kafka node pools.
 +
@@ -33,6 +32,10 @@ If your ZooKeeper-based cluster is already using node pools, it is ready to migr
 If not, you can xref:proc-migrating-clusters-node-pools-str[migrate the cluster to use node pools]. 
 To migrate when the cluster is not using node pools, brokers must be contained in a `KafkaNodePool` resource configuration that is assigned a `broker` role and has the name `kafka`.
 Support for node pools is enabled in the `Kafka` resource configuration using the `strimzi.io/node-pools: enabled` annotation.
+
+IMPORTANT: Migrating to KRaft by using just one controller with `ephemeral` storage isn't going to work.
+On controller restart, during the migration process, it's going to lose the metadata synced from ZooKeeper (i.e. topics, ACLs, and so on).
+In general, migrating an ephemeral based ZooKeeper cluster to KRaft isn't recommended.
 
 In this procedure, the Kafka cluster name is `my-cluster`, which is located in the `my-project` namespace. 
 The name of the controller node pool created is `controller`.

--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -33,9 +33,9 @@ If not, you can xref:proc-migrating-clusters-node-pools-str[migrate the cluster 
 To migrate when the cluster is not using node pools, brokers must be contained in a `KafkaNodePool` resource configuration that is assigned a `broker` role and has the name `kafka`.
 Support for node pools is enabled in the `Kafka` resource configuration using the `strimzi.io/node-pools: enabled` annotation.
 
-IMPORTANT: Migrating to KRaft by using just one controller with `ephemeral` storage isn't going to work.
-On controller restart, during the migration process, it's going to lose the metadata synced from ZooKeeper (that is, topics, ACLs, and so on).
-In general, migrating an ephemeral based ZooKeeper cluster to KRaft isn't recommended.
+IMPORTANT: Using a single controller with ephemeral storage for migrating to KRaft will not work.
+During the migration, controller restart will cause loss of metadata synced from ZooKeeper (such as topics and ACLs).
+In general, migrating an ephemeral-based ZooKeeper cluster to KRaft is not recommended.
 
 In this procedure, the Kafka cluster name is `my-cluster`, which is located in the `my-project` namespace. 
 The name of the controller node pool created is `controller`.

--- a/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
+++ b/documentation/modules/deploying/proc-deploy-migrate-kraft.adoc
@@ -34,7 +34,7 @@ To migrate when the cluster is not using node pools, brokers must be contained i
 Support for node pools is enabled in the `Kafka` resource configuration using the `strimzi.io/node-pools: enabled` annotation.
 
 IMPORTANT: Migrating to KRaft by using just one controller with `ephemeral` storage isn't going to work.
-On controller restart, during the migration process, it's going to lose the metadata synced from ZooKeeper (i.e. topics, ACLs, and so on).
+On controller restart, during the migration process, it's going to lose the metadata synced from ZooKeeper (that is, topics, ACLs, and so on).
 In general, migrating an ephemeral based ZooKeeper cluster to KRaft isn't recommended.
 
 In this procedure, the Kafka cluster name is `my-cluster`, which is located in the `my-project` namespace. 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

The KRaft migration can't work if brokers (and controllers) use the `ephemeral` storage because the multiple restarts and the fact that the formatting is lost across them when the storage is ephemeral.
This PR tries to clarify it by setting a new pre-requisite: not using ephemeral storage.
It comes from this issue https://github.com/strimzi/strimzi-kafka-operator/issues/10187 raised by a community user facing this problem.

### Checklist

- [x] Update documentation