### PR TITLE
[helm] add kafkanodepools to RBAC AggregateRoles

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/070-ClusterRole-strimzi-admin.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/070-ClusterRole-strimzi-admin.yaml
@@ -17,6 +17,8 @@ rules:
       - "kafka.strimzi.io"
     resources:
       - kafkas
+      - kafkanodepools
+      - kafkanodepools/scale
       - kafkaconnects
       - kafkaconnects/scale
       - kafkamirrormakers

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/080-ClusterRole-strimzi-view.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/080-ClusterRole-strimzi-view.yaml
@@ -16,6 +16,7 @@ rules:
       - "kafka.strimzi.io"
     resources:
       - kafkas
+      - kafkanodepools
       - kafkaconnects
       - kafkamirrormakers
       - kafkausers


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds missing kafkanodepools to the Aggregation roles view and admin.

For the view role I've used https://github.com/strimzi/strimzi-kafka-operator/blob/main/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml#L15 as reference 

and https://github.com/strimzi/strimzi-kafka-operator/blob/main/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml#L15 and https://github.com/strimzi/strimzi-kafka-operator/blob/main/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml#L35 as reference for the admin role

### Checklist

- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally (not from pod but from view/admin roles)
- [ ] Update CHANGELOG.md


