### PR TITLE
Renamed `reason` tag on the operator metrics

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -585,7 +585,7 @@ public abstract class AbstractOperator<
                 Tag.of("kind", reconciliation.kind()),
                 Tag.of("name", reconciliation.name()),
                 Tag.of("resource-namespace", reconciliation.namespace()),
-                Tag.of("reason", errorReason));
+                Tag.of("error-reason", errorReason));
 
         boolean removed = metrics().removeMetric(MetricsHolder.METRICS_RESOURCE_STATE,
                 Tags.of(Tag.of("kind", reconciliation.kind()),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
@@ -173,7 +173,7 @@ public class OperatorMetricsTest {
                             .tag("kind", "TestResource")
                             .tag("name", "my-resource")
                             .tag("resource-namespace", "my-namespace")
-                            .tag("reason", "Test error")
+                            .tag("error-reason", "Test error")
                             .gauge().value(), is(0.0));
 
                     async.flag();


### PR DESCRIPTION
I found not so clear that the `reason` tag in operator metrics was about errors. When no errors, reading something like `reason=none` doesn't make much sense imho.
This PR changes the tag name to `error-reason`.
