### PR TITLE
Auto-comment on invalid changes of released files

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -58,8 +58,33 @@ jobs:
         displayName: "Run Shellcheck"
       - bash: "make release_files_check"
         displayName: "Check released files"
+      - task: GitHubComment@0
+        displayName: "Comment on the PR for forbidden release file changes"
+        condition: failed()
+        inputs:
+          gitHubConnection: strimzi
+          comment: >
+              This PR contains forbidden changes to the `examples/`, `install/`, or `helm-chart/` directories.
+              These directories can be updated only as part of a Strimzi release.
+              Any other changes to examples, installation files, or to the Helm chart should be done in the `packaging/` directory.
       - bash: ".azure/scripts/uncommitted-changes.sh"
         displayName: "Check for uncommitted files"
+      - task: GitHubComment@0
+        displayName: "Comment on the PR for uncommitted files"
+        condition: failed()
+        inputs:
+          gitHubConnection: strimzi
+          comment: |
+            This PR contains uncommitted changes to the generated files in the `packaging/`, `documentation/`, `cluster-operator/src/main/resources/cluster-roles`, or `api/src/test/resources/io/strimzi/api/kafka/model` directories.
+            To fix this, please run the following command:
+            ```
+            mvn clean verify -DskipTests -DskipITs \
+                && make crd_install \
+                && make dashboard_install \
+                && make helm_install \
+                && git add packaging/install/ packaging/helm-charts/ documentation/modules/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles \
+                && git commit -s -m 'Update derived resources'
+            ```
 
       # We have to TAR the artifacts directory and store it
       - bash: tar -cvpf binaries.tar ./docker-images/artifacts/binaries


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds automated GitHub comments from Azure pipelines. They will inform the users about:
* Forbidden changes to the released files
* Uncommitted changes to the derived files (CRDs, Dashboards, RBAC files in packaging, generated docs, etc.)

This should save us some effort and provide automated feedback to the authors of the PRs. the examples of such comments are visible below:
* For release files: https://github.com/strimzi/strimzi-kafka-operator/pull/10242#issuecomment-2179361010
* For generated / derived files: https://github.com/strimzi/strimzi-kafka-operator/pull/10242#issuecomment-2179447126

_(The other comments are from the development)_