### PR TITLE
Raise warnings when broker IDs in listener configs don't match the actual broker IDs

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -109,7 +110,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique port number"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique port number"));
     }
 
     @ParallelTest
@@ -121,7 +122,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("port 9000 is forbidden and cannot be used"));
     }
 
     @ParallelTest
@@ -133,7 +134,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("port 9404 is forbidden and cannot be used"));
     }
 
     @ParallelTest
@@ -157,7 +158,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique name"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("every listener needs to have a unique name"));
     }
 
     @ParallelTest
@@ -181,7 +182,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("listener names [listener 1, LISTENER2, listener12345678901234567890] are invalid and do not match the pattern ^[a-z0-9]{1,11}$"));
     }
 
     @ParallelTest
@@ -196,7 +197,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener plain cannot use tls type authentication with disabled TLS encryption"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("listener plain cannot use tls type authentication with disabled TLS encryption"));
     }
 
     @ParallelTest
@@ -216,7 +217,7 @@ public class ListenersValidatorTest {
                 .build();
 
         List<GenericKafkaListener> listeners = List.of(listener1);
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder("listener plain cannot configure custom TLS certificate with disabled TLS encryption"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder("listener plain cannot configure custom TLS certificate with disabled TLS encryption"));
     }
 
     @ParallelTest
@@ -291,7 +292,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure publishNotReadyAddresses because it is internal listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -349,7 +350,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -431,7 +432,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -451,7 +452,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " is Route or Ingress type listener and requires enabled TLS encryption"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -519,7 +520,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -552,7 +553,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " is Route or Ingress type listener and requires enabled TLS encryption"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -616,7 +617,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -628,13 +629,13 @@ public class ListenersValidatorTest {
                 .withTls(true)
                 .build();
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
@@ -648,7 +649,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 1 which is required for Ingress based listeners"));
 
@@ -662,7 +663,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -678,7 +679,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, List.of(listener)), hasSize(0));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), hasSize(0));
     }
 
     @ParallelTest
@@ -690,13 +691,13 @@ public class ListenersValidatorTest {
                 .withTls(true)
                 .build();
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
@@ -713,7 +714,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 1000 which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners",
                 "listener ingress is missing a broker host name for broker with ID 2001 which is required for Ingress based listeners"));
@@ -732,7 +733,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -752,7 +753,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(NODE_POOL_NODES, List.of(listener)), hasSize(0));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), hasSize(0));
     }
 
     @ParallelTest
@@ -780,7 +781,7 @@ public class ListenersValidatorTest {
 
         List<GenericKafkaListener> listeners = List.of(listener1);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), hasSize(0));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), hasSize(0));
     }
 
     @ParallelTest
@@ -846,7 +847,7 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
         );
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
     }
 
     @ParallelTest
@@ -942,7 +943,7 @@ public class ListenersValidatorTest {
 
         List<GenericKafkaListener> listeners = List.of(internal, route, lb, np, inq);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), empty());
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), empty());
     }
 
     @ParallelTest
@@ -1129,7 +1130,7 @@ public class ListenersValidatorTest {
 
         List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(
                 "listener listener1 cannot configure createBootstrapService because it is not load balancer listener",
                 "listener listener2 cannot configure createBootstrapService because it is not load balancer listener",
                 "listener listener3 cannot configure createBootstrapService because it is not load balancer listener"));
@@ -1189,10 +1190,53 @@ public class ListenersValidatorTest {
                 .build();
         List<GenericKafkaListener> listeners = List.of(listener1, listener2, listener3);
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(THREE_NODES, listeners), containsInAnyOrder(
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(
                 "listener listener1 cannot configure bootstrap.externalIPs because it is not NodePort based listener",
                 "listener listener2 cannot configure bootstrap.externalIPs because it is not NodePort based listener",
                 "listener listener1 cannot configure brokers[].externalIPs because it is not NodePort based listener",
                 "listener listener2 cannot configure brokers[].externalIPs because it is not NodePort based listener"));
+    }
+
+    @ParallelTest
+    public void testUnusedBrokerIds() {
+        GenericKafkaListener listener = new GenericKafkaListenerBuilder()
+                .withName("my-name")
+                .withPort(9094)
+                .withType(KafkaListenerType.LOADBALANCER)
+                .withTls(true)
+                .withNewConfiguration()
+                    .withBrokers(new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(0).withAdvertisedHost("advertised-host").build())
+                .endConfiguration()
+                .build();
+
+        assertThat(ListenersValidator.unusedBrokerIds(listener, THREE_NODES), is(Set.of()));
+
+        listener = new GenericKafkaListenerBuilder()
+                .withName("my-name")
+                .withPort(9094)
+                .withType(KafkaListenerType.LOADBALANCER)
+                .withTls(true)
+                .withNewConfiguration()
+                    .withBrokers(List.of())
+                .endConfiguration()
+                .build();
+
+        assertThat(ListenersValidator.unusedBrokerIds(listener, THREE_NODES), is(Set.of()));
+
+        listener = new GenericKafkaListenerBuilder()
+                .withName("my-name")
+                .withPort(9094)
+                .withType(KafkaListenerType.LOADBALANCER)
+                .withTls(true)
+                .withNewConfiguration()
+                    .withBrokers(
+                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(0).withAdvertisedHost("advertised-host").build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(1874).withAdvertisedHost("advertised-host").build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(2).withAdvertisedHost("advertised-host").build(),
+                            new GenericKafkaListenerConfigurationBrokerBuilder().withBroker(1919).withAdvertisedHost("advertised-host").build())
+                .endConfiguration()
+                .build();
+
+        assertThat(ListenersValidator.unusedBrokerIds(listener, THREE_NODES), is(Set.of(1874, 1919)));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

With the introduction of node pools, the brokers can have different user-configured node IDs. That sometimes leads to confusions when user configures various per-broker options in the listener configuration as they might get the IDs wrong. Tat is problem that I saw multiple times already -> user configures the options for brokers 0, 1, and 2. But they are ignored because they use brokers 100, 101, and 102. This is not easy to deal with as it is not immediately obvious that there is a mismatch.

This PR adds a warning that is raised in the operator log when this situation happens. E.g.:

```
2024-06-18 15:09:36 WARN  ListenersValidator:534 - Reconciliation #222(timer) Kafka(myproject/my-cluster): Listener external contains configuration for brokers with IDs [1874] that are currently not used
```

This is only a log warning as this might be a valid situation (e.g. these settings are prepared for scale-up etc.). But it should help to detect the issues as mentioned above.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally