### PR TITLE
docs(reconciliation): note on ContinueReconciliationOnManualRollingUpdateFailure

### DIFF
--- a/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
@@ -70,3 +70,7 @@ kubectl annotate pod <cluster_name>-mirrormaker2-<index_number> strimzi.io/manua
 . Wait for the next reconciliation to occur (every two minutes by default).
 A rolling update of the annotated `Pod` is triggered, as long as the annotation was detected by the reconciliation process.
 When the rolling update of a pod is complete, the annotation is automatically removed from the `Pod`.
+
+NOTE: If the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is enabled, reconciliation continues even if the manual rolling update of the cluster fails.
+This allows the Cluster Operator to recover from certain rectifiable situations that can be addressed later in the reconciliation. 
+For example, it can recreate a missing Persistent Volume Claim (PVC) or Persistent Volume (PV) that caused the update to fail.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -134,13 +134,13 @@ It applies to the following operands that support manual rolling updates using t
 * Kafka Connect
 * Kafka MirrorMaker 2
 
-Continuing the reconciliation after the manual rolling update failure allows the operator to recover from various situations that might prevent the manual rolling update from succeeding.
+Continuing the reconciliation after a manual rolling update failure allows the operator to recover from various situations that might prevent the update from succeeding.
 For example, a missing Persistent Volume Claim (PVC) or Persistent Volume (PV) might cause the manual rolling update to fail.
-But the PVCs and PVs are created only in a later stage of the reconciliation.
-Continuing the reconciliation after the failure would allow to recreate the missing PVC or PV and recover from the failure.
+However, the PVCs and PVs are created only in a later stage of the reconciliation.
+By continuing the reconciliation after this failure, the process can recreate the missing PVC or PV and recover.
 
-The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is used by the Strimzi Cluster Operator.
-It will be ignored by the User and Topic Operators.
+The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is used by the Cluster Operator.
+It is ignored by the User and Topic Operators.
 
 .Enabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
 To enable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `+ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.


### PR DESCRIPTION
**Documentation**

Adds a note on `ContinueReconciliationOnManualRollingUpdateFailure` feature gate to [Performing a rolling update using a pod annotation](https://strimzi.io/docs/operators/in-development/deploying#proc-manual-rolling-update-pods-str)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

