### PR TITLE
Add logLevel param to the helm readme

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -205,6 +205,7 @@ the documentation for more details.
 | `mavenBuilder.image.tag`                    | Override default Maven Builder image tag                                        | `nil`                        |
 | `mavenBuilder.image.digest`                 | Override Maven Builder image tag with digest                                    | `nil`                        |
 | `logConfiguration`                          | Override default `log4j.properties` content                                     | `nil`                        |
+| `logLevel`                                  | Override default logging level                                                  | `INFO`                       |
 | `dashboards.enable`                         | Generate configmaps containing the dashboards                                   | `false`                      |
 | `dashboards.label`                          | How should the dashboards be labeled for the sidecar                            | `grafana_dashboard`          |
 | `dashboards.labelValue`                     | What should the dashboards label value be for the sidecar                       | `"1"`                        |

--- a/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -205,7 +205,6 @@ the documentation for more details.
 | `mavenBuilder.image.tag`                    | Override default Maven Builder image tag                                        | `nil`                        |
 | `mavenBuilder.image.digest`                 | Override Maven Builder image tag with digest                                    | `nil`                        |
 | `logConfiguration`                          | Override default `log4j.properties` content                                     | `nil`                        |
-| `logLevel`                                  | Override default logging level                                                  | `INFO`                       |
 | `dashboards.enable`                         | Generate configmaps containing the dashboards                                   | `false`                      |
 | `dashboards.label`                          | How should the dashboards be labeled for the sidecar                            | `grafana_dashboard`          |
 | `dashboards.labelValue`                     | What should the dashboards label value be for the sidecar                       | `"1"`                        |

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/README.md
@@ -205,6 +205,7 @@ the documentation for more details.
 | `mavenBuilder.image.tag`                    | Override default Maven Builder image tag                                        | `nil`                        |
 | `mavenBuilder.image.digest`                 | Override Maven Builder image tag with digest                                    | `nil`                        |
 | `logConfiguration`                          | Override default `log4j.properties` content                                     | `nil`                        |
+| `logLevel`                                  | Override default logging level                                                  | `INFO`                       |
 | `dashboards.enable`                         | Generate configmaps containing the dashboards                                   | `false`                      |
 | `dashboards.label`                          | How should the dashboards be labeled for the sidecar                            | `grafana_dashboard`          |
 | `dashboards.labelValue`                     | What should the dashboards label value be for the sidecar                       | `"1"`                        |


### PR DESCRIPTION
Issue: #10453

### Type of change

_Select the type of your PR_
- Enhancement

### Description

logLevel is a valid helm param, but it is not mentioned in the README.md files related to helm-charts.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

