### PR TITLE
Fix broken system tests that should be run only in KRaft

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -64,6 +64,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(REGRESSION)
 @Tag(INTERNAL_CLIENTS_USED)
@@ -484,6 +485,9 @@ class AlternativeReconcileTriggersST extends AbstractST {
      */
     @ParallelNamespaceTest
     void testJbodMetadataLogRelocation() {
+        // This test makes sense only in KRaft mode
+        assumeTrue(Environment.isKRaftModeEnabled());
+
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int numberOfKafkaReplicas = 3;
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes broken assumption in the System test testing the JBOD metadata log dir relocation that should run only in KRaft. This was broken by #10398.

### Checklist

- [ ] Make sure all tests pass