### PR TITLE
Fix duplicate clustersrolebindings issue

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/020-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 {{- $root := . -}}
-{{- range append .Values.watchNamespaces .Release.Namespace }}
+{{- $watchNamespaces := .Values.watchNamespaces -}}
+{{- if $root.Values.watchAnyNamespace }}
+  {{- $watchNamespaces = list -}}  
+{{- end }}
+{{- range append $watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if $root.Values.watchAnyNamespace }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/023-RoleBinding-strimzi-cluster-operator.yaml
@@ -1,6 +1,10 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.create -}}
 {{- $root := . -}}
-{{- range append .Values.watchNamespaces .Release.Namespace }}
+{{- $watchNamespaces := .Values.watchNamespaces -}}
+{{- if $root.Values.watchAnyNamespace }}
+  {{- $watchNamespaces = list -}}  
+{{- end }}
+{{- range append $watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if $root.Values.watchAnyNamespace }}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/031-RoleBinding-strimzi-cluster-operator-entity-operator-delegation.yaml
@@ -1,6 +1,10 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.create -}}
 {{- $root := . -}}
-{{- range append .Values.watchNamespaces .Release.Namespace }}
+{{- $watchNamespaces := .Values.watchNamespaces -}}
+{{- if $root.Values.watchAnyNamespace }}
+  {{- $watchNamespaces = list -}}  
+{{- end }}
+{{- range append $watchNamespaces .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if $root.Values.watchAnyNamespace }}


### PR DESCRIPTION
### Type of change
- Bugfix


### Description
Duplicate ClusterRoleBindings will be attempted to be created when we set watchAnyNamespace to true and add some namespaces to watchNamespaces.

Fixes: https://github.com/strimzi/strimzi-kafka-operator/issues/10378

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

