### PR TITLE
[ST] Add CC API Users test

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/SecretTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/kubernetes/SecretTemplates.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.templates.kubernetes;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+
+import java.util.Collections;
+
+public class SecretTemplates {
+
+    private SecretTemplates() {}
+
+    public static SecretBuilder secret(String namespaceName, String secretName, String dataKey, String dataValue) {
+        return new SecretBuilder()
+            .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(namespaceName)
+            .endMetadata()
+            .withType("Opaque")
+            .withStringData(Collections.singletonMap(dataKey, dataValue));
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.cruisecontrol;
 
-import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -72,6 +72,23 @@ public class CruiseControlApiST extends AbstractST {
         assertThat(responseText, containsString("NO_TASK_IN_PROGRESS"));
     }
 
+    /**
+     * @description This test case verifies the creation and usage of CruiseControl's API users.
+     *
+     * @steps
+     *  1. - Create NodePools for the Kafka cluster
+     *     - NodePools are created
+     *  2. - Create Secret containing the `arnost: heslo, USER` in the `.key` field
+     *     - Secret is correctly created
+     *  3. - Deploy Kafka with CruiseControl containing configuration for the CC API users, with reference to the Secret (and its `.key` value) created in
+     *       previous step
+     *     - Kafka cluster with CruiseControl are deployed, the CC API users configuration is applied
+     *  4. - Do request to CruiseControl's API, specifically to `/state` endpoint with `arnost:heslo` user
+     *     - Request is successful and response contains information about state of the CruiseControl
+     *
+     * @usecase
+     *  - cruise-control-api
+     */
     @ParallelNamespaceTest
     void testCruiseControlAPIUsers() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -592,8 +592,8 @@ public class MetricsST extends AbstractST {
      */
     @ParallelTest
     void testCruiseControlMetrics() {
-        String cruiseControlMetrics = CruiseControlUtils.callApi(namespaceFirst, CruiseControlUtils.HttpMethod.GET, CruiseControlUtils.Scheme.HTTP,
-                CruiseControlUtils.CRUISE_CONTROL_METRICS_PORT, "/metrics", "", true).getResponseText();
+        String cruiseControlMetrics = CruiseControlUtils.callApiWithAdminCredentials(namespaceFirst, CruiseControlUtils.HttpMethod.GET, CruiseControlUtils.Scheme.HTTP,
+                CruiseControlUtils.CRUISE_CONTROL_METRICS_PORT, "/metrics", "").getResponseText();
         Matcher regex = Pattern.compile("^([^#].*)\\s+([^\\s]*)$", Pattern.MULTILINE).matcher(cruiseControlMetrics);
 
         LOGGER.info("Verifying that we have more than 0 groups");


### PR DESCRIPTION
### Type of change

- New test

### Description

This PR adds test for the new feature - CC API users. It creates API user with `USER` permissions (that has `GET` permissions to almost all endpoints) and verifies that we can check the `/state` endpoint without need to disable security.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass

