### PR TITLE
Rename private `reconcile` method to `reconcileKafkaRebalance`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -356,9 +356,9 @@ public class KafkaRebalanceAssemblyOperator
         return rebalanceOptionsBuilder;
     }
 
-    private Future<KafkaRebalanceStatus> reconcile(Reconciliation reconciliation, String host,
-                                                   CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                   KafkaRebalanceState currentState) {
+    private Future<KafkaRebalanceStatus> reconcileKafkaRebalance(Reconciliation reconciliation, String host,
+                                                                 CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
+                                                                 KafkaRebalanceState currentState) {
 
         if (kafkaRebalance != null && kafkaRebalance.getStatus() != null
                 && "Ready".equals(rebalanceStateConditionType(kafkaRebalance.getStatus()))
@@ -1133,7 +1133,7 @@ public class KafkaRebalanceAssemblyOperator
                                                 }
                                                 currentState = KafkaRebalanceState.valueOf(rebalanceStateType);
                                             }
-                                            return reconcile(reconciliation, cruiseControlHost(clusterName, clusterNamespace),
+                                            return reconcileKafkaRebalance(reconciliation, cruiseControlHost(clusterName, clusterNamespace),
                                                     apiClient, currentKafkaRebalance, currentState);
                                         }, exception -> Future.failedFuture(exception));
                             });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -356,9 +356,9 @@ public class KafkaRebalanceAssemblyOperator
         return rebalanceOptionsBuilder;
     }
 
-    private Future<KafkaRebalanceStatus> reconcileKafkaRebalance(Reconciliation reconciliation, String host,
-                                                                 CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                                 KafkaRebalanceState currentState) {
+    private Future<KafkaRebalanceStatus> handleRebalance(Reconciliation reconciliation, String host,
+                                                         CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
+                                                         KafkaRebalanceState currentState) {
 
         if (kafkaRebalance != null && kafkaRebalance.getStatus() != null
                 && "Ready".equals(rebalanceStateConditionType(kafkaRebalance.getStatus()))
@@ -1031,7 +1031,7 @@ public class KafkaRebalanceAssemblyOperator
      * Reconcile loop for the KafkaRebalance
      */
     @SuppressWarnings({"checkstyle:NPathComplexity"})
-    /* test */ Future<KafkaRebalanceStatus> reconcileRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
+    /* test */ Future<KafkaRebalanceStatus> reconcileKafkaRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
         if (kafkaRebalance == null) {
             LOGGER.infoCr(reconciliation, "KafkaRebalance resource deleted");
             return Future.succeededFuture();
@@ -1133,7 +1133,7 @@ public class KafkaRebalanceAssemblyOperator
                                                 }
                                                 currentState = KafkaRebalanceState.valueOf(rebalanceStateType);
                                             }
-                                            return reconcileKafkaRebalance(reconciliation, cruiseControlHost(clusterName, clusterNamespace),
+                                            return handleRebalance(reconciliation, cruiseControlHost(clusterName, clusterNamespace),
                                                     apiClient, currentKafkaRebalance, currentState);
                                         }, exception -> Future.failedFuture(exception));
                             });
@@ -1353,12 +1353,12 @@ public class KafkaRebalanceAssemblyOperator
 
     @Override
     protected Future<KafkaRebalanceStatus> createOrUpdate(Reconciliation reconciliation, KafkaRebalance resource) {
-        return reconcileRebalance(reconciliation, resource);
+        return reconcileKafkaRebalance(reconciliation, resource);
     }
 
     @Override
     protected Future<Boolean> delete(Reconciliation reconciliation) {
-        return reconcileRebalance(reconciliation, null).map(v -> Boolean.TRUE);
+        return reconcileKafkaRebalance(reconciliation, null).map(v -> Boolean.TRUE);
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1311,7 +1311,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
         Checkpoint checkpoint = context.checkpoint();
         krao = createKafkaRebalanceAssemblyOperator(ClusterOperatorConfig.buildFromMap(Map.of(ClusterOperatorConfig.CUSTOM_RESOURCE_SELECTOR.key(), "selector=matching"), KafkaVersionTestUtils.getKafkaVersionLookup()));
-        krao.reconcileRebalance(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, RESOURCE_NAME), kr)
+        krao.reconcileKafkaRebalance(new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, namespace, RESOURCE_NAME), kr)
                 .onComplete(context.succeeding(v -> context.verify(() -> {
                     assertThat(v, is(nullValue()));
                     checkpoint.flag();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Refactoring

### Description

Fixing issue #10420
Renaming for less confusion as `AbstractOperator` as well exposes a `reconcile` method.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

