### PR TITLE
[ST] Fix TieredStorageST.testTieredStorageWithAivenPlugin

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -85,7 +85,7 @@ public class TieredStorageST extends AbstractST {
             )
         );
 
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 1)
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(testStorage.getClusterName(), 3)
             .editMetadata()
                 .withNamespace(testStorage.getNamespaceName())
             .endMetadata()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix testTieredStorageWithAivenPlugin which fails due to misconfiguration of Kafka replicas when Kafka cluster doesn't use KafkaNodePools (test requires at least 3 replicas).

### Checklist


- [x] Make sure all tests pass

