### PR TITLE
Deprecate storage class overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   On the listener `serverBearerTokenLocation` and `userNamePrefix` have been added. 
   On the client `accessTokenLocation`, `clientAssertion`, `clientAssertionLocation`, `clientAssertionType`, and `saslExtensions` have been added.
 
+### Changes, deprecations and removals
+
+* The storage overrides for configuring per-broker storage class are deprecated and will be removed in the future.
+  If you are using the storage overrides, you should migrate to KafkaNodePool resources and use multiple node pools with a different storage class each. 
+
 ## 0.42.0
 
 * Add support for Kafka 3.7.1

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.kafka;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
@@ -114,6 +115,9 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
     @Description("Overrides for individual brokers. " +
             "The `overrides` field allows to specify a different configuration for different brokers.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Deprecated
+    @DeprecatedProperty(description = "The storage overrides for individual brokers are deprecated and will be removed in the future. " +
+            "Please use multiple KafkaNodePool custom resources with different storage classes instead.")
     public List<PersistentClaimStorageOverride> getOverrides() {
         return overrides;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -113,11 +113,11 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
     }
 
     @Description("Overrides for individual brokers. " +
-            "The `overrides` field allows to specify a different configuration for different brokers.")
+            "The `overrides` field allows you to specify a different configuration for different brokers.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Deprecated
     @DeprecatedProperty(description = "The storage overrides for individual brokers are deprecated and will be removed in the future. " +
-            "Please use multiple KafkaNodePool custom resources with different storage classes instead.")
+            "Please use multiple `KafkaNodePool` custom resources with different storage classes instead.")
     public List<PersistentClaimStorageOverride> getOverrides() {
         return overrides;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtils.java
@@ -85,6 +85,7 @@ public class PersistentVolumeClaimUtils {
      *
      * @return  Storage class which should be used for this PVC
      */
+    @SuppressWarnings("deprecation") // Storage overrides are deprecated
     private static String storageClassNameForBrokerId(int brokerId, PersistentClaimStorage storage)    {
         String storageClass = storage.getStorageClass();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -275,6 +275,7 @@ public class StorageDiff extends AbstractJsonDiff {
      *
      * @return                  True if only allowed override changes were done, false otherwise
      */
+    @SuppressWarnings("deprecation") // Storage overrides are deprecated
     private boolean isOverrideChangeAllowed(Storage current, Storage desired, Set<Integer> currentNodeIds, Set<Integer> desiredNodeIds)   {
         List<PersistentClaimStorageOverride> currentOverrides = ((PersistentClaimStorage) current).getOverrides();
         if (currentOverrides == null)   {

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -668,7 +668,7 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |overrides
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
-|Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+|**The `overrides` property has been deprecated.** The storage overrides for individual brokers are deprecated and will be removed in the future. Please use multiple KafkaNodePool custom resources with different storage classes instead. Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
 |====
 
 [id='type-PersistentClaimStorageOverride-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -668,7 +668,7 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |overrides
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
-|**The `overrides` property has been deprecated.** The storage overrides for individual brokers are deprecated and will be removed in the future. Please use multiple KafkaNodePool custom resources with different storage classes instead. Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+|**The `overrides` property has been deprecated.** The storage overrides for individual brokers are deprecated and will be removed in the future. Please use multiple `KafkaNodePool` custom resources with different storage classes instead. Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
 |====
 
 [id='type-PersistentClaimStorageOverride-{context}']

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -124,6 +124,8 @@ storage:
 
 == Storage class overrides
 
+WARNING: Storage class overrides are deprecated and will be removed in the future. Please use Kafka Node Pool resources instead.
+
 Instead of using the default storage class, you can specify a different storage class for one or more Kafka or ZooKeeper nodes.
 This is useful, for example, when storage classes are restricted to different availability zones or data centers.
 You can use the `overrides` field for this purpose.
@@ -189,6 +191,19 @@ As a result of the configured `overrides` property, the volumes use the followin
 
 The `overrides` property is currently used only to override the storage `class`. 
 Overrides for other storage configuration properties is not currently supported.
+
+=== Migrating from storage class overrides to Kafka Node Pools
+
+Storage class overrides are deprecated and will be removed in the future.
+If you use storage class overrides, you should use Kafka Node Pools instead.
+To migrate the existing configuration, you should follow these steps:
+
+1. Make sure you already use node pools resources.
+   If not, you should xref:proc-migrating-clusters-node-pools-str[migrate the cluster to use node pools] first.
+2. Create new xref:config-node-pools-str[node pools] with storage configuration using the desired storage class without using the overrides.
+3. Move all partition replicas from the old broker using the storage class overrides.
+   You can do this using xref:cruise-control-concepts-str[Cruise Control] or xref:assembly-reassign-tool-str[using the partition reassignment tool].
+4. Delete the old node pool with the old brokers using the storage class overrides.
 
 [id='ref-persistent-storage-pvc-{context}']
 == PVC resources for persistent storage

--- a/documentation/modules/configuring/ref-storage-persistent.adoc
+++ b/documentation/modules/configuring/ref-storage-persistent.adoc
@@ -124,7 +124,7 @@ storage:
 
 == Storage class overrides
 
-WARNING: Storage class overrides are deprecated and will be removed in the future. Please use Kafka Node Pool resources instead.
+WARNING: Storage class overrides are deprecated and will be removed in the future. As a replacement, use `KafkaNodePool` resources instead.
 
 Instead of using the default storage class, you can specify a different storage class for one or more Kafka or ZooKeeper nodes.
 This is useful, for example, when storage classes are restricted to different availability zones or data centers.
@@ -192,11 +192,11 @@ As a result of the configured `overrides` property, the volumes use the followin
 The `overrides` property is currently used only to override the storage `class`. 
 Overrides for other storage configuration properties is not currently supported.
 
-=== Migrating from storage class overrides to Kafka Node Pools
+=== Migrating from storage class overrides to node pools
 
 Storage class overrides are deprecated and will be removed in the future.
-If you use storage class overrides, you should use Kafka Node Pools instead.
-To migrate the existing configuration, you should follow these steps:
+If you are using storage class overrides, we encourage you to transition to using node pools instead.
+To migrate the existing configuration, follow these steps:
 
 1. Make sure you already use node pools resources.
    If not, you should xref:proc-migrating-clusters-node-pools-str[migrate the cluster to use node pools] first.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -575,7 +575,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                         selector:
                           additionalProperties:
                             type: string
@@ -626,7 +626,7 @@ spec:
                                     broker:
                                       type: integer
                                       description: Id of the kafka broker (broker identifier).
-                                description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                                description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                               selector:
                                 additionalProperties:
                                   type: string
@@ -2068,7 +2068,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                         selector:
                           additionalProperties:
                             type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -90,7 +90,7 @@ spec:
                         broker:
                           type: integer
                           description: Id of the kafka broker (broker identifier).
-                    description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                    description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                   selector:
                     additionalProperties:
                       type: string
@@ -141,7 +141,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                         selector:
                           additionalProperties:
                             type: string

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -574,7 +574,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                       selector:
                         additionalProperties:
                           type: string
@@ -625,7 +625,7 @@ spec:
                                   broker:
                                     type: integer
                                     description: Id of the kafka broker (broker identifier).
-                              description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                              description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                             selector:
                               additionalProperties:
                                 type: string
@@ -2067,7 +2067,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                       selector:
                         additionalProperties:
                           type: string

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -90,7 +90,7 @@ spec:
                         broker:
                           type: integer
                           description: Id of the kafka broker (broker identifier).
-                    description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                    description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                   selector:
                     additionalProperties:
                       type: string
@@ -141,7 +141,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                         selector:
                           additionalProperties:
                             type: string


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the storage class overrides in storage configuration as approved in [Strimzi Proposal no. 80](https://github.com/strimzi/proposals/blob/main/080-deprecation-and-removal-of-storage-overrides.md). It also updates the documentation accordingly. The warnings when the overrides are used are issued automatically for the deprecations. So there is no special code or test for them.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md