### PR TITLE
Add RackAwareDistributionGoal to CC goal config by default

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
@@ -28,6 +28,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
      */
     protected static final List<String> CRUISE_CONTROL_GOALS_LIST = List.of(
             CruiseControlGoals.RACK_AWARENESS_GOAL.toString(),
+            CruiseControlGoals.RACK_AWARENESS_DISTRIBUTION_GOAL.toString(),
             CruiseControlGoals.MIN_TOPIC_LEADERS_PER_BROKER_GOAL.toString(),
             CruiseControlGoals.REPLICA_CAPACITY_GOAL.toString(),
             CruiseControlGoals.DISK_CAPACITY_GOAL.toString(),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconcilerTest.java
@@ -181,7 +181,7 @@ public class CruiseControlReconcilerTest {
                     assertThat(deployCaptor.getValue(), is(notNullValue()));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION), is("0"));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION), is("0"));
-                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("096591fb"));
+                    assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_SERVER_CONFIGURATION_HASH), is("4b8f68dd"));
                     assertThat(deployCaptor.getAllValues().get(0).getSpec().getTemplate().getMetadata().getAnnotations().get(CruiseControl.ANNO_STRIMZI_CAPACITY_CONFIGURATION_HASH), is("1eb49220"));
                     assertThat(deployCaptor.getValue().getSpec().getTemplate().getMetadata().getAnnotations().get(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH), is("4d715cdd"));
                     if (topicOperatorEnabled) {

--- a/documentation/modules/cruise-control/con-optimization-goals.adoc
+++ b/documentation/modules/cruise-control/con-optimization-goals.adoc
@@ -15,6 +15,7 @@ Strimzi supports most of the optimization goals developed in the Cruise Control 
 The supported goals, in the default descending order of priority, are as follows:
 
 . Rack-awareness
+* Rack-awareness distribution
 . Minimum number of leader replicas per broker for a set of topics
 . Replica capacity
 . Capacity goals

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlGoals.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlGoals.java
@@ -14,6 +14,11 @@ public enum CruiseControlGoals {
     RACK_AWARENESS_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal"),
 
     /**
+     * Rack aware distribution goal
+     */
+    RACK_AWARENESS_DISTRIBUTION_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal"),
+
+    /**
      * Minimum topic leaders per broker goal
      */
     MIN_TOPIC_LEADERS_PER_BROKER_GOAL("com.linkedin.kafka.cruisecontrol.analyzer.goals.MinTopicLeadersPerBrokerGoal"),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Resolves https://github.com/strimzi/strimzi-kafka-operator/issues/10297

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

