### PR TITLE
Fix feature added to a wrong release in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Additional OAuth configuration options have been added for 'oauth' authentication on the listener and the client. 
   On the listener `serverBearerTokenLocation` and `userNamePrefix` have been added. 
   On the client `accessTokenLocation`, `clientAssertion`, `clientAssertionLocation`, `clientAssertionType`, and `saslExtensions` have been added.
+* Add support for custom Cruise Control API users
 
 ### Changes, deprecations and removals
 
@@ -29,7 +30,6 @@
 * Uncommented and enabled (by default) KRaft-related metrics in the `kafka-metrics.yaml` example file.
 * Added support for configuring the quotas plugin with type `strimzi` or `kafka` in the `Kafka` custom resource.
   The Strimzi Quotas plugin version was updated to 0.3.1.
-* Add support for custom Cruise Control API users
 
 ### Changes, deprecations and removals
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The CHANGELOG.md entry from #10072 was added under the previous 0.42 release instead of under 0.43. This PR fixes it.

### Checklist

- [x] Update CHANGELOG.md