### PR TITLE
Use mutable HashMap instead of immutable Map.of() in the API classes in places that should be editable

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeAdminClientSpec.java
@@ -27,8 +27,9 @@ public class KafkaBridgeAdminClientSpec extends KafkaBridgeClientSpec {
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     @Override
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Kafka AdminClient configuration used for AdminClient instances created by the bridge.")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeClientSpec.java
@@ -22,11 +22,12 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public abstract class KafkaBridgeClientSpec implements UnknownPropertyPreserving {
-    protected Map<String, Object> config;
+    protected Map<String, Object> config = new HashMap<>(0);
     private Map<String, Object> additionalProperties;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeConsumerSpec.java
@@ -34,9 +34,10 @@ public class KafkaBridgeConsumerSpec extends KafkaBridgeClientSpec {
     private long timeoutSeconds = HTTP_DEFAULT_TIMEOUT;
 
     @Override
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Kafka consumer configuration used for consumer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeProducerSpec.java
@@ -31,9 +31,10 @@ public class KafkaBridgeProducerSpec extends KafkaBridgeClientSpec {
     private boolean enabled = true;
 
     @Override
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Kafka producer configuration used for producer instances created by the bridge. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/MetadataTemplate.java
@@ -30,14 +30,14 @@ import java.util.Map;
 @EqualsAndHashCode
 @ToString
 public class MetadataTemplate implements UnknownPropertyPreserving {
-    private Map<String, String> labels;
-    private Map<String, String> annotations;
+    private Map<String, String> labels = new HashMap<>(0);
+    private Map<String, String> annotations = new HashMap<>(0);
     private Map<String, Object> additionalProperties;
 
     @Description("Labels added to the Kubernetes resource.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getLabels() {
-        return labels != null ? labels : Map.of();
+        return labels;
     }
 
     public void setLabels(Map<String, String> labels) {
@@ -47,7 +47,7 @@ public class MetadataTemplate implements UnknownPropertyPreserving {
     @Description("Annotations added to the Kubernetes resource.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getAnnotations() {
-        return annotations != null ? annotations : Map.of();
+        return annotations;
     }
 
     public void setAnnotations(Map<String, String> annotations) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -17,6 +17,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @DescriptionFile
@@ -36,15 +37,16 @@ public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
     public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
     private String bootstrapServers;
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Build build;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The Kafka Connect configuration. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -16,6 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,7 +39,7 @@ public abstract class AbstractConnectorSpec extends Spec {
 
     private Integer tasksMax;
     private Boolean pause;
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
     private ConnectorState state;
 
     private AutoRestart autoRestart;
@@ -67,7 +68,7 @@ public abstract class AbstractConnectorSpec extends Spec {
     @Description("The Kafka Connector configuration. The following properties cannot be set: " + FORBIDDEN_PARAMETERS)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     /**

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -69,7 +69,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     protected Storage storage;
     private String version;
     private String metadataVersion;
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
     private String brokerRackInitImage;
     private Rack rack;
     private Logging logging;
@@ -112,7 +112,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     @Description("Kafka broker config properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -58,7 +58,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
     private Logging logging;
     private CruiseControlTemplate template;
     private BrokerCapacity brokerCapacity;
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
     private MetricsConfig metricsConfig;
     private Map<String, Object> additionalProperties;
 
@@ -102,7 +102,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
             " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -34,8 +34,8 @@ import java.util.Map;
 public class GenericKafkaListenerConfigurationBootstrap implements UnknownPropertyPreserving {
     private List<String> alternativeNames;
     private String host;
-    private Map<String, String> annotations;
-    private Map<String, String> labels;
+    private Map<String, String> annotations = new HashMap<>(0);
+    private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
     private List<String> externalIPs;
@@ -69,7 +69,7 @@ public class GenericKafkaListenerConfigurationBootstrap implements UnknownProper
             "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getAnnotations() {
-        return annotations != null ? annotations : Map.of();
+        return annotations;
     }
 
     public void setAnnotations(Map<String, String> annotations) {
@@ -80,7 +80,7 @@ public class GenericKafkaListenerConfigurationBootstrap implements UnknownProper
             "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getLabels() {
-        return labels != null ? labels : Map.of();
+        return labels;
     }
 
     public void setLabels(Map<String, String> labels) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -37,8 +37,8 @@ public class GenericKafkaListenerConfigurationBroker implements UnknownPropertyP
     private String advertisedHost;
     private Integer advertisedPort;
     private String host;
-    private Map<String, String> annotations;
-    private Map<String, String> labels;
+    private Map<String, String> annotations = new HashMap<>(0);
+    private Map<String, String> labels = new HashMap<>(0);
     private Integer nodePort;
     private String loadBalancerIP;
     private List<String> externalIPs;
@@ -92,7 +92,7 @@ public class GenericKafkaListenerConfigurationBroker implements UnknownPropertyP
             "This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getAnnotations() {
-        return annotations != null ? annotations : Map.of();
+        return annotations;
     }
 
     public void setAnnotations(Map<String, String> annotations) {
@@ -103,7 +103,7 @@ public class GenericKafkaListenerConfigurationBroker implements UnknownPropertyP
             "This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getLabels() {
-        return labels != null ? labels : Map.of();
+        return labels;
     }
 
     public void setLabels(Map<String, String> labels) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/tieredstorage/RemoteStorageManager.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class RemoteStorageManager implements UnknownPropertyPreserving {
     private String className;
     private String classPath;
-    private Map<String, String> config;
+    private Map<String, String> config = new HashMap<>(0);
     protected Map<String, Object> additionalProperties;
 
     @Description("The class name for the `RemoteStorageManager` implementation.")
@@ -56,9 +56,9 @@ public class RemoteStorageManager implements UnknownPropertyPreserving {
 
     @Description("The additional configuration map for the `RemoteStorageManager` implementation. " +
         "Keys will be automatically prefixed with `rsm.config.`, and added to Kafka broker configuration.")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, String> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, String> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerClientSpec.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @ToString
 public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving {
     private String bootstrapServers;
-    protected Map<String, Object> config;
+    protected Map<String, Object> config = new HashMap<>(0);
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Map<String, Object> additionalProperties;
@@ -44,7 +44,7 @@ public class KafkaMirrorMakerClientSpec implements UnknownPropertyPreserving {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -36,9 +36,10 @@ public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {
     private Integer offsetCommitInterval;
 
     @Override
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The MirrorMaker consumer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     @Description("Specifies the number of consumer stream threads to create.")

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -41,8 +41,9 @@ public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {
     }
 
     @Override
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The MirrorMaker producer config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2ClusterSpec.java
@@ -36,7 +36,7 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving {
 
     private String alias;
     private String bootstrapServers;
-    protected Map<String, Object> config;
+    protected Map<String, Object> config = new HashMap<>(0);
     private ClientTls tls;
     private KafkaClientAuthentication authentication;
     private Map<String, Object> additionalProperties;
@@ -65,9 +65,10 @@ public class KafkaMirrorMaker2ClusterSpec implements UnknownPropertyPreserving {
     @Description("The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public void setConfig(Map<String, Object> config) {
         this.config = config;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceStatus.java
@@ -13,6 +13,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -29,12 +30,12 @@ import java.util.Map;
 @ToString(callSuper = true)
 public class KafkaRebalanceStatus extends Status {
     private String sessionId;
-    private Map<String, Object> optimizationResult;
+    private Map<String, Object> optimizationResult = new HashMap<>(0);
 
     @Description("A JSON object describing the optimization result")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getOptimizationResult() {
-        return optimizationResult != null ? optimizationResult : Map.of();
+        return optimizationResult;
     }
 
     public void setOptimizationResult(Map<String, Object> optimizationResult) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/KafkaTopicSpec.java
@@ -15,6 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Buildable(
@@ -29,7 +30,7 @@ public class KafkaTopicSpec extends Spec {
     private String topicName;
     private Integer partitions;
     private Integer replicas;
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
 
     @Description("The name of the topic. " +
             "When absent this will default to the metadata.name of the topic. " +
@@ -70,9 +71,10 @@ public class KafkaTopicSpec extends Spec {
         this.replicas = replicas;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Description("The topic configuration.")
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {

--- a/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/zookeeper/ZookeeperClusterSpec.java
@@ -54,7 +54,7 @@ public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigur
             "ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification";
 
     protected SingleVolumeStorage storage;
-    private Map<String, Object> config;
+    private Map<String, Object> config = new HashMap<>(0);
     private Logging logging;
     private int replicas;
     private String image;
@@ -70,7 +70,7 @@ public class ZookeeperClusterSpec implements HasConfigurableMetrics, HasConfigur
     @Description("The ZooKeeper broker config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES + " (with the exception of: " + FORBIDDEN_PREFIX_EXCEPTIONS + ").")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Map<String, Object> getConfig() {
-        return this.config != null ? this.config : Map.of();
+        return config;
     }
 
     public void setConfig(Map<String, Object> config) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The PR #10226 started using immutable maps (`Map.of()`) in many places of the API classes. In some places, that seems to be fine - e.g. in the additional properties. But in other, this beats the purpose of the editable and fluent APIs. This PR partially reverts the changes from #10226 and uses the mutable HashMaps kn the places where it seems to make sense. It also adds back the initialization of the fields since otherwise they might be inconsistently initialized in different places (such as the generated classes etc.). I do not expect any of this to matter for the additional proeprties, so they remain unchanged.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally