### PR TITLE
Added DEBUG logging on the Cruise Control API client

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
+import io.strimzi.operator.common.Reconciliation;
 import io.vertx.core.Future;
 
 /**
@@ -23,16 +24,18 @@ public interface CruiseControlApi {
     /**
      *  Gets the state of the Cruise Control server.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @param verbose Whether the response from state endpoint should include more details.
      * @return A future for the response from the Cruise Control server with details of the Cruise Control server state.
      */
-    Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose);
+    Future<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose);
 
     /**
      *  Send a request to the Cruise Control server to perform a cluster rebalance.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @param options The rebalance parameters to be passed to the Cruise Control server.
@@ -41,13 +44,14 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when adding new brokers.
      * This method allows to move replicas from existing brokers to the new ones and avoids to run a full rebalance
-     * across all brokers in the cluster as done by {@link #rebalance(String, int, RebalanceOptions, String)}.
+     * across all brokers in the cluster as done by {@link #rebalance(Reconciliation, String, int, RebalanceOptions, String)}.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @param options The add broker parameters to be passed to the Cruise Control server.
@@ -56,12 +60,13 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> addBroker(String host, int port, AddBrokerOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> addBroker(Reconciliation reconciliation, String host, int port, AddBrokerOptions options, String userTaskId);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when removing existing brokers.
      * This method allows to move replicas out from the brokers to remove to the others remaining in the cluster.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @param options The remove broker parameters to be passed to the Cruise Control server.
@@ -70,27 +75,29 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> removeBroker(String host, int port, RemoveBrokerOptions options, String userTaskId);
+    Future<CruiseControlRebalanceResponse> removeBroker(Reconciliation reconciliation, String host, int port, RemoveBrokerOptions options, String userTaskId);
 
     /**
      *  Get the state of a specific task (e.g. a rebalance) from the Cruise Control server.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @param userTaskID This is the unique ID of a previous rebalance request or other task supported by Cruise Control.
      *                   This is used to retrieve the task's current state.
      * @return A future for the state of the specified task.
      */
-    Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskID);
+    Future<CruiseControlResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskID);
 
     /**
      *  Issue a stop command to the Cruise Control server. This will halt any task (e.g. a rebalance) which is currently
      *  in execution.
      *
+     * @param reconciliation The reconciliation marker
      * @param host The address of the Cruise Control server.
      * @param port The port the Cruise Control Server is listening on.
      * @return A future for the response from the Cruise Control server indicating if the stop command was issued.
      */
-    Future<CruiseControlResponse> stopExecution(String host, int port);
+    Future<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port);
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -130,7 +130,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                                 response.result().bodyHandler(buffer -> {
                                     JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
                                     if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                         result.fail(new CruiseControlRestException(
                                                 "Error for request: " + host + ":" + port + path + ". Server returned: " +
@@ -185,7 +185,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                         response.result().bodyHandler(buffer -> {
                             String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                             JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, summary = {}", response.result().statusCode(), path, userTaskID, json.getString("summary"));
                             CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
                             result.complete(ccResponse);
                         });
@@ -193,7 +193,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                         response.result().bodyHandler(buffer -> {
                             String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                             JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, in progress = {}", response.result().statusCode(), path, userTaskID, json.containsKey(CC_REST_API_PROGRESS_KEY));
                             CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
                             if (json.containsKey(CC_REST_API_PROGRESS_KEY)) {
                                 // If the response contains a "progress" key then the rebalance proposal has not yet completed processing
@@ -210,7 +210,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                         response.result().bodyHandler(buffer -> {
                             String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                             JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
                             if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                 // If there was a client side error, check whether it was due to not enough data being available ...
                                 if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
@@ -338,8 +338,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                                 response.result().bodyHandler(buffer -> {
                                     JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
                                     JsonObject jsonUserTask = json.getJsonArray("userTasks").getJsonObject(0);
+                                    String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
+                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, status = {}", response.result().statusCode(), path, userTaskID, taskStatusStr);
                                     // This should not be an error with a 200 status but we play it safe
                                     if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
                                         result.fail(new CruiseControlRestException(
@@ -347,7 +348,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                                         json.getString(CC_REST_API_ERROR_KEY)));
                                     }
                                     JsonObject statusJson = new JsonObject();
-                                    String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
                                     statusJson.put(STATUS_KEY, taskStatusStr);
                                     CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
                                     switch (taskStatus) {
@@ -384,7 +384,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 response.result().bodyHandler(buffer -> {
                                     String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                                     JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
                                     String errorString;
                                     if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                         errorString = json.getString(CC_REST_API_ERROR_KEY);
@@ -439,7 +439,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
                                 response.result().bodyHandler(buffer -> {
                                     JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, json = {}", response.result().statusCode(), path, userTaskID, json);
+                                    LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
                                     if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                         result.fail(json.getString(CC_REST_API_ERROR_KEY));
                                     } else {
@@ -447,7 +447,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                         result.complete(ccResponse);
                                     }
                                 });
-
                             } else {
                                 result.fail(new CruiseControlRestException(
                                         "Unexpected status code " + response.result().statusCode() + " for GET request to " +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.strimzi.certs.Subject;
+import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlRebalanceKeys;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlUserTaskStatus;
@@ -84,7 +85,7 @@ public class CruiseControlClientTest {
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getCruiseControlState(HOST, cruiseControlPort, false)
+        client.getCruiseControlState(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, false)
             .onComplete(context.succeeding(result -> context.verify(() -> {
                 assertThat(result.getJson().getJsonObject("ExecutorState"),
                         hasEntry("state", "NO_TASK_IN_PROGRESS"));
@@ -137,7 +138,7 @@ public class CruiseControlClientTest {
         String userTaskID = MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID;
 
         Checkpoint checkpoint = context.checkpoint();
-        client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID).onComplete(context.succeeding(result -> {
+        client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID).onComplete(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()), is(notNullValue())));
             checkpoint.flag();
@@ -266,21 +267,21 @@ public class CruiseControlClientTest {
         Checkpoint checkpoint = context.checkpoint();
         switch (endpoint) {
             case REBALANCE:
-                client.rebalance(HOST, cruiseControlPort, (RebalanceOptions) options, null)
+                client.rebalance(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RebalanceOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case ADD_BROKER:
-                client.addBroker(HOST, cruiseControlPort, (AddBrokerOptions) options, null)
+                client.addBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (AddBrokerOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
-                client.removeBroker(HOST, cruiseControlPort, (RemoveBrokerOptions) options, null)
+                client.removeBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RemoveBrokerOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
@@ -297,21 +298,21 @@ public class CruiseControlClientTest {
         Checkpoint checkpoint = context.checkpoint();
         switch (endpoint) {
             case REBALANCE:
-                client.rebalance(HOST, cruiseControlPort, (RebalanceOptions) options, null)
+                client.rebalance(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RebalanceOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case ADD_BROKER:
-                client.addBroker(HOST, cruiseControlPort, (AddBrokerOptions) options, null)
+                client.addBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (AddBrokerOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
-                client.removeBroker(HOST, cruiseControlPort, (RemoveBrokerOptions) options, null)
+                client.removeBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RemoveBrokerOptions) options, null)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
@@ -328,21 +329,21 @@ public class CruiseControlClientTest {
         Checkpoint checkpoint = context.checkpoint();
         switch (endpoint) {
             case REBALANCE:
-                client.rebalance(HOST, cruiseControlPort, (RebalanceOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.rebalance(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RebalanceOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case ADD_BROKER:
-                client.addBroker(HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.addBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
-                client.removeBroker(HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.removeBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
@@ -359,21 +360,21 @@ public class CruiseControlClientTest {
         Checkpoint checkpoint = context.checkpoint();
         switch (endpoint) {
             case REBALANCE:
-                client.rebalance(HOST, cruiseControlPort, (RebalanceOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.rebalance(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RebalanceOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case ADD_BROKER:
-                client.addBroker(HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.addBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
-                client.removeBroker(HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
+                client.removeBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)
                         .onComplete(context.succeeding(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
@@ -390,14 +391,14 @@ public class CruiseControlClientTest {
         Checkpoint checkpoint = context.checkpoint();
         switch (endpoint) {
             case ADD_BROKER:
-                client.addBroker(HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
+                client.addBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (AddBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
                         .onComplete(context.failing(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
                         })));
                 break;
             case REMOVE_BROKER:
-                client.removeBroker(HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
+                client.removeBroker(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, (RemoveBrokerOptions) options, MockCruiseControl.BROKERS_NOT_EXIST_ERROR)
                         .onComplete(context.failing(result -> context.verify(() -> {
                             assertion.accept(result);
                             checkpoint.flag();
@@ -444,7 +445,7 @@ public class CruiseControlClientTest {
 
         cruiseControlServer.setupCCUserTasksResponseNoGoals(0, pendingCalls1);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID);
+        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
 
         for (int i = 1; i <= pendingCalls1; i++) {
             statusFuture = statusFuture.compose(response -> {
@@ -453,7 +454,7 @@ public class CruiseControlClientTest {
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
                 firstPending.flag();
-                return client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID);
+                return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
         }
 
@@ -475,7 +476,7 @@ public class CruiseControlClientTest {
             return Future.succeededFuture();
         });
 
-        statusFuture = statusFuture.compose(ignore -> client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID));
+        statusFuture = statusFuture.compose(ignore -> client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID));
 
         for (int i = 1; i <= pendingCalls2; i++) {
             statusFuture = statusFuture.compose(response -> {
@@ -484,7 +485,7 @@ public class CruiseControlClientTest {
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
                 secondPending.flag();
-                return client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID);
+                return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
         }
 
@@ -502,7 +503,7 @@ public class CruiseControlClientTest {
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID);
+        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
 
         // One interaction is always expected at the end of the test, hence the +1
         Checkpoint expectedInteractions = context.checkpoint(pendingCalls + 1);
@@ -514,7 +515,7 @@ public class CruiseControlClientTest {
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
                 expectedInteractions.flag();
-                return client.getUserTaskStatus(HOST, cruiseControlPort, userTaskID);
+                return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
         }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adds DEBUG logging support in the Cruise Control API client.
When testing/debugging `KafkaRebalance` related stuff is really useful and important to see what's going on in terms of requests/response with the Cruise Control REST API server.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally