### PR TITLE
Disable unmanaged topics reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Changes, deprecations and removals
 
-* When finalizers are enabled (default), if they are removed from unmanaged KafkaTopic resources, the Topic Operator restores them in the next reconciliation.
-  This does not happen for paused KafkaTopic resources, and it's not expected by users, so we disabled that behavior.
+* When finalizers are enabled (default), the Topic Operator will no longer restore finalizers on unmanaged `KafkaTopic` resources if they are removed, aligning the behavior with paused topics, where finalizers are also not restored.
+  This change matches user expectations.
 
 ## 0.43.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Changes, deprecations and removals
 
-* When enabled, finalizers are no more reconciled on unmanaged KafkaTopics.
+* When finalizers are enabled (default), if they are removed from unmanaged KafkaTopic resources, the Topic Operator restores them in the next reconciliation.
+  This does not happen for paused KafkaTopic resources, and it's not expected by users, so we disabled that behavior.
 
 ## 0.43.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.44.0
 
+* Add the "Unmanaged" KafkaTopic status update.
+
+### Changes, deprecations and removals
+
+* When enabled, finalizers are no more reconciled on unmanaged KafkaTopics.
 
 ## 0.43.0
 

--- a/documentation/modules/operators/proc-converting-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-managed-topics.adoc
@@ -6,7 +6,7 @@
 = Managing KafkaTopic resources without impacting Kafka topics
 
 [role="_abstract"]
-This procedure describes how to convert Kafka topics that are currently managed through the `KafkaTopic` resource into non-managed topics.
+This procedure describes how to convert Kafka topics that are currently managed through the `KafkaTopic` resource into unmanaged topics.
 This capability can be useful in various scenarios. 
 For instance, you might want to update the `metadata.name` of a `KafkaTopic` resource.
 You can only do that by deleting the original `KafkaTopic` resource and recreating a new one.
@@ -24,7 +24,7 @@ This allows you to retain the Kafka topic while making changes to the resource's
 +
 [source,shell,subs="+quotes"]
 ----
-kubectl annotate kafkatopic my-topic-1 strimzi.io/managed="false"
+kubectl annotate kafkatopic my-topic-1 strimzi.io/managed="false" --overwrite
 ----
 +
 Specify the `metadata.name` of the topic in your `KafkaTopic` resource, which is `my-topic-1` in this example.
@@ -33,10 +33,10 @@ Specify the `metadata.name` of the topic in your `KafkaTopic` resource, which is
 +
 [source,shell,subs="+quotes"]
 ----
-oc get kafkatopics my-topic-1 -o yaml
+kubectl get kafkatopic my-topic-1 -o yaml
 ----
 +
-.Example topic with a `Ready` status
+.Example topic with the `Unmanaged` status
 [source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
@@ -45,25 +45,25 @@ metadata:
   generation: 124
   name: my-topic-1
   finalizer: 
-    strimzi.io/topic-operator
+  - strimzi.io/topic-operator
   labels:
     strimzi.io/cluster: my-cluster
+  annotations:
+    strimzi.io/managed: "false"
 spec:
   partitions: 10
   replicas: 2
-
-# ...
+  config:
+    retention.ms: 432000000
 status: 
   observedGeneration: 124 # <1>
-  topicName: my-topic-1
   conditions:
-  - type: Ready
-    status: True
-    lastTransitionTime: 20230301T103000Z  
+  - lastTransitionTime: "2024-08-22T06:07:57.671085635Z"
+    status: "True"
+    type: Unmanaged # <2>
 ----
-<1> Successful reconciliation of the resource means the topic is no longer managed.
-+
-The value of `metadata.generation` (the current version of the deployment) must `match status.observedGeneration` (the latest reconciliation of the resource).
+<1> The value of `metadata.generation` must `match status.observedGeneration`.
+<2> The Unmanaged condition means that the KafkaTopic is not reconciled anymore.
 
 . You can now make changes to the `KafkaTopic` resource without it affecting the Kafka topic it was managing.
 +

--- a/documentation/modules/operators/proc-converting-managed-topics.adoc
+++ b/documentation/modules/operators/proc-converting-managed-topics.adoc
@@ -36,7 +36,7 @@ Specify the `metadata.name` of the topic in your `KafkaTopic` resource, which is
 kubectl get kafkatopic my-topic-1 -o yaml
 ----
 +
-.Example topic with the `Unmanaged` status
+.Example topic with an `Unmanaged` status
 [source,shell,subs="+attributes"]
 ----
 apiVersion: {KafkaTopicApiVersion}
@@ -63,7 +63,7 @@ status:
     type: Unmanaged # <2>
 ----
 <1> The value of `metadata.generation` must `match status.observedGeneration`.
-<2> The Unmanaged condition means that the KafkaTopic is not reconciled anymore.
+<2> The `Unmanaged` condition means that the `KafkaTopic` is no longer reconciled.
 
 . You can now make changes to the `KafkaTopic` resource without it affecting the Kafka topic it was managing.
 +

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -186,7 +186,8 @@ public class BatchingTopicController {
     private List<ReconcilableTopic> addOrRemoveFinalizer(boolean useFinalizer, List<ReconcilableTopic> reconcilableTopics) {
         List<ReconcilableTopic> collect = reconcilableTopics.stream()
                 .map(reconcilableTopic ->
-                        new ReconcilableTopic(reconcilableTopic.reconciliation(), useFinalizer ? addFinalizer(reconcilableTopic) : removeFinalizer(reconcilableTopic), reconcilableTopic.topicName()))
+                        new ReconcilableTopic(reconcilableTopic.reconciliation(), useFinalizer 
+                            ? addFinalizer(reconcilableTopic) : removeFinalizer(reconcilableTopic), reconcilableTopic.topicName()))
                 .collect(Collectors.toList());
         LOGGER.traceOp("{} {} topics", useFinalizer ? "Added finalizers to" : "Removed finalizers from", reconcilableTopics.size());
         return collect;
@@ -411,28 +412,31 @@ public class BatchingTopicController {
         }
 
         // process remaining
+        Map<ReconcilableTopic, Either<TopicOperatorException, Object>> results = new HashMap<>();
         var remainingAfterDeletions = partitionedByDeletion.get(false);
         var timerSamples = remainingAfterDeletions.stream().collect(
             Collectors.toMap(identity(), rt -> startReconciliationTimer(metrics)));
-        Map<ReconcilableTopic, Either<TopicOperatorException, Object>> results = new HashMap<>();
-        var partitionedByManaged = remainingAfterDeletions.stream().collect(Collectors.partitioningBy(reconcilableTopic -> TopicOperatorUtil.isManaged(reconcilableTopic.kt())));
-        
-        // process remaining unmanaged
+
+        var partitionedByManaged = remainingAfterDeletions.stream().collect(
+            Collectors.partitioningBy(reconcilableTopic -> TopicOperatorUtil.isManaged(reconcilableTopic.kt())));
+
+        // process unmanaged
         var unmanaged = partitionedByManaged.get(false);
-        addOrRemoveFinalizer(useFinalizer, unmanaged).forEach(rt -> putResult(results, rt, Either.ofRight(null)));
-        metrics.reconciliationsCounter(namespace).increment(unmanaged.size());
+        unmanaged.forEach(rt -> putResult(results, rt, Either.ofRight(null)));
 
-        // process remaining managed, skipping paused KTs
-        var partitionedByPaused = validateManagedTopics(partitionedByManaged).stream().filter(hasTopicSpec)
+        // process paused
+        var managed = partitionedByManaged.get(true);
+        var partitionedByPaused = validateManagedTopics(managed).stream().filter(hasTopicSpec)
             .collect(Collectors.partitioningBy(reconcilableTopic -> TopicOperatorUtil.isPaused(reconcilableTopic.kt())));
-        partitionedByPaused.get(true).forEach(reconcilableTopic -> putResult(results, reconcilableTopic, Either.ofRight(null)));
+        var paused = partitionedByPaused.get(true);
+        paused.forEach(rt -> putResult(results, rt, Either.ofRight(null)));
 
+        // process managed not paused
         var mayNeedUpdate = partitionedByPaused.get(false);
-        metrics.reconciliationsCounter(namespace).increment(mayNeedUpdate.size());
-        var addedFinalizer = addOrRemoveFinalizer(useFinalizer, mayNeedUpdate);
-        var currentStatesOrError = describeTopic(addedFinalizer);
-        
+        addOrRemoveFinalizer(useFinalizer, mayNeedUpdate);
+
         // figure out necessary updates
+        var currentStatesOrError = describeTopic(mayNeedUpdate);
         createMissingTopics(results, currentStatesOrError);
         List<Pair<ReconcilableTopic, Collection<AlterConfigOp>>> someAlterConfigs = configChanges(results, currentStatesOrError);
         List<Pair<ReconcilableTopic, NewPartitions>> someCreatePartitions = partitionChanges(results, currentStatesOrError);
@@ -441,10 +445,11 @@ public class BatchingTopicController {
         var alterConfigsResults = alterConfigs(someAlterConfigs);
         var createPartitionsResults = createPartitions(someCreatePartitions);
         var checkReplicasChangesResults = checkReplicasChanges(batch, currentStatesOrError);
-        
+
         // update statuses
         accumulateResults(results, alterConfigsResults, createPartitionsResults, checkReplicasChangesResults);
         updateStatuses(results);
+        metrics.reconciliationsCounter(namespace).increment(results.size());
         timerSamples.keySet().forEach(rt -> stopReconciliationTimer(metrics, timerSamples.get(rt), namespace));
         LOGGER.traceOp("Reconciled batch of {} KafkaTopics", results.size());
     }
@@ -594,8 +599,8 @@ public class BatchingTopicController {
         return hasSpec;
     };
 
-    private List<ReconcilableTopic> validateManagedTopics(Map<Boolean, List<ReconcilableTopic>> partitionedByManaged) {
-        var mayNeedUpdate = partitionedByManaged.get(true).stream().filter(reconcilableTopic -> {
+    private List<ReconcilableTopic> validateManagedTopics(List<ReconcilableTopic> reconcilableTopics) {
+        var mayNeedUpdate = reconcilableTopics.stream().filter(reconcilableTopic -> {
             var e = validate(reconcilableTopic);
             if (e.isRightEqual(false)) {
                 // Do nothing
@@ -1121,8 +1126,15 @@ public class BatchingTopicController {
     
     private void updateStatusForSuccess(ReconcilableTopic reconcilableTopic) {
         List<Condition> conditions = new ArrayList<>();
+        var conditionType = "Ready";
+        if (!TopicOperatorUtil.isManaged(reconcilableTopic.kt())) {
+            conditionType = "Unmanaged";
+        } else if (TopicOperatorUtil.isPaused(reconcilableTopic.kt())) {
+            conditionType = "ReconciliationPaused";
+        }
+        
         conditions.add(new ConditionBuilder()
-              .withType(TopicOperatorUtil.isPaused(reconcilableTopic.kt()) ? "ReconciliationPaused" : "Ready")
+              .withType(conditionType)
               .withStatus("True")
               .withLastTransitionTime(StatusUtils.iso8601Now())
               .build());
@@ -1198,24 +1210,34 @@ public class BatchingTopicController {
         var oldStatus = Crds.topicOperation(kubeClient)
             .inNamespace(reconcilableTopic.kt().getMetadata().getNamespace())
             .withName(reconcilableTopic.kt().getMetadata().getName()).get().getStatus();
+
+        // set observedGeneration
+        if ((!TopicOperatorUtil.isManaged(reconcilableTopic.kt()) || TopicOperatorUtil.isPaused(reconcilableTopic.kt())) && oldStatus == null) {
+            // observedGeneration is initialized to 0 when creating a new unmanaged or paused topic
+            reconcilableTopic.kt().getStatus().setObservedGeneration(0L);
+        } else {
+            reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getMetadata().getGeneration());
+        }
+
+        // set topicName
+        reconcilableTopic.kt().getStatus().setTopicName(
+            !TopicOperatorUtil.isManaged(reconcilableTopic.kt())
+                ? null
+                : oldStatus != null && oldStatus.getTopicName() != null
+                ? oldStatus.getTopicName()
+                : TopicOperatorUtil.topicName(reconcilableTopic.kt())
+        );
+        
         if (statusChanged(reconcilableTopic.kt(), oldStatus)) {
-            // the observedGeneration is initialized to 0 when creating a paused topic (oldStatus null, paused true)
-            // this will result in metadata.generation: 1 > status.observedGeneration: 0 (not reconciled)
-            reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getStatus() != null && oldStatus != null
-                ? !TopicOperatorUtil.isPaused(reconcilableTopic.kt()) ? reconcilableTopic.kt().getMetadata().getGeneration() : oldStatus.getObservedGeneration()
-                : !TopicOperatorUtil.isPaused(reconcilableTopic.kt()) ? reconcilableTopic.kt().getMetadata().getGeneration() : 0L);
-            reconcilableTopic.kt().getStatus().setTopicName(!TopicOperatorUtil.isManaged(reconcilableTopic.kt()) ? null
-                : oldStatus != null && oldStatus.getTopicName() != null ? oldStatus.getTopicName()
-                : TopicOperatorUtil.topicName(reconcilableTopic.kt()));
-            var updatedTopic = new KafkaTopicBuilder(reconcilableTopic.kt())
-                .editOrNewMetadata()
-                .withResourceVersion(null)
-                .endMetadata()
-                .withStatus(reconcilableTopic.kt().getStatus())
-                .build();
-            LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status with {}", updatedTopic.getStatus());
-            var timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, enableAdditionalMetrics);
             try {
+                var updatedTopic = new KafkaTopicBuilder(reconcilableTopic.kt())
+                    .editOrNewMetadata()
+                        .withResourceVersion(null)
+                    .endMetadata()
+                    .withStatus(reconcilableTopic.kt().getStatus())
+                    .build();
+                LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status with {}", updatedTopic.getStatus());
+                var timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, enableAdditionalMetrics);
                 var got = Crds.topicOperation(kubeClient).resource(updatedTopic).updateStatus();
                 TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::updateStatusTimer, enableAdditionalMetrics, namespace);
                 LOGGER.traceCr(reconcilableTopic.reconciliation(), "Updated status to observedGeneration {}, resourceVersion {}",

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -1210,16 +1210,11 @@ public class BatchingTopicController {
         var oldStatus = Crds.topicOperation(kubeClient)
             .inNamespace(reconcilableTopic.kt().getMetadata().getNamespace())
             .withName(reconcilableTopic.kt().getMetadata().getName()).get().getStatus();
-
-        // set observedGeneration
-        if ((!TopicOperatorUtil.isManaged(reconcilableTopic.kt()) || TopicOperatorUtil.isPaused(reconcilableTopic.kt())) && oldStatus == null) {
-            // observedGeneration is initialized to 0 when creating a new unmanaged or paused topic
-            reconcilableTopic.kt().getStatus().setObservedGeneration(0L);
-        } else {
-            reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getMetadata().getGeneration());
-        }
-
-        // set topicName
+        
+        // the observedGeneration is a marker that shows that the operator works and that it saw the last update to the resource
+        reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getMetadata().getGeneration());
+        
+        // set or reset the topicName
         reconcilableTopic.kt().getStatus().setTopicName(
             !TopicOperatorUtil.isManaged(reconcilableTopic.kt())
                 ? null

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -2030,7 +2030,7 @@ class TopicControllerIT {
             pausedIsTrue()
         );
 
-        assertEquals(0, kt.getStatus().getObservedGeneration());
+        assertEquals(1, kt.getStatus().getObservedGeneration());
         assertNotExistsInKafka(topicName);
     }
 

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -484,7 +484,7 @@ class TopicControllerIT {
     }
 
     private KafkaTopic createTopic(KafkaCluster kc, KafkaTopic kt) throws ExecutionException, InterruptedException {
-        return TopicOperatorUtil.isManaged(kt) ? createTopic(kc, kt, readyIsTrueOrFalse()) : createTopic(kc, kt, unmanagedIsTrue());
+        return createTopic(kc, kt, TopicOperatorUtil.isManaged(kt) ? readyIsTrueOrFalse() : unmanagedIsTrue());
     }
 
     private KafkaTopic createTopic(KafkaCluster kc, KafkaTopic kt, Predicate<KafkaTopic> condition) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If someone removes the finalizer of an unmanaged topic, the operator restores the finalizer in the next reconciliation. Instead, this does not happen for paused topics. This change makes unmanaged topics behave like paused topics, which is what users expect.

### Checklist

- [x] Make sure all tests pass
