### PR TITLE
Do not generate empty required arrays in OneOf definition

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -616,11 +616,17 @@ class CrdGenerator {
                 for (OneOf.Alternative.Property prop: alt.value()) {
                     properties.putObject(prop.value());
                 }
-                ArrayNode required = alternative.putArray("required");
+
+                ArrayNode required = nf.arrayNode();
                 for (OneOf.Alternative.Property prop: alt.value()) {
                     if (prop.required()) {
                         required.add(prop.value());
                     }
+                }
+                // We attach only non-empty array. Empty arrays would be removed by Kubernetes and might confuse various
+                // tools when diffing the resources (such as ArgoCD)
+                if (!required.isEmpty())    {
+                    alternative.set("required", required);
                 }
             }
         } else {

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1567,7 +1567,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Kafka `Pods`.
                         bootstrapService:
@@ -3018,7 +3017,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for ZooKeeper `Pods`.
                         clientService:
@@ -4325,7 +4323,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Entity Operator `Pods`.
                         topicOperatorContainer:
@@ -5599,7 +5596,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Cruise Control `Pods`.
                         apiService:
@@ -6681,7 +6677,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for JmxTrans `Pods`.
                         container:
@@ -7518,7 +7513,6 @@ spec:
                                       configMap: {}
                                       emptyDir: {}
                                       persistentVolumeClaim: {}
-                                    required: []
                               description: Additional volumes that can be mounted to the pod.
                           description: Template for Kafka Exporter `Pods`.
                         service:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1109,7 +1109,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
@@ -2019,7 +2018,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1274,7 +1274,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka MirrorMaker `Pods`.
                     podDisruptionBudget:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1098,7 +1098,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Bridge `Pods`.
                     apiService:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1254,7 +1254,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect `Pods`.
                     apiService:
@@ -2164,7 +2163,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                           description: Additional volumes that can be mounted to the pod.
                       description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                     buildContainer:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -835,7 +835,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka `Pods`.
                   perPodService:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1566,7 +1566,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
@@ -3017,7 +3016,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
@@ -4324,7 +4322,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Entity Operator `Pods`.
                       topicOperatorContainer:
@@ -5598,7 +5595,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Cruise Control `Pods`.
                       apiService:
@@ -6680,7 +6676,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for JmxTrans `Pods`.
                       container:
@@ -7517,7 +7512,6 @@ spec:
                                   configMap: {}
                                   emptyDir: {}
                                   persistentVolumeClaim: {}
-                                required: []
                             description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka Exporter `Pods`.
                       service:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1108,7 +1108,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
@@ -2018,7 +2017,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1273,7 +1273,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka MirrorMaker `Pods`.
                   podDisruptionBudget:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1097,7 +1097,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Bridge `Pods`.
                   apiService:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1253,7 +1253,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
@@ -2163,7 +2162,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -835,7 +835,6 @@ spec:
                               configMap: {}
                               emptyDir: {}
                               persistentVolumeClaim: {}
-                            required: []
                         description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka `Pods`.
                   perPodService:


### PR DESCRIPTION
### Type of change

- Improvement

### Description

Currently, we generate empty `required` arrays in the `OneOf` definitions in the CRDs. That seems to cause issues to some tools that do the diffing of the CRDs as Kubernetes seems to remove the empty arrays (see https://cloud-native.slack.com/archives/CMH3Q3SNP/p1724662526753129 as an example). 

This PR adds a check and generates the arrays only if they have any values. This is what we already do for the `required` arrays in other places, so it should hopefully not cause any issues.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally