### PR TITLE
Fixed the KafkaRebalance resource reconciliation getting stuck if CC pod is restarted during rebalance

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -917,7 +917,9 @@ public class KafkaRebalanceAssemblyOperator
             apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId)
                 .onSuccess(cruiseControlResponse -> {
                     if (cruiseControlResponse.getJson().isEmpty()) {
-                        LOGGER.warnCr(reconciliation, "Json data for response is empty since user task was not found, going to generate a new proposal");
+                        // Cruise Control restarted: reset the state because the tasks queue is not persisted
+                        // this may also happen when the tasks' retention time expires, or the cache becomes full
+                        LOGGER.warnCr(reconciliation, "User task {} not found, going to generate a new proposal", sessionId);
                         requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
                     } else {
                         JsonObject taskStatusJson = cruiseControlResponse.getJson();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -917,7 +917,7 @@ public class KafkaRebalanceAssemblyOperator
             apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId)
                 .onSuccess(cruiseControlResponse -> {
                     if (cruiseControlResponse.getJson().isEmpty()) {
-                        LOGGER.infoCr(reconciliation, "Cruise Control restarted, going to generate a new proposal");
+                        LOGGER.warnCr(reconciliation, "Json data for response is empty since user task was not found, going to generate a new proposal");
                         requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
                     } else {
                         JsonObject taskStatusJson = cruiseControlResponse.getJson();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -917,8 +917,9 @@ public class KafkaRebalanceAssemblyOperator
             apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId)
                 .onSuccess(cruiseControlResponse -> {
                     if (cruiseControlResponse.getJson().isEmpty()) {
-                        // Cruise Control restarted: reset the state because the tasks queue is not persisted
-                        // this may also happen when the tasks' retention time expires, or the cache becomes full
+                        // This may happen if:
+                        // 1. Cruise Control restarted so resetting the state because the tasks queue is not persisted
+                        // 2. Task's retention time expired, or the cache has become full
                         LOGGER.warnCr(reconciliation, "User task {} not found, going to generate a new proposal", sessionId);
                         requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
                     } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -342,7 +342,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                     JsonArray userTasks = json.getJsonArray("userTasks");
                                     JsonObject statusJson = new JsonObject();
                                     if (userTasks.isEmpty()) {
-                                        // Cruise Control restarted
+                                        // This may happen if:
+                                        // 1. Cruise Control restarted so resetting the state because the tasks queue is not persisted
+                                        // 2. Task's retention time expired, or the cache has become full
                                         result.complete(new CruiseControlResponse(userTaskID, statusJson));
                                     } else {
                                         JsonObject jsonUserTask = userTasks.getJsonObject(0);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -25,6 +25,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemTrustOptions;
 
@@ -338,47 +339,53 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                                 response.result().bodyHandler(buffer -> {
                                     JsonObject json = buffer.toJsonObject();
-                                    JsonObject jsonUserTask = json.getJsonArray("userTasks").getJsonObject(0);
-                                    String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, status = {}", response.result().statusCode(), path, userTaskID, taskStatusStr);
-                                    // This should not be an error with a 200 status but we play it safe
-                                    if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
-                                        result.fail(new CruiseControlRestException(
-                                                "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                        json.getString(CC_REST_API_ERROR_KEY)));
-                                    }
+                                    JsonArray userTasks = json.getJsonArray("userTasks");
                                     JsonObject statusJson = new JsonObject();
-                                    statusJson.put(STATUS_KEY, taskStatusStr);
-                                    CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
-                                    switch (taskStatus) {
-                                        case ACTIVE:
-                                            // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
-                                            break;
-                                        case IN_EXECUTION:
-                                            // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
-                                            // We handle these in the same way as COMPLETED tasks so we drop down to that case.
-                                        case COMPLETED:
-                                            // Completed tasks will have the original rebalance proposal summary in their original response
-                                            JsonObject originalResponse = (JsonObject) Json.decodeValue(jsonUserTask.getString(
-                                                    CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
-                                            statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(),
-                                                    originalResponse.getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()));
-                                            // Extract the load before/after information for the brokers
-                                            statusJson.put(
-                                                    CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey(),
-                                                    originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey()));
-                                            statusJson.put(
-                                                    CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey(),
-                                                    originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey()));
-                                            break;
-                                        case COMPLETED_WITH_ERROR:
-                                            // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
-                                            statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(), jsonUserTask.getString(CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
-                                            break;
-                                        default:
-                                            throw new IllegalStateException("Unexpected user task status: " + taskStatus);
+                                    if (userTasks.isEmpty()) {
+                                        // Cruise Control restarted
+                                        result.complete(new CruiseControlResponse(userTaskID, statusJson));
+                                    } else {
+                                        JsonObject jsonUserTask = userTasks.getJsonObject(0);
+                                        String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
+                                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, status = {}", response.result().statusCode(), path, userTaskID, taskStatusStr);
+                                        // This should not be an error with a 200 status but we play it safe
+                                        if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
+                                            result.fail(new CruiseControlRestException(
+                                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                                            json.getString(CC_REST_API_ERROR_KEY)));
+                                        }
+                                        statusJson.put(STATUS_KEY, taskStatusStr);
+                                        CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
+                                        switch (taskStatus) {
+                                            case ACTIVE:
+                                                // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
+                                                break;
+                                            case IN_EXECUTION:
+                                                // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
+                                                // We handle these in the same way as COMPLETED tasks so we drop down to that case.
+                                            case COMPLETED:
+                                                // Completed tasks will have the original rebalance proposal summary in their original response
+                                                JsonObject originalResponse = (JsonObject) Json.decodeValue(jsonUserTask.getString(
+                                                        CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
+                                                statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(),
+                                                        originalResponse.getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()));
+                                                // Extract the load before/after information for the brokers
+                                                statusJson.put(
+                                                        CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey(),
+                                                        originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey()));
+                                                statusJson.put(
+                                                        CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey(),
+                                                        originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey()));
+                                                break;
+                                            case COMPLETED_WITH_ERROR:
+                                                // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
+                                                statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(), jsonUserTask.getString(CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
+                                                break;
+                                            default:
+                                                throw new IllegalStateException("Unexpected user task status: " + taskStatus);
+                                        }
+                                        result.complete(new CruiseControlResponse(userTaskID, statusJson));
                                     }
-                                    result.complete(new CruiseControlResponse(userTaskID, statusJson));
                                 });
                             } else if (response.result().statusCode() == 500) {
                                 response.result().bodyHandler(buffer -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1453,7 +1453,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     @Test
     public void shouldGenerateNewProposalWhenUserTaskNotFound(VertxTestContext context) throws IOException, URISyntaxException {
-
         cruiseControlServer.setupCCRebalanceResponse(2, CruiseControlEndpoints.REBALANCE);
 
         KafkaRebalance kr = new KafkaRebalanceBuilder(createKafkaRebalance(namespace, CLUSTER_NAME, RESOURCE_NAME, EMPTY_KAFKA_REBALANCE_SPEC, true))
@@ -1479,9 +1478,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     assertState(context, client, namespace, RESOURCE_NAME, KafkaRebalanceState.Rebalancing);
                 }))
                 .compose(v -> {
-                    // Sets the user task to empty
+                    // Sets a user_tasks response with an empty task list simulating CC restart
                     cruiseControlServer.setupUserTasktoEmpty();
-
                     return krao.reconcile(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, kr.getMetadata().getName()));
                 })
                 .onComplete(context.succeeding(v -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -514,7 +514,10 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
     }
 
-    public void setupUserTasktoEmpty() throws IOException, URISyntaxException {
+    /**
+     * Setup response when user task is not found
+     */
+    public void setupUserTasktoEmpty() {
         // This simulates asking for the status with empty user task
         JsonBody jsonEmptyUserTask = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-status-empty.json"));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -514,6 +514,27 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
     }
 
+    public void setupUserTasktoEmpty() throws IOException, URISyntaxException {
+        // This simulates asking for the status with empty user task
+        JsonBody jsonEmptyUserTask = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-status-empty.json"));
+
+        server
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.toString(), "true"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.toString(), "true"))
+                                .withPath(CruiseControlEndpoints.USER_TASKS.toString())
+                                .withHeader(AUTH_HEADER)
+                                .withSecure(true))
+                .respond(
+                        response()
+                                .withBody(jsonEmptyUserTask)
+                                .withStatusCode(200)
+                                .withHeaders(header("User-Task-ID", USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID))
+                                .withDelay(TimeUnit.SECONDS, 0));
+    }
+
     /**
      * Setup response of task being stopped.
      */

--- a/cluster-operator/src/test/resources/io/strimzi/operator/cluster/operator/assembly/CruiseControlJSON/CC-User-task-status-empty.json
+++ b/cluster-operator/src/test/resources/io/strimzi/operator/cluster/operator/assembly/CruiseControlJSON/CC-User-task-status-empty.json
@@ -1,0 +1,1 @@
+{"userTasks":[],"version":1}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fixes #10091 . This PR makes sure that in case the CC pod is restarted in middle of a rebalance, then we generate a new optimization proposal and then this newly generated proposal can be reviewed by the user.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

