### PR TITLE
Fix topicId status update

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -1245,7 +1245,7 @@ public class BatchingTopicController {
                 .build();
             LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status with {}", updatedTopic.getStatus());
             var timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, enableAdditionalMetrics);
-            try {    
+            try {
                 var got = Crds.topicOperation(kubeClient).resource(updatedTopic).updateStatus();
                 LOGGER.traceCr(reconcilableTopic.reconciliation(), "Updated status to observedGeneration {}, resourceVersion {}",
                     got.getStatus().getObservedGeneration(), got.getMetadata().getResourceVersion());

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -102,6 +102,9 @@ public class BatchingTopicController {
 
     // Key: topic name, Value: The KafkaTopics known to manage that topic
     /* test */ final Map<String, List<KubeRef>> topics = new HashMap<>();
+    
+    // topic name id map, which is updated on every reconciliation
+    private Map<String, String> topicNameIdMap;
 
     private final TopicOperatorMetricsHolder metrics;
     private final String namespace;
@@ -134,6 +137,7 @@ public class BatchingTopicController {
         this.namespace = config.namespace();
         this.enableAdditionalMetrics = config.enableAdditionalMetrics();
         this.replicasChangeHandler = replicasChangeHandler;
+        this.topicNameIdMap = new HashMap<>();
     }
 
     /**
@@ -312,8 +316,7 @@ public class BatchingTopicController {
         return partitionedByError(kts.stream().map(reconcilableTopic -> {
             try {
                 values.get(reconcilableTopic.topicName()).get();
-                reconcilableTopic.kt().setStatus(new KafkaTopicStatusBuilder()
-                    .withTopicId(ctr.topicId(reconcilableTopic.topicName()).get().toString()).build());
+                topicNameIdMap.put(reconcilableTopic.topicName(), ctr.topicId(reconcilableTopic.topicName()).get().toString());
                 return new Pair<>(reconcilableTopic, Either.ofRight((null)));
             } catch (ExecutionException e) {
                 if (e.getCause() != null && e.getCause() instanceof TopicExistsException) {
@@ -388,6 +391,9 @@ public class BatchingTopicController {
 
     private void updateInternal(List<ReconcilableTopic> batch) {
         LOGGER.debugOp("Reconciling batch {}", batch);
+        Map<ReconcilableTopic, Either<TopicOperatorException, Object>> results = new HashMap<>();
+        topicNameIdMap.clear();
+        
         // process deletions
         var partitionedByDeletion = batch.stream().filter(reconcilableTopic -> {
             var kt = reconcilableTopic.kt();
@@ -412,7 +418,6 @@ public class BatchingTopicController {
         }
 
         // process remaining
-        Map<ReconcilableTopic, Either<TopicOperatorException, Object>> results = new HashMap<>();
         var remainingAfterDeletions = partitionedByDeletion.get(false);
         var timerSamples = remainingAfterDeletions.stream().collect(
             Collectors.toMap(identity(), rt -> startReconciliationTimer(metrics)));
@@ -878,6 +883,7 @@ public class BatchingTopicController {
             ExecutionException exception = null;
             try {
                 description = cs1.get(reconcilableTopic.topicName()).get();
+                topicNameIdMap.put(reconcilableTopic.topicName(), description.topicId().toString());
             } catch (ExecutionException e) {
                 exception = e;
             } catch (InterruptedException e) {
@@ -1214,33 +1220,39 @@ public class BatchingTopicController {
         // the observedGeneration is a marker that shows that the operator works and that it saw the last update to the resource
         reconcilableTopic.kt().getStatus().setObservedGeneration(reconcilableTopic.kt().getMetadata().getGeneration());
 
-        // set or reset the topicName
+        // add or remove topicName
         reconcilableTopic.kt().getStatus().setTopicName(
             !TopicOperatorUtil.isManaged(reconcilableTopic.kt())
                 ? null
                 : oldStatus != null && oldStatus.getTopicName() != null
-                ? oldStatus.getTopicName()
-                : TopicOperatorUtil.topicName(reconcilableTopic.kt())
+                    ? oldStatus.getTopicName()
+                    : TopicOperatorUtil.topicName(reconcilableTopic.kt())
+        );
+
+        // add or remove topicId
+        reconcilableTopic.kt().getStatus().setTopicId(
+            (!TopicOperatorUtil.isManaged(reconcilableTopic.kt()) || TopicOperatorUtil.isPaused(reconcilableTopic.kt()))
+                ? null : topicNameIdMap.get(reconcilableTopic.topicName())
         );
 
         StatusDiff statusDiff = new StatusDiff(oldStatus, reconcilableTopic.kt().getStatus());
         if (!statusDiff.isEmpty()) {
-            try {
-                var updatedTopic = new KafkaTopicBuilder(reconcilableTopic.kt())
-                    .editOrNewMetadata()
-                        .withResourceVersion(null)
-                    .endMetadata()
-                    .withStatus(reconcilableTopic.kt().getStatus())
-                    .build();
-                LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status with {}", updatedTopic.getStatus());
-                var timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, enableAdditionalMetrics);
+            var updatedTopic = new KafkaTopicBuilder(reconcilableTopic.kt())
+                .editOrNewMetadata()
+                    .withResourceVersion(null)
+                .endMetadata()
+                .withStatus(reconcilableTopic.kt().getStatus())
+                .build();
+            LOGGER.debugCr(reconcilableTopic.reconciliation(), "Updating status with {}", updatedTopic.getStatus());
+            var timerSample = TopicOperatorUtil.startExternalRequestTimer(metrics, enableAdditionalMetrics);
+            try {    
                 var got = Crds.topicOperation(kubeClient).resource(updatedTopic).updateStatus();
-                TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::updateStatusTimer, enableAdditionalMetrics, namespace);
                 LOGGER.traceCr(reconcilableTopic.reconciliation(), "Updated status to observedGeneration {}, resourceVersion {}",
                     got.getStatus().getObservedGeneration(), got.getMetadata().getResourceVersion());
             } catch (Throwable e) {
                 LOGGER.errorOp("Status update failed: {}", e.getMessage());
             }
+            TopicOperatorUtil.stopExternalRequestTimer(timerSample, metrics::updateStatusTimer, enableAdditionalMetrics, namespace);
         }
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -2296,5 +2296,4 @@ class TopicControllerIT {
                 resourceVersionAfterUpdate.equals(kt.getMetadata().getResourceVersion())
         );
     }
-
 }


### PR DESCRIPTION
### Type of change

Bugfix

### Description

The KafkaTopic.status.topicId keeps the old value when the topic is recreated in Kafka while the reconciliation is paused/disabled, or the operator is not running.

This change adds the topicId when the KafkaTopic is managed and topicId is not set, and removes the topicId when KafkaTopic is paused or unmanaged.

Should close #10467.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

