### PR TITLE
Use correct version of Strimzi Quotas plugin in Kafka 3.7.1 image

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
@@ -20,7 +20,7 @@
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
-        <kafka-quotas-plugin.version>0.2.0</kafka-quotas-plugin.version>
+        <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Kafka 3.7.1 container image is not using the right version of the Strimzi Quotas plugin as the 3.7.1. This PR updates it to the correct version (0.3.1).

This should be cherry-picked into the 0.42.x release branch and used for 0.42.0-rc2

### Checklist

- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally