### PR TITLE
Update the link to Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation for the current _main_ branch as well as all releases can be found
 
 ## Roadmap
 
-The roadmap of the Strimzi Operator project is maintained as [GitHub Project](https://github.com/orgs/strimzi/projects/1).
+The roadmap of the Strimzi Operator project is maintained as [GitHub Project](https://github.com/orgs/strimzi/projects/4).
 
 ## Getting help
 


### PR DESCRIPTION
### Type of change

- Task

### Description

The old GitHub projects that we use for Readmap are being shutdown. So the Roadmap was migrated to the new Projects and the link changed. This PR updates the link in the README.md.