### PR TITLE
Update assembly-drain-cleaner.adoc

### DIFF
--- a/documentation/assemblies/deploying/assembly-drain-cleaner.adoc
+++ b/documentation/assemblies/deploying/assembly-drain-cleaner.adoc
@@ -11,7 +11,7 @@ If your Kafka and ZooKeeper pods were deployed by Strimzi, you can use the Strim
 The Strimzi Drain Cleaner handles the eviction instead of Kubernetes.
 
 By deploying the Strimzi Drain Cleaner, you can use the Cluster Operator to move Kafka pods instead of Kubernetes.
-The Cluster Operator ensures that topics are never under-replicated and Kafka can remain operational during the eviction process.
+The Cluster Operator ensures that the number of in sync replicas for topics are at or above the configured `min.insync.replicas` and Kafka can remain operational during the eviction process.
 The Cluster Operator waits for topics to synchronize, as the Kubernetes worker nodes drain consecutively.
 
 An admission webhook notifies the Strimzi Drain Cleaner of pod eviction requests to the Kubernetes API.


### PR DESCRIPTION
Add info regarding in sync replicas and underreplication.

### Type of change

- Documentation

### Description

Add some clarity regarding the Cluster Operator functionality during Drain Cleaner usage

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

