### PR TITLE
[ST] Increase ZK replicas in TopicST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -532,7 +532,7 @@ public class TopicST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPool(Environment.TEST_SUITE_NAMESPACE, sharedTestStorage.getControllerPoolName(), sharedTestStorage.getClusterName(), 1).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaEphemeral(sharedTestStorage.getClusterName(), 3, 1)
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaEphemeral(sharedTestStorage.getClusterName(), 3, 3)
             .editMetadata()
                 .withNamespace(Environment.TEST_SUITE_NAMESPACE)
             .endMetadata()


### PR DESCRIPTION
### Type of change

- Small enhancement

### Description

This small PR increases number of ZK replicas in `TopicST` - because the ZK issue we are hitting with 1 replica.
The increase should fix the problem with forming the quorum.

### Checklist

- [x] Make sure all tests pass