### PR TITLE
Make sure Helm Unit tests work even for releases

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/tests/operator_deployment_test.yaml
@@ -46,9 +46,9 @@ tests:
     asserts:
       - isKind:
           of: Deployment
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: quay.io/strimzi/operator:latest
+          pattern: 'quay.io/strimzi/operator:(latest|[0-9]+\.[0-9]+\.[0-9]+)'
 
   - it: should have custom image if details are provided
     set:
@@ -128,22 +128,22 @@ tests:
           value: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
       - matchRegex:
           path: spec.template.spec.containers[0].env[3].value
-          pattern: 'quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: 'quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
       - matchRegex:
           path: spec.template.spec.containers[0].env[4].value
-          pattern: 'quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: 'quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
       - matchRegex:
           path: spec.template.spec.containers[0].env[5].value
-          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
       - matchRegex:
           path: spec.template.spec.containers[0].env[6].value
-          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
       - matchRegex:
           path: spec.template.spec.containers[0].env[7].value
-          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
       - matchRegex:
           path: spec.template.spec.containers[0].env[8].value
-          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:latest-kafka-[0-9]+\.[0-9]+\.[0-9]+'
+          pattern: '[0-9]+\.[0-9]+\.[0-9]+=quay.io/strimzi/kafka:(latest|[0-9]+\.[0-9]+\.[0-9]+)-kafka-[0-9]+\.[0-9]+\.[0-9]+'
 
   - it: should construct custom kafka images from specified image registry if provided
     set:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Helm Chart unit tests currently don't work in releases because they have hardcoded `:latest` version for container images. This PR updates the tests to use a regex that either accepts `:latest` or a particular version such as `0.42.0`. This should allow the tests to pass. 

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally