### PR TITLE
Add unregistering Kafka nodes to known KRaft limitations

### DIFF
--- a/documentation/assemblies/deploying/assembly-kraft-mode.adoc
+++ b/documentation/assemblies/deploying/assembly-kraft-mode.adoc
@@ -57,6 +57,7 @@ Currently, the KRaft mode in Strimzi has the following major limitations:
 It is considered early-access in Apache Kafka 3.7.x.
 (Storage with `type: jbod` configuration can be used also with older Kafka versions, but the JBOD array can contain only one disk.)
 * Scaling of KRaft controller nodes up or down is not supported.
+* Unregistering Kafka nodes removed from the Kafka cluster.
 
 NOTE: If you are using JBOD storage, you can xref:ref-jbod-storage-str[change the volume that stores the metadata log]. 
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR adds the unregistering of Kafka nodes to the KRaft limitations. As we will be doing RC2 of Strimzi 0.42.0, we should backport this to 0.42.x release branch.

### Checklist

- [x] Update documentation