### PR TITLE
Refactoring KafkaRebalance state extraction

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceState;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility class for handling KafkaRebalance custom resource
+ */
+public class KafkaRebalanceUtils {
+
+    /**
+     * Searches through the conditions in the supplied status instance and finds those whose type matches one of the values defined
+     * in the {@link KafkaRebalanceState} enum.
+     * If there are none it will return null.
+     * If there is only one it will return that Condition.
+     * If there are more than one it will throw a RuntimeException.
+     *
+     * @param status The KafkaRebalanceStatus instance whose conditions will be searched.
+     * @return The Condition instance from the supplied status that has a type value matching one of the values of the
+     *         {@link KafkaRebalanceState} enum. If none are found then the method will return null.
+     * @throws RuntimeException If there is more than one Condition instance in the supplied status whose type matches one of the
+     *                          {@link KafkaRebalanceState} enum values.
+     */
+    public static Condition rebalanceStateCondition(KafkaRebalanceStatus status) {
+        if (status.getConditions() != null) {
+
+            List<Condition> statusConditions = status.getConditions()
+                    .stream()
+                    .filter(condition -> condition.getType() != null)
+                    .filter(condition -> Arrays.stream(KafkaRebalanceState.values())
+                            .anyMatch(stateValue -> stateValue.toString().equals(condition.getType())))
+                    .toList();
+
+            if (statusConditions.size() == 1) {
+                return statusConditions.get(0);
+            } else if (statusConditions.size() > 1) {
+                throw new RuntimeException("Multiple KafkaRebalance State Conditions were present in the KafkaRebalance status");
+            }
+        }
+        // If there are no conditions or none that have the correct status
+        return null;
+    }
+
+    /**
+     * Extract the {@link KafkaRebalanceState} enum state from the status of the corresponding KafkaRebalance custom resource
+     *
+     * @param kafkaRebalanceStatus  KafkaRebalance custom resource status from which extracting the rebalancing state
+     * @return  the corresponding {@link KafkaRebalanceState} enum state
+     */
+    public static KafkaRebalanceState rebalanceState(KafkaRebalanceStatus kafkaRebalanceStatus) {
+        if (kafkaRebalanceStatus != null) {
+            Condition rebalanceStateCondition = rebalanceStateCondition(kafkaRebalanceStatus);
+            String statusString = rebalanceStateCondition != null ? rebalanceStateCondition.getType() : null;
+            if (statusString != null) {
+                return KafkaRebalanceState.valueOf(statusString);
+            }
+        }
+        return null;
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -313,7 +313,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // the resource moved from New to NotReady due to the error
                     KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(client).inNamespace(namespace).withName(kr.getMetadata().getName()).get();
                     assertThat(kr1, StateMatchers.hasState());
-                    Condition condition = krao.rebalanceStateCondition(kr1.getStatus());
+                    Condition condition = KafkaRebalanceUtils.rebalanceStateCondition(kr1.getStatus());
                     assertThat(condition, StateMatchers.hasStateInCondition(KafkaRebalanceState.NotReady, CruiseControlRestException.class,
                             "Error processing POST request '/rebalance' due to: " +
                                     "'java.lang.IllegalArgumentException: Missing hard goals [NetworkInboundCapacityGoal, DiskCapacityGoal, RackAwareGoal, NetworkOutboundCapacityGoal, CpuCapacityGoal, ReplicaCapacityGoal] " +
@@ -910,7 +910,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // the resource moved from New to NotReady due to the error
                     KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(client).inNamespace(namespace).withName(kr.getMetadata().getName()).get();
                     assertThat(kr1, StateMatchers.hasState());
-                    Condition condition = krao.rebalanceStateCondition(kr1.getStatus());
+                    Condition condition = KafkaRebalanceUtils.rebalanceStateCondition(kr1.getStatus());
                     assertThat(condition, StateMatchers.hasStateInCondition(KafkaRebalanceState.NotReady, CruiseControlRestException.class,
                             "Error processing POST request '/rebalance' due to: " +
                                     "'java.lang.IllegalArgumentException: Missing hard goals [NetworkInboundCapacityGoal, DiskCapacityGoal, RackAwareGoal, NetworkOutboundCapacityGoal, CpuCapacityGoal, ReplicaCapacityGoal] " +
@@ -1055,7 +1055,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                     // the resource moved from New to NotReady due to the error
                     KafkaRebalance kr1 = Crds.kafkaRebalanceOperation(client).inNamespace(namespace).withName(kr.getMetadata().getName()).get();
                     assertThat(kr1, StateMatchers.hasState());
-                    Condition condition = krao.rebalanceStateCondition(kr1.getStatus());
+                    Condition condition = KafkaRebalanceUtils.rebalanceStateCondition(kr1.getStatus());
                     assertThat(condition, StateMatchers.hasStateInCondition(KafkaRebalanceState.NotReady, CruiseControlRestException.class,
                             "Error processing POST request '/rebalance' due to: " +
                                     "'java.lang.IllegalArgumentException: Missing hard goals [NetworkInboundCapacityGoal, DiskCapacityGoal, RackAwareGoal, NetworkOutboundCapacityGoal, CpuCapacityGoal, ReplicaCapacityGoal] " +
@@ -1671,7 +1671,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         context.verify(() -> {
             KafkaRebalance kafkaRebalance = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(namespace).withName(resource).get();
             assertThat(kafkaRebalance, StateMatchers.hasState());
-            Condition condition = krao.rebalanceStateCondition(kafkaRebalance.getStatus());
+            Condition condition = KafkaRebalanceUtils.rebalanceStateCondition(kafkaRebalance.getStatus());
             assertThat(Collections.singletonList(condition), StateMatchers.hasStateInConditions(state));
         });
     }
@@ -1689,7 +1689,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
             KafkaRebalance kafkaRebalance = Crds.kafkaRebalanceOperation(kubernetesClient).inNamespace(namespace).withName(resource).get();
 
             assertThat(kafkaRebalance, StateMatchers.hasState());
-            Condition condition = krao.rebalanceStateCondition(kafkaRebalance.getStatus());
+            Condition condition = KafkaRebalanceUtils.rebalanceStateCondition(kafkaRebalance.getStatus());
             assertThat(condition, StateMatchers.hasStateInCondition(state, reason, message));
         });
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly;
+
+import io.strimzi.api.kafka.model.common.ConditionBuilder;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceState;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatus;
+import io.strimzi.api.kafka.model.rebalance.KafkaRebalanceStatusBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KafkaRebalanceUtilsTest {
+
+    @Test
+    public void testValidSingleState() {
+        KafkaRebalanceStatus kafkaRebalanceStatus = new KafkaRebalanceStatusBuilder()
+                .withConditions(
+                        new ConditionBuilder()
+                                .withType(KafkaRebalanceState.Rebalancing.toString())
+                                .withStatus("Ready")
+                                .build())
+                .build();
+
+        KafkaRebalanceState state = KafkaRebalanceUtils.rebalanceState(kafkaRebalanceStatus);
+        assertThat(state, is(KafkaRebalanceState.Rebalancing));
+    }
+
+    @Test
+    public void testMultipleState() {
+        KafkaRebalanceStatus kafkaRebalanceStatus = new KafkaRebalanceStatusBuilder()
+                .withConditions(
+                        new ConditionBuilder()
+                                .withType(KafkaRebalanceState.ProposalReady.toString())
+                                .withStatus("Ready")
+                                .build(),
+                        new ConditionBuilder()
+                                .withType(KafkaRebalanceState.Rebalancing.toString())
+                                .withStatus("Ready")
+                                .build())
+                .build();
+
+        Throwable ex = assertThrows(RuntimeException.class, () -> KafkaRebalanceUtils.rebalanceState(kafkaRebalanceStatus));
+        assertThat(ex.getMessage(), is("Multiple KafkaRebalance State Conditions were present in the KafkaRebalance status"));
+    }
+
+    @Test
+    public void testNoConditionWithState() {
+        KafkaRebalanceStatus kafkaRebalanceStatus = new KafkaRebalanceStatusBuilder()
+                .withConditions(
+                        new ConditionBuilder()
+                                .withType("Some other type")
+                                .withStatus("Ready")
+                                .build())
+                .build();
+
+        KafkaRebalanceState state = KafkaRebalanceUtils.rebalanceState(kafkaRebalanceStatus);
+        assertThat(state, is(nullValue()));
+    }
+
+    @Test
+    public void testNoConditions() {
+        KafkaRebalanceStatus kafkaRebalanceStatus = new KafkaRebalanceStatusBuilder().build();
+
+        KafkaRebalanceState state = KafkaRebalanceUtils.rebalanceState(kafkaRebalanceStatus);
+        assertThat(state, is(nullValue()));
+    }
+
+    @Test
+    public void testNullStatus() {
+        KafkaRebalanceState state = KafkaRebalanceUtils.rebalanceState(null);
+        assertThat(state, is(nullValue()));
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
@@ -23,7 +23,7 @@ public class KafkaRebalanceUtilsTest {
                 .withConditions(
                         new ConditionBuilder()
                                 .withType(KafkaRebalanceState.Rebalancing.toString())
-                                .withStatus("Ready")
+                                .withStatus("True")
                                 .build())
                 .build();
 
@@ -37,11 +37,11 @@ public class KafkaRebalanceUtilsTest {
                 .withConditions(
                         new ConditionBuilder()
                                 .withType(KafkaRebalanceState.ProposalReady.toString())
-                                .withStatus("Ready")
+                                .withStatus("True")
                                 .build(),
                         new ConditionBuilder()
                                 .withType(KafkaRebalanceState.Rebalancing.toString())
-                                .withStatus("Ready")
+                                .withStatus("True")
                                 .build())
                 .build();
 
@@ -55,7 +55,7 @@ public class KafkaRebalanceUtilsTest {
                 .withConditions(
                         new ConditionBuilder()
                                 .withType("Some other type")
-                                .withStatus("Ready")
+                                .withStatus("True")
                                 .build())
                 .build();
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR does a little bit of refactoring around how the "state" of a rebalancing is extracted from the `KafkaRebalance` status, avoiding using String for comparison and too many methods.
Doing that, it provides a new `KafkaRebalanceUtils` class where the main related methods are moved. This class could host more in a future refactoring.
Also, it provides a way to access the rebalancing state for a `KafkaRebalance` even in relation to the auto-rebalancing work.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally