### PR TITLE
Fixed bridge alerts summary and description

### DIFF
--- a/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
+++ b/packaging/examples/metrics/prometheus-install/prometheus-rules.yaml
@@ -191,8 +191,8 @@ spec:
       labels:
         severity: warning
       annotations:
-        summary: 'Kafka Bridge average consumer fetch latency'
-        description: 'The average fetch latency is {{ $value }} on {{ $labels.clientId }}'
+        summary: 'Kafka Bridge producer average request latency'
+        description: 'The average producer request latency is {{ $value }} on {{ $labels.clientId }}'
     - alert: AvgConsumerFetchLatency
       expr: strimzi_bridge_kafka_consumer_fetch_latency_avg > 500
       for: 10s
@@ -200,7 +200,7 @@ spec:
         severity: warning
       annotations:
         summary: 'Kafka Bridge consumer average fetch latency'
-        description: 'The average consumer commit latency is {{ $value }} on {{ $labels.clientId }}'
+        description: 'The average consumer fetch latency is {{ $value }} on {{ $labels.clientId }}'
     - alert: AvgConsumerCommitLatency
       expr: strimzi_bridge_kafka_consumer_commit_latency_avg > 200
       for: 10s


### PR DESCRIPTION
This trivial PR just fixes summary and description for a couple of alerts on latency related to Kafka bridge producer and consumer.