### PR TITLE
Update the KRaft limitations as JBOD is now GA in Kafka 3.8.0

### DIFF
--- a/documentation/assemblies/deploying/assembly-kraft-mode.adoc
+++ b/documentation/assemblies/deploying/assembly-kraft-mode.adoc
@@ -53,9 +53,6 @@ image::kraft-dual-role-quorum.png[KRaft cluster with nodes that combine roles]
 
 Currently, the KRaft mode in Strimzi has the following major limitations:
 
-* JBOD storage is supported only with Apache Kafka 3.7.0 and higher.
-It is considered early-access in Apache Kafka 3.7.x.
-(Storage with `type: jbod` configuration can be used also with older Kafka versions, but the JBOD array can contain only one disk.)
 * Scaling of KRaft controller nodes up or down is not supported.
 * Unregistering Kafka nodes removed from the Kafka cluster.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR removes JBOD from the KRaft limitations as we don't support Kafka 3.6.x without JBOD support anymore.

### Checklist

- [x] Update documentation