### PR TITLE
Unify use of `MirrorMaker` and `Mirror Maker` in the docs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -175,7 +175,7 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
         this.tracing = tracing;
     }
 
-    @Description("Template for Kafka Connect and Kafka Mirror Maker 2 resources. " +
+    @Description("Template for Kafka Connect and Kafka MirrorMaker 2 resources. " +
             "The template allows users to specify how the `Pods`, `Service`, and other services are generated.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public KafkaConnectTemplate getTemplate() {

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2277,7 +2277,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |The configuration of tracing in Kafka Connect.
 |template
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
+|Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
@@ -4030,7 +4030,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |The configuration of tracing in Kafka Connect.
 |template
 |xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
-|Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
+|Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 |Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.

--- a/documentation/modules/configuring/con-config-examples.adoc
+++ b/documentation/modules/configuring/con-config-examples.adoc
@@ -34,7 +34,7 @@ examples
 ├── mirror-maker <4>
 ├── metrics <5>
 ├── kafka <6>
-│   └── nodepools <7>
+│   └── kraft <7>
 ├── cruise-control <8>
 ├── connect <9>
 └── bridge <10>
@@ -42,10 +42,10 @@ examples
 <1> `KafkaUser` custom resource configuration, which is managed by the User Operator.
 <2> `KafkaTopic` custom resource configuration, which is managed by Topic Operator.
 <3> Authentication and authorization configuration for Kafka components. Includes example configuration for TLS and SCRAM-SHA-512 authentication. The Keycloak example includes `Kafka` custom resource configuration and a Keycloak realm specification. You can use the example to try Keycloak authorization services. There is also an example with enabled `oauth` authentication and `keycloak` authorization metrics.
-<4> `Kafka` custom resource configuration for a deployment of Mirror Maker. Includes example configuration for replication policy and synchronization frequency.
+<4> `KafkaMirrorMaker` and `KafkaMirrorMaker2` custom resource configurations for a deployment of MirrorMaker. Includes example configuration for replication policy and synchronization frequency.
 <5> xref:assembly-metrics-config-files-{context}[Metrics configuration], including Prometheus installation and Grafana dashboard files.
-<6> `Kafka` custom resource configuration for a deployment of Kafka. Includes example configuration for an ephemeral or persistent single or multi-node deployment.
-<7> `KafkaNodePool` configuration for Kafka nodes in a Kafka cluster. Includes example configuration for nodes in clusters that use KRaft (Kafka Raft metadata) mode or ZooKeeper.  
+<6> `Kafka` and `KafkaNodePool` custom resource configurations for a deployment of Kafka clusters that use ZooKeeper mode. Includes example configuration for an ephemeral or persistent single or multi-node deployment.
+<7> `Kafka` and `KafkaNodePool` configurations for a deployment of Kafka clusters that use KRaft (Kafka Raft metadata) mode.
 <8> `Kafka` custom resource with a deployment configuration for Cruise Control. Includes `KafkaRebalance` custom resources to generate optimization proposals from Cruise Control, with example configurations to use the default or user optimization goals.
 <9> `KafkaConnect` and `KafkaConnector` custom resource configuration for a deployment of Kafka Connect. Includes example configurations for a single or multi-node deployment.
 <10> `KafkaBridge` custom resource configuration for a deployment of Kafka Bridge.

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -38,8 +38,8 @@ m|Strimzi resource      |Long name          |Short name
 | Kafka User            | kafkauser         | ku
 | Kafka Connect         | kafkaconnect      | kc
 | Kafka Connector       | kafkaconnector    | kctr
-| Kafka Mirror Maker    | kafkamirrormaker  | kmm
-| Kafka Mirror Maker 2  | kafkamirrormaker2 | kmm2
+| Kafka MirrorMaker     | kafkamirrormaker  | kmm
+| Kafka MirrorMaker 2   | kafkamirrormaker2 | kmm2
 | Kafka Bridge          | kafkabridge       | kb
 | Kafka Rebalance       | kafkarebalance    | kr
 

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1935,7 +1935,7 @@ spec:
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
                       description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                  description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
                 externalConfiguration:
                   type: object
                   properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -2080,7 +2080,7 @@ spec:
                               description: Annotations added to the Kubernetes resource.
                           description: Metadata applied to the resource.
                       description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                  description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                  description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
                 externalConfiguration:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1934,7 +1934,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -2079,7 +2079,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

In most places in our documentation, we use `MirrorMaker` as a single word.But in few places, we seem to use `Mirror Maker` with space in-between. This makes it harder to search for things in the docs. This PR unifies it to use `MirrorMaker` everywhere.

It also improves/updates the descriptions for the examples.

### Checklist

- [x] Update documentation