### PR TITLE
Fix `to_bytes.gawk` for memory in terabytes

### DIFF
--- a/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/dynamic_resources.sh
@@ -6,7 +6,7 @@ function get_heap_size {
   MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
   POSSIBLE_HEAP=$(java -XX:MaxRAMPercentage="$PERCENTAGE" -XshowSettings:vm -version \
-    |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
+    |& awk '/Max\. Heap Size \(Estimated\): [0-9KMGT]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 
   if [ "${MAX}" ]; then

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/to_bytes.gawk
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/to_bytes.gawk
@@ -4,8 +4,9 @@ BEGIN {
   suffixes["K"]=1024
   suffixes["M"]=1024**2
   suffixes["G"]=1024**3
+  suffixes["T"]=1024**4
 }
 
-match($0, /([0-9.]*)([kKmMgG]?)/, a) {
+match($0, /([0-9.]*)([kKmMgGtT]?)/, a) {
   printf("%d", a[1] * suffixes[toupper(a[2])])
 }

--- a/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
+++ b/docker-images/kafka-based/kafka/scripts/dynamic_resources.sh
@@ -6,7 +6,7 @@ function get_heap_size {
   MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
   POSSIBLE_HEAP=$(java -XX:MaxRAMPercentage="$PERCENTAGE" -XshowSettings:vm -version \
-    |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
+    |& awk '/Max\. Heap Size \(Estimated\): [0-9KMGT]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 
   if [ "${MAX}" ]; then

--- a/docker-images/kafka-based/kafka/scripts/to_bytes.gawk
+++ b/docker-images/kafka-based/kafka/scripts/to_bytes.gawk
@@ -4,8 +4,9 @@ BEGIN {
   suffixes["K"]=1024
   suffixes["M"]=1024**2
   suffixes["G"]=1024**3
+  suffixes["T"]=1024**4
 }
 
-match($0, /([0-9.]*)([kKmMgG]?)/, a) {
+match($0, /([0-9.]*)([kKmMgGtT]?)/, a) {
   printf("%d", a[1] * suffixes[toupper(a[2])])
 }


### PR DESCRIPTION
### Type of change
Bugfix

### Description

Fix `to_bytes.gawk` to handle max heap size in terabytes.

