### PR TITLE
Update Sundrio dependency to 0.200.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <!-- Build tools -->
         <checkstyle.version>10.12.2</checkstyle.version>
         <spotbugs.version>4.7.3</spotbugs.version>
-        <sundrio.version>0.100.3</sundrio.version>
+        <sundrio.version>0.200.0</sundrio.version>
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Sundrio dependency to 0.200.0. I originally planned to update Sundrio together with the last Fabric8 update, but it did not work due to https://github.com/sundrio/sundrio/issues/471. This is now fixed, so we can update it.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally