### PR TITLE
Remove `getPodName()` method from `AbstractModel`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -151,16 +151,6 @@ public abstract class AbstractModel {
     }
 
     /**
-     * Gets the name of a given pod in a StrimziPodSet.
-     *
-     * @param podId The ID (ordinal) of the pod.
-     * @return The name of the pod with the given name.
-     */
-    public String getPodName(Integer podId) {
-        return componentName + "-" + podId;
-    }
-
-    /**
      * @param cluster The cluster name
      * @return The name of the Cluster CA certificate secret.
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -517,7 +517,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
                 labels.strimziSelectorLabels().withStrimziPodSetController(componentName),
                 podId -> WorkloadUtils.createStatefulPod(
                         reconciliation,
-                        getPodName(podId),
+                        componentName + "-" + podId,
                         namespace,
                         labels,
                         componentName,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -413,7 +413,7 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
                 labels.strimziSelectorLabels(),
                 podNum -> WorkloadUtils.createStatefulPod(
                         reconciliation,
-                        getPodName(podNum),
+                        KafkaResources.zookeeperPodName(cluster, podNum),
                         namespace,
                         labels,
                         componentName,
@@ -425,7 +425,7 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
                         templatePod != null ? templatePod.getAffinity() : null,
                         null,
                         List.of(createContainer(imagePullPolicy)),
-                        getPodSetVolumes(getPodName(podNum), isOpenShift),
+                        getPodSetVolumes(KafkaResources.zookeeperPodName(cluster, podNum), isOpenShift),
                         imagePullSecrets,
                         securityProvider.zooKeeperPodSecurityContext(new PodSecurityProviderContextImpl(storage, templatePod))
                 )
@@ -636,7 +636,7 @@ public class ZookeeperCluster extends AbstractModel implements SupportsMetrics, 
         Set<NodeRef> nodes = new LinkedHashSet<>();
 
         for (int i = 0; i < replicas; i++)  {
-            nodes.add(new NodeRef(getPodName(i), i, null, false, false));
+            nodes.add(new NodeRef(KafkaResources.zookeeperPodName(cluster, i), i, null, false, false));
         }
 
         return nodes;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectMigration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectMigration.java
@@ -199,6 +199,6 @@ public class KafkaConnectMigration {
     private Future<Void> scaleUpStrimziPodSet(int replicas)    {
         LOGGER.infoCr(reconciliation, "Scaling up StrimziPodSet {}", connect.getComponentName());
         return podSetOperator.reconcile(reconciliation, reconciliation.namespace(), connect.getComponentName(), connect.generatePodSet(replicas, controllerAnnotations, podAnnotations, isOpenshift, imagePullPolicy, imagePullSecrets, customContainerImage))
-                .compose(i -> podOperator.readiness(reconciliation, reconciliation.namespace(), connect.getPodName(replicas - 1), 1_000, operationTimeoutMs));
+                .compose(i -> podOperator.readiness(reconciliation, reconciliation.namespace(), connect.getComponentName() + "-" + (replicas - 1), 1_000, operationTimeoutMs));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterPodSetTest.java
@@ -107,7 +107,7 @@ public class KafkaClusterPodSetTest {
 
     @ParallelTest
     public void testPodSet()   {
-        StrimziPodSet ps = KC.generatePodSets(true, null, null, brokerId -> Map.of("test-anno", KC.getPodName(brokerId))).get(0);
+        StrimziPodSet ps = KC.generatePodSets(true, null, null, brokerId -> Map.of("test-anno", KafkaResources.kafkaPodName(CLUSTER, brokerId))).get(0);
 
         assertThat(ps.getMetadata().getName(), is(KafkaResources.kafkaComponentName(CLUSTER)));
         assertThat(ps.getMetadata().getLabels().entrySet().containsAll(KC.labels.withAdditionalLabels(null).toMap().entrySet()), is(true));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -752,14 +752,6 @@ public class KafkaClusterTest {
     }
 
     @ParallelTest
-    public void testPodNames() {
-
-        for (int i = 0; i < REPLICAS; i++) {
-            assertThat(KC.getPodName(i), is(KafkaResources.kafkaComponentName(CLUSTER) + "-" + i));
-        }
-    }
-
-    @ParallelTest
     public void testPvcNames() {
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -372,13 +372,6 @@ public class ZookeeperClusterTest {
     }
 
     @ParallelTest
-    public void testPodNames() {
-        for (int i = 0; i < REPLICAS; i++) {
-            assertThat(ZC.getPodName(i), is(KafkaResources.zookeeperPodName(CLUSTER, i)));
-        }
-    }
-
-    @ParallelTest
     public void testPvcNames() {
         Kafka ka = new KafkaBuilder(KAFKA)
                 .editSpec()


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes `getPodName()` method from the `AbstractModel` class. This method was used only in a few places and in reality applies only to very small number of the model classes - to ZooKeeper and Connect / MM2. It does not generate the pod names for Kafka or Deployment based operands which might be confusing and can lead to bugs. The method can be also easily replaced as it does not contain any complicated logic.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally