### PR TITLE
docs(cruise control): format fix for cc api users section

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -160,8 +160,10 @@ The following use cases would benefit from accessing the Cruise Control API with
 Cruise Control reads authentication credentials for API users in Jetty's `HashLoginService` file format.
 
 Standard Cruise Control `USER` and `VIEWER` roles are supported.
-* `USER` has has access to all the `GET` endpoints except bootstrap and train.
-* `VIEWER` has access to `kafka_cluster_state`, `user_tasks` and `review_board` endpoints.
+
+* `USER` has has access to all the `GET` endpoints except `bootstrap` and `train`.
+* `VIEWER` has access to `kafka_cluster_state`, `user_tasks`, and `review_board` endpoints.
+
 In this example, we define two custom API users in the supported format in a text file called `cruise-control-auth.txt`:
 
 [source]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -161,7 +161,7 @@ Cruise Control reads authentication credentials for API users in Jetty's `HashLo
 
 Standard Cruise Control `USER` and `VIEWER` roles are supported.
 
-* `USER` has has access to all the `GET` endpoints except `bootstrap` and `train`.
+* `USER` has access to all the `GET` endpoints except `bootstrap` and `train`.
 * `VIEWER` has access to `kafka_cluster_state`, `user_tasks`, and `review_board` endpoints.
 
 In this example, we define two custom API users in the supported format in a text file called `cruise-control-auth.txt`:


### PR DESCRIPTION
Documentation

Minor format fix for the  API Users section in the [CruiseControlSpec schema reference](https://strimzi.io/docs/operators/in-development/configuring#type-CruiseControlSpec-reference)


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

