### PR TITLE
Add Drain Cleaner 1.2.0 to the Operators repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   Remove support for Apache Kafka 3.6.0, 3.6.1, and 3.6.2.
 * Added alerts for Connectors/Tasks in failed state.
 * Support for specifying additional volumes and volume mounts in Strimzi custom resources
+* Strimzi Drain Cleaner updated to 1.2.0 (included in the Strimzi installation files)
 * Additional OAuth configuration options have been added for 'oauth' authentication on the listener and the client. 
   On the listener `serverBearerTokenLocation` and `userNamePrefix` have been added. 
   On the client `accessTokenLocation`, `clientAssertion`, `clientAssertionLocation`, `clientAssertionType`, and `saslExtensions` have been added.

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -40,7 +40,7 @@
 :BridgeVersion: 0.29.0
 
 // Drain Cleaner Version
-:DrainCleanerVersion: 1.1.0
+:DrainCleanerVersion: 1.2.0
 
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi-kafka-operator/releases[GitHub releases page^]

--- a/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/certmanager/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/kubernetes/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http

--- a/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/packaging/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: strimzi-drain-cleaner
       containers:
         - name: strimzi-drain-cleaner
-          image: quay.io/strimzi/drain-cleaner:1.1.0
+          image: quay.io/strimzi/drain-cleaner:1.2.0
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the new Drain Cleaner release (1.2.0) to the Operators repo installation files and docs.

### Checklist

- [x] Update documentation
- [x] Update CHANGELOG.md