### PR TITLE
feat(example,metrics): kube-state-metrics to monitor custom resource …

### DIFF
--- a/packaging/examples/metrics/kube-state-metrics/README.md
+++ b/packaging/examples/metrics/kube-state-metrics/README.md
@@ -1,0 +1,12 @@
+# Custom resource monitoring
+
+## Usage
+
+For deploying the monitoring of custom resources (CR) the [kube-state-metrics Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) is used.
+This assumes that [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is used.
+
+```
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm upgrade --install [RELEASE_NAME] prometheus-community/kube-state-metrics -f kube-state-metrics-values.yaml
+```

--- a/packaging/examples/metrics/kube-state-metrics/kube-state-metrics-values.yaml
+++ b/packaging/examples/metrics/kube-state-metrics/kube-state-metrics-values.yaml
@@ -1,0 +1,91 @@
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml
+prometheus:
+  monitor:
+    enabled: true
+collectors: []
+extraArgs:
+  - --custom-resource-state-only=true
+rbac:
+  extraRules:
+    - apiGroups:
+        - kafka.strimzi.io
+      resources:
+        - kafkatopics
+        - kafkausers
+      verbs: [ "list", "watch" ]
+customResourceState:
+  enabled: true
+  config:
+    spec:
+      resources:
+        - groupVersionKind:
+            group: kafka.strimzi.io
+            version: v1beta2
+            kind: KafkaTopic
+          metricNamePrefix: strimzi_kafka_topic
+          metrics:
+            - name: "resource_info"
+              help: "The current state of a Strimzi kafka topic resource"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                partitions: [ spec, partitions ]
+                replicas: [ spec, replicas ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                generation: [ status, observedGeneration ]
+                topicId: [ status, topicId ]
+                topicName: [ status, topicName ]
+        - groupVersionKind:
+            group: kafka.strimzi.io
+            version: v1beta2
+            kind: KafkaUser
+          metricNamePrefix: strimzi_kafka_user
+          metrics:
+            - name: "resource_info"
+              help: "The current state of a Strimzi kafka user resource"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                deprecated: [ status, conditions, "[reason=DeprecatedFields]", type ]
+                secret: [ status, secret ]
+                generation: [ status, observedGeneration ]
+                username: [ status, username ]
+extraManifests:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+      name: strimzi-kube-state-metrics
+    spec:
+      groups:
+        - name: strimzi-kube-state-metrics
+          rules:
+            - alert: KafkaUserDeprecated
+              expr: strimzi_kafka_user_resource_info{deprecated="Warning"}
+              for: 15m
+              labels:
+                severity: warning
+              annotations:
+                message: 'Strimzi Kafka User {{`{{ $labels.username }}`}} has a deprecated configuration'
+            - alert: KafkaUserNotReady
+              expr: strimzi_kafka_user_resource_info{ready!="True"}
+              for: 15m
+              labels:
+                severity: warning
+              annotations:
+                message: 'Strimzi Kafka User {{`{{ $labels.username }}`}} is not ready'
+            - alert: KafkaTopicNotReady
+              expr: strimzi_kafka_topic_resource_info{ready!="True"}
+              for: 15m
+              labels:
+                severity: warning
+              annotations:
+                message: 'Strimzi Kafka Topic {{`{{ $labels.topicName }}`}} is not ready'


### PR DESCRIPTION
…state

In order to monitor the state of custom resources (CR) inside of the Kubernetes cluster, kube-state-metrics can be deployed. This describes the deployment using the prometheus-community Helm chart.

Issue: https://github.com/strimzi/strimzi-kafka-operator/issues/10276

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

In order to monitor the state of custom resources (CR) inside of the Kubernetes cluster, kube-state-metrics can be deployed. This describes the deployment using the prometheus-community Helm chart.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

