### PR TITLE
Remove unused method from KafkaRoller

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -185,14 +185,6 @@ public class KafkaRoller {
         this.allowReconfiguration = allowReconfiguration;
     }
 
-    /**
-     * Returns a Future which completed with the actual pod corresponding to the abstract representation
-     * of the given {@code pod}.
-     */
-    protected Future<Pod> pod(Integer podId) {
-        return podOperations.getAsync(namespace, KafkaResources.kafkaPodName(cluster, podId));
-    }
-
     private final ScheduledExecutorService singleExecutor = Executors.newSingleThreadScheduledExecutor(
         runnable -> new Thread(runnable, "kafka-roller"));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `pod(...)` method in the `KafkaRoller` does not seem to be used. It is also getting the Pod based on the old naming schema, so it would not work with node pools. So it is better to remove it so that it isn't used by mistake in the future.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally