### PR TITLE
Exclude Logback from Cruise Control

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -31,6 +31,18 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
+            <!-- The exclusion is needed because of https://github.com/linkedin/cruise-control/issues/2174.
+                 It can be removed once it is fixed and released in new Cruise Control version. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Cruise Control 2.5.138 updated ZooKeeper dependency to 3.8.4 and that seems to pull Logback as transitive dependency. This causes failures in our system tests (and possibly for users as well) as sometimes Cruise Control picks Logback for logging and sometimes Log4j2. This PR excludes the Logback dependency to have only Log4j2 in the classpath and always use it.

This is related to https://github.com/linkedin/cruise-control/issues/2174.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging