### PR TITLE
Add warning about Mirror Maker 1 deprecation and removal

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <p>Assembly operator for a "Kafka Mirror Maker" assembly, which manages:</p>
@@ -124,6 +125,10 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                 .compose(i -> mirrorHasZeroReplicas ? Future.succeededFuture() : deploymentOperations.readiness(reconciliation, namespace, mirror.getComponentName(), 1_000, operationTimeoutMs))
                 .onComplete(reconciliationResult -> {
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult.cause());
+
+                        // Add warning about Mirror Maker 1 being deprecated and removed soon
+                        LOGGER.warnCr(reconciliation, "Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2.");
+                        StatusUtils.addConditionsToStatus(kafkaMirrorMakerStatus, Set.of(StatusUtils.buildWarningCondition("MirrorMaker1Deprecation", "Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2.")));
 
                         kafkaMirrorMakerStatus.setReplicas(mirror.getReplicas());
                         kafkaMirrorMakerStatus.setLabelSelector(mirror.getSelectorLabels().toSelectorString());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -172,8 +172,13 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 KafkaMirrorMaker mm = capturedMM.get(0);
                 assertThat(mm.getStatus().getReplicas(), is(mirror.getReplicas()));
                 assertThat(mm.getStatus().getLabelSelector(), is(mirror.getSelectorLabels().toSelectorString()));
+                assertThat(mm.getStatus().getConditions().size(), is(2));
                 assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready"));
                 assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
+                assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
+                assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
+                assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
+                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
 
                 async.flag();
             })));
@@ -644,9 +649,14 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 List<KafkaMirrorMaker> capturedMM = statusCaptor.getAllValues();
                 assertThat(capturedMM, hasSize(1));
                 KafkaMirrorMaker mm = capturedMM.get(0);
+                assertThat(mm.getStatus().getConditions().size(), is(2));
                 assertThat(mm.getStatus().getConditions().get(0).getType(), is("NotReady"));
                 assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
                 assertThat(mm.getStatus().getConditions().get(0).getMessage(), is(failureMsg));
+                assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
+                assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
+                assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
+                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
 
                 async.flag();
             })));
@@ -696,7 +706,18 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                     // 0 Replicas - readiness should never get called.
                     verify(mockDcOps, never()).readiness(any(), anyString(), anyString(), anyLong(), anyLong());
 
-                    assertThat(mirrorMakerCaptor.getValue().getStatus().getConditions().get(0).getType(), is("Ready"));
+                    List<KafkaMirrorMaker> capturedMM = mirrorMakerCaptor.getAllValues();
+                    assertThat(capturedMM, hasSize(1));
+                    KafkaMirrorMaker mm = capturedMM.get(0);
+
+                    assertThat(mm.getStatus().getConditions().size(), is(2));
+                    assertThat(mm.getStatus().getConditions().get(0).getType(), is("Ready"));
+                    assertThat(mm.getStatus().getConditions().get(0).getStatus(), is("True"));
+                    assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
+                    assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
+                    assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
+                    assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
+
                     async.flag();
                 })));
     }


### PR DESCRIPTION
### Type of change

- Task

### Description

As Mirror Maker 1 is reaching its end, we should start pushing users to stop using it and move to MM2. This PR adds log warning and a warning condition about this.

Log warning:
```
2024-07-11 11:35:17 INFO  AbstractOperator:264 - Reconciliation #12(timer) KafkaMirrorMaker(myproject/my-mirror-maker): KafkaMirrorMaker my-mirror-maker will be checked for creation or modification
2024-07-11 11:35:17 WARN  KafkaMirrorMakerAssemblyOperator:130 - Reconciliation #12(timer) KafkaMirrorMaker(myproject/my-mirror-maker): Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2.
2024-07-11 11:35:17 INFO  AbstractOperator:536 - Reconciliation #12(timer) KafkaMirrorMaker(myproject/my-mirror-maker): reconciled
```

Condition:
```yaml
status:
  conditions:
  - lastTransitionTime: "2024-07-11T11:35:17.082849788Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-07-11T11:35:17.083248695Z"
    message: Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0.
      Please migrate to Mirror Maker 2.
    reason: MirrorMaker1Deprecation
    status: "True"
    type: Warning
  labelSelector: strimzi.io/cluster=my-mirror-maker,strimzi.io/name=my-mirror-maker-mirror-maker,strimzi.io/kind=KafkaMirrorMaker
  observedGeneration: 2
  replicas: 1
```

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally