### PR TITLE
Update the default value of `STRIMZI_LABELS_EXCLUSION_PATTERN`

### DIFF
--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -80,7 +80,7 @@ env:
     value: label1=value1,label2=value2
 ----
 
-`STRIMZI_LABELS_EXCLUSION_PATTERN`:: Optional, default regex pattern is `^app.kubernetes.io/(?!part-of).*`.
+`STRIMZI_LABELS_EXCLUSION_PATTERN`:: Optional, default regex pattern is `(^app.kubernetes.io/(?!part-of).*|^kustomize.toolkit.fluxcd.io.*)`.
 The regex exclusion pattern used to filter labels propagation from the main custom resource to its subresources.
 The labels exclusion filter is not applied to labels in template sections such as `spec.kafka.template.pod.metadata.labels`.
 +


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR updates the default value of the `STRIMZI_LABELS_EXCLUSION_PATTERN` environment variable to use the correct default value.

This was discovered in #10349.

### Checklist

- [x] Update documentation