### PR TITLE
Fixed warnings on potential final fields in Cruise Control related classes

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -60,7 +60,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
     private BrokerCapacity brokerCapacity;
     private Map<String, Object> config = new HashMap<>(0);
     private MetricsConfig metricsConfig;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
+    private final Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("The container image used for Cruise Control pods. "
         + "If no image name is explicitly specified, the image name corresponds to the name specified in the Cluster Operator configuration. "

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlTemplate.java
@@ -44,7 +44,7 @@ public class CruiseControlTemplate implements UnknownPropertyPreserving {
     private ContainerTemplate cruiseControlContainer;
     private ContainerTemplate tlsSidecarContainer;
     private ResourceTemplate serviceAccount;
-    private Map<String, Object> additionalProperties = new HashMap<>(0);
+    private final Map<String, Object> additionalProperties = new HashMap<>(0);
 
     @Description("Template for Cruise Control `Deployment`.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/CruiseControlUtils.java
@@ -55,8 +55,8 @@ public class CruiseControlUtils {
     }
 
     public static class ApiResult {
-        private String responseText;
-        private int responseCode;
+        private final String responseText;
+        private final int responseCode;
 
         public ApiResult(ExecResult execResult) {
             this.responseText = execResult.out();

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -50,18 +50,18 @@ import static org.apache.logging.log4j.core.util.Throwables.getRootCause;
 public class CruiseControlClientImpl implements CruiseControlClient {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(CruiseControlClientImpl.class);
     
-    private String serverHostname;
-    private int serverPort;
-    private boolean rackEnabled;
-    private boolean sslEnabled;
-    private byte[] sslCertificate;
-    private boolean authEnabled;
-    private String authUsername;
-    private String authPassword;
+    private final String serverHostname;
+    private final int serverPort;
+    private final boolean rackEnabled;
+    private final boolean sslEnabled;
+    private final byte[] sslCertificate;
+    private final boolean authEnabled;
+    private final String authUsername;
+    private final String authPassword;
     
-    private ExecutorService httpClientExecutor;
+    private final ExecutorService httpClientExecutor;
     private HttpClient httpClient;
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
     
     CruiseControlClientImpl(String serverHostname,
                             int serverPort,


### PR DESCRIPTION
Trivial PR to fix some compiler warnings on potential `final` fields in Cruise Control related classes.