### PR TITLE
[ST] Fix Namespace issue with TieredStorageST and add base image env variable to AZP

### DIFF
--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -114,6 +114,11 @@ jobs:
       displayName: "Setup environment for upgrade"
       condition: contains('${{ parameters.profile }}', 'upgrade')
 
+    - bash: |
+        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
+        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
+      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+
     - task: Maven@3
       inputs:
         mavenPomFile: 'systemtest/pom.xml'
@@ -149,7 +154,6 @@ jobs:
         RESOURCE_ALLOCATION_STRATEGY: "NOT_SHARED"
         TEST_LOG_DIR: $(test_log_dir)
         CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN: $(connectImage)
-        KAFKA_TIERED_STORAGE_BASE_IMAGE: '$(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-$(st_kafka_version)'
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -65,6 +65,14 @@ jobs:
       parameters:
         JDK_VERSION: $(jdk_version)
 
+    - bash: |
+        set -x
+        echo $([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
+        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
+        echo $KAFKA_VERSION
+        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
+      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+
     # Build Strimzi and its images => used when running STs against PR or main branch where container images should be built
     - bash: |
         eval $(minikube docker-env)
@@ -114,10 +122,12 @@ jobs:
       displayName: "Setup environment for upgrade"
       condition: contains('${{ parameters.profile }}', 'upgrade')
 
-    - bash: |
-        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
-        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
-      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+#    - bash: |
+#        cat kafka-versions.yaml
+#        echo $(yq eval '.[] | select(.default) | .version' kafka-versions.yaml)
+#        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
+#        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
+#      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
 
     - task: Maven@3
       inputs:

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -72,6 +72,8 @@ jobs:
         echo $KAFKA_VERSION
         echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
       displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+      env:
+        KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
 
     # Build Strimzi and its images => used when running STs against PR or main branch where container images should be built
     - bash: |

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -149,6 +149,7 @@ jobs:
         RESOURCE_ALLOCATION_STRATEGY: "NOT_SHARED"
         TEST_LOG_DIR: $(test_log_dir)
         CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN: $(connectImage)
+        KAFKA_TIERED_STORAGE_BASE_IMAGE: '$(docker_registry)/$(docker_org)/kafka:$(docker_tag)-kafka-$(st_kafka_version)'
       displayName: 'Run systemtests'
 
     - task: PublishTestResults@2

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -65,16 +65,6 @@ jobs:
       parameters:
         JDK_VERSION: $(jdk_version)
 
-    - bash: |
-        set -x
-        echo $([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
-        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
-        echo $KAFKA_VERSION
-        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
-      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
-      env:
-        KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
-
     # Build Strimzi and its images => used when running STs against PR or main branch where container images should be built
     - bash: |
         eval $(minikube docker-env)
@@ -124,12 +114,12 @@ jobs:
       displayName: "Setup environment for upgrade"
       condition: contains('${{ parameters.profile }}', 'upgrade')
 
-#    - bash: |
-#        cat kafka-versions.yaml
-#        echo $(yq eval '.[] | select(.default) | .version' kafka-versions.yaml)
-#        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
-#        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
-#      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+    - bash: |
+        export KAFKA_VERSION=$([[ "${KAFKA_VERSION}" == *"latest"* ]] && yq eval '.[] | select(.default) | .version' kafka-versions.yaml || echo "${KAFKA_VERSION}")
+        echo "##vso[task.setvariable variable=kafka_tiered_storage_base_image]$(echo $DOCKER_REGISTRY/$DOCKER_ORG/kafka:$DOCKER_TAG-kafka-$KAFKA_VERSION)"
+      displayName: "Set KAFKA_TIERED_STORAGE_BASE_IMAGE for the Tiered Storage tests"
+      env:
+        KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
 
     - task: Maven@3
       inputs:

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -275,7 +275,6 @@ public class Environment {
 
     public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE = getOrDefault(KAFKA_TIERED_STORAGE_BASE_IMAGE_ENV, KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT);
 
-
     private Environment() { }
 
     static {

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -30,6 +30,7 @@ public interface TestConstants {
     long GLOBAL_CMD_CLIENT_TIMEOUT = Duration.ofMinutes(5).toMillis();
     long GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3).toMillis();
     long GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1).toMillis();
+    long GLOBAL_POLL_INTERVAL_5_SECS = Duration.ofSeconds(5).toMillis();
     long GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10).toMillis();
     long PRODUCER_TIMEOUT = Duration.ofSeconds(25).toMillis();
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/objects/BuildUtils.java
@@ -33,13 +33,15 @@ public class BuildUtils {
      * @param namespace namespace where the resources are deployed
      */
     public static void waitForBuildComplete(String buildConfigName, String namespace) {
-        TestUtils.waitFor("build " + buildConfigName + " complete", TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS, TestConstants.GLOBAL_TIMEOUT_SHORT, () -> {
+        LOGGER.info("Waiting for build of {} to be completed", buildConfigName);
+
+        TestUtils.waitFor("build " + buildConfigName + " complete", TestConstants.GLOBAL_POLL_INTERVAL_5_SECS, TestConstants.GLOBAL_TIMEOUT_SHORT, () -> {
             Long buildLatestVersion = BuildConfigResource.buildConfigClient().inNamespace(namespace).withName(buildConfigName).get().getStatus().getLastVersion();
             String buildName = getBuildName(buildConfigName, buildLatestVersion);
 
             BuildStatus buildStatus = BuildConfigResource.buildsClient().inNamespace(namespace).withName(buildName).get().getStatus();
 
-            LOGGER.info("Build status of {} is '{}'", buildName, buildStatus.getPhase());
+            LOGGER.debug("Build status of {} is '{}'", buildName, buildStatus.getPhase());
 
             return buildStatus.getPhase().equals("Complete");
         });


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes two issues that we encountered with `TieredStorageST` when running in AZP:

- `default` Namespace was marked for deletion in the ResourceManager, which caused issues in all other STs -> because `default` Namespace is the essential Namespace, it cannot be deleted -> it threw exceptions about protected Namespace. This issue is resolved by moving to the suite's Namespace (and also specifying test-suite's `TestStorage` to prevent issues with wrong context).
- issue with wrong base image used for building the "new Kafka" image with Aiven Tiered Storage plugin. This is fixed by specifying the `KAFKA_TIERED_STORAGE_BASE_IMAGE` in AZP. 

### Checklist

- [x] Make sure all tests pass

