### PR TITLE
Add NodeIds in KafkaNodePool printer columns

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePool.java
@@ -59,7 +59,12 @@ import java.util.Map;
                                 name = "Roles",
                                 description = "Roles of the nodes in the pool",
                                 jsonPath = ".status.roles",
-                                type = "string")
+                                type = "string"),
+                    @Crd.Spec.AdditionalPrinterColumn(
+                        name = "NodeIds",
+                        description = "Node IDs used by Kafka nodes in this pool",
+                        jsonPath = ".status.nodeIds",
+                        type = "string")
                 }
         )
 )

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -38,6 +38,10 @@ spec:
       description: Roles of the nodes in the pool
       jsonPath: .status.roles
       type: string
+    - name: NodeIds
+      description: Node IDs used by Kafka nodes in this pool
+      jsonPath: .status.nodeIds
+      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -38,6 +38,10 @@ spec:
       description: Roles of the nodes in the pool
       jsonPath: .status.roles
       type: string
+    - name: NodeIds
+      description: Node IDs used by Kafka nodes in this pool
+      jsonPath: .status.nodeIds
+      type: string
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

Add a new printer column for KafkaNodePool objects: NodeIds.

### Checklist

- [ ] Make sure all tests pass
- [ ] Update CHANGELOG.md
