### PR TITLE
Add `super.users` to controller relevant options

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -186,6 +186,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
             "ssl.truststore.location",
             "ssl.truststore.password",
             "ssl.truststore.type",
+            "super.users",
             "transaction.state.log.min.isr",
             "transaction.state.log.replication.factor",
             "queued.max.requests",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some Admin API queries such as `describeMetadataQuorum` seem to be executed and authorized on the controller nodes even when the Admin API is connected to a broker. But currently, we do not roll controller nodes when the `super.users` field changes. That means that even through a user is configured as super user, it still gets ACL denied because the controller is not aware of this.

This Pr adds the `super.users` option to the controller-relevant configuration options to make sure the contoller nodes are roled when it changes. That should help us to avoid such confusing issues as described above when super users is denied something by ACLs.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally