### PR TITLE
Fix flaky `MultipleClusterOperatorsST.testKafkaCCAndRebalanceWithMultipleCOs` system test

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1052,7 +1052,7 @@ public class KafkaRebalanceAssemblyOperator
                          .addToAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh.toString()))
                     .endMetadata()
                     .editStatus()
-                        .withObservedGeneration(kafkaRebalance.getMetadata().getGeneration())
+                         .withObservedGeneration(kafkaRebalance.getMetadata().getGeneration())
                     .endStatus();
 
             kafkaRebalanceOperator.patchAsync(reconciliation, patchedKafkaRebalance.build()).onComplete(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1050,7 +1050,10 @@ public class KafkaRebalanceAssemblyOperator
             patchedKafkaRebalance
                     .editMetadata()
                          .addToAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh.toString()))
-                    .endMetadata();
+                    .endMetadata()
+                    .editStatus()
+                        .withObservedGeneration(kafkaRebalance.getMetadata().getGeneration())
+                    .endStatus();;
 
             kafkaRebalanceOperator.patchAsync(reconciliation, patchedKafkaRebalance.build()).onComplete(
                     r -> LOGGER.debugCr(reconciliation, "The KafkaRebalance resource is updated with refresh annotation"));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -1053,7 +1053,7 @@ public class KafkaRebalanceAssemblyOperator
                     .endMetadata()
                     .editStatus()
                         .withObservedGeneration(kafkaRebalance.getMetadata().getGeneration())
-                    .endStatus();;
+                    .endStatus();
 
             kafkaRebalanceOperator.patchAsync(reconciliation, patchedKafkaRebalance.build()).onComplete(
                     r -> LOGGER.debugCr(reconciliation, "The KafkaRebalance resource is updated with refresh annotation"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -122,12 +122,12 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
         vertx = Vertx.vertx();
         sharedWorkerExecutor = vertx.createSharedWorkerExecutor("kubernetes-ops-pool");
-        
+
         // Configure Cruise Control mock
         cruiseControlPort = TestUtils.getFreePort();
         tlsKeyFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".key");
         tlsCrtFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".crt");
-        
+
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);
 
@@ -1253,11 +1253,10 @@ public class KafkaRebalanceAssemblyOperatorTest {
     }
 
     /**
-     * Tests the transition from 'New' to 'NotReady' due to missing Kafka cluster
-     *
-     * 1. A new KafkaRebalance resource is created; it is in the New state
-     * 2. The operator checks that the Kafka cluster specified in the KafkaRebalance resource (via label) doesn't exist
-     * 4. The KafkaRebalance resource moves to NotReady state
+     * Tests the scenario when the Kafka cluster to which the KafkaRebalance resource belongs does not match the custom
+     * resource selector of this operator. In this case, the operator should not do anything and return null status (as
+     * null status means that the status will nto be updated). This is important to avoid conflict between the operator
+     * actively managing this rebalance and other operators.
      */
     @Test
     public void testKafkaClusterNotMatchingSelector(VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -127,7 +127,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         cruiseControlPort = TestUtils.getFreePort();
         tlsKeyFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".key");
         tlsCrtFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".crt");
-
+        
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaRebalanceUtils.java
@@ -111,10 +111,6 @@ public class KafkaRebalanceUtils {
             }
         }
 
-        LOGGER.info("Verifying that annotation triggers the {} state", KafkaRebalanceState.Rebalancing);
-
-        waitForKafkaRebalanceCustomResourceState(namespaceName, rebalanceName, KafkaRebalanceState.Rebalancing);
-
         LOGGER.info("Verifying that KafkaRebalance is in the {} state", KafkaRebalanceState.Ready);
 
         waitForKafkaRebalanceCustomResourceState(namespaceName, rebalanceName, KafkaRebalanceState.Ready);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR attempts to fix the failing `MultipleClusterOperatorsST.testKafkaCCAndRebalanceWithMultipleCOs` system test. The reason for the failures in this test is that the passive operator correctly detected that the KafkaRebalance should not be acted upon. But it reconciles the status of the Krafka Rebalance resource which can lead to race conditions. It also removes the wait for the Rebalancing status in the system test tool (since `Rebalancing` is a transition state and might be hard to catch and create race conditions of its own - although this did not seem to be the reason for the failures here).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally