### PR TITLE
Fix flaky `CustomCaST.testReplacingCustomClusterKeyPairToInvokeRenewalProcess` system test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -139,9 +139,8 @@ public class CustomCaST extends AbstractST {
 
         // Start a manual rolling update of your cluster to pick up the changes made to the secret configuration.
         StrimziPodSetUtils.annotateStrimziPodSet(testStorage.getNamespaceName(), testStorage.getControllerComponentName(), Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
-        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getControllerSelector(), 3, controllerPods);
-
         StrimziPodSetUtils.annotateStrimziPodSet(testStorage.getNamespaceName(), testStorage.getBrokerComponentName(), Collections.singletonMap(Annotations.ANNO_STRIMZI_IO_MANUAL_ROLLING_UPDATE, "true"));
+        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getControllerSelector(), 3, controllerPods);
         RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), 3, brokerPods);
 
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `CustomCaST.testReplacingCustomClusterKeyPairToInvokeRenewalProcess` seems to be very flaky in KRaft mode. This is because the annotation for the manual rolling update of the broker StrimziPodSet resources is done right after the manual rolling update of the controllers and that makes it very likely to be overwritten right away when the broker pod set is patched.

This PR tries to set both annotations right at the beginning to avoid this race condition. This should also speed up the test as it will not need to wait for another reconciliation.

### Checklist

- [ ] Make sure all tests pass