### PR TITLE
Add Kubernetes 1.23 and 1.24 support removal warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * The storage overrides for configuring per-broker storage class are deprecated and will be removed in the future.
   If you are using the storage overrides, you should migrate to KafkaNodePool resources and use multiple node pools with a different storage class each. 
+* Strimzi 0.43.0 (and any of its patch releases) is the last Strimzi version with support for Kubernetes 1.23 and 1.24.
+  From Strimzi 0.44.0 on, we will support only Kubernetes 1.25 and newer.
 
 ## 0.42.0
 


### PR DESCRIPTION
### Type of change

- Task

### Description

As discussed on the community call of 25th July, we plan to remove support for Kubernetes 1.23 and 1.24 in Strimzi 0.44. And we want to warn about it in the Strimzi 0.43 release notes. This PR adds the corresponding note to the CHANGELOG.md.

### Checklist

- [x] Update CHANGELOG.md