### PR TITLE
Address some build warnings with deprecations or unchecked casts

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java
@@ -50,6 +50,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
         + "webserver.http.cors.origin, webserver.http.cors.exposeheaders, webserver.security.enable, webserver.ssl.enable";
 
     private String image;
+    @SuppressWarnings("deprecation")  // TLS Sidecar is not used anymore and is deprecated
     private TlsSidecar tlsSidecar;
     private ResourceRequirements resources;
     private Probe livenessProbe;
@@ -82,6 +83,7 @@ public class CruiseControlSpec implements HasConfigurableMetrics, HasConfigurabl
         return tlsSidecar;
     }
 
+    @Deprecated
     public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/entityoperator/EntityOperatorSpec.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public class EntityOperatorSpec implements UnknownPropertyPreserving {
     private EntityTopicOperatorSpec topicOperator;
     private EntityUserOperatorSpec userOperator;
+    @SuppressWarnings("deprecation") // TLS Sidecar is not used anymore and is deprecated
     private TlsSidecar tlsSidecar;
     private EntityOperatorTemplate template;
     private Map<String, Object> additionalProperties;
@@ -63,6 +64,7 @@ public class EntityOperatorSpec implements UnknownPropertyPreserving {
         return tlsSidecar;
     }
 
+    @Deprecated
     public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
     }

--- a/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
+++ b/api/src/main/java/io/strimzi/plugin/security/profiles/impl/RestrictedPodSecurityProvider.java
@@ -66,11 +66,6 @@ public class RestrictedPodSecurityProvider extends BaselinePodSecurityProvider {
     }
 
     @Override
-    public SecurityContext entityOperatorTlsSidecarContainerSecurityContext(ContainerSecurityProviderContext context) {
-        return createRestrictedContainerSecurityContext(context);
-    }
-
-    @Override
     public SecurityContext kafkaExporterContainerSecurityContext(ContainerSecurityProviderContext context) {
         return createRestrictedContainerSecurityContext(context);
     }

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -239,26 +239,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.version}</version>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <useIncrementalCompilation>false</useIncrementalCompilation>
-                            <compilerArgs combine.self="override">
-                                <arg>-Xlint:deprecation</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven.javadoc.version}</version>
                 <configuration>

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.systemtest;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.Service;
@@ -429,7 +430,7 @@ public class Environment {
                 Paths.get(System.getProperty("user.dir"), "config.yaml").toAbsolutePath().toString());
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         try {
-            return mapper.readValue(new File(config), Map.class);
+            return mapper.readValue(new File(config), new TypeReference<>() { });
         } catch (IOException ex) {
             LOGGER.info("Yaml configuration not provider or not exists");
             return Collections.emptyMap();

--- a/systemtest/src/main/java/io/strimzi/systemtest/performance/report/BasePerformanceReporter.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/performance/report/BasePerformanceReporter.java
@@ -101,6 +101,7 @@ public abstract class BasePerformanceReporter {
         writePerformanceMetricsToFile(testPerformanceData, performanceLogFilePath);
 
         // Assuming serializeMetricsHistory handles serialization of the metrics history within the map
+        @SuppressWarnings("unchecked")
         Map<Long, Map<String, List<Double>>> metricsHistory = (Map<Long, Map<String, List<Double>>>) performanceAttributes.get(PerformanceConstants.METRICS_HISTORY);
         if (metricsHistory != null) {
             serializeMetricsHistory(metricsHistory, performanceLogFilePath);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
@@ -260,6 +260,7 @@ public class VerificationUtils {
      * @param clusterName Name of the cluster linked with configmaps
      * @param additionalClusterName Name of the second cluster - used mainly for source + target cluster verification
      */
+    @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
     public static void verifyConfigMapsLabels(String namespaceName, String clusterName, String additionalClusterName) {
         LOGGER.info("Verifying labels for Config maps");
 
@@ -311,6 +312,7 @@ public class VerificationUtils {
      * @param namespaceName Namespace name where service accounts are located
      * @param clusterName Name of the cluster linked with service accounts
      */
+    @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
     public static void verifyServiceAccountsLabels(String namespaceName, String clusterName) {
         LOGGER.info("Verifying labels for Service Accounts");
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaConnectorUtils.java
@@ -121,6 +121,7 @@ public class KafkaConnectorUtils {
 
     public static String getConnectorTaskState(String namespaceName, String connectorName, int taskId) {
         KafkaConnectorStatus connectorState = KafkaConnectorResource.kafkaConnectorClient().inNamespace(namespaceName).withName(connectorName).get().getStatus();
+        @SuppressWarnings("unchecked")
         Map<String, Object> connectorTask = ((ArrayList<Map<String, Object>>) connectorState.getConnectorStatus().get("tasks")).stream().filter(conn -> conn.get("id").equals(taskId)).collect(Collectors.toList()).get(0);
         return  (String) connectorTask.get("state");
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR addresses some deprecation and unchecked warnings in the `api` and `systemtests` modules. It fixes some of them and use supression on some of the others. It also updates the `systemtest` compilation to fail on deprecations or unchecked casts to at least make everyone think whether what they do is really correct. This cannot be done for the `api` module because of the generated classes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally