### PR TITLE
Fix broken link in OAuth example

### DIFF
--- a/packaging/examples/security/keycloak-authorization/README.md
+++ b/packaging/examples/security/keycloak-authorization/README.md
@@ -7,7 +7,7 @@ This folder contains an example `Kafka` custom resource configured for OAuth 2.0
 
 The folder also contains a Keycloak realm export to import into your Keycloak instance to support the example.
 
-Full instructions for the example are available in the [Strimzi Documentation](https://strimzi.io/docs/operators/in-development/configuring.html#proc-oauth-authorization-keycloak-example_str).
+Full instructions for the example are available in the [Strimzi Documentation](https://strimzi.io/docs/operators/in-development/deploying.html#proc-oauth-authorization-keycloak-example_str).
 
 - [kafka-authz-realm.json](./kafka-authz-realm.json)
   - The Keycloak realm export file


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR fixes the broken link in the OAuth example.

### Checklist

- [x] Update documentation