### PR TITLE
Make the name option forbidden for Kafka Connect connector configs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -34,7 +34,7 @@ public abstract class AbstractConnectorSpec extends Spec {
     /**
      * Forbidden options in the connector configuration
      */
-    public static final String FORBIDDEN_PARAMETERS = "connector.class, tasks.max";
+    public static final String FORBIDDEN_PARAMETERS = "name, connector.class, tasks.max";
 
     private Integer tasksMax;
     private Boolean pause;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3812,7 +3812,7 @@ Used in: xref:type-KafkaConnector-{context}[`KafkaConnector`]
 |Automatic restart of connector and tasks configuration.
 |config
 |map
-|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max.
 |pause
 |boolean
 |**The `pause` property has been deprecated.** Deprecated in Strimzi 0.38.0, use state instead. Whether the connector should be paused. Defaults to false.
@@ -4068,7 +4068,7 @@ Used in: xref:type-KafkaMirrorMaker2MirrorSpec-{context}[`KafkaMirrorMaker2Mirro
 |**The `pause` property has been deprecated.** Deprecated in Strimzi 0.38.0, use state instead. Whether the connector should be paused. Defaults to false.
 |config
 |map
-|The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max.
+|The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max.
 |state
 |string (one of [running, paused, stopped])
 |The state the connector should be in. Defaults to running.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
@@ -81,7 +81,7 @@ spec:
                 config:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
-                  description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                  description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                 pause:
                   type: boolean
                   description: Whether the connector should be paused. Defaults to false.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -292,7 +292,7 @@ spec:
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
-                            description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                            description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                           state:
                             type: string
                             enum:
@@ -324,7 +324,7 @@ spec:
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
-                            description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                            description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                           state:
                             type: string
                             enum:
@@ -356,7 +356,7 @@ spec:
                           config:
                             x-kubernetes-preserve-unknown-fields: true
                             type: object
-                            description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                            description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                           state:
                             type: string
                             enum:

--- a/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -80,7 +80,7 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
-                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -291,7 +291,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:
@@ -323,7 +323,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:
@@ -355,7 +355,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, the `name` option is allowed for the `.spec.config` section of the KafkaConnector resources. But when user configures it to an option that does not match the name of the connector resource, it results in the following error:

```
io.strimzi.operator.cluster.operator.assembly.ConnectRestException: PUT /connectors/echo-sink-timer-connector/config returned 400 (Bad Request): Connector name configuration (traktor) doesn't match connector name in the URL (echo-sink-timer-connector)
	at io.strimzi.operator.cluster.operator.assembly.KafkaConnectApiImpl.lambda$createOrUpdatePutRequest$1(KafkaConnectApiImpl.java:92) ~[io.strimzi.cluster-operator-0.42.0-SNAPSHOT.jar:0.42.0-SNAPSHOT]
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91) ~[io.vertx.vertx-core-4.5.8.jar:4.5.8]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.8.jar:4.5.8]
        ...
```

This PR adds the `name` option to the forbidden options. If a user sets it, it will be filtered out and not used (+ a user will get a warning about using a forbidden option). That way, we should avoid the errors like the one above.

This option is also inherited by the configuration of the Mirror Maker 2 connectors and will apply to them as well.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally