### PR TITLE
Remove the GitHub comment feature as it doesn't work with PRs from forks

### DIFF
--- a/.azure/templates/jobs/build/build_strimzi.yaml
+++ b/.azure/templates/jobs/build/build_strimzi.yaml
@@ -58,33 +58,8 @@ jobs:
         displayName: "Run Shellcheck"
       - bash: "make release_files_check"
         displayName: "Check released files"
-      - task: GitHubComment@0
-        displayName: "Comment on the PR for forbidden release file changes"
-        condition: failed()
-        inputs:
-          gitHubConnection: strimzi
-          comment: >
-              This PR contains forbidden changes to the `examples/`, `install/`, or `helm-chart/` directories.
-              These directories can be updated only as part of a Strimzi release.
-              Any other changes to examples, installation files, or to the Helm chart should be done in the `packaging/` directory.
       - bash: ".azure/scripts/uncommitted-changes.sh"
         displayName: "Check for uncommitted files"
-      - task: GitHubComment@0
-        displayName: "Comment on the PR for uncommitted files"
-        condition: failed()
-        inputs:
-          gitHubConnection: strimzi
-          comment: |
-            This PR contains uncommitted changes to the generated files in the `packaging/`, `documentation/`, `cluster-operator/src/main/resources/cluster-roles`, or `api/src/test/resources/io/strimzi/api/kafka/model` directories.
-            To fix this, please run the following command:
-            ```
-            mvn clean verify -DskipTests -DskipITs \
-                && make crd_install \
-                && make dashboard_install \
-                && make helm_install \
-                && git add packaging/install/ packaging/helm-charts/ documentation/modules/appendix_crds.adoc cluster-operator/src/main/resources/cluster-roles \
-                && git commit -s -m 'Update derived resources'
-            ```
 
       # We have to TAR the artifacts directory and store it
       - bash: tar -cvpf binaries.tar ./docker-images/artifacts/binaries


### PR DESCRIPTION
### Type of change

- Task

### Description

Unfortunately, the comments from Azure CI that I added in #10242 when some forbidden changes are done do not work for PRs from forks 🤦. So I think we can remove it again because it would be just a maintenance effort without much value as all the people who can open PRs directly from the main repo should know what not to change :-(.