### PR TITLE
Updated reconcileRebalance to be private not used in tests anymore

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1031,7 +1031,7 @@ public class KafkaRebalanceAssemblyOperator
      * Reconcile loop for the KafkaRebalance
      */
     @SuppressWarnings({"checkstyle:NPathComplexity"})
-    /* test */ Future<KafkaRebalanceStatus> reconcileRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
+    private Future<KafkaRebalanceStatus> reconcileRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
         if (kafkaRebalance == null) {
             LOGGER.infoCr(reconciliation, "KafkaRebalance resource deleted");
             return Future.succeededFuture();


### PR DESCRIPTION
From the latest refactoring on the rebalance operator, using the reconciliation loop, even tests were refactored the right way and now the `reconcileRebalance` method doesn't need to be exposed anymore to them because not called anymore.