### PR TITLE
[DOC] add namespace to each kafkatopic operation commands

### DIFF
--- a/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-upgrade-cluster-operator.adoc
@@ -67,8 +67,8 @@ For the `strimzi-store-topic` and `strimzi-topic-operator` topics, delete the re
 .Deleting internal topics used by the operator
 [source,shell,subs=+quotes]
 ----
-kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-store-topic) \
-  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-topic-operator)
+kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-store-topic) -n <namespace> \
+  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep strimzi-topic-operator) -n <namespace>
 ----
 
 For the internal topics for storing consumer offsets and transaction states, `consumer-offsets` and `transaction-state`, you want to retain them in Kafka, but you don't want them to be managed by the Topic Operator.
@@ -79,8 +79,8 @@ Annotating the `KafkaTopic` resources with `strimzi.io/managed="false"` indicate
 .Discontinuing management of internal topics
 [source,shell,subs=+quotes]
 ----
-kubectl annotate $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) strimzi.io/managed="false" \
-  && kubectl annotate $(kubectl get kt -n <namespace> -o name | grep transaction-state) strimzi.io/managed="false"
+kubectl annotate $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) strimzi.io/managed="false" -n <namespace> \
+  && kubectl annotate $(kubectl get kt -n <namespace> -o name | grep transaction-state) strimzi.io/managed="false" -n <namespace>
 ----
 
 Check the statuses of the `KafkaTopic` resources to make sure the reconciliation was successful and the topics are no longer managed, as shown in the   xref:proc-converting-managed-topics-str[procedure to stop managing topics]. 
@@ -90,8 +90,8 @@ Having discontinued their management, delete the `KafkaTopic` resources:
 .Deleting the resources for managing internal topics
 [source,shell,subs=+quotes]
 ----
-kubectl delete $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) \
-  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep transaction-state)
+kubectl delete $(kubectl get kt -n <namespace> -o name | grep consumer-offsets) -n <namespace> \
+  && kubectl delete $(kubectl get kt -n <namespace> -o name | grep transaction-state) -n <namespace>
 ----
 
 By discontinuing their management, they won't also be deleted in Kafka.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

`namespace` is missing from those kafkatopic operations in Section 24.5.5
https://strimzi.io/docs/operators/latest/deploying#upgrading_from_a_strimzi_version_using_the_bidirectional_topic_operator


### Checklist

- [x] Update documentation

