### PR TITLE
Update Maven task version in Azure Pipelines to Maven@4

### DIFF
--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -121,9 +121,9 @@ jobs:
       env:
         KAFKA_VERSION: '${{ parameters.kafkaVersion }}'
 
-    - task: Maven@3
+    - task: Maven@4
       inputs:
-        mavenPomFile: 'systemtest/pom.xml'
+        mavenPOMFile: 'systemtest/pom.xml'
         mavenOptions: '-Xmx3072m'
         javaHomeOption: 'JDKVersion'
         jdkVersionOption: 'default'


### PR DESCRIPTION
### Type of change

- Task

### Description

The `Maven@3` task used in our Azure Pipelines to run system tests is deprecated and this PR replaces it with `Maven@4`.