### PR TITLE
[ST] Fix StrimziUpgradeST.testUpgradeAcrossVersionsWithUnsupportedKafkaVersion test to run only when there is really an unsupported Kafka version across versions

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/TestKafkaVersion.java
@@ -29,11 +29,11 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
     static {
         try {
             kafkaVersions = parseKafkaVersions(TestUtils.USER_PATH + "/../kafka-versions.yaml");
-            supportedKafkaVersions = kafkaVersions.stream().filter(TestKafkaVersion::isSupported).collect(Collectors.toList());
+            supportedKafkaVersions = getSupportedKafkaVersionsFromAllVersions(kafkaVersions);
             Collections.sort(kafkaVersions);
             Collections.sort(supportedKafkaVersions);
 
-            if (supportedKafkaVersions == null || supportedKafkaVersions.size() == 0) {
+            if (supportedKafkaVersions.isEmpty()) {
                 throw new Exception("There is no one Kafka version supported inside " + TestUtils.USER_PATH + "/../kafka-versions.yaml file");
             }
 
@@ -179,6 +179,10 @@ public class TestKafkaVersion implements Comparable<TestKafkaVersion> {
 
     public static List<TestKafkaVersion> getSupportedKafkaVersions() {
         return supportedKafkaVersions;
+    }
+
+    public static List<TestKafkaVersion> getSupportedKafkaVersionsFromAllVersions(List<TestKafkaVersion> kafkaVersions) {
+        return kafkaVersions.stream().filter(TestKafkaVersion::isSupported).collect(Collectors.toList());
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
@@ -109,10 +110,11 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
     @IsolatedTest
     void testUpgradeAcrossVersionsWithUnsupportedKafkaVersion() throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
+        Optional<UpgradeKafkaVersion> upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaVersionSupportedBeforeUnsupportedAfterUpgrade(acrossUpgradeData.getFromKafkaVersionsUrl());
+        assumeTrue(upgradeKafkaVersion.isPresent(), "Supported Kafka versions after upgrade contains all supported Kafka versions before upgrade so test is skipped");
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, testStorage, acrossUpgradeData, upgradeKafkaVersion);
+        setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, testStorage, acrossUpgradeData, upgradeKafkaVersion.get());
 
         // Make snapshots of all Pods
         makeComponentsSnapshots(TEST_SUITE_NAMESPACE);


### PR DESCRIPTION
#10495 
### Type of change
- Enhancement / Bug

### Description
It is described in #10495.
The problem is that StrimziUpgradeST.testUpgradeAcrossVersionsWithUnsupportedKafkaVersion is use a supported Kafka version from start so the required test with an unsupported Kafka version is not happen. We should use unsupported Kafka version in the test.

### Checklist
_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

