### PR TITLE
ST: Evenly split components systemtest profile to more closely match with execution time for operators profile

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,7 +64,7 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "regression-components-1"
+    identifier: "regression-brokers-and-operands"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
@@ -79,11 +79,11 @@ jobs:
     tf_extra_params:
       test:
         tmt:
-          name: regression-components-1
+          name: regression-brokers-and-operands
 
   - job: tests
     trigger: pull_request
-    identifier: "regression-components-2"
+    identifier: "regression-brokers-and-operands"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
@@ -98,7 +98,7 @@ jobs:
     tf_extra_params:
       test:
         tmt:
-          name: regression-components-2
+          name: regression-operands
   ###############################################################################################
 
   - job: tests

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,7 +55,6 @@ jobs:
       - regression
       - operators
       - regression-operators
-      - ro
     tf_extra_params:
       test:
         tmt:
@@ -73,9 +72,9 @@ jobs:
     env: { IP_FAMILY: ipv4 }
     labels:
       - regression
-      - components
-      - regression-components
-      - rc
+      - brokers-and-security
+      - regression-brokers-and-security
+      - bas
     tf_extra_params:
       test:
         tmt:
@@ -83,7 +82,7 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "regression-brokers-and-security"
+    identifier: "regression-operands"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
@@ -92,9 +91,8 @@ jobs:
     env: { IP_FAMILY: ipv4 }
     labels:
       - regression
-      - components
-      - regression-components
-      - rc
+      - operands
+      - regression-operands
     tf_extra_params:
       test:
         tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,7 +64,7 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "regression-brokers-and-operands"
+    identifier: "regression-brokers-and-security"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
@@ -79,11 +79,11 @@ jobs:
     tf_extra_params:
       test:
         tmt:
-          name: regression-brokers-and-operands
+          name: regression-brokers-and-security
 
   - job: tests
     trigger: pull_request
-    identifier: "regression-brokers-and-operands"
+    identifier: "regression-brokers-and-security"
     targets:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -385,21 +385,29 @@
         </profile>
 
         <profile>
-            <id>components</id>
+            <id>components-1</id>
             <properties>
                 <skipTests>false</skipTests>
                 <groups>regression</groups>
                 <it.test>
                     kafka/**/*ST,
-                    bridge/**/*ST,
-                    cruisecontrol/**/*ST,
-                    mirrormaker/**/*ST,
-                    connect/**/*ST,
-                    security/**/*ST,
-                    rollingupdate/**/*ST,
-                    watcher/**/*ST,
-                    rollingupdate/**/*ST,
-                    tracing/**/*ST
+                    security/**/*ST
+                </it.test>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>components-2</id>
+            <properties>
+                <skipTests>false</skipTests>
+                <groups>regression</groups>
+                <it.test>
+                    !kafka/**/*ST,
+                    !security/**/*ST,
+                    !operators/**/*ST,
+                    !log/**/*ST,
+                    !metrics/**/*ST,
+                    !specific/**/*ST
                 </it.test>
             </properties>
         </profile>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -385,7 +385,7 @@
         </profile>
 
         <profile>
-            <id>components-1</id>
+            <id>brokers-and-security</id>
             <properties>
                 <skipTests>false</skipTests>
                 <groups>regression</groups>
@@ -397,7 +397,7 @@
         </profile>
 
         <profile>
-            <id>components-2</id>
+            <id>operands</id>
             <properties>
                 <skipTests>false</skipTests>
                 <groups>regression</groups>

--- a/systemtest/tmt/README.md
+++ b/systemtest/tmt/README.md
@@ -24,7 +24,7 @@ plan defines selectors for [tests](./tests) which should be executed.
 * smoke
 * upgrade
 * regression-operators
-* regression-brokers-and-operands
+* regression-brokers-and-security
 * regression-operands
 * sanity
 * performance

--- a/systemtest/tmt/README.md
+++ b/systemtest/tmt/README.md
@@ -24,8 +24,8 @@ plan defines selectors for [tests](./tests) which should be executed.
 * smoke
 * upgrade
 * regression-operators
-* regression-components-1
-* regression-components-2
+* regression-brokers-and-operands
+* regression-operands
 * sanity
 * performance
 * performance-capacity

--- a/systemtest/tmt/README.md
+++ b/systemtest/tmt/README.md
@@ -84,25 +84,26 @@ Run selected jobs by label
 Packit jobs has plenty of available labels that you can use in trigger command.
 The jobs are grouped based on specific use-case.
 
-| Group           | Labels                              | Description                                                             |
-|-----------------|-------------------------------------|-------------------------------------------------------------------------|
-| acceptance      | acceptance                          | Acceptance tests                                                        |
-| acceptance_ipv6 | acceptance_ipv6                     | Acceptance tests with IPv6 configuration for Kube cluster               |
-|                 | ipv6                                |                                                                         |
-| acceptance_dual | acceptance_dual                     | Acceptance tests with dual (IPv4 + IPv6) configuration for Kube cluster |
-|                 | dual                                |                                                                         |
-| upgrade         | upgrade                             | Upgrade tests                                                           |
-| sanity          | sanity                              | Sanity tests (plan with 1h execution time)                              |
-| smoke           | smoke                               | Smoke tests (just one test)                                             |
-| regression      | regression                          | Regression tests (all regression related labels)                        |
-|                 | components                          | Tests related to components (operands)                                  |
-|                 | regression-components               |                                                                         |
-|                 | rc                                  |                                                                         |
-|                 | operators                           | Tests more related to operators                                         |
-|                 | regression-operators                |                                                                         |
-|                 | ro                                  |                                                                         |
-| performance     | performance                         | Performance tests (all performance related labels)                      |
-|                 | performance-common                  | Common performance tests                                                |
-|                 | performance-capacity                | Capacity tests for operators                                            |
-|                 | performance-topic-operator-capacity | Capacity tests for Topic Operator only                                  |
+| Group           | Labels                              | Description                                                                                   |
+|-----------------|-------------------------------------|-----------------------------------------------------------------------------------------------|
+| acceptance      | acceptance                          | Acceptance tests                                                                              |
+| acceptance_ipv6 | acceptance_ipv6                     | Acceptance tests with IPv6 configuration for Kube cluster                                     |
+|                 | ipv6                                |                                                                                               |
+| acceptance_dual | acceptance_dual                     | Acceptance tests with dual (IPv4 + IPv6) configuration for Kube cluster                       |
+|                 | dual                                |                                                                                               |
+| upgrade         | upgrade                             | Upgrade tests                                                                                 |
+| sanity          | sanity                              | Sanity tests (plan with 1h execution time)                                                    |
+| smoke           | smoke                               | Smoke tests (just one test)                                                                   |
+| regression      | regression                          | Regression tests (all regression related labels, operators + operands + brokers-and-security) |
+|                 | operands                            | Tests related to operands                                                                     |
+|                 | regression-operands                 |                                                                                               |
+|                 | brokers-and-security                | Tests related to Kafka Brokers and Security (specific test classes)                           |
+|                 | regression-brokers-and-security     |                                                                                               |
+|                 | bas                                 |                                                                                               |
+|                 | operators                           | Tests more related to operators                                                               |
+|                 | regression-operators                |                                                                                               |
+| performance     | performance                         | Performance tests (all performance related labels)                                            |
+|                 | performance-common                  | Common performance tests                                                                      |
+|                 | performance-capacity                | Capacity tests for operators                                                                  |
+|                 | performance-topic-operator-capacity | Capacity tests for Topic Operator only                                                        |
 

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -165,11 +165,11 @@ finish:
     test:
       - regression-operators
 
-/regression-brokers-and-operands:
+/regression-brokers-and-security:
   summary: Run regression strimzi test suite with kraft
   discover+:
     test:
-      - regression-brokers-and-operands
+      - regression-brokers-and-security
 
 /regression-operands:
   summary: Run regression strimzi test suite with kraft

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -165,17 +165,17 @@ finish:
     test:
       - regression-operators
 
-/regression-components-1:
+/regression-brokers-and-operands:
   summary: Run regression strimzi test suite with kraft
   discover+:
     test:
-      - regression-components-1
+      - regression-brokers-and-operands
 
-/regression-components-2:
+/regression-operands:
   summary: Run regression strimzi test suite with kraft
   discover+:
     test:
-      - regression-components-2
+      - regression-operands
 
 /acceptance:
   summary: Run acceptance strimzi test suite with kraft

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -45,16 +45,14 @@ adjust:
   duration: 12h
   tier: 2
   environment+:
-    TEST_PROFILE: components
-    TESTS: "kafka/**/*ST,security/**/*ST"
+    TEST_PROFILE: components-1
 
 /regression-components-2:
   summary: Run regression strimzi test suite
   duration: 12h
   tier: 2
   environment+:
-    TEST_PROFILE: components
-    TESTS: "!kafka/**/*ST,!security/**/*ST,!operators/**/*ST,!log/**/*ST,!metrics/**/*ST,!specific/**/*ST"
+    TEST_PROFILE: components-2
 
 /acceptance:
   summary: Run acceptance strimzi test suite

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -40,12 +40,12 @@ adjust:
   environment+:
     TEST_PROFILE: operators
 
-/regression-brokers-and-operands:
+/regression-brokers-and-security:
   summary: Run regression strimzi test suite
   duration: 12h
   tier: 2
   environment+:
-    TEST_PROFILE: brokers-and-operands
+    TEST_PROFILE: brokers-and-security
 
 /regression-operands:
   summary: Run regression strimzi test suite

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -40,19 +40,19 @@ adjust:
   environment+:
     TEST_PROFILE: operators
 
-/regression-components-1:
+/regression-brokers-and-operands:
   summary: Run regression strimzi test suite
   duration: 12h
   tier: 2
   environment+:
-    TEST_PROFILE: components-1
+    TEST_PROFILE: brokers-and-operands
 
-/regression-components-2:
+/regression-operands:
   summary: Run regression strimzi test suite
   duration: 12h
   tier: 2
   environment+:
-    TEST_PROFILE: components-2
+    TEST_PROFILE: operands
 
 /acceptance:
   summary: Run acceptance strimzi test suite


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
Currently we have two main testing profiles in systemtest package pom's - `components` and `operators`. `operators` execution time is around 7h without running in parallel. `components` takes around 16h so I decided to split it into two different profiles - `brokers-and-security and `operands`, same way as we already have for TF pipelines. The execution time for all three profiles should be more or less the same now. 

### Checklist

- [x] Make sure all tests pass

