### PR TITLE
[system test] - re-write some tests to use pattern with trusted certi…

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -867,7 +867,7 @@ class ConnectST extends AbstractST {
                 .addToConfig("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .withNewTls()
                     .withTrustedCertificates(new CertSecretSourceBuilder()
-                        .withCertificate("ca.crt")
+                        .withPattern("*.crt")
                         .withSecretName(KafkaResources.clusterCaCertificateSecretName(testStorage.getClusterName()))
                         .build())
                 .endTls()

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -1008,9 +1008,9 @@ class MirrorMaker2ST extends AbstractST {
         certSecretSource.setCertificate("ca.crt");
         certSecretSource.setSecretName(KafkaResources.clusterCaCertificateSecretName(testStorage.getSourceClusterName()));
 
-        // Initialize CertSecretSource with certificate and secret names for target
+        // Initialize CertSecretSource with certificate and secret names for target (using pattern)
         CertSecretSource certSecretTarget = new CertSecretSource();
-        certSecretTarget.setCertificate("ca.crt");
+        certSecretTarget.setPattern("*.crt");
         certSecretTarget.setSecretName(KafkaResources.clusterCaCertificateSecretName(testStorage.getTargetClusterName()));
 
         resourceManager.createResourceWithWait(KafkaMirrorMaker2Templates.kafkaMirrorMaker2(testStorage, 1, true)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -516,10 +516,10 @@ public class OauthTlsST extends OauthAbstractST {
             .withAlias(testStorage.getTargetClusterName())
             .withConfig(connectorConfig)
             .withBootstrapServers(KafkaResources.tlsBootstrapAddress(targetKafkaCluster))
-            // this is for kafka tls connection
+            // this is for kafka tls connection (using pattern)
             .withNewTls()
                 .withTrustedCertificates(new CertSecretSourceBuilder()
-                    .withCertificate("ca.crt")
+                    .withPattern("*.crt")
                     .withSecretName(KafkaResources.clusterCaCertificateSecretName(targetKafkaCluster))
                     .build())
             .endTls()


### PR DESCRIPTION
…ficates

### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR re-writes, some of our test cases, where we use trusted certificates without using regex approach. I found out that we do not use such regex anywhere. So I have updated a few tests (i.e., KafkaConnect, MirrorMaker2 and MirrorMaker2 with Ouath) to have some coverage on it. 

### Checklist

- [x] Write tests
- [ ] Make sure all tests pass

