### PR TITLE
[DOC] Don't suggest that the `tls` flag in listener configuration has a default value

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
@@ -263,11 +263,8 @@ spec:
 = `tls`
 
 The TLS property is required.
-
-By default, TLS encryption is not enabled.
 To enable it, set the `tls` property to `true`.
-
-For `route` and `ingress` type listeners, TLS encryption must be enabled.
+For `route` and `ingress` type listeners, TLS encryption must be always enabled.
 
 = `authentication`
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
@@ -263,7 +263,7 @@ spec:
 = `tls`
 
 The TLS property is required.
-To enable it, set the `tls` property to `true`.
+To enable TLS encryption, set the `tls` property to `true`.
 For `route` and `ingress` type listeners, TLS encryption must be always enabled.
 
 = `authentication`

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -143,7 +143,7 @@ spec:
 <9> Name to identify the listener. Must be unique within the Kafka cluster.
 <10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <11> Listener type specified as `internal` or `cluster-ip` (to expose Kafka using per-broker `ClusterIP` services), or for external listeners, as `route` (OpenShift only), `loadbalancer`, `nodeport` or `ingress` (Kubernetes only).
-<12> Enables or disables TLS encryption for each listener. For `route` and `ingress` type listeners, TLS encryption must be always enabled.
+<12> Enables or disables TLS encryption for each listener. For `route` and `ingress` type listeners, TLS encryption must always be enabled by setting it to `true`.
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0.
 <15> External listener configuration specifies how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`.

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -143,7 +143,7 @@ spec:
 <9> Name to identify the listener. Must be unique within the Kafka cluster.
 <10> Port number used by the listener inside Kafka. The port number has to be unique within a given Kafka cluster. Allowed port numbers are 9092 and higher with the exception of ports 9404 and 9999, which are already used for Prometheus and JMX. Depending on the listener type, the port number might not be the same as the port number that connects Kafka clients.
 <11> Listener type specified as `internal` or `cluster-ip` (to expose Kafka using per-broker `ClusterIP` services), or for external listeners, as `route` (OpenShift only), `loadbalancer`, `nodeport` or `ingress` (Kubernetes only).
-<12> Enables TLS encryption for each listener. Default is `false`. TLS encryption has to be enabled, by setting it to `true`, for `route` and `ingress` type listeners.
+<12> Enables or disables TLS encryption for each listener. For `route` and `ingress` type listeners, TLS encryption must be always enabled.
 <13> Defines whether the fully-qualified DNS names including the cluster service suffix (usually `.cluster.local`) are assigned.
 <14> Listener authentication mechanism specified as mTLS, SCRAM-SHA-512, or token-based OAuth 2.0.
 <15> External listener configuration specifies how the Kafka cluster is exposed outside Kubernetes, such as through a `route`, `loadbalancer` or `nodeport`.


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The `tls` field in the listener configuration is a required option. So the docs should not suggest that it has a default value. This PR fixes it in two different places where we mention it probably as a copy-paste from the old versions with different listener configuration.

### Checklist

- [x] Update documentation