### PR TITLE
ST: Check that messages are not available in local storage when tiered storage is used

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -209,6 +209,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.7.0";
+    // TODO - remove overridden version from TieredStorageST - see TODO in the class
     public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.8.1";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
     public static final String OLM_OPERATOR_VERSION_DEFAULT = "0.42.0";

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/admin/AdminClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/admin/AdminClient.java
@@ -121,6 +121,17 @@ public class AdminClient {
         cmdKubeClient(namespaceName).execInPod(podName, CMD, "configure", "common", "--from-env");
     }
 
+    public String fetchOffsets(String topicName, String time) {
+        AdminTopicCommand adminTopicCommand = new AdminTopicCommand()
+            .withFetchOffsetsSubCommand()
+            .withTopicName(topicName)
+            .withTime(time)
+            .withOutputJson();
+
+        ExecResult result = cmdKubeClient(namespaceName).execInPod(podName, false, adminTopicCommand.getCommand());
+        return result.returnCode() == 0 ? result.out() : result.err();
+    }
+
     static class AdminTopicCommand {
         private final static String TOPIC_SUBCOMMAND = "topic";
         private List<String> command = new ArrayList<>(List.of(CMD, TOPIC_SUBCOMMAND));
@@ -152,6 +163,11 @@ public class AdminClient {
 
         public AdminTopicCommand withListSubCommand() {
             this.command.add("list");
+            return this;
+        }
+
+        public AdminTopicCommand withFetchOffsetsSubCommand() {
+            this.command.add("fetch-offsets");
             return this;
         }
 
@@ -187,6 +203,11 @@ public class AdminClient {
 
         public AdminTopicCommand withAll() {
             this.command.add("--all");
+            return this;
+        }
+
+        public AdminTopicCommand withTime(String time) {
+            this.command.addAll(List.of("--time", time));
             return this;
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -16,13 +16,10 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.enums.DeploymentTypes;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SetupMinio {
     private static final Logger LOGGER = LogManager.getLogger(SetupMinio.class);
@@ -132,71 +129,5 @@ public class SetupMinio {
             "mc",
             "mb",
             MINIO_STORAGE_ALIAS + "/" + bucketName);
-    }
-
-    /**
-     * Collect data from Minio about usage of a specific bucket
-     * @param namespace
-     * @param bucketName
-     * @return Overall statistics about the bucket in String format
-     */
-    public static String getBucketSizeInfo(String namespace, String bucketName) {
-        final String minioPod = ResourceManager.kubeClient().listPods(namespace, Map.of(TestConstants.APP_POD_LABEL, MINIO)).get(0).getMetadata().getName();
-
-        return ResourceManager.cmdKubeClient().namespace(namespace).execInPod(minioPod,
-            "mc",
-            "stat",
-            "local/" + bucketName).out();
-
-    }
-
-    /**
-     * Parse out total size of bucket from the information about usage.
-     * @param bucketInfo String containing all stat info about bucket
-     * @return Map consists of parsed size and it's unit
-     */
-    private static Map<String, Object> parseTotalSize(String bucketInfo) {
-        Pattern pattern = Pattern.compile("Total size:\\s*(?<size>[\\d.]+)\\s*(?<unit>.*)");
-        Matcher matcher = pattern.matcher(bucketInfo);
-
-        if (matcher.find()) {
-            return Map.of("size", Double.parseDouble(matcher.group("size")), "unit", matcher.group("unit"));
-        } else {
-            throw new IllegalArgumentException("Total size not found in the provided string");
-        }
-    }
-
-    /**
-     * Wait until size of the bucket is not 0 B.
-     * @param namespace Minio location
-     * @param bucketName bucket name
-     */
-    public static void waitForDataInMinio(String namespace, String bucketName) {
-        TestUtils.waitFor("data sync from Kafka to Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
-            String bucketSizeInfo = SetupMinio.getBucketSizeInfo(namespace, bucketName);
-            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
-            double bucketSize = (Double) parsedSize.get("size");
-            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
-            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
-
-            return bucketSize > 0;
-        });
-    }
-
-    /**
-     * Wait until size of the bucket is 0 B.
-     * @param namespace Minio location
-     * @param bucketName bucket name
-     */
-    public static void waitForNoDataInMinio(String namespace, String bucketName) {
-        TestUtils.waitFor("data deletion in Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
-            String bucketSizeInfo = SetupMinio.getBucketSizeInfo(namespace, bucketName);
-            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
-            double bucketSize = (Double) parsedSize.get("size");
-            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
-            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
-
-            return bucketSize == 0;
-        });
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -182,4 +182,21 @@ public class SetupMinio {
             return bucketSize > 0;
         });
     }
+
+    /**
+     * Wait until size of the bucket is 0 B.
+     * @param namespace Minio location
+     * @param bucketName bucket name
+     */
+    public static void waitForNoDataInMinio(String namespace, String bucketName) {
+        TestUtils.waitFor("data deletion in Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
+            String bucketSizeInfo = SetupMinio.getBucketSizeInfo(namespace, bucketName);
+            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
+            double bucketSize = (Double) parsedSize.get("size");
+            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
+            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
+
+            return bucketSize == 0;
+        });
+    }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/AdminClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/AdminClientUtils.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.systemtest.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.strimzi.systemtest.TestConstants;
@@ -114,5 +117,19 @@ public class AdminClientUtils {
         return new LabelSelectorBuilder()
             .withMatchLabels(matchLabels)
             .build();
+    }
+
+    public static long getPartitionsOffset(String data, String partition) throws JsonProcessingException {
+        // Create ObjectMapper instance
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Read JSON string as JsonNode
+        JsonNode rootNode = mapper.readTree(data);
+
+        // Get the node for the partition number
+        JsonNode partitionNode = rootNode.get(partition);
+
+        // Get the offset value
+        return partitionNode.get("offset").asLong();
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MinioUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MinioUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.specific;
+
+import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.resources.ResourceManager;
+import io.strimzi.systemtest.resources.minio.SetupMinio;
+import io.strimzi.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MinioUtils {
+    private static final Logger LOGGER = LogManager.getLogger(SetupMinio.class);
+
+    private MinioUtils() {
+
+    }
+
+    /**
+     * Collect data from Minio about usage of a specific bucket
+     * @param namespace
+     * @param bucketName
+     * @return Overall statistics about the bucket in String format
+     */
+    public static String getBucketSizeInfo(String namespace, String bucketName) {
+        final String minioPod = ResourceManager.kubeClient().listPods(namespace, Map.of(TestConstants.APP_POD_LABEL, SetupMinio.MINIO)).get(0).getMetadata().getName();
+
+        return ResourceManager.cmdKubeClient().namespace(namespace).execInPod(minioPod,
+            "mc",
+            "stat",
+            "local/" + bucketName).out();
+
+    }
+
+    /**
+     * Parse out total size of bucket from the information about usage.
+     * @param bucketInfo String containing all stat info about bucket
+     * @return Map consists of parsed size and it's unit
+     */
+    private static Map<String, Object> parseTotalSize(String bucketInfo) {
+        Pattern pattern = Pattern.compile("Total size:\\s*(?<size>[\\d.]+)\\s*(?<unit>.*)");
+        Matcher matcher = pattern.matcher(bucketInfo);
+
+        if (matcher.find()) {
+            return Map.of("size", Double.parseDouble(matcher.group("size")), "unit", matcher.group("unit"));
+        } else {
+            throw new IllegalArgumentException("Total size not found in the provided string");
+        }
+    }
+
+    /**
+     * Wait until size of the bucket is not 0 B.
+     * @param namespace Minio location
+     * @param bucketName bucket name
+     */
+    public static void waitForDataInMinio(String namespace, String bucketName) {
+        TestUtils.waitFor("data sync from Kafka to Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
+            String bucketSizeInfo = getBucketSizeInfo(namespace, bucketName);
+            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
+            double bucketSize = (Double) parsedSize.get("size");
+            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
+            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
+
+            return bucketSize > 0;
+        });
+    }
+
+    /**
+     * Wait until size of the bucket is 0 B.
+     * @param namespace Minio location
+     * @param bucketName bucket name
+     */
+    public static void waitForNoDataInMinio(String namespace, String bucketName) {
+        TestUtils.waitFor("data deletion in Minio", TestConstants.GLOBAL_POLL_INTERVAL_MEDIUM, TestConstants.GLOBAL_TIMEOUT_LONG, () -> {
+            String bucketSizeInfo = getBucketSizeInfo(namespace, bucketName);
+            Map<String, Object> parsedSize = parseTotalSize(bucketSizeInfo);
+            double bucketSize = (Double) parsedSize.get("size");
+            LOGGER.info("Collected bucket size: {} {}", bucketSize, parsedSize.get("unit"));
+            LOGGER.debug("Collected bucket info:\n{}", bucketSizeInfo);
+
+            return bucketSize == 0;
+        });
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -28,6 +28,7 @@ import io.strimzi.systemtest.utils.AdminClientUtils;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.specific.MinioUtils;
 import io.strimzi.test.TestUtils;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -171,7 +172,7 @@ public class TieredStorageST extends AbstractST {
             () -> {
                 // Fetch earliest-local offsets
                 // Check that data are not present locally, earliest-local offset should be higher than 0
-                String offsetData = adminClient.fetchOffsets(testStorage.getTopicName(), "earliest-local");
+                String offsetData = adminClient.fetchOffsets(testStorage.getTopicName(), String.valueOf(ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP));
                 long earliestLocalOffset = 0;
                 try {
                     earliestLocalOffset = AdminClientUtils.getPartitionsOffset(offsetData, "0");

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -135,7 +135,8 @@ public class TieredStorageST extends AbstractST {
                 .addToConfig("retention.ms", 86400000)
                 // Segment size is set to 10mb to make it quickier to sync data to Minio
                 .addToConfig("segment.bytes", 1048576)
-            .endSpec().build());
+            .endSpec()
+            .build());
 
         final KafkaClients clients = ClientUtils.getInstantPlainClientBuilder(testStorage)
             .withMessageCount(10000)
@@ -163,7 +164,8 @@ public class TieredStorageST extends AbstractST {
                         .endContainer()
                     .endSpec()
                 .endTemplate()
-            .endSpec().build()
+            .endSpec()
+            .build()
         );
         final AdminClient adminClient = AdminClientUtils.getConfiguredAdminClient(testStorage.getNamespaceName(), testStorage.getAdminName());
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds additional check to TieredStorageST:
- check that data are removed from local storage when are moved to remote storage
- check that data are deleted from remote storage when retention mechanism clears data

Cannot be merged before https://github.com/strimzi/test-clients/pull/103

Resolves https://github.com/strimzi/strimzi-kafka-operator/issues/10302

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

