### PR TITLE
Add Cruise Control restart comment to the Topic Operator

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/ReplicasChangeHandler.java
@@ -137,6 +137,7 @@ public class ReplicasChangeHandler {
             UserTasksResponse utr = cruiseControlClient.userTasks(groupByUserTaskId.keySet());
             if (utr.userTasks().isEmpty()) {
                 // Cruise Control restarted: reset the state because the tasks queue is not persisted
+                // this may also happen when the tasks' retention time expires, or the cache becomes full
                 updateToPending(result, "Task not found, Resetting the state");
             } else {
                 for (var userTask : utr.userTasks()) {


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This trivial PR just adds a comment to the `ReplicasChangeHandler` to add other cases that could produce an empty user tasks list.


