### PR TITLE
Use release javac option

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,8 +17,7 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
         <!-- No Javadocs warnings as errors here => we do not want to fail because of warnings -->
         <javadoc.fail.on.warnings>false</javadoc.fail.on.warnings>

--- a/crd-annotations/pom.xml
+++ b/crd-annotations/pom.xml
@@ -12,8 +12,7 @@
     <artifactId>crd-annotations</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>

--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -18,8 +18,7 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Configures if we should fail on warnings when generating Javadocs -->
         <javadoc.fail.on.warnings>true</javadoc.fail.on.warnings>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -12,8 +12,7 @@
     <artifactId>test</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
         <!-- Points to the root directory of the Strimzi project directory and can be used for fixed location to configuration files -->
         <strimziRootDirectory>${basedir}${file.separator}..</strimziRootDirectory>


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

Starting JDK 9, the javac executable can accept the `--release` option to specify against which Java SE release you want to build the project. Unlike the `-source` and `-target` options, the compiler will detect and generate an error when using APIs that don't exist in previous releases of Java SE. This option is available in maven-compiler-plugin since version 3.6.

Using `--release N` is roughly equivalent to:

- for N < 9: `-source N -target N -bootclasspath <documented-APIs-from-N>`
- for N >= 9: `-source N -target N --system <documented-APIs-from-N>`

For more details see https://openjdk.org/jeps/247.

### Checklist

- [x] Make sure all tests pass
