### PR TITLE
Update logging of Kafka Connect when Connector operator is disabled

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaConnectCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaConnectCluster.properties
@@ -3,5 +3,4 @@ log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingModelTest.java
@@ -37,7 +37,6 @@ public class LoggingModelTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 """));
@@ -63,7 +62,6 @@ public class LoggingModelTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=ERROR
                                 
                 monitorInterval=30

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/logging/LoggingUtilsTest.java
@@ -39,7 +39,6 @@ public class LoggingUtilsTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=ERROR
                 """));
     }
@@ -92,7 +91,6 @@ public class LoggingUtilsTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=ERROR
                 """));
     }
@@ -112,7 +110,6 @@ public class LoggingUtilsTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=ERROR
                 
                 monitorInterval=30
@@ -140,7 +137,6 @@ public class LoggingUtilsTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 """));
@@ -167,7 +163,6 @@ public class LoggingUtilsTest {
                 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
                 connect.root.logger.level=INFO
                 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-                log4j.logger.org.apache.zookeeper=ERROR
                 log4j.logger.org.reflections=DEBUG
                 logger.myclass.level=TRACE
                 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -216,6 +216,9 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     StrimziPodSet podSet = capturesPodSets.get(0);
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
+                    PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("6e428c4f"));
+                    });
 
                     // Verify services => one regular and one headless
                     List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -350,6 +353,9 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     StrimziPodSet podSet = capturesPodSets.get(0);
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
+                    PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("06ee78c4"));
+                    });
 
                     // Verify services => one regular and one headless
                     List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -985,6 +991,243 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     });
 
                     // NetworkPolicies => Connector Operator, policy is created
+                    assertThat(npCaptor.getValue(), is(notNullValue()));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    assertThat(connectStatus.getConnectorPlugins(), hasSize(1));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getConnectorClass(), is("io.strimzi.MyClass"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getType(), is("sink"));
+                    assertThat(connectStatus.getConnectorPlugins().get(0).getVersion(), is("1.0.0"));
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUpdateLoggingWithoutConnectors(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
+                .editSpec()
+                    .withNewInlineLogging()
+                        .addToLoggers(Map.of("log4j.logger.org.apache.kafka.connect.runtime.rest.RestServer", "WARN"))
+                    .endInlineLogging()
+                .endSpec()
+                .build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        ArgumentCaptor<NetworkPolicy> npCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), npCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig()
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Check rolling happened
+                    verify(mockPodOps, times(3)).deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false));
+
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+                    PodSetUtils.podSetToPods(podSet).forEach(pod -> {
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("8a7507b8"));
+                    });
+
+                    // NetworkPolicies => No Connector Operator, no policy is created
+                    assertThat(npCaptor.getValue(), is(Matchers.nullValue()));
+
+                    // Verify CR status
+                    List<KafkaConnect> capturedConnects = connectCaptor.getAllValues();
+                    assertThat(capturedConnects, hasSize(1));
+                    KafkaConnectStatus connectStatus = capturedConnects.get(0).getStatus();
+
+                    assertThat(connectStatus.getUrl(), is("http://my-connect-connect-api.my-namespace.svc:8083"));
+                    assertThat(connectStatus.getReplicas(), is(3));
+                    assertThat(connectStatus.getLabelSelector(), is("strimzi.io/cluster=my-connect,strimzi.io/name=my-connect-connect,strimzi.io/kind=KafkaConnect"));
+                    assertThat(connectStatus.getConditions().get(0).getStatus(), is("True"));
+                    assertThat(connectStatus.getConditions().get(0).getType(), is("Ready"));
+
+                    assertThat(connectStatus.getConnectorPlugins(), nullValue());
+
+                    async.flag();
+                })));
+    }
+
+    @Test
+    public void testUpdateLoggingWithConnectors(VertxTestContext context)  {
+        KafkaConnect connect = new KafkaConnectBuilder(CONNECT)
+                .editMetadata()
+                    .addToAnnotations(Annotations.STRIMZI_IO_USE_CONNECTOR_RESOURCES, "true")
+                .endMetadata()
+                .editSpec()
+                    .withNewInlineLogging()
+                        .addToLoggers(Map.of("log4j.logger.org.apache.kafka.connect.runtime.rest.RestServer", "WARN"))
+                    .endInlineLogging()
+                .endSpec()
+                .build();
+        StrimziPodSet oldPodSet = CLUSTER.generatePodSet(3, null, null, false, null, null, null);
+        List<Pod> oldPods = PodSetUtils.podSetToPods(oldPodSet);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        // Mock deployment
+        DeploymentOperator mockDepOps = supplier.deploymentOperations;
+        when(mockDepOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture());
+
+        // Mock PodSets
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        when(mockPodSetOps.getAsync(eq(NAMESPACE), eq(COMPONENT_NAME))).thenReturn(Future.succeededFuture(oldPodSet));
+        when(mockPodSetOps.readiness(any(), eq(NAMESPACE), eq(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<StrimziPodSet> podSetCaptor = ArgumentCaptor.forClass(StrimziPodSet.class);
+        when(mockPodSetOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), podSetCaptor.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(3))));
+
+        // Mock PDBs
+        PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
+        ArgumentCaptor<PodDisruptionBudget> pdbCaptor = ArgumentCaptor.forClass(PodDisruptionBudget.class);
+        when(mockPdbOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), pdbCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Config Maps
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+
+        // Mock Services
+        ServiceOperator mockServiceOps = supplier.serviceOperations;
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Network Policies
+        NetworkPolicyOperator mockNetPolOps = supplier.networkPolicyOperator;
+        ArgumentCaptor<NetworkPolicy> npCaptor = ArgumentCaptor.forClass(NetworkPolicy.class);
+        when(mockNetPolOps.reconcile(any(), eq(NAMESPACE), eq(COMPONENT_NAME), npCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Pods
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(oldPods));
+        when(mockPodOps.getAsync(eq(NAMESPACE), startsWith(COMPONENT_NAME))).thenAnswer(i -> {
+            Pod pod = oldPods.stream().filter(p -> i.getArgument(1).equals(p.getMetadata().getName())).findFirst().orElse(null);
+            return Future.succeededFuture(pod);
+        });
+        when(mockPodOps.deleteAsync(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), eq(false))).thenReturn(Future.succeededFuture());
+        when(mockPodOps.reconcile(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.readiness(any(), eq(NAMESPACE), startsWith(COMPONENT_NAME), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+
+        // Mock Secrets
+        SecretOperator mockSecretOps = supplier.secretOperations;
+        when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaConnectResources.jmxSecretName(NAME)))).thenReturn(Future.succeededFuture());
+
+        // Mock Connect CRs
+        CrdOperator<KubernetesClient, KafkaConnect, KafkaConnectList> mockConnectOps = supplier.connectOperator;
+        when(mockConnectOps.get(eq(NAMESPACE), eq(NAME))).thenReturn(connect);
+        when(mockConnectOps.getAsync(eq(NAMESPACE), eq(NAME))).thenReturn(Future.succeededFuture(connect));
+        ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
+        when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        // Mock Connector CRs
+        CrdOperator<KubernetesClient, KafkaConnector, KafkaConnectorList> mockConnectorOps = supplier.kafkaConnectorOperator;
+        when(mockConnectorOps.listAsync(anyString(), any(LabelSelector.class))).thenReturn(Future.succeededFuture(emptyList()));
+
+        // Mock Connect REST API
+        KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
+                .withConnectorClass("io.strimzi.MyClass")
+                .withType("sink")
+                .withVersion("1.0.0")
+                .build();
+        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+
+        KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
+                vertx,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                supplier,
+                ResourceUtils.dummyClusterOperatorConfig(),
+                x -> mockConnectClient
+        );
+
+        Checkpoint async = context.checkpoint();
+        ops.reconcile(new Reconciliation("test-trigger", KafkaConnect.RESOURCE_KIND, NAMESPACE, NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    // Verify PodSets
+                    List<StrimziPodSet> capturesPodSets = podSetCaptor.getAllValues();
+                    assertThat(capturesPodSets.size(), is(1));
+                    StrimziPodSet podSet = capturesPodSets.get(0);
+                    assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
+                    assertThat(podSet.getSpec().getPods().size(), is(3));
+                    PodSetUtils.podSetToPods(podSet).forEach(pod -> {
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("06ee78c4"));
+                    });
+
+                    // NetworkPolicies => No Connector Operator, no policy is created
                     assertThat(npCaptor.getValue(), is(notNullValue()));
 
                     // Verify CR status


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the Connector operator is disabled in Kafka Connect deployment, the logging is never updated by Strimzi because we do not do dynamic updates in such cases. This PR updates the Connect reconciliation to roll the Connect Pods in such situations. It does that by using the logging annotation based on the full logging config and not just based on the parts that are not dynamically configurable such as appenders.

It also removes the irrelevant ZooKeeper log level configuration from the default Connect logging configuration (this was removed in Kafka as well).

This should resolve #9986.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md