### PR TITLE
Fix the Helm Chart release pipeline to ignore the state of container push with suffix

### DIFF
--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -69,7 +69,7 @@ stages:
     displayName: Publish Helm Chart as OCI artifact
     dependsOn:
       - containers_publish
-    condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
+    condition: and(in(dependencies.containers_publish, 'Succeeded', 'SucceededWithIssues'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'))
     jobs:
       - template: 'templates/jobs/build/publish_helm_chart_as_oci.yaml'
         parameters:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #10112, we reordered the release pipeline to push the Helm Chart to the OCI registry only at the end. But we kept the condition as `succeeded()` which means that it is run when all previous steps ended as `Succeeded` or `SucceededWithIssues`. So when we run the release pipeline with for an RC and the `containers_publish_with_suffix` stage is skipped, the Helm Chart is not pushed to the OCI registry. This PR should address it by linking the condition only to the result of the `containers_publish` stage instead of using `succeeding()` and fix the dependency issue.