### PR TITLE
Fix pushing of artifacts to Nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
+set -e
+
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
+
+# Run the cleanup on failure / exit
+trap cleanup EXIT
 
 export GPG_TTY=$(tty)
-
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn -B $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl ./,crd-annotations,crd-generator,test,api -P ossrh deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
         <maven.enforcer.version>3.0.0-M2</maven.enforcer.version>
         <maven.jar.version>3.1.0</maven.jar.version>
-        <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
+        <sonatype.nexus.staging.version>1.7.0</sonatype.nexus.staging.version>
         <maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
         <maven.jacoco.version>0.8.12</maven.jacoco.version>
         <maven.exec.version>3.1.0</maven.exec.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some changes at Sonatype broker the way we push the JAR artifacts to Sonatype Nexus. This PR fixes it by updating the Sonatype plugin. It also updates the script we use for it to make it fail in case of problems.