### PR TITLE
Fix bugs for automatic refresh of KafkaRebalance

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -991,23 +991,6 @@ public class KafkaRebalanceAssemblyOperator
                 KafkaRebalanceUtils.rebalanceState(kafkaRebalance.getStatus()),
                 ANNO_STRIMZI_IO_REBALANCE, rawRebalanceAnnotation(kafkaRebalance));
 
-        if (kafkaRebalance.getStatus() != null
-                && kafkaRebalance.getStatus().getObservedGeneration() != kafkaRebalance.getMetadata().getGeneration()) {
-
-            KafkaRebalanceBuilder patchedKafkaRebalance = new KafkaRebalanceBuilder(kafkaRebalance);
-
-            patchedKafkaRebalance
-                    .editMetadata()
-                         .addToAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh.toString()))
-                    .endMetadata()
-                    .editStatus()
-                         .withObservedGeneration(kafkaRebalance.getMetadata().getGeneration())
-                    .endStatus();
-
-            kafkaRebalanceOperator.patchAsync(reconciliation, patchedKafkaRebalance.build()).onComplete(
-                    r -> LOGGER.debugCr(reconciliation, "The KafkaRebalance resource is updated with refresh annotation"));
-        }
-
         String clusterName = kafkaRebalance.getMetadata().getLabels() == null ? null : kafkaRebalance.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
         String clusterNamespace = kafkaRebalance.getMetadata().getNamespace();
         if (clusterName == null) {
@@ -1043,21 +1026,46 @@ public class KafkaRebalanceAssemblyOperator
                                 new InvalidResourceException(CruiseControlIssues.cruiseControlDisabled.getMessage())));
                     }
 
+                    Future<Void> resourcePatchFuture = Future.future(future -> {
+                        if (kafkaRebalance.getStatus() != null
+                                && kafkaRebalance.getStatus().getObservedGeneration() != kafkaRebalance.getMetadata().getGeneration()) {
+
+                            KafkaRebalanceBuilder patchedKafkaRebalance = new KafkaRebalanceBuilder(kafkaRebalance);
+
+                            patchedKafkaRebalance
+                                    .editMetadata()
+                                        .addToAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh.toString()))
+                                    .endMetadata();
+
+                            kafkaRebalanceOperator.patchAsync(reconciliation, patchedKafkaRebalance.build()).onComplete(
+                                    r -> {
+                                        if (r.succeeded()) {
+                                        LOGGER.debugCr(reconciliation, "The KafkaRebalance resource is updated with refresh annotation");
+                                            future.complete();
+                                        } else {
+                                        LOGGER.errorCr(reconciliation, "Failed to update the KafkaRebalance resource with refresh annotation");
+                                        future.fail(r.cause());
+                                        }
+                                    });
+                        } else {
+                            future.complete();
+                        }
+                    });
+
                     String ccSecretName =  CruiseControlResources.secretName(clusterName);
                     String ccApiSecretName =  CruiseControlResources.apiSecretName(clusterName);
 
                     Future<Secret> ccSecretFuture = secretOperations.getAsync(clusterNamespace, ccSecretName);
                     Future<Secret> ccApiSecretFuture = secretOperations.getAsync(clusterNamespace, ccApiSecretName);
 
-                    return Future.join(ccSecretFuture, ccApiSecretFuture)
+                    return Future.join(resourcePatchFuture, ccSecretFuture, ccApiSecretFuture)
                             .compose(compositeFuture -> {
-
-                                Secret ccSecret = compositeFuture.resultAt(0);
+                                Secret ccSecret = compositeFuture.resultAt(1);
                                 if (ccSecret == null) {
                                     return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccSecretName));
                                 }
 
-                                Secret ccApiSecret = compositeFuture.resultAt(1);
+                                Secret ccApiSecret = compositeFuture.resultAt(2);
                                 if (ccApiSecret == null) {
                                     return Future.failedFuture(Util.missingSecretException(clusterNamespace, ccApiSecretName));
                                 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

- Automatic refreshing of the KafkaRebalance is plugged into the asynchronous flow of the Vert.x futures
- Move the logic so that it's done after checking Kafka cluster exists and is ready, and the resource belongs to the operator annotating it. 
- Remove unnecessary status update that gets ignored

Closes #10423 and #10416 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

