### PR TITLE
Fixed missed renaming from DescribeFile to DescriptionFile annotation

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -399,7 +399,7 @@ class DocGenerator {
             File includeFile = new File(filename);
 
             if (!includeFile.isFile())   {
-                throw new RuntimeException("Class " + cls.getCanonicalName() + " has @DescribeFile annotation, but file " + filename + " does not exist!");
+                throw new RuntimeException("Class " + cls.getCanonicalName() + " has @DescriptionFile annotation, but file " + filename + " does not exist!");
             }
 
             out.append("xref:type-").append(cls.getSimpleName()).append("-schema-{context}[Full list of `").append(cls.getSimpleName()).append("` schema properties]").append(NL);

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/DescriptionFile.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/DescriptionFile.java
@@ -10,7 +10,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The DescribeFile annotation indicates that given class has an additional file with Asciidoc description.
+ * The DescriptionFile annotation indicates that given class has an additional file with Asciidoc description.
  * The file has to be placed in the documentation/book/api folder and the filename has to be a fully classified class
  * name (e.g. io.strimzi.api.kafka.MyApiClass). The asciidoc file will be included into the API reference for given
  * class.


### PR DESCRIPTION
Trivial PR to fix a leftover for the old `DescribeFile` name annotation in the Javadoc and runtime exception (compared to the new `DescriptionFile` name).