### PR TITLE
Remove keystore/truststore pwd from kafka agent command

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -110,7 +110,16 @@ fi
 
 KEY_STORE=/tmp/kafka/cluster.keystore.p12
 TRUST_STORE=/tmp/kafka/cluster.truststore.p12
-KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=$KAFKA_READY:$ZK_CONNECTED:$KEY_STORE:$CERTS_STORE_PASSWORD:$TRUST_STORE:$CERTS_STORE_PASSWORD"
+
+rm -f /tmp/kafka-agent.properties
+tee /tmp/kafka-agent.properties <<EOF
+sslKeyStorePath=${KEY_STORE}
+sslKeyStorePass=${CERTS_STORE_PASSWORD}
+sslTrustStorePath=${TRUST_STORE}
+sslTrustStorePass=${CERTS_STORE_PASSWORD}
+EOF
+
+KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=$KAFKA_READY:$ZK_CONNECTED:/tmp/kafka-agent.properties"
 export KAFKA_OPTS
 
 # Configure Garbage Collection logging


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR is to refactor the kafka-agent startup command, move the keystore/truststore related parameters to a properties file, so that they don't show up in the process table.

This is an improvement on issue: https://github.com/strimzi/strimzi-kafka-operator/issues/9957

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

