### PR TITLE
Fix Migration system test pipeline to not skip all tests

### DIFF
--- a/.azure/templates/jobs/system-tests/migration_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/migration_jobs.yaml
@@ -5,6 +5,7 @@ jobs:
       display_name: 'migration-bundle'
       profile: 'azp_migration'
       cluster_operator_install_type: 'bundle'
+      strimzi_use_kraft_in_tests: "true"
       timeout: 240
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, the Migration system test pipeline skips all tests because it is missing the `strimzi_use_kraft_in_tests` flag that is checked as an assumption in the `MigrationST` class.