### PR TITLE
Uncommented (and enabled by default) KRaft-related metrics in the example YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add support for feature gates to User and Topic Operators
 * Add support for setting `publishNotReadyAddresses` on services for listener types other than internal.
 * Update HTTP bridge to latest 0.29.0 release
+* Uncommented and enabled (by default) KRaft-related metrics in the `kafka-metrics.yaml` example file.
 
 ### Changes, deprecations and removals
 

--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -197,27 +197,26 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
-    # KRaft mode: uncomment the following lines to export KRaft related metrics
     # KRaft overall related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    #- pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
-    #  name: kafka_server_raftmetrics_$1
-    #  type: COUNTER
-    #- pattern: "kafka.server<type=raft-metrics><>(.+):"
-    #  name: kafka_server_raftmetrics_$1
-    #  type: GAUGE
+    - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-metrics><>(.+):"
+      name: kafka_server_raftmetrics_$1
+      type: GAUGE
     # KRaft "low level" channels related metrics
     # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
-    #- pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
-    #  name: kafka_server_raftchannelmetrics_$1
-    #  type: COUNTER
-    #- pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
-    #  name: kafka_server_raftchannelmetrics_$1
-    #  type: GAUGE
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: COUNTER
+    - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
+      name: kafka_server_raftchannelmetrics_$1
+      type: GAUGE
     # Broker metrics related to fetching metadata topic records in KRaft mode
-    #- pattern: "kafka.server<type=broker-metadata-metrics><>(.+):"
-    #  name: kafka_server_brokermetadatametrics_$1
-    #  type: GAUGE
+    - pattern: "kafka.server<type=broker-metadata-metrics><>(.+):"
+      name: kafka_server_brokermetadatametrics_$1
+      type: GAUGE
   zookeeper-metrics-config.yml: |
     # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
     lowercaseOutputName: true


### PR DESCRIPTION
With KRaft being mainstream, this PR uncomments (and enable by default) the KRaft metrics scraping by JMX exporter in the corresponding `kafka-metrics.yaml` example file.