### PR TITLE
docs(config): adds comments to config examples

### DIFF
--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -34,7 +34,7 @@ spec:
         pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         certificate: ca2.crt
-  # Authentication (recommended)
+  # Authentication (optional)
   authentication: # <4>
     type: tls
     certificateAndKey:
@@ -44,6 +44,7 @@ spec:
   # HTTP configuration (essential)
   http: # <5>
     port: 8080
+    # CORS configuration (optional)
     cors: # <6>
       allowedOrigins: "https://strimzi.io"
       allowedMethods: "GET,POST,PUT,DELETE,OPTIONS,PATCH"
@@ -71,15 +72,15 @@ spec:
       # Enabling DEBUG just for send operation
       logger.send.name: "http.openapi.operation.send"
       logger.send.level: DEBUG
-  # JVM options (recommended)
+  # JVM options (optional)
   jvmOptions: # <11>
     "-Xmx": "1g"
     "-Xms": "1g"
-  # Readiness probe (recommended)
+  # Readiness probe (optional)
   readinessProbe: # <12>
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  # Liveness probe (recommended)
+  # Liveness probe (optional)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -17,36 +17,45 @@ For a deeper understanding of the Kafka Bridge cluster configuration options, re
 .Example `KafkaBridge` custom resource configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaBridgeApiVersion}
 kind: KafkaBridge
 metadata:
   name: my-bridge
 spec:
+  # Replicas (essential)
   replicas: 3 # <1>
+  # Kafka bootstrap servers (essential)
   bootstrapServers: _<cluster_name>_-cluster-kafka-bootstrap:9092 # <2>
+  # TLS configuration (optional)
   tls: # <3>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         certificate: ca2.crt
+  # Authentication (recommended)
   authentication: # <4>
     type: tls
     certificateAndKey:
       secretName: my-secret
       certificate: public.crt
       key: private.key
+  # HTTP configuration (essential)
   http: # <5>
     port: 8080
     cors: # <6>
       allowedOrigins: "https://strimzi.io"
       allowedMethods: "GET,POST,PUT,DELETE,OPTIONS,PATCH"
+  # Consumer configuration (optional)
   consumer: # <7>
     config:
       auto.offset.reset: earliest
+  # Producer configuration (optional)
   producer: # <8>
     config:
       delivery.timeout.ms: 300000
+  # Resources requests and limits (recommended)
   resources: # <9>
     requests:
       cpu: "1"
@@ -54,23 +63,29 @@ spec:
     limits:
       cpu: "2"
       memory: 2Gi
+  # Logging configuration (optional)
   logging: # <10>
     type: inline
     loggers:
       logger.bridge.level: INFO
-      # enabling DEBUG just for send operation
+      # Enabling DEBUG just for send operation
       logger.send.name: "http.openapi.operation.send"
       logger.send.level: DEBUG
+  # JVM options (recommended)
   jvmOptions: # <11>
     "-Xmx": "1g"
     "-Xms": "1g"
+  # Readiness probe (recommended)
   readinessProbe: # <12>
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # Liveness probe (recommended)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # Custom image (optional)
   image: my-org/my-image:latest # <13>
+  # Pod template (optional)
   template: # <14>
     pod:
       affinity:
@@ -90,6 +105,7 @@ spec:
           value: my-otel-service
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://otlp-host:4317"
+  # Tracing configuration (optional)
   tracing:
     type: opentelemetry # <16>
 ----

--- a/documentation/modules/configuring/con-config-kafka-bridge.adoc
+++ b/documentation/modules/configuring/con-config-kafka-bridge.adoc
@@ -17,15 +17,15 @@ For a deeper understanding of the Kafka Bridge cluster configuration options, re
 .Example `KafkaBridge` custom resource configuration
 [source,yaml,subs="+quotes,attributes"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaBridgeApiVersion}
 kind: KafkaBridge
 metadata:
   name: my-bridge
 spec:
-  # Replicas (essential)
+  # Replicas (required)
   replicas: 3 # <1>
-  # Kafka bootstrap servers (essential)
+  # Kafka bootstrap servers (required)
   bootstrapServers: _<cluster_name>_-cluster-kafka-bootstrap:9092 # <2>
   # TLS configuration (optional)
   tls: # <3>
@@ -41,7 +41,7 @@ spec:
       secretName: my-secret
       certificate: public.crt
       key: private.key
-  # HTTP configuration (essential)
+  # HTTP configuration (required)
   http: # <5>
     port: 8080
     # CORS configuration (optional)

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -37,27 +37,34 @@ For more information, see xref:con-high-volume-config-properties-{context}[Handl
 .Example `KafkaConnect` custom resource configuration
 [source,yaml,subs=attributes+,options="nowrap"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect # <1>
 metadata:
   name: my-connect-cluster
   annotations:
     strimzi.io/use-connector-resources: "true" # <2>
+# Deployment specifications
 spec:
+  # Replicas (essential)
   replicas: 3 # <3>
+  # Authentication (recommended)
   authentication: # <4>
     type: tls
     certificateAndKey:
       certificate: source.crt
       key: source.key
       secretName: my-user-source
+  # Bootstrap servers (essential)
   bootstrapServers: my-cluster-kafka-bootstrap:9092 # <5>
+  # TLS configuration (optional)
   tls: # <6>
     trustedCertificates:
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
+  # Kafka Connect configuration (optional)
   config: # <7>
     group.id: my-connect-cluster
     offset.storage.topic: my-connect-cluster-offsets
@@ -70,6 +77,7 @@ spec:
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
+  # Build configuration (recommended)
   build: # <8>
     output: # <9>
       type: docker
@@ -86,6 +94,7 @@ spec:
           - type: jar
             url: <url_to_download_connector_2_artifact>
             sha512sum: <SHA-512_checksum_of_connector_2_artifact>
+  # External configuration (optional)
   externalConfiguration: # <11>
     env:
       - name: AWS_ACCESS_KEY_ID
@@ -98,6 +107,7 @@ spec:
           secretKeyRef:
             name: aws-creds
             key: awsSecretAccessKey
+  # Resources requests and limits (optional)
   resources: # <12>
     requests:
       cpu: "1"
@@ -105,28 +115,36 @@ spec:
     limits:
       cpu: "2"
       memory: 2Gi
+  # Logging configuration (optional)
   logging: # <13>
     type: inline
     loggers:
       log4j.rootLogger: INFO
+  # Readiness probe (recommended)
   readinessProbe: # <14>
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # Liveness probe (recommended)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # Metrics configuration (optional)
   metricsConfig: # <15>
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
         name: my-config-map
         key: my-key
+  # JVM options (recommended)
   jvmOptions: # <16>
     "-Xmx": "1g"
     "-Xms": "1g"
+  # Custom image (optional)
   image: my-org/my-image:latest # <17>
+  # Rack awareness (optional)
   rack:
     topologyKey: topology.kubernetes.io/zone # <18>
+  # Pod template (optional)
   template: # <19>
     pod:
       affinity:
@@ -146,6 +164,7 @@ spec:
           value: my-otel-service
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://otlp-host:4317"
+  # Tracing configuration (optional)
   tracing:
     type: opentelemetry # <21>
 ----

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -48,7 +48,7 @@ metadata:
 spec:
   # Replicas (essential)
   replicas: 3 # <3>
-  # Authentication (recommended)
+  # Authentication (optional)
   authentication: # <4>
     type: tls
     certificateAndKey:
@@ -64,7 +64,7 @@ spec:
         pattern: "*.crt"
       - secretName: my-cluster-cluster-cert
         pattern: "*.crt"
-  # Kafka Connect configuration (optional)
+  # Kafka Connect configuration (recommended)
   config: # <7>
     group.id: my-connect-cluster
     offset.storage.topic: my-connect-cluster-offsets
@@ -77,7 +77,7 @@ spec:
     config.storage.replication.factor: 3
     offset.storage.replication.factor: 3
     status.storage.replication.factor: 3
-  # Build configuration (recommended)
+  # Build configuration (optional)
   build: # <8>
     output: # <9>
       type: docker
@@ -107,7 +107,7 @@ spec:
           secretKeyRef:
             name: aws-creds
             key: awsSecretAccessKey
-  # Resources requests and limits (optional)
+  # Resources requests and limits (recommended)
   resources: # <12>
     requests:
       cpu: "1"
@@ -120,11 +120,11 @@ spec:
     type: inline
     loggers:
       log4j.rootLogger: INFO
-  # Readiness probe (recommended)
+  # Readiness probe (optional)
   readinessProbe: # <14>
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  # Liveness probe (recommended)
+  # Liveness probe (optional)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
@@ -135,7 +135,7 @@ spec:
       configMapKeyRef:
         name: my-config-map
         key: my-key
-  # JVM options (recommended)
+  # JVM options (optional)
   jvmOptions: # <16>
     "-Xmx": "1g"
     "-Xms": "1g"

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -37,7 +37,7 @@ For more information, see xref:con-high-volume-config-properties-{context}[Handl
 .Example `KafkaConnect` custom resource configuration
 [source,yaml,subs=attributes+,options="nowrap"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect # <1>
 metadata:
@@ -46,7 +46,7 @@ metadata:
     strimzi.io/use-connector-resources: "true" # <2>
 # Deployment specifications
 spec:
-  # Replicas (essential)
+  # Replicas (required)
   replicas: 3 # <3>
   # Authentication (optional)
   authentication: # <4>
@@ -55,7 +55,7 @@ spec:
       certificate: source.crt
       key: source.key
       secretName: my-user-source
-  # Bootstrap servers (essential)
+  # Bootstrap servers (required)
   bootstrapServers: my-cluster-kafka-bootstrap:9092 # <5>
   # TLS configuration (optional)
   tls: # <6>

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -38,7 +38,7 @@ metadata:
 # Deployment specifications
 spec:
   kafka:
-    # Kafka version (essential) 
+    # Kafka version (recommended) 
     version: {DefaultKafkaVersion} # <1>
     # KRaft metadata version (recommended)
     metadataVersion: {DefaultKafkaMetadataVersion} # <2>
@@ -55,15 +55,15 @@ spec:
       limits:
         memory: 64Gi
         cpu: "12"
-    #readiness probe (recommended)    
+    # Readiness probe (optional)    
     readinessProbe: # <5>
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    # Liveness probe (recommended)  
+    # Liveness probe (optional)  
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    # JVM options (recommended)
+    # JVM options (optional)
     jvmOptions: # <6>
       -Xms: 8192m
       -Xmx: 8192m

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -30,7 +30,7 @@ For a deeper understanding of the Kafka cluster configuration options, refer to 
 .Example `Kafka` custom resource configuration
 [source,yaml,subs="+attributes"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
@@ -69,7 +69,7 @@ spec:
       -Xmx: 8192m
     # Custom image (optional)  
     image: my-org/my-image:latest # <7>
-    # Listener configuration (essential)
+    # Listener configuration (required)
     listeners: # <8>
       - name: plain # <9>
         port: 9092 # <10>

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -95,7 +95,7 @@ spec:
     # Authorization (optional)
     authorization: # <17>
       type: simple
-    # Kafka configuration (optional)  
+    # Kafka configuration (recommended)  
     config: # <18>
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3

--- a/documentation/modules/configuring/con-config-kafka-kraft.adoc
+++ b/documentation/modules/configuring/con-config-kafka-kraft.adoc
@@ -30,18 +30,24 @@ For a deeper understanding of the Kafka cluster configuration options, refer to 
 .Example `Kafka` custom resource configuration
 [source,yaml,subs="+attributes"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster
+# Deployment specifications
 spec:
   kafka:
+    # Kafka version (essential) 
     version: {DefaultKafkaVersion} # <1>
+    # KRaft metadata version (recommended)
     metadataVersion: {DefaultKafkaMetadataVersion} # <2>
+    # Logging configuration (optional)
     logging: # <3>
       type: inline
       loggers:
         kafka.root.logger.level: INFO
+    # Resources requests and limits (recommended)
     resources: # <4>
       requests:
         memory: 64Gi
@@ -49,16 +55,21 @@ spec:
       limits:
         memory: 64Gi
         cpu: "12"
+    #readiness probe (recommended)    
     readinessProbe: # <5>
       initialDelaySeconds: 15
       timeoutSeconds: 5
+    # Liveness probe (recommended)  
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
+    # JVM options (recommended)
     jvmOptions: # <6>
       -Xms: 8192m
       -Xmx: 8192m
+    # Custom image (optional)  
     image: my-org/my-image:latest # <7>
+    # Listener configuration (essential)
     listeners: # <8>
       - name: plain # <9>
         port: 9092 # <10>
@@ -81,8 +92,10 @@ spec:
             secretName: my-secret
             certificate: my-certificate.crt
             key: my-key.key
+    # Authorization (optional)
     authorization: # <17>
       type: simple
+    # Kafka configuration (optional)  
     config: # <18>
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3
@@ -90,22 +103,27 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
+    # Rack awareness (optional) 
     rack: # <19>
       topologyKey: topology.kubernetes.io/zone
+    # Metrics configuration (optional)
     metricsConfig: # <20>
       type: jmxPrometheusExporter
       valueFrom:
         configMapKeyRef: # <21>
           name: my-config-map
           key: my-key
+  # Entity Operator (recommended)
   entityOperator: # <22>
     topicOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalMs: 60000
+      # Logging configuration (optional)
       logging: # <23>
         type: inline
         loggers:
           rootLogger.level: INFO
+      # Resources requests and limits (recommended)
       resources:
         requests:
           memory: 512Mi
@@ -116,10 +134,12 @@ spec:
     userOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalMs: 60000
+      # Logging configuration (optional)
       logging: # <24>
         type: inline
         loggers:
           rootLogger.level: INFO
+      # Resources requests and limits (recommended)
       resources:
         requests:
           memory: 512Mi
@@ -127,13 +147,15 @@ spec:
         limits:
           memory: 512Mi
           cpu: "1"
+  # Kafka Exporter (optional)
   kafkaExporter: # <25>
     # ...
+  # Cruise Control (optional)
   cruiseControl: # <26>
     # ...
 ----
 <1> Kafka version, which can be changed to a supported version by following the upgrade procedure.
-<2> Kafka metadata version,  which can be changed to a supported version by following the upgrade procedure.  
+<2> Kafka metadata version, which can be changed to a supported version by following the upgrade procedure.  
 <3> Kafka loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` key in the ConfigMap. For the Kafka `kafka.root.logger.level` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
 <4> Requests for reservation of supported resources, currently `cpu` and `memory`, and limits to specify the maximum resources that can be consumed.
 <5> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).

--- a/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
+++ b/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
@@ -39,7 +39,7 @@ spec:
   kafka:
     # Replicas (essential)
     replicas: 3
-    # Kafka version (essential)
+    # Kafka version (recommended)
     version: {DefaultKafkaVersion}
     # Logging configuration (optional)
     logging:
@@ -54,15 +54,15 @@ spec:
       limits:
         memory: 64Gi
         cpu: "12"
-    # Readiness probe (recommended)
+    # Readiness probe (optional)
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    # Liveness probe (recommended)
+    # Liveness probe (optional)
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    # JVM options (recommended)
+    # JVM options (optional)
     jvmOptions:
       -Xms: 8192m
       -Xmx: 8192m
@@ -135,7 +135,7 @@ spec:
       limits:
         memory: 8Gi
         cpu: "2"
-    # JVM options (recommended)
+    # JVM options (optional)
     jvmOptions: # <5>
       -Xms: 4096m
       -Xmx: 4096m

--- a/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
+++ b/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
@@ -29,7 +29,7 @@ For a deeper understanding of the ZooKeeper cluster configuration options, refer
 .Example `Kafka` custom resource configuration when using ZooKeeper
 [source,yaml,subs="+attributes"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
@@ -37,7 +37,7 @@ metadata:
 # Deployment specifications
 spec:
   kafka:
-    # Replicas (essential)
+    # Replicas (required)
     replicas: 3
     # Kafka version (recommended)
     version: {DefaultKafkaVersion}
@@ -68,7 +68,7 @@ spec:
       -Xmx: 8192m
     # Custom image (optional)
     image: my-org/my-image:latest
-    # Listener configuration (essential)
+    # Listener configuration (required)
     listeners:
       - name: plain
         port: 9092
@@ -103,7 +103,7 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
-    # Storage configuration (essential)
+    # Storage configuration (required)
     storage:
       type: persistent-claim
       size: 10000Gi
@@ -118,9 +118,9 @@ spec:
           name: my-config-map
           key: my-key
     # ...
-  # ZooKeeper configuration (essential)
+  # ZooKeeper configuration (required)
   zookeeper: # <1>
-    # Replicas (essential)
+    # Replicas (required)
     replicas: 3 # <2>
     # Logging configuration (optional)
     logging: # <3>
@@ -139,7 +139,7 @@ spec:
     jvmOptions: # <5>
       -Xms: 4096m
       -Xmx: 4096m
-    # Storage configuration (essential)
+    # Storage configuration (required)
     storage: # <6>
       type: persistent-claim
       size: 1000Gi

--- a/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
+++ b/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
@@ -94,7 +94,7 @@ spec:
     # Authorization (optional)
     authorization:
       type: simple
-    # Kafka configuration (optional)
+    # Kafka configuration (recommended)
     config:
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3

--- a/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
+++ b/documentation/modules/configuring/con-config-kafka-zookeeper.adoc
@@ -29,18 +29,24 @@ For a deeper understanding of the ZooKeeper cluster configuration options, refer
 .Example `Kafka` custom resource configuration when using ZooKeeper
 [source,yaml,subs="+attributes"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaApiVersion}
 kind: Kafka
 metadata:
   name: my-cluster
+# Deployment specifications
 spec:
   kafka:
+    # Replicas (essential)
     replicas: 3
+    # Kafka version (essential)
     version: {DefaultKafkaVersion}
+    # Logging configuration (optional)
     logging:
       type: inline
       loggers:
         kafka.root.logger.level: INFO
+    # Resources requests and limits (recommended)
     resources:
       requests:
         memory: 64Gi
@@ -48,16 +54,21 @@ spec:
       limits:
         memory: 64Gi
         cpu: "12"
+    # Readiness probe (recommended)
     readinessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
+    # Liveness probe (recommended)
     livenessProbe:
       initialDelaySeconds: 15
       timeoutSeconds: 5
+    # JVM options (recommended)
     jvmOptions:
       -Xms: 8192m
       -Xmx: 8192m
+    # Custom image (optional)
     image: my-org/my-image:latest
+    # Listener configuration (essential)
     listeners:
       - name: plain
         port: 9092
@@ -80,8 +91,10 @@ spec:
             secretName: my-secret
             certificate: my-certificate.crt
             key: my-key.key
+    # Authorization (optional)
     authorization:
       type: simple
+    # Kafka configuration (optional)
     config:
       auto.create.topics.enable: "false"
       offsets.topic.replication.factor: 3
@@ -90,11 +103,14 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       inter.broker.protocol.version: "{DefaultInterBrokerVersion}"
+    # Storage configuration (essential)
     storage:
       type: persistent-claim
       size: 10000Gi
+    # Rack awareness (optional)
     rack:
       topologyKey: topology.kubernetes.io/zone
+    # Metrics configuration (optional)
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:
@@ -102,12 +118,16 @@ spec:
           name: my-config-map
           key: my-key
     # ...
+  # ZooKeeper configuration (essential)
   zookeeper: # <1>
+    # Replicas (essential)
     replicas: 3 # <2>
+    # Logging configuration (optional)
     logging: # <3>
       type: inline
       loggers:
         zookeeper.root.logger: INFO
+    # Resources requests and limits (recommended)
     resources: # <4>
       requests:
         memory: 8Gi
@@ -115,27 +135,33 @@ spec:
       limits:
         memory: 8Gi
         cpu: "2"
+    # JVM options (recommended)
     jvmOptions: # <5>
       -Xms: 4096m
       -Xmx: 4096m
+    # Storage configuration (essential)
     storage: # <6>
       type: persistent-claim
       size: 1000Gi
+    # Metrics configuration (optional)
     metricsConfig: # <7>
       type: jmxPrometheusExporter
       valueFrom:
         configMapKeyRef: # <8>
           name: my-config-map
           key: my-key
-      # ...
+    # ...
+  # Entity operator (recommended)
   entityOperator:
     topicOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalSeconds: 60
+      # Logging configuration (optional)
       logging:
         type: inline
         loggers:
           rootLogger.level: INFO
+      # Resources requests and limits (recommended)
       resources:
         requests:
           memory: 512Mi
@@ -146,10 +172,12 @@ spec:
     userOperator:
       watchedNamespace: my-topic-namespace
       reconciliationIntervalSeconds: 60
+      # Logging configuration (optional)
       logging:
         type: inline
         loggers:
           rootLogger.level: INFO
+      # Resources requests and limits (recommended)
       resources:
         requests:
           memory: 512Mi
@@ -157,8 +185,10 @@ spec:
         limits:
           memory: 512Mi
           cpu: "1"
+  # Kafka Exporter (optional)
   kafkaExporter:
     # ...
+  # Cruise Control (optional)
   cruiseControl:
     # ...
 ----

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -76,7 +76,7 @@ For more information, see xref:con-high-volume-config-properties-{context}[Handl
 .Example `KafkaMirrorMaker2` custom resource configuration
 [source,yaml,subs="+attributes"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaMirrorMaker2ApiVersion}
 kind: KafkaMirrorMaker2 # <1>
 metadata:
@@ -85,11 +85,11 @@ metadata:
 spec:
   # Kafka version (recommended)
   version: {DefaultKafkaVersion} # <1>
-  # Replicas (essential)
+  # Replicas (required)
   replicas: 3 # <2>
-  # Connect cluster name (essential)
+  # Connect cluster name (required)
   connectCluster: "my-cluster-target" # <3>
-  # Cluster configurations (essential)
+  # Cluster configurations (required)
   clusters: # <4>
     - alias: "my-cluster-source" # <5>
       # Authentication (optional)
@@ -124,7 +124,7 @@ spec:
         trustedCertificates:
           - pattern: "*.crt"
             secretName: my-cluster-target-cluster-ca-cert
-  # Mirroring configurations (essential)
+  # Mirroring configurations (required)
   mirrors: # <14>
     - sourceCluster: "my-cluster-source" # <15>
       targetCluster: "my-cluster-target" # <16>
@@ -157,7 +157,7 @@ spec:
           sync.group.offsets.interval.seconds: 60 # <31>
           emit.checkpoints.interval.seconds: 60 # <32>
           replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
-      # Topic and group patterns (essential)
+      # Topic and group patterns (required)
       topicsPattern: "topic1|topic2|topic3" # <33>
       groupsPattern: "group1|group2|group3" # <34>
   # Resources requests and limits (recommended)

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -76,74 +76,91 @@ For more information, see xref:con-high-volume-config-properties-{context}[Handl
 .Example `KafkaMirrorMaker2` custom resource configuration
 [source,yaml,subs="+attributes"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaMirrorMaker2ApiVersion}
-kind: KafkaMirrorMaker2
+kind: KafkaMirrorMaker2 # <1>
 metadata:
   name: my-mirror-maker2
+# Deployment specifications
 spec:
+  # Kafka version (essential)
   version: {DefaultKafkaVersion} # <1>
+  # Replicas (essential)
   replicas: 3 # <2>
+  # Connect cluster name (essential)
   connectCluster: "my-cluster-target" # <3>
+  # Cluster configurations (essential)
   clusters: # <4>
-  - alias: "my-cluster-source" # <5>
-    authentication: # <6>
-      certificateAndKey:
-        certificate: source.crt
-        key: source.key
-        secretName: my-user-source
-      type: tls
-    bootstrapServers: my-cluster-source-kafka-bootstrap:9092 # <7>
-    tls: # <8>
-      trustedCertificates:
-        - pattern: "*.crt"
-          secretName: my-cluster-source-cluster-ca-cert
-  - alias: "my-cluster-target" # <9>
-    authentication: # <10>
-      certificateAndKey:
-        certificate: target.crt
-        key: target.key
-        secretName: my-user-target
-      type: tls
-    bootstrapServers: my-cluster-target-kafka-bootstrap:9092 # <11>
-    config: # <12>
-      config.storage.replication.factor: 1
-      offset.storage.replication.factor: 1
-      status.storage.replication.factor: 1
-    tls: # <13>
-      trustedCertificates:
-        - pattern: "*.crt"
-          secretName: my-cluster-target-cluster-ca-cert
+    - alias: "my-cluster-source" # <5>
+      # Authentication (recommended)
+      authentication: # <6>
+        certificateAndKey:
+          certificate: source.crt
+          key: source.key
+          secretName: my-user-source
+        type: tls
+      bootstrapServers: my-cluster-source-kafka-bootstrap:9092 # <7>
+      # TLS configuration (optional)
+      tls: # <8>
+        trustedCertificates:
+          - pattern: "*.crt"
+            secretName: my-cluster-source-cluster-ca-cert
+    - alias: "my-cluster-target" # <9>
+      # Authentication (recommended)
+      authentication: # <10>
+        certificateAndKey:
+          certificate: target.crt
+          key: target.key
+          secretName: my-user-target
+        type: tls
+      bootstrapServers: my-cluster-target-kafka-bootstrap:9092 # <11>
+      # Kafka Connect configuration (optional)
+      config: # <12>
+        config.storage.replication.factor: 1
+        offset.storage.replication.factor: 1
+        status.storage.replication.factor: 1
+      # TLS configuration (optional)
+      tls: # <13>
+        trustedCertificates:
+          - pattern: "*.crt"
+            secretName: my-cluster-target-cluster-ca-cert
+  # Mirroring configurations (essential)
   mirrors: # <14>
-  - sourceCluster: "my-cluster-source" # <15>
-    targetCluster: "my-cluster-target" # <16>
-    sourceConnector: # <17>
-      tasksMax: 10 # <18>
-      autoRestart: # <19>
-        enabled: true
-      config
-        replication.factor: 1 # <20>
-        offset-syncs.topic.replication.factor: 1 # <21>
-        sync.topic.acls.enabled: "false" # <22>
-        refresh.topics.interval.seconds: 60 # <23>
-        replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" # <24>
-    heartbeatConnector: # <25>
-      autoRestart:
-        enabled: true
-      config:
-        heartbeats.topic.replication.factor: 1 # <26>
-        replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
-    checkpointConnector: # <27>
-      autoRestart:
-        enabled: true
-      config:
-        checkpoints.topic.replication.factor: 1 # <28>
-        refresh.groups.interval.seconds: 600 # <29>
-        sync.group.offsets.enabled: true # <30>
-        sync.group.offsets.interval.seconds: 60 # <31>
-        emit.checkpoints.interval.seconds: 60 # <32>
-        replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
-    topicsPattern: "topic1|topic2|topic3" # <33>
-    groupsPattern: "group1|group2|group3" # <34>
+    - sourceCluster: "my-cluster-source" # <15>
+      targetCluster: "my-cluster-target" # <16>
+      # Source connector configuration (optional)
+      sourceConnector: # <17>
+        tasksMax: 10 # <18>
+        autoRestart: # <19>
+          enabled: true
+        config:
+          replication.factor: 1 # <20>
+          offset-syncs.topic.replication.factor: 1 # <21>
+          sync.topic.acls.enabled: "false" # <22>
+          refresh.topics.interval.seconds: 60 # <23>
+          replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy" # <24>
+      # Heartbeat connector configuration (optional)
+      heartbeatConnector: # <25>
+        autoRestart:
+          enabled: true
+        config:
+          heartbeats.topic.replication.factor: 1 # <26>
+          replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+      # Checkpoint connector configuration (optional)
+      checkpointConnector: # <27>
+        autoRestart:
+          enabled: true
+        config:
+          checkpoints.topic.replication.factor: 1 # <28>
+          refresh.groups.interval.seconds: 600 # <29>
+          sync.group.offsets.enabled: true # <30>
+          sync.group.offsets.interval.seconds: 60 # <31>
+          emit.checkpoints.interval.seconds: 60 # <32>
+          replication.policy.class: "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+      # Topic and group patterns (essential)
+      topicsPattern: "topic1|topic2|topic3" # <33>
+      groupsPattern: "group1|group2|group3" # <34>
+  # Resources requests and limits (recommended)
   resources: # <35>
     requests:
       cpu: "1"
@@ -151,22 +168,29 @@ spec:
     limits:
       cpu: "2"
       memory: 2Gi
+  # Logging configuration (optional)
   logging: # <36>
     type: inline
     loggers:
       connect.root.logger.level: INFO
+  # Readiness probe (recommended)
   readinessProbe: # <37>
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # Liveness probe (recommended)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
+  # JVM options (recommended)
   jvmOptions: # <38>
     "-Xmx": "1g"
     "-Xms": "1g"
+  # Custom image (optional)
   image: my-org/my-image:latest # <39>
+  # Rack awareness (optional)
   rack:
     topologyKey: topology.kubernetes.io/zone # <40>
+  # Pod template (optional)
   template: # <41>
     pod:
       affinity:
@@ -186,8 +210,10 @@ spec:
           value: my-otel-service
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://otlp-host:4317"
+  # Tracing configuration (optional)
   tracing:
     type: opentelemetry # <43>
+  # External configuration (optional)
   externalConfiguration: # <44>
     env:
       - name: AWS_ACCESS_KEY_ID

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -83,7 +83,7 @@ metadata:
   name: my-mirror-maker2
 # Deployment specifications
 spec:
-  # Kafka version (essential)
+  # Kafka version (recommended)
   version: {DefaultKafkaVersion} # <1>
   # Replicas (essential)
   replicas: 3 # <2>
@@ -92,7 +92,7 @@ spec:
   # Cluster configurations (essential)
   clusters: # <4>
     - alias: "my-cluster-source" # <5>
-      # Authentication (recommended)
+      # Authentication (optional)
       authentication: # <6>
         certificateAndKey:
           certificate: source.crt
@@ -106,7 +106,7 @@ spec:
           - pattern: "*.crt"
             secretName: my-cluster-source-cluster-ca-cert
     - alias: "my-cluster-target" # <9>
-      # Authentication (recommended)
+      # Authentication (optional)
       authentication: # <10>
         certificateAndKey:
           certificate: target.crt
@@ -128,7 +128,7 @@ spec:
   mirrors: # <14>
     - sourceCluster: "my-cluster-source" # <15>
       targetCluster: "my-cluster-target" # <16>
-      # Source connector configuration (optional)
+      # Source connector configuration (required)
       sourceConnector: # <17>
         tasksMax: 10 # <18>
         autoRestart: # <19>
@@ -173,15 +173,15 @@ spec:
     type: inline
     loggers:
       connect.root.logger.level: INFO
-  # Readiness probe (recommended)
+  # Readiness probe (optional)
   readinessProbe: # <37>
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  # Liveness probe (recommended)
+  # Liveness probe (optional)
   livenessProbe:
     initialDelaySeconds: 15
     timeoutSeconds: 5
-  # JVM options (recommended)
+  # JVM options (optional)
   jvmOptions: # <38>
     "-Xmx": "1g"
     "-Xms": "1g"

--- a/documentation/modules/configuring/con-config-node-pools.adoc
+++ b/documentation/modules/configuring/con-config-node-pools.adoc
@@ -35,17 +35,22 @@ For a deeper understanding of the node pool configuration options, refer to the 
 .Example configuration for a node pool in a cluster using KRaft mode 
 [source,yaml,subs="+attributes"]
 ----
+# Basic configuration (essential)
 apiVersion: {KafkaNodePoolApiVersion}
 kind: KafkaNodePool
 metadata:
   name: kraft-dual-role # <1>
   labels:
     strimzi.io/cluster: my-cluster # <2>
+# Node pool specifications
 spec:
+  # Replicas (essential)
   replicas: 3 # <3>
+  # Roles (essential)
   roles: # <4>
     - controller
     - broker
+  # Storage configuration (essential)
   storage: # <5>
     type: jbod
     volumes:
@@ -53,13 +58,14 @@ spec:
         type: persistent-claim
         size: 100Gi
         deleteClaim: false
+  # Resources requests and limits (optional)
   resources: # <6>
-      requests:
-        memory: 64Gi
-        cpu: "8"
-      limits:
-        memory: 64Gi
-        cpu: "12"      
+    requests:
+      memory: 64Gi
+      cpu: "8"
+    limits:
+      memory: 64Gi
+      cpu: "12"
 ----
 <1> Unique name for the node pool.
 <2> The Kafka cluster the node pool belongs to. A node pool can only belong to a single cluster.

--- a/documentation/modules/configuring/con-config-node-pools.adoc
+++ b/documentation/modules/configuring/con-config-node-pools.adoc
@@ -35,7 +35,7 @@ For a deeper understanding of the node pool configuration options, refer to the 
 .Example configuration for a node pool in a cluster using KRaft mode 
 [source,yaml,subs="+attributes"]
 ----
-# Basic configuration (essential)
+# Basic configuration (required)
 apiVersion: {KafkaNodePoolApiVersion}
 kind: KafkaNodePool
 metadata:
@@ -44,13 +44,13 @@ metadata:
     strimzi.io/cluster: my-cluster # <2>
 # Node pool specifications
 spec:
-  # Replicas (essential)
+  # Replicas (required)
   replicas: 3 # <3>
-  # Roles (essential)
+  # Roles (required)
   roles: # <4>
     - controller
     - broker
-  # Storage configuration (essential)
+  # Storage configuration (required)
   storage: # <5>
     type: jbod
     volumes:

--- a/documentation/modules/configuring/con-config-node-pools.adoc
+++ b/documentation/modules/configuring/con-config-node-pools.adoc
@@ -58,7 +58,7 @@ spec:
         type: persistent-claim
         size: 100Gi
         deleteClaim: false
-  # Resources requests and limits (optional)
+  # Resources requests and limits (recommended)
   resources: # <6>
     requests:
       memory: 64Gi


### PR DESCRIPTION
**Documentation**

This PR updates the Strimzi documentation to add comments for the full configuration examples, including Kafka in Kraft mode, Kafka with ZooKeeper, node pools, Kafka Connect, MirrorMaker 2, and Kafka Bridge. 

The comments categorize configuration settings as Essential, Recommended, or Optional.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

