### PR TITLE
docs(format): updates asciidoc format for config examples

### DIFF
--- a/documentation/modules/configuring/con-config-mirrormaker.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker.adoc
@@ -19,7 +19,7 @@ The `KafkaMirrorMaker` resource will be removed from Strimzi when we adopt Apach
 As a replacement, use the `KafkaMirrorMaker2` custom resource with the xref:unidirectional_replication_activepassive[`IdentityReplicationPolicy`].
 
 .Example `KafkaMirrorMaker` custom resource configuration
-[source,yaml,subs="+quotes,attributes"]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaMirrorMakerApiVersion}
 kind: KafkaMirrorMaker
@@ -34,8 +34,8 @@ spec:
     offsetCommitInterval: 120000 # <5>
     tls: # <6>
       trustedCertificates:
-      - secretName: my-source-cluster-ca-cert
-        pattern: "*.crt"
+        - secretName: my-source-cluster-ca-cert
+          pattern: "*.crt"
     authentication: # <7>
       type: tls
       certificateAndKey:
@@ -50,8 +50,8 @@ spec:
     abortOnSendFailure: false # <9>
     tls:
       trustedCertificates:
-      - secretName: my-target-cluster-ca-cert
-        pattern: "*.crt"
+        - secretName: my-target-cluster-ca-cert
+          pattern: "*.crt"
     authentication:
       type: tls
       certificateAndKey:

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -74,7 +74,7 @@ You can tune the configuration to handle high volumes of messages.
 For more information, see xref:con-high-volume-config-properties-{context}[Handling high volumes of messages].
 
 .Example `KafkaMirrorMaker2` custom resource configuration
-[source,yaml,subs="+quotes,attributes"]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaMirrorMaker2ApiVersion}
 kind: KafkaMirrorMaker2
@@ -95,8 +95,8 @@ spec:
     bootstrapServers: my-cluster-source-kafka-bootstrap:9092 # <7>
     tls: # <8>
       trustedCertificates:
-      - pattern: "*.crt"
-        secretName: my-cluster-source-cluster-ca-cert
+        - pattern: "*.crt"
+          secretName: my-cluster-source-cluster-ca-cert
   - alias: "my-cluster-target" # <9>
     authentication: # <10>
       certificateAndKey:
@@ -111,8 +111,8 @@ spec:
       status.storage.replication.factor: 1
     tls: # <13>
       trustedCertificates:
-      - pattern: "*.crt"
-        secretName: my-cluster-target-cluster-ca-cert
+        - pattern: "*.crt"
+          secretName: my-cluster-target-cluster-ca-cert
   mirrors: # <14>
   - sourceCluster: "my-cluster-source" # <15>
     targetCluster: "my-cluster-target" # <16>


### PR DESCRIPTION
**Documentation**

Format fix for asciidoc.
Examples were not rendering correctly due to the interpretation of the asterisk in certificate pattern config examples.
Fixed by removing `quotes` to control formatting in affected examples.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

