### PR TITLE
Use proper time values in one of KafkaExporter's dashbord queries

### DIFF
--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -819,7 +819,7 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[5m])/60) by (consumergroup, topic)",
+          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[5m])/300) by (consumergroup, topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{consumergroup}} (topic: {{topic}})",

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kafka-exporter.json
@@ -819,7 +819,7 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[5m])/60) by (consumergroup, topic)",
+          "expr": "sum(delta(kafka_consumergroup_current_offset{consumergroup=~\"$consumergroup\",topic=~\"$topic\", namespace=~\"$kubernetes_namespace\"}[5m])/300) by (consumergroup, topic)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{consumergroup}} (topic: {{topic}})",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I accidentally changed the values in KafkaExporter query from 1m to 5m in the past. This is more or less fine, but the following value that compute proper value for consumed messages remained the same. The proper values here are `[1m]/60` or `[5m]/300` as the second number reflects the number of minutes for which the collected data are computed on prometheus side. 

The reason why I used 5m is due to data granularity available in the monitoring system. In case the users has configured metrics scraping to some longer intervals it could happen that dashboard didn't show data with 1m config. With this change everything should be fine.

It is based on https://github.com/strimzi/strimzi-kafka-operator/pull/10235

Producer:
![image](https://github.com/user-attachments/assets/65863d16-eb14-4b86-84e3-e0c39b3e3336)

Consumer broken:
![image](https://github.com/user-attachments/assets/ec74d10f-edcf-4177-ba83-f40a91f9bfd8)

Consumer fixed:
![image](https://github.com/user-attachments/assets/1fce6ddb-c2c1-4743-84c2-c6a48d5b47a5)


### Checklist

- [x] Supply screenshots for visual changes, such as Grafana dashboards

