### PR TITLE
[ST] Remove `storageMap` from the suite

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractST.java
@@ -12,7 +12,6 @@ import io.strimzi.systemtest.parallel.TestSuiteNamespaceManager;
 import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.operator.SetupClusterOperator;
-import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.StUtils;
 import io.strimzi.test.interfaces.TestSeparator;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -29,7 +28,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static io.strimzi.systemtest.matchers.Matchers.logHasNoUnexpectedErrors;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
@@ -53,9 +51,6 @@ public abstract class AbstractST implements TestSeparator {
 
     // {thread-safe} this needs to be static because when more threads spawns diff. TestSuites it might produce race conditions
     private static final Object LOCK = new Object();
-
-    protected static ConcurrentHashMap<ExtensionContext, TestStorage> storageMap = new ConcurrentHashMap<>();
-
 
     protected void assertNoCoErrorsLogged(String namespaceName, long sinceSeconds) {
         LOGGER.info("Search in strimzi-cluster-operator log for errors in last {} second(s)", sinceSeconds);
@@ -109,7 +104,6 @@ public abstract class AbstractST implements TestSeparator {
         synchronized (LOCK) {
             LOGGER.info("Not first test we are gonna generate cluster name");
             testSuiteNamespaceManager.createParallelNamespace();
-            storageMap.put(ResourceManager.getTestContext(), new TestStorage(ResourceManager.getTestContext()));
         }
     }
 
@@ -172,7 +166,7 @@ public abstract class AbstractST implements TestSeparator {
         try {
             // This method needs to be disabled for the moment, as it brings flakiness and is unstable due to regexes and current matcher checks.
             // Needs to be reworked on what errors to ignore. Better error logging should be added.
-            //assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), storageMap.get(extensionContext).getTestExecutionTimeInSeconds());
+//            assertNoCoErrorsLogged(clusterOperator.getDeploymentNamespace(), (long) extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(TestConstants.TEST_EXECUTION_START_TIME_KEY));
         } finally {
             afterEachMayOverride();
             afterEachMustExecute();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAbstractST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.security.oauth;
 
-import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -15,19 +14,15 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IPv6NotSupported;
 import io.strimzi.systemtest.keycloak.KeycloakInstance;
 import io.strimzi.systemtest.resources.NamespaceManager;
-import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.keycloak.SetupKeycloak;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
-import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -140,20 +135,6 @@ public class OauthAbstractST extends AbstractST {
         keycloakInstance = SetupKeycloak.deployKeycloakAndImportRealms(keycloakNamespace);
 
         createSecretsForDeployments(keycloakNamespace);
-    }
-
-    @AfterEach
-    void tearDownEach() {
-        List<Job> clusterJobList = kubeClient().getJobList().getItems()
-            .stream()
-            .filter(
-                job -> job.getMetadata().getName().contains(storageMap.get(ResourceManager.getTestContext()).getClusterName()))
-            .toList();
-
-        for (Job job : clusterJobList) {
-            LOGGER.info("Deleting Job: {}/{} ", job.getMetadata().getNamespace(), job.getMetadata().getName());
-            JobUtils.deleteJobWithWait(job.getMetadata().getNamespace(), job.getMetadata().getName());
-        }
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 
 import java.util.HashMap;
@@ -330,11 +329,6 @@ class RackAwarenessST extends AbstractST {
         KafkaConnectUtils.waitUntilKafkaConnectRestApiIsAvailable(namespace, kafkaConnectPodName);
 
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(namespace, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, msgCount);
-    }
-
-    @BeforeEach
-    void createTestResources() {
-        storageMap.put(ResourceManager.getTestContext(), new TestStorage(ResourceManager.getTestContext()));
     }
 
     @BeforeAll

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -36,7 +36,6 @@ import io.strimzi.systemtest.utils.specific.TracingUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -75,14 +74,10 @@ public class OpenTelemetryST extends AbstractST {
 
     private final Tracing otelTracing = new OpenTelemetryTracing();
 
-    @ParallelNamespaceTest
     @Tag(ACCEPTANCE)
+    @ParallelNamespaceTest
     void testProducerConsumerStreamsService() {
-        // Current implementation of Jaeger deployment and test parallelism does not allow to run this test with STRIMZI_RBAC_SCOPE=NAMESPACE`
-        assumeFalse(Environment.isNamespaceRbacScope());
-
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -121,11 +116,7 @@ public class OpenTelemetryST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(MIRROR_MAKER2)
     void testProducerConsumerMirrorMaker2Service() {
-        // Current implementation of Jaeger deployment and test parallelism does not allow to run this test with STRIMZI_RBAC_SCOPE=NAMESPACE`
-        assumeFalse(Environment.isNamespaceRbacScope());
-
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -204,11 +195,7 @@ public class OpenTelemetryST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(MIRROR_MAKER)
     void testProducerConsumerMirrorMakerService() {
-        // Current implementation of Jaeger deployment and test parallelism does not allow to run this test with STRIMZI_RBAC_SCOPE=NAMESPACE`
-        assumeFalse(Environment.isNamespaceRbacScope());
-
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -277,11 +264,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerStreamsConnectService() {
-        // Current implementation of Jaeger deployment and test parallelism does not allow to run this test with STRIMZI_RBAC_SCOPE=NAMESPACE`
-        assumeFalse(Environment.isNamespaceRbacScope());
-
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -359,8 +342,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(BRIDGE)
     @ParallelNamespaceTest
     void testKafkaBridgeService() {
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -425,8 +407,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(BRIDGE)
     @ParallelNamespaceTest
     void testKafkaBridgeServiceWithHttpTracing() {
-        // This testStorage gets resources set by BeforeEach, so it must be retrieved from storageMap
-        final TestStorage testStorage = storageMap.get(ResourceManager.getTestContext());
+        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -489,8 +470,7 @@ public class OpenTelemetryST extends AbstractST {
         TracingUtils.verify(testStorage.getNamespaceName(), bridgeProducer, testStorage.getScraperPodName(), JAEGER_QUERY_SERVICE);
     }
 
-    @BeforeEach
-    void createTestResources() {
+    private TestStorage deployInitialResourcesAndGetTestStorage() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
         SetupJaeger.deployJaegerInstance(testStorage.getNamespaceName());
@@ -517,11 +497,13 @@ public class OpenTelemetryST extends AbstractST {
 
         testStorage.addToTestStorage(TestConstants.KAFKA_TRACING_CLIENT_KEY, kafkaTracingClients);
 
-        storageMap.put(ResourceManager.getTestContext(), testStorage);
+        return testStorage;
     }
 
     @BeforeAll
     void setup() {
+        assumeFalse(Environment.isNamespaceRbacScope());
+
         this.clusterOperator = this.clusterOperator
             .defaultInstallation()
             .createInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -77,7 +77,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(ACCEPTANCE)
     @ParallelNamespaceTest
     void testProducerConsumerStreamsService() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -116,7 +116,7 @@ public class OpenTelemetryST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(MIRROR_MAKER2)
     void testProducerConsumerMirrorMaker2Service() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -195,7 +195,7 @@ public class OpenTelemetryST extends AbstractST {
     @ParallelNamespaceTest
     @Tag(MIRROR_MAKER)
     void testProducerConsumerMirrorMakerService() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -264,7 +264,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(CONNECT_COMPONENTS)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testProducerConsumerStreamsConnectService() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -342,7 +342,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(BRIDGE)
     @ParallelNamespaceTest
     void testKafkaBridgeService() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(
@@ -407,7 +407,7 @@ public class OpenTelemetryST extends AbstractST {
     @Tag(BRIDGE)
     @ParallelNamespaceTest
     void testKafkaBridgeServiceWithHttpTracing() {
-        TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
+        final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();
 
         resourceManager.createResourceWithWait(
             NodePoolsConverter.convertNodePoolsIfNeeded(


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR removes `storageMap` from the last occurrences we have in our STs. Previously it was used for various things -> even during the tests to get the `TestStorage` object etc.
However, once the `ResourceManager.getTestContext()` was added and change to the `TestStorage`, this is not really needed.
The only place it can be useful is when we are getting start time for the test in the `tearDownTestCase` in the `assertNoCoErrorsLogged`, which is currently not used anyway. Just because of that it's not useful to keep the Map, is it can be done differently and take just the value from the extensionContext.

Additionally, for the other tests, some of the operations (like deletion of Jobs) is done now "automatically" or it can be done a little bit differently.

### Checklist

- [ ] Make sure all tests pass
