### PR TITLE
docs(tls): updates example config to show cert pattern property

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationOAuth.adoc
@@ -13,12 +13,12 @@ You can configure the address of your authorization server in the `tokenEndpoint
 The OAuth client will connect to the OAuth server, authenticate using the client ID and secret and get an access token which it will use to authenticate with the Kafka broker.
 In the `clientSecret` property, specify a link to a `Secret` containing the client secret.
 
-.An example of OAuth client authentication using client ID and client secret
+.Example client ID and client secret configuration
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   clientId: my-client-id
   clientSecret:
     secretName: my-client-oauth-secret
@@ -32,12 +32,12 @@ You can configure the address of your OAuth server in the `tokenEndpointUri` pro
 The OAuth client will connect to the OAuth server, authenticate using the client ID and refresh token and get an access token which it will use to authenticate with the Kafka broker.
 In the `refreshToken` property, specify a link to a `Secret` containing the refresh token.
 
-.An example of OAuth client authentication using client ID and refresh token
+.Example client ID and refresh token configuration
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   clientId: my-client-id
   refreshToken:
     secretName: my-refresh-token-secret
@@ -49,7 +49,7 @@ You can configure the access token used for authentication with the Kafka broker
 In this case, you do not specify the `tokenEndpointUri`.
 In the `accessToken` property, specify a link to a `Secret` containing the access token.
 
-.An example of OAuth client authentication using only an access token
+.Example access token only configuration
 [source,yaml,subs=attributes+]
 ----
 authentication:
@@ -74,12 +74,12 @@ In the `passwordSecret` property, specify a link to a `Secret` containing the pa
 Normally, you also have to configure a `clientId` using a public OAuth client. 
 If you are using a confidential OAuth client, you also have to configure a `clientSecret`.
 
-.An example of OAuth client authentication using username and a password with a public client
+.Example username and password configuration with a public client
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   username: my-username
   passwordSecret:
     secretName: my-password-secret-name
@@ -87,12 +87,12 @@ authentication:
   clientId: my-public-client-id
 ----
 
-.An example of OAuth client authentication using a username and a password with a confidential client
+.Example username and password configuration with a confidential client
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   username: my-username
   passwordSecret:
     secretName: my-password-secret-name
@@ -108,34 +108,33 @@ Optionally, `scope` and `audience` can be specified if needed.
 .TLS
 Accessing the OAuth server using the HTTPS protocol does not require any additional configuration as long as the TLS certificates used by it are signed by a trusted certification authority and its hostname is listed in the certificate.
 
-If your OAuth server is using certificates which are self-signed or are signed by a certification authority which is not trusted, you can configure a list of trusted certificates in the custom resource.
-The `tlsTrustedCertificates` property contains a list of secrets with key names under which the certificates are stored.
-The certificates must be stored in X509 format.
+If your OAuth server uses self-signed certificates or certificates signed by an untrusted certification authority, use the `tlsTrustedCertificates` property to specify the secrets containing them. 
+The certificates must be in X.509 format.
 
-.An example of TLS certificates provided
+.Example configuration specifying TLS certificates
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   clientId: my-client-id
   refreshToken:
     secretName: my-refresh-token-secret
     key: refresh-token
   tlsTrustedCertificates:
     - secretName: oauth-server-ca
-      certificate: tls.crt
+      pattern: "*.crt"
 ----
 
 The OAuth client will by default verify that the hostname of your OAuth server matches either the certificate subject or one of the alternative DNS names.
 If it is not required, you can disable the hostname verification.
 
-.An example of disabled TLS hostname verification
+.Example configuration to disable TLS hostname verification
 [source,yaml,subs=attributes+]
 ----
 authentication:
   type: oauth
-  tokenEndpointUri: https://sso.myproject.svc:8443/auth/realms/internal/protocol/openid-connect/token
+  tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint>
   clientId: my-client-id
   refreshToken:
     secretName: my-refresh-token-secret

--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -76,27 +76,34 @@ config:
 [id='con-common-configuration-trusted-certificates-{context}']
 == `trustedCertificates`
 
-Having set `tls` to configure TLS encryption, use the `trustedCertificates` property to provide a list of secrets with key names under which the certificates are stored in X.509 format.
+Use the `tls` and `trustedCertificates` properties to enable TLS encryption and specify secrets under which TLS certificates are stored in X.509 format.
+You can add this configuration to the Kafka Connect, Kafka MirrorMaker, and Kafka Bridge components for TLS connections to the Kafka cluster.
 
 You can use the secrets created by the Cluster Operator for the Kafka cluster,
 or you can create your own TLS certificate file, then create a `Secret` from the file:
 
+.Creating a secret
 [source,shell,subs=+quotes]
-kubectl create secret generic _MY-SECRET_ \
---from-file=_MY-TLS-CERTIFICATE-FILE.crt_
+kubectl create secret generic <my_secret> \
+--from-file=<my_tls_certificate_file.crt>
 
-.Example TLS encryption configuration
+* Replace `<my_secret>` with your secret name.
+* Replace `<my_tls_certificate_file.crt>` with the path to your TLS certificate file.
+
+Use the `pattern` property to include all files in the secret that match the pattern.
+Using the `pattern` property means that the custom resource does not need to be updated if certificate file names change.
+However, you can specify a specific file using the `certificate` property instead of the `pattern` property. 
+
+.Example TLS encryption configuration for components
 [source,yaml,subs=attributes+]
 ----
 tls:
   trustedCertificates:
     - secretName: my-cluster-cluster-cert
-      certificate: ca.crt
+      pattern: "*.crt"
     - secretName: my-cluster-cluster-cert
       certificate: ca2.crt
 ----
-
-If certificates are stored in the same secret, it can be listed multiple times.
 
 If you want to enable TLS encryption, but use the default set of public certification authorities shipped with Java,
 you can specify `trustedCertificates` as an empty array:
@@ -106,6 +113,17 @@ you can specify `trustedCertificates` as an empty array:
 ----
 tls:
   trustedCertificates: []
+----
+
+Similarly, you can use the `tlstrustedCertificates` property in the configuration for `oauth`, `keycloak`, and `opa` authentication and authorization types that integrate with authorization servers.
+The configuration sets up encrypted TLS connections to the authorization server.
+
+.Example TLS encryption configuration for authentication types
+[source,yaml,subs=attributes+]
+----
+tlsTrustedCertificates:
+  - secretName: oauth-server-ca
+    pattern: "*.crt"
 ----
 
 For information on configuring mTLS authentication, see the xref:type-KafkaClientAuthenticationTls-reference[`KafkaClientAuthenticationTls` schema reference].

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -27,7 +27,7 @@ spec:
   tls: # <3>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
-        certificate: ca.crt
+        pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         certificate: ca2.crt
   authentication: # <4>
@@ -94,8 +94,8 @@ spec:
     type: opentelemetry # <16>
 ----
 <1> The number of replica nodes.
-<2> Bootstrap server for connection to the target Kafka cluster. Use the name of the Kafka cluster as the _<cluster_name>_.
-<3> TLS encryption with key names under which TLS certificates are stored in X.509 format for the source Kafka cluster. If certificates are stored in the same secret, it can be listed multiple times.
+<2> Bootstrap server for connection to the target Kafka cluster. Use the name of the Kafka cluster as the <cluster_name>.
+<3> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
 <4> Authentication for the Kafka Bridge cluster, specified as mTLS, token-based OAuth, SASL-based SCRAM-SHA-256/SCRAM-SHA-512, or PLAIN.
 By default, the Kafka Bridge connects to Kafka brokers without authentication.
 <5> HTTP access to Kafka brokers.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -55,9 +55,9 @@ spec:
   tls: # <6>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
-        certificate: ca.crt
+        pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
-        certificate: ca2.crt
+        pattern: "*.crt"
   config: # <7>
     group.id: my-connect-cluster
     offset.storage.topic: my-connect-cluster-offsets
@@ -155,7 +155,7 @@ spec:
 <4> Authentication for the Kafka Connect cluster, specified as mTLS, token-based OAuth, SASL-based SCRAM-SHA-256/SCRAM-SHA-512, or PLAIN.
 By default, Kafka Connect connects to Kafka brokers using a plain text connection.
 <5> Bootstrap server for connection to the Kafka cluster.
-<6> TLS encryption with key names under which TLS certificates are stored in X.509 format for the cluster. If certificates are stored in the same secret, it can be listed multiple times.
+<6> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
 <7> Kafka Connect configuration of workers (not connectors).
 Standard Apache Kafka configuration may be provided, restricted to those properties not managed directly by Strimzi.
 <8> Build configuration properties for building a container image with connector plugins automatically.

--- a/documentation/modules/configuring/con-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker.adoc
@@ -35,7 +35,7 @@ spec:
     tls: # <6>
       trustedCertificates:
       - secretName: my-source-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
     authentication: # <7>
       type: tls
       certificateAndKey:
@@ -51,7 +51,7 @@ spec:
     tls:
       trustedCertificates:
       - secretName: my-target-cluster-ca-cert
-        certificate: ca.crt
+        pattern: "*.crt"
     authentication:
       type: tls
       certificateAndKey:
@@ -116,7 +116,7 @@ spec:
 <3> Group ID for the consumer.
 <4> The number of consumer streams.
 <5> The offset auto-commit interval in milliseconds.
-<6> TLS encryption with key names under which TLS certificates are stored in X.509 format for consumer or producer. If certificates are stored in the same secret, it can be listed multiple times.
+<6> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
 <7> Authentication for consumer or producer, specified as mTLS, token-based OAuth, SASL-based SCRAM-SHA-256/SCRAM-SHA-512, or PLAIN.
 <8> Kafka configuration options for consumer and producer.
 <9> If the `abortOnSendFailure` property is set to `true`, Kafka MirrorMaker will exit and the container will restart following a send failure for a message.

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -95,7 +95,7 @@ spec:
     bootstrapServers: my-cluster-source-kafka-bootstrap:9092 # <7>
     tls: # <8>
       trustedCertificates:
-      - certificate: ca.crt
+      - pattern: "*.crt"
         secretName: my-cluster-source-cluster-ca-cert
   - alias: "my-cluster-target" # <9>
     authentication: # <10>
@@ -111,7 +111,7 @@ spec:
       status.storage.replication.factor: 1
     tls: # <13>
       trustedCertificates:
-      - certificate: ca.crt
+      - pattern: "*.crt"
         secretName: my-cluster-target-cluster-ca-cert
   mirrors: # <14>
   - sourceCluster: "my-cluster-source" # <15>
@@ -208,7 +208,7 @@ spec:
 <5> Cluster alias for the source Kafka cluster.
 <6> Authentication for the source cluster, specified as mTLS, token-based OAuth, SASL-based SCRAM-SHA-256/SCRAM-SHA-512, or PLAIN.
 <7> Bootstrap server for connection to the source Kafka cluster.
-<8> TLS encryption with key names under which TLS certificates are stored in X.509 format for the source Kafka cluster. If certificates are stored in the same secret, it can be listed multiple times.
+<8> TLS configuration for encrypted connections to the Kafka cluster, with trusted certificates stored in X.509 format within the specified secrets.
 <9> Cluster alias for the target Kafka cluster.
 <10> Authentication for the target Kafka cluster is configured in the same way as for the source Kafka cluster.
 <11> Bootstrap server for connection to the target Kafka cluster.

--- a/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
+++ b/documentation/modules/configuring/proc-config-mirrormaker2-securing-connection.adoc
@@ -336,7 +336,7 @@ spec:
       tls: # <1>
         trustedCertificates:
           - secretName: my-source-cluster-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication: # <2>
         type: tls
         certificateAndKey:
@@ -348,7 +348,7 @@ spec:
       tls: # <3>
         trustedCertificates:
           - secretName: my-target-cluster-cluster-ca-cert
-            certificate: ca.crt
+            pattern: "*.crt"
       authentication: # <4>
         type: tls
         certificateAndKey:

--- a/documentation/modules/oauth/con-oauth-authentication-broker.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-broker.adoc
@@ -117,7 +117,7 @@ You activate fast local JWT token validation by specifying a `jwksEndpointUri` a
 The endpoint contains the public keys used to validate signed JWT tokens, which are sent as credentials by Kafka clients.
 
 All communication with the authorization server should be performed using TLS encryption.
-You can configure a certificate truststore as a Kubernetes `Secret` in your Strimzi project namespace, and use a `tlsTrustedCertificates` attribute to point to the Kubernetes Secret containing the truststore file.
+You can configure a certificate truststore as a Kubernetes `Secret` in your Strimzi project namespace, and use the `tlsTrustedCertificates` property to point to the Kubernetes secret containing the truststore file.
 
 You might want to configure a `userNameClaim` to properly extract a username from the JWT token. 
 If required, you can use a JsonPath expression like `"['user.info'].['user.id']"` to retrieve the username from nested JSON attributes within a token.
@@ -139,8 +139,8 @@ If you want to use Kafka ACL authorization, identify the user by their username 
     userNameClaim: preferred_username # <4>
     maxSecondsWithoutReauthentication: 3600 # <5>
     tlsTrustedCertificates: # <6>
-    - secretName: oauth-server-cert
-      certificate: ca.crt
+      - secretName: oauth-server-cert
+        pattern: "*.crt"
     disableTlsHostnameVerification: true # <7>
     jwksExpirySeconds: 360 # <8>
     jwksRefreshSeconds: 300 # <9>
@@ -151,7 +151,7 @@ If you want to use Kafka ACL authorization, identify the user by their username 
 <3> URI of the JWKS certificate endpoint used for local JWT validation.
 <4> The token claim (or key) that contains the actual username used to identify the user. Its value depends on the authorization server. If necessary, a JsonPath expression like `"['user.info'].['user.id']"` can be used to retrieve the username from nested JSON attributes within a token. 
 <5> (Optional) Activates the Kafka re-authentication mechanism that enforces session expiry to the same length of time as the access token. If the specified value is less than the time left for the access token to expire, then the client will have to re-authenticate before the actual token expiry. By default, the session does not expire when the access token expires, and the client does not attempt re-authentication.
-<6> (Optional) Trusted certificates for TLS connection to the authorization server.
+<6> (Optional) Certificates stored in X.509 format within the specified secrets for TLS connection to the authorization server.
 <7> (Optional) Disable TLS hostname verification. Default is `false`.
 <8> The duration the JWKS certificates are considered valid before they expire. Default is `360` seconds. If you specify a longer time, consider the risk of allowing access to revoked certificates.
 <9> The period between refreshes of JWKS certificates. The interval must be at least 60 seconds shorter than the expiry interval. Default is `300` seconds.
@@ -185,8 +185,8 @@ Depending on the authorization server, you typically have to specify a `clientId
     userNameClaim: preferred_username # <4>
     maxSecondsWithoutReauthentication: 3600 # <5>
     tlsTrustedCertificates:
-          - secretName: oauth-server-cert
-            certificate: ca.crt
+      - secretName: oauth-server-cert
+        pattern: "*.crt"
 ----
 <1> URI of the token introspection endpoint.
 <2> Client ID to identify the client.

--- a/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-broker-config.adoc
@@ -60,12 +60,12 @@ spec:
       delegateToKafkaAcls: false <4>
       disableTlsHostnameVerification: false <5>
       superUsers: <6>
-      - CN=fred
-      - sam
-      - CN=edward
+        - CN=client_1
+        - user_2
+        - CN=client_3
       tlsTrustedCertificates: <7>
-      - secretName: oauth-server-cert
-        certificate: ca.crt
+        - secretName: oauth-server-cert
+          pattern: "*.crt"
       grantsRefreshPeriodSeconds: 60 <8>
       grantsRefreshPoolSize: 5 <9>
       grantsMaxIdleSeconds: 300 <10>
@@ -87,7 +87,7 @@ The hostname for the `tokenEndpointUri` URI must be the same.
 Default is `false`.
 <5> (Optional) Disable TLS hostname verification. Default is `false`.
 <6> (Optional) Designated super users.
-<7> (Optional) Trusted certificates for TLS connection to the authorization server.
+<7> (Optional) Certificates stored in X.509 format within the specified secrets for TLS connection to the authorization server.
 <8> (Optional) The time between two consecutive grants refresh runs. That is the maximum time for active sessions to detect any permissions changes for the user on Keycloak. The default value is 60.
 <9> (Optional) The number of threads to use to refresh (in parallel) the grants for the active sessions. The default value is 5.
 <10> (Optional) The time, in seconds, after which an idle grant in the cache can be evicted. The default value is 300.

--- a/documentation/modules/oauth/proc-oauth-kafka-config.adoc
+++ b/documentation/modules/oauth/proc-oauth-kafka-config.adoc
@@ -71,18 +71,18 @@ spec:
   # ...
   authentication:
     type: oauth # <1>
-    tokenEndpointUri: https://<auth-server-address>/auth/realms/master/protocol/openid-connect/token # <2>
+    tokenEndpointUri: https://<auth_server_address>/<path_to_token_endpoint> # <2>
     clientId: kafka-bridge
     clientSecret:
       secretName: my-bridge-oauth
       key: clientSecret
     tlsTrustedCertificates: # <3>
-    - secretName: oauth-server-cert
-      certificate: tls.crt
+      - secretName: oauth-server-cert
+        pattern: "*.crt"
 ----
 <1> Authentication type set to `oauth`.
 <2> URI of the token endpoint for authentication.
-<3> Trusted certificates for TLS connection to the authorization server.
+<3> Certificates stored in X.509 format within the specified secrets for TLS connection to the authorization server.
 --
 +
 Depending on how you apply OAuth 2.0 authentication, and the type of authorization server, there are additional configuration options you can use:


### PR DESCRIPTION
**Documentation**

Updates the examples in docs that show configuration for trusted certificates. 
Replaces the config that uses certificate names with the `pattern` config.

Also updates some OAuth config for consistency in affected files.

It's now possible to specify trusted certificates in resource config based on patternsinstead of using certificate names using the new pattern property  (`pattern: "*.crt"`) rather than specific certificate names when configuring trusted certificates.
The means that the related custom resource does not need to be updated if the certificate file name changes.

You can add this configuration to the Kafka Connect, Kafka MirrorMaker, and Kafka Bridge components for TLS connections to the Kafka cluster.
You can also use the pattern property in the configuration for oauth, keycloak, and opa authentication and authorization types that integrate with authorization servers.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

