### PR TITLE
Fix API reference for the VolumeMounts object

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerTemplate.java
@@ -5,7 +5,6 @@
 package io.strimzi.api.kafka.model.common.template;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -42,7 +41,7 @@ public class ContainerTemplate implements UnknownPropertyPreserving {
     private List<VolumeMount> volumeMounts;
     
     @Description("Additional volume mounts which should be applied to the container")
-    @JsonProperty("volumeMounts")
+    @KubeLink(group = "core", version = "v1", kind = "volumemount")
     public List<VolumeMount> getVolumeMounts() {
         return volumeMounts;
     }

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1347,7 +1347,7 @@ include::../api/io.strimzi.api.kafka.model.common.template.ContainerTemplate.ado
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core[SecurityContext]
 |Security context for the container.
 |volumeMounts
-|xref:type-VolumeMount-{context}[`VolumeMount`] array
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volumemount-v1-core[VolumeMount] array
 |Additional volume mounts which should be applied to the container.
 |====
 
@@ -1366,38 +1366,6 @@ Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |value
 |string
 |The environment variable value.
-|====
-
-[id='type-VolumeMount-{context}']
-= `VolumeMount` schema reference
-
-Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
-
-
-[cols="2,2,3a",options="header"]
-|====
-|Property |Property type |Description
-|mountPath
-|string
-|
-|mountPropagation
-|string
-|
-|name
-|string
-|
-|readOnly
-|boolean
-|
-|recursiveReadOnly
-|string
-|
-|subPath
-|string
-|
-|subPathExpr
-|string
-|
 |====
 
 [id='type-TieredStorageCustom-{context}']


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

The `volumeMounts` field in the container template references a Kubernetes API through a Fabric8 object. This results in a table in the API reference without any descriptions: https://strimzi.io/docs/operators/in-development/full/configuring.html#type-VolumeMount-reference

This PR adds the KubeLink annotation to link to the Kubernetes API docs instead.

It also removes the unnecessary `JsonProperty` annotation.

### Checklist

- [x] Update documentation