### PR TITLE
improve tiered storage system test

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -396,11 +396,11 @@ Pass additional parameters to `mvn` by populating the `EXTRA_ARGS` env var.
 
 Use the `verify` build goal and provide `-Dit.test=TestClassName[#testMethodName]` system property.
 
-    mvn verify -pl systemtest -P all -Dit.test=KafkaST#testCustomAndUpdatedValues
+    mvn verify -pl systemtest -P all -Dit.test=KafkaST#testJvmAndResources
 
 You can also run a test with a particular feature gate enabled via the feature gate environment variable.
 
-    STRIMZI_FEATURE_GATES="+FeatureName" mvn verify -pl systemtest -P all -Dit.test=KafkaST#testCustomAndUpdatedValues
+    STRIMZI_FEATURE_GATES="+FeatureName" mvn verify -pl systemtest -P all -Dit.test=KafkaST#testJvmAndResources
 
 ## Skip Teardown
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -119,6 +119,9 @@ public class TieredStorageST extends AbstractST {
                             .addToConfig("storage.aws.secret.access.key", SetupMinio.ADMIN_CREDS)
                         .endRemoteStorageManager()
                     .endTieredStorageCustomTiered()
+                    // reduce the interval to speed up the test
+                    .addToConfig("remote.log.manager.task.interval.ms", 5000)
+                    .addToConfig("log.retention.check.interval.ms", 5000)
                 .endKafka()
             .endSpec()
             .build());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement=
- Documentation

### Description

1. In `testTieredStorageWithAivenPlugin`, we'll wait for the log uploaded or deleted in remote storage, this can be speeded up by reducing `remote.log.manager.task.interval.ms` config value (default is 30 sec). 
2. In `testTieredStorageWithAivenPlugin`, we'll wait for the local log got deleted, this can be speeded up by reducing `log.retention.check.interval.ms` config value (default is 5 min). 
3. Update the dev guide because we don't have `testCustomAndUpdatedValues` test in `KafkaST` now.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

