### PR TITLE
Update the Kind test container and remove the Etcd version override and Maven overrides

### DIFF
--- a/mockkube/pom.xml
+++ b/mockkube/pom.xml
@@ -95,10 +95,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
@@ -25,7 +25,6 @@ import io.strimzi.test.mockkube3.controllers.MockDeletionController;
 import io.strimzi.test.mockkube3.controllers.MockDeploymentController;
 import io.strimzi.test.mockkube3.controllers.MockPodController;
 import io.strimzi.test.mockkube3.controllers.MockServiceController;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,8 +39,6 @@ import java.util.concurrent.TimeUnit;
  * running controllers.
  */
 public class MockKube3 {
-    private final static String ETCD_IMAGE = "registry.k8s.io/etcd:3.5.12-0";
-
     private final ApiServerContainer<?> apiServer;
     private final List<AbstractMockController> controllers = new ArrayList<>();
     private final List<String> crds = new ArrayList<>();
@@ -56,8 +53,7 @@ public class MockKube3 {
      * Constructs the Kubernetes Mock Kube Server
      */
     public MockKube3() {
-        // Override the Etcd version to get multiplatform support
-        this.apiServer = new ApiServerContainer<>().withEtcdImage(DockerImageName.parse(ETCD_IMAGE));
+        this.apiServer = new ApiServerContainer<>();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -170,9 +170,7 @@
         <rest-assured-json-path.version>4.4.0</rest-assured-json-path.version>
         <bouncycastle.version>1.76</bouncycastle.version>
         <kroxylicious-testing.version>0.8.1</kroxylicious-testing.version>
-        <kindcontainer.version>1.4.5</kindcontainer.version>
-        <testcontainer.version>1.19.5</testcontainer.version>
-        <docker-java.version>3.3.4</docker-java.version>
+        <kindcontainer.version>1.4.6</kindcontainer.version>
         <junit4.version>4.13.2</junit4.version>
 
         <!-- properties to skip surefire tests during failsafe execution -->
@@ -877,24 +875,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit4.version}</version>
-            </dependency>
-            <!-- TestContainer dependency is needed at compile time by MockKube -->
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers</artifactId>
-                <version>${testcontainer.version}</version>
-            </dependency>
-            <!-- Needed to align TestContainer version between different TestContainer implementations -->
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>toxiproxy</artifactId>
-                <version>${testcontainer.version}</version>
-            </dependency>
-            <!-- Needed to align Java Docker API version between different TestContainer implementations -->
-            <dependency>
-                <groupId> com.github.docker-java</groupId>
-                <artifactId>docker-java-api</artifactId>
-                <version>${docker-java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR udpates the Kind test container used for the Mockkube tests. It also remove the Etcd version override and the Maven dependency overrides that are not needed anymore.

### Checklist

- [x] Make sure all tests pass