### PR TITLE
Restart the correct Pod when resizing PVCs

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -535,7 +535,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             }
         }
 
-        throw new RuntimeException("Node ID " + nodeId + " does not belong to any known node pool!");
+        throw new NodePoolNotFoundException("Node ID " + nodeId + " does not belong to any known node pool!");
     }
 
     /**
@@ -1998,6 +1998,20 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             return labels.strimziSelectorLabels().withStrimziBrokerRole(true);
         } else {
             return labels.strimziSelectorLabels();
+        }
+    }
+
+    /**
+     * Exception used to indicate that a matching Node Pool was not found
+     */
+    public static final class NodePoolNotFoundException extends RuntimeException {
+        /**
+         * Creates new exception
+         *
+         * @param message   Error message
+         */
+        public NodePoolNotFoundException(String message) {
+            super(message);
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -411,9 +411,9 @@ public class ZooKeeperReconciler {
         List<PersistentVolumeClaim> pvcs = zk.generatePersistentVolumeClaims();
 
         return new PvcReconciler(reconciliation, pvcOperator, storageClassOperator)
-                .resizeAndReconcilePvcs(kafkaStatus, podIndex -> KafkaResources.zookeeperPodName(reconciliation.name(), podIndex), pvcs)
-                .compose(podsToRestart -> {
-                    fsResizingRestartRequest.addAll(podsToRestart);
+                .resizeAndReconcilePvcs(kafkaStatus, pvcs)
+                .compose(podIdsToRestart -> {
+                    fsResizingRestartRequest.addAll(podIdsToRestart.stream().map(podId -> KafkaResources.zookeeperPodName(reconciliation.name(), podId)).collect(Collectors.toSet()));
                     return Future.succeededFuture();
                 });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterWithKRaftTest.java
@@ -687,4 +687,24 @@ public class KafkaClusterWithKRaftTest {
 
         assertThat(kc.getMetadataVersion(), is("3.5-IV1"));
     }
+
+    @Test
+    public void testNodePoolForNodeId()   {
+        KafkaCluster kc = KafkaCluster.fromCrd(
+                Reconciliation.DUMMY_RECONCILIATION,
+                KAFKA,
+                List.of(KAFKA_POOL_CONTROLLERS, KAFKA_POOL_BROKERS),
+                VERSIONS,
+                new KafkaVersionChange(VERSIONS.defaultVersion(), VERSIONS.defaultVersion(), null, null, "3.5-IV1"),
+                KafkaMetadataConfigurationState.KRAFT,
+                null,
+                SHARED_ENV_PROVIDER);
+
+        // Existing node
+        assertThat(kc.nodePoolForNodeId(1001), is(KAFKA_POOL_BROKERS));
+
+        // Non-existing node
+        KafkaCluster.NodePoolNotFoundException e = assertThrows(KafkaCluster.NodePoolNotFoundException.class, () -> kc.nodePoolForNodeId(1874));
+        assertThat(e.getMessage(), is("Node ID 1874 does not belong to any known node pool!"));
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorWithKRaftTest.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimConditionBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
@@ -49,6 +51,7 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
+import io.strimzi.operator.cluster.operator.resource.kubernetes.PvcOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StatefulSetOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
@@ -249,6 +252,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
 
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
         when(mockPodSetOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(kafkaPodSets));
@@ -356,6 +363,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
 
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
         when(mockPodSetOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(List.of()));
@@ -458,6 +469,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockCmOps.reconcile(any(), any(), startsWith("my-cluster-"), any())).thenReturn(Future.succeededFuture());
         when(mockCmOps.deleteAsync(any(), any(), eq("my-cluster-kafka-config"), anyBoolean())).thenReturn(Future.succeededFuture());
 
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         when(mockPodSetOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(oldKafkaPodSets));
         when(mockPodSetOps.batchReconcile(any(), any(), any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenAnswer(i -> {
@@ -552,6 +567,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockCmOps.reconcile(any(), any(), cmReconciliationCaptor.capture(), any())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
 
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
@@ -673,6 +692,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockCmOps.reconcile(any(), any(), cmReconciliationCaptor.capture(), any())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
 
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
@@ -808,6 +831,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockCmOps.reconcile(any(), any(), cmReconciliationCaptor.capture(), any())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
 
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
@@ -951,6 +978,10 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         when(mockCmOps.reconcile(any(), any(), cmReconciliationCaptor.capture(), any())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
         when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
 
         StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
         // Kafka
@@ -1134,6 +1165,113 @@ public class KafkaAssemblyOperatorWithKRaftTest {
                 })));
     }
 
+    /**
+     * Tests that the Pod that needs a restart to finish PVC resizing is rolled
+     *
+     * @param context   Test context
+     */
+    @Test
+    public void testRollDueToPersistentVolumeResizing(VertxTestContext context)  {
+        List<StrimziPodSet> kafkaPodSets = KAFKA_CLUSTER.generatePodSets(false, null, null, brokerId -> null);
+
+        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
+
+        SecretOperator secretOps = supplier.secretOperations;
+        when(secretOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        when(secretOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
+
+        ConfigMapOperator mockCmOps = supplier.configMapOperations;
+        when(mockCmOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(List.of()));
+        ArgumentCaptor<String> cmReconciliationCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockCmOps.reconcile(any(), any(), cmReconciliationCaptor.capture(), any())).thenReturn(Future.succeededFuture());
+        ArgumentCaptor<String> cmDeletionCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockCmOps.deleteAsync(any(), any(), cmDeletionCaptor.capture(), anyBoolean())).thenReturn(Future.succeededFuture());
+
+        PvcOperator mockPvcOps = supplier.pvcOperations;
+        when(mockPvcOps.getAsync(any(), any())).thenReturn(Future.succeededFuture());
+        when(mockPvcOps.getAsync(any(), eq("data-0-my-cluster-brokers-4"))).thenReturn(Future.succeededFuture(
+                new PersistentVolumeClaimBuilder()
+                        .withNewMetadata()
+                            .withNamespace(NAMESPACE)
+                            .withName("data-0-my-cluster-brokers-4")
+                        .endMetadata()
+                        .withNewSpec()
+                        .endSpec()
+                        .withNewStatus()
+                            .withPhase("Bound")
+                            .withConditions(new PersistentVolumeClaimConditionBuilder().withType("FileSystemResizePending").withStatus("True").build())
+                        .endStatus()
+                        .build()
+        ));
+        when(mockPvcOps.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+
+        StrimziPodSetOperator mockPodSetOps = supplier.strimziPodSetOperator;
+        // Kafka
+        when(mockPodSetOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(kafkaPodSets));
+        when(mockPodSetOps.batchReconcile(any(), any(), any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenAnswer(i -> {
+            List<StrimziPodSet> podSets = i.getArgument(2);
+            HashMap<String, ReconcileResult<StrimziPodSet>> result = new HashMap<>();
+
+            for (StrimziPodSet podSet : podSets)    {
+                StrimziPodSet patched = kafkaPodSets.stream().filter(sps -> podSet.getMetadata().getName().equals(sps.getMetadata().getName())).findFirst().orElse(null);
+                result.put(podSet.getMetadata().getName(), patched == null ? ReconcileResult.created(podSet) : ReconcileResult.noop(patched));
+            }
+
+            return Future.succeededFuture(result);
+        });
+
+        StatefulSetOperator mockStsOps = supplier.stsOperations;
+        when(mockStsOps.getAsync(any(), eq(KAFKA_CLUSTER.getComponentName()))).thenReturn(Future.succeededFuture(null)); // Kafka STS is queried and deleted if it still exists
+
+        PodOperator mockPodOps = supplier.podOperations;
+        when(mockPodOps.listAsync(any(), eq(KAFKA_CLUSTER.getSelectorLabels()))).thenReturn(Future.succeededFuture(Collections.emptyList()));
+        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(Collections.emptyList()));
+
+        CrdOperator<KubernetesClient, Kafka, KafkaList> mockKafkaOps = supplier.kafkaOperator;
+        when(mockKafkaOps.getAsync(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(Future.succeededFuture(KAFKA));
+        when(mockKafkaOps.get(eq(NAMESPACE), eq(CLUSTER_NAME))).thenReturn(KAFKA);
+        when(mockKafkaOps.updateStatusAsync(any(), any())).thenReturn(Future.succeededFuture());
+
+        CrdOperator<KubernetesClient, KafkaNodePool, KafkaNodePoolList> mockKafkaNodePoolOps = supplier.kafkaNodePoolOperator;
+        ArgumentCaptor<KafkaNodePool> kafkaNodePoolStatusCaptor = ArgumentCaptor.forClass(KafkaNodePool.class);
+        when(mockKafkaNodePoolOps.updateStatusAsync(any(), kafkaNodePoolStatusCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        MockKafkaReconciler kr = new MockKafkaReconciler(
+                new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME),
+                vertx,
+                CONFIG,
+                supplier,
+                new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                KAFKA,
+                List.of(CONTROLLERS, BROKERS),
+                KAFKA_CLUSTER,
+                CLUSTER_CA,
+                CLIENTS_CA);
+
+        MockKafkaAssemblyOperator kao = new MockKafkaAssemblyOperator(
+                vertx, new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
+                CERT_MANAGER,
+                PASSWORD_GENERATOR,
+                supplier,
+                CONFIG,
+                kr);
+
+        Checkpoint async = context.checkpoint();
+        kao.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, CLUSTER_NAME))
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertThat(kr.maybeRollKafkaInvocations, is(1));
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(0), "my-cluster-controllers-0")), is(RestartReasons.empty()));
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(0), "my-cluster-controllers-1")), is(RestartReasons.empty()));
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(0), "my-cluster-controllers-2")), is(RestartReasons.empty()));
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(1), "my-cluster-brokers-3")), is(RestartReasons.empty()));
+                    // Only the pod that needs volume resizing is rolled
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(1), "my-cluster-brokers-4")), is(RestartReasons.of(RestartReason.FILE_SYSTEM_RESIZE_NEEDED)));
+                    assertThat(kr.kafkaPodNeedsRestart.apply(podFromPodSet(kafkaPodSets.get(1), "my-cluster-brokers-5")), is(RestartReasons.empty()));
+
+                    async.flag();
+                })));
+    }
+
     // Internal utility methods
     private Pod podFromPodSet(StrimziPodSet podSet, String name) {
         return PodSetUtils.podSetToPods(podSet).stream().filter(p -> name.equals(p.getMetadata().getName())).findFirst().orElse(null);
@@ -1192,6 +1330,7 @@ public class KafkaAssemblyOperatorWithKRaftTest {
         public Future<Void> reconcile(KafkaStatus kafkaStatus, Clock clock)    {
             return manualPodCleaning()
                     .compose(i -> manualRollingUpdate())
+                    .compose(i -> pvcs(kafkaStatus))
                     .compose(i -> scaleDown())
                     .compose(i -> updateNodePoolStatuses(kafkaStatus))
                     .compose(i -> listeners())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/PvcReconcilerTest.java
@@ -89,7 +89,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -135,7 +135,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -199,7 +199,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -264,7 +264,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(false));
                     assertThat(res.cause(), is(instanceOf(IllegalArgumentException.class)));
@@ -327,7 +327,7 @@ public class PvcReconcilerTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(kafkaStatus, i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(kafkaStatus, pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -399,7 +399,7 @@ public class PvcReconcilerTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(kafkaStatus, i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(kafkaStatus, pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -468,7 +468,7 @@ public class PvcReconcilerTest {
         KafkaStatus kafkaStatus = new KafkaStatus();
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(kafkaStatus, i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(kafkaStatus, pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -536,7 +536,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
@@ -598,12 +598,12 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 
                     assertThat(res.result().size(), is(3));
-                    assertThat(res.result(), is(Set.of("pod-0", "pod-1", "pod-2")));
+                    assertThat(res.result(), is(Set.of(0, 1, 2)));
 
                     assertThat(pvcCaptor.getAllValues().size(), is(0));
 
@@ -657,7 +657,7 @@ public class PvcReconcilerTest {
         );
 
         Checkpoint async = context.checkpoint();
-        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), i -> "pod-" + i, pvcs)
+        reconciler.resizeAndReconcilePvcs(new KafkaStatus(), pvcs)
                 .onComplete(res -> {
                     assertThat(res.succeeded(), is(true));
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When resizing the PVCs, we might need to restart some of the Pods for the resizing to complete (file system expansion). But we might miss the right pod because the code currently does not work with node pools and expects that all Kafka pods will be named `<cluster-name>-kafka-<index>`. 

This PR addresses it and makes sure that the logic uses the correct name of the Pod depending on the node pool. That way it now works when using node pools or KRaft.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally