### PR TITLE
Unify different logging annotations

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -191,11 +191,11 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                     if (useConnectorResources) {
                         // When connector resources are used, we do dynamic configuration update, and we need the hash to
                         // contain only settings that cannot be updated dynamically
-                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     } else {
                         // When connector resources are not used, we do not do dynamic logging updates, and we need the
                         // hash to cover complete logging configuration
-                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(logging));
+                        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(logging));
                     }
 
                     desiredLogging.set(logging);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -133,7 +133,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
                 .compose(i -> generateMetricsAndLoggingConfigMap(reconciliation, mirrorMaker2Cluster))
                 .compose(logAndMetricsConfigMap -> {
                     String logging = logAndMetricsConfigMap.getData().get(mirrorMaker2Cluster.logging().configMapKey());
-                    podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
+                    podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(Util.getLoggingDynamicallyUnmodifiableEntries(logging)));
                     desiredLogging.set(logging);
                     return configMapOperations.reconcile(reconciliation, namespace, logAndMetricsConfigMap.getMetadata().getName(), logAndMetricsConfigMap);
                 })

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationException;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.model.StatusUtils;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
@@ -105,7 +106,7 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> MetricsAndLoggingUtils.metricsAndLogging(reconciliation, configMapOperations, mirror.logging(), mirror.metrics()))
                 .compose(metricsAndLoggingCm -> {
                     ConfigMap logAndMetricsConfigMap = mirror.generateMetricsAndLogConfigMap(metricsAndLoggingCm);
-                    annotations.put(Annotations.STRIMZI_LOGGING_ANNOTATION, logAndMetricsConfigMap.getData().get(mirror.logging().configMapKey()));
+                    annotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, Util.hashStub(logAndMetricsConfigMap.getData().get(mirror.logging().configMapKey())));
                     return configMapOperations.reconcile(reconciliation, namespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(reconciliation.name()), logAndMetricsConfigMap);
                 })
                 .compose(i -> podDisruptionBudgetOperator.reconcile(reconciliation, namespace, mirror.getComponentName(), mirror.generatePodDisruptionBudget()))

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -769,7 +769,7 @@ public class KafkaReconciler {
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, String.valueOf(this.clusterCa.caCertGeneration()));
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, String.valueOf(this.clusterCa.caKeyGeneration()));
         podAnnotations.put(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, String.valueOf(this.clientsCa.caCertGeneration()));
-        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH, brokerLoggingHash.get(nodeId));
+        podAnnotations.put(Annotations.ANNO_STRIMZI_LOGGING_HASH, brokerLoggingHash.get(nodeId));
         podAnnotations.put(KafkaCluster.ANNO_STRIMZI_BROKER_CONFIGURATION_HASH, brokerConfigurationHash.get(nodeId));
         podAnnotations.put(ANNO_STRIMZI_IO_KAFKA_VERSION, kafka.getKafkaVersion().version());
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithPoolsKRaftMockTest.java
@@ -305,14 +305,14 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
                     assertThat(spsControllers, is(notNullValue()));
 
                     spsControllers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
-                        loggingConfigurationAnnos.put(pod.getMetadata().getName(), pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH));
+                        loggingConfigurationAnnos.put(pod.getMetadata().getName(), pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH));
                     });
 
                     StrimziPodSet spsBrokers = supplier.strimziPodSetOperator.client().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers").get();
                     assertThat(spsBrokers, is(notNullValue()));
 
                     spsBrokers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
-                        loggingConfigurationAnnos.put(pod.getMetadata().getName(), pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH));
+                        loggingConfigurationAnnos.put(pod.getMetadata().getName(), pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH));
                     });
 
                     // Update Kafka and change the log level => only controller pod annotations should change
@@ -326,7 +326,7 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
 
                     spsControllers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                         // Controller annotations should differ
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
                     });
 
                     StrimziPodSet spsBrokers = supplier.strimziPodSetOperator.client().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers").get();
@@ -334,7 +334,7 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
 
                     spsBrokers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                         // Broker annotations should be the same
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is(loggingConfigurationAnnos.get(pod.getMetadata().getName())));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is(loggingConfigurationAnnos.get(pod.getMetadata().getName())));
                     });
 
                     // Update Kafka and change appender => both controller and broker pod annotations should change
@@ -348,7 +348,7 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
 
                     spsControllers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                         // Controller annotations should differ
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
                     });
 
                     StrimziPodSet spsBrokers = supplier.strimziPodSetOperator.client().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers").get();
@@ -356,7 +356,7 @@ public class KafkaAssemblyOperatorWithPoolsKRaftMockTest {
 
                     spsBrokers.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
                         // Broker annotations should differ
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is(not(loggingConfigurationAnnos.get(pod.getMetadata().getName()))));
                     });
 
                     async.flag();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -217,7 +217,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
                     PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("6e428c4f"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is("6e428c4f"));
                     });
 
                     // Verify services => one regular and one headless
@@ -354,7 +354,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
                     PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("06ee78c4"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is("06ee78c4"));
                     });
 
                     // Verify services => one regular and one headless
@@ -1099,7 +1099,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
                     PodSetUtils.podSetToPods(podSet).forEach(pod -> {
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("8a7507b8"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is("8a7507b8"));
                     });
 
                     // NetworkPolicies => No Connector Operator, no policy is created
@@ -1224,7 +1224,7 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
                     assertThat(podSet.getMetadata().getName(), is(COMPONENT_NAME));
                     assertThat(podSet.getSpec().getPods().size(), is(3));
                     PodSetUtils.podSetToPods(podSet).forEach(pod -> {
-                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_APPENDERS_HASH), is("06ee78c4"));
+                        assertThat(pod.getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_LOGGING_HASH), is("06ee78c4"));
                     });
 
                     // NetworkPolicies => No Connector Operator, no policy is created

--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -30,20 +30,10 @@ public class Annotations extends ResourceAnnotations {
     public static final String ANNO_STRIMZI_SERVER_CERT_HASH = STRIMZI_DOMAIN + "server-cert-hash";
 
     /**
-     * Strimzi logging annotation
-     */
-    public static final String STRIMZI_LOGGING_ANNOTATION = STRIMZI_DOMAIN + "logging";
-
-    /**
-     * Annotations for rolling a cluster whenever the logging (or it's part) has changed.
-     * By changing the annotation we force a restart since the pod will be out of date compared to the StrimziPodSet.
+     * Annotation for tracking changes to logging configurations which cannot be changed dynamically. By changing the
+     * annotation we force a restart of the pods managed by StrimziPodSets or Deployments.
      */
     public static final String ANNO_STRIMZI_LOGGING_HASH = STRIMZI_DOMAIN + "logging-hash";
-
-    /**
-     * Annotation for tracking changes to logging appenders which cannot be changed dynamically
-     */
-    public static final String ANNO_STRIMZI_LOGGING_APPENDERS_HASH = STRIMZI_DOMAIN + "logging-appenders-hash";
 
     /**
      * Annotation for tracking authentication changes


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Currently, we have three different annotations used to help trigger rolling updates when logging configuration changes:
1) `strimzi.io/logging` is used in Mirror Maker (1) and uses a full logging configuration as a value
2) `strimzi.io/logging-hash` is used in ZooKeeper and contains a hash stub of the logging configuration
3) `strimzi.io/logging-appenders-hash` is used in all other operands. For Kafka nodes with broker role, MM2, Connect with enabled connector operator it contains a hash-stub of appender configurations from the logging configuration (since loggers can be configured dynamically in these cases). For Kafka controller-only nodes and for Connect without connector operator, this annotation actually contains the hash-stub of the full logging configuration (since in these cases, dynamic updates are not supported).

_(Note: Other components such as Bridge, CC, TO and UO use Log4j2 with automatic log reloading, KE is Golang based and has completely different logging configuration)_

This PR unifies the annotations and uses `strimzi.io/logging-hash` everywhere (as originally suggested by @ppatierno in #10209). For ZooKeeper, the content has been changed to be a hash stub as well instead of having the full logging config in the annotation. For the other components, the value of the annotation is not changed.

As part of the change to the `KafkaMirrorMakerAssemblyOperatorTest`, I also removed some unused fields.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally