### PR TITLE
Collect test coverage data from unit and integration tests

### DIFF
--- a/.azure/templates/jobs/build/test_strimzi.yaml
+++ b/.azure/templates/jobs/build/test_strimzi.yaml
@@ -39,4 +39,11 @@ jobs:
           testResultsFormat: JUnit
           testResultsFiles: '**/TEST-*.xml'
           testRunTitle: "Unit & Integration tests"
+        displayName: "Publish Test Results"
         condition: always()
+
+      # Publish test coverage results
+      - task: PublishCodeCoverageResults@2
+        inputs:
+          summaryFileLocation: $(System.DefaultWorkingDirectory)/**/target/site/jacoco/jacoco.xml
+        displayName: "Publish Test Coverage"

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <maven.jar.version>3.1.0</maven.jar.version>
         <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
         <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
-        <maven.jacoco.version>0.8.8</maven.jacoco.version>
+        <maven.jacoco.version>0.8.12</maven.jacoco.version>
         <maven.exec.version>3.1.0</maven.exec.version>
         <maven.resources.version>3.1.0</maven.resources.version>
 
@@ -1010,19 +1010,22 @@
                 <version>${maven.jacoco.version}</version>
                 <executions>
                     <execution>
+                        <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
-                        <configuration>
-                            <propertyName>surefireArgLine</propertyName>
-                        </configuration>
                     </execution>
                     <execution>
-                        <id>report</id>
-                        <phase>package</phase>
+                        <id>default-report</id>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>io/strimzi/api/**/*Fluent*.class</exclude>
+                                <exclude>io/strimzi/api/**/*Builder*.class</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR tries to update the Jacoco configuration to generate test coverage data from our unit and integration tests and it also integrates the coverage data into the Azure Pipeline. Azure provides only basic information in the UI (see the screenshot). But more information can be found in the build artifacts and of course also locally.

![Screenshot 2024-06-22 at 15 49 41](https://github.com/strimzi/strimzi-kafka-operator/assets/5658439/74d7fa03-c176-4276-9c33-2a8efb2cc68b)