### PR TITLE
Fixed ZooKeeper service usage to delete /controller znode on migration rollback

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -898,7 +898,7 @@ public class ZooKeeperReconciler {
      */
     protected Future<Void> deleteControllerZnode() {
         // migration rollback process ongoing
-        String zkConnectionString = DnsNameGenerator.serviceDnsNameWithClusterDomain(reconciliation.namespace(), KafkaResources.zookeeperServiceName(reconciliation.name()))  + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
+        String zkConnectionString = DnsNameGenerator.serviceDnsNameWithoutClusterDomain(reconciliation.namespace(), KafkaResources.zookeeperServiceName(reconciliation.name()))  + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
         return KRaftMigrationUtils.deleteZooKeeperControllerZnode(
                 reconciliation,
                 vertx,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -898,7 +898,7 @@ public class ZooKeeperReconciler {
      */
     protected Future<Void> deleteControllerZnode() {
         // migration rollback process ongoing
-        String zkConnectionString = KafkaResources.zookeeperServiceName(reconciliation.name()) + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
+        String zkConnectionString = DnsNameGenerator.serviceDnsNameWithClusterDomain(reconciliation.namespace(), KafkaResources.zookeeperServiceName(reconciliation.name()))  + ":" + ZookeeperCluster.CLIENT_TLS_PORT;
         return KRaftMigrationUtils.deleteZooKeeperControllerZnode(
                 reconciliation,
                 vertx,


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #10371.
The current code, to get the ZooKeeper connection string from the service in order to connect to ZooKeeper and delete the `/controller` znode during KRaft migration rollback, doesn't take into account the full name (i.e. including namespace), so the operator can't connect when the cluster is running in a different namespace.
The PR fixes it.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging