### PR TITLE
Block options and not prefixes in Kafka Connector configs

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connector/AbstractConnectorSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @ToString(callSuper = true)
 public abstract class AbstractConnectorSpec extends Spec {
     /**
-     * Forbidden options in the connector configuration
+     * Forbidden options in the connector configuration => these are full options and not prefixes
      */
     public static final String FORBIDDEN_PARAMETERS = "name, connector.class, tasks.max";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractConfiguration.java
@@ -9,7 +9,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.OrderedProperties;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,125 +34,84 @@ public abstract class AbstractConfiguration {
     }
 
     /**
-     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
-     * from the Assembly.
-     *
-     * @param reconciliation    The reconciliation
-     * @param configuration     Configuration in String format. Should contain zero or more lines with with key=value
-     *                          pairs.
-     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                          these prefixes will be ignored.
-     */
-    public AbstractConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes) {
-        options.addStringPairs(configuration);
-        filterForbidden(reconciliation, forbiddenPrefixes);
-    }
-
-    /**
-     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
-     * from the Assembly.
-     *
-     * @param reconciliation    The reconciliation
-     * @param configuration     Configuration in String format. Should contain zero or more lines with with key=value
-     *                          pairs.
-     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                          these prefixes will be ignored.
-     * @param defaults          Properties object with default options
-     */
-    public AbstractConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes, Map<String, String> defaults) {
-        options.addMapPairs(defaults);
-        options.addStringPairs(configuration);
-        filterForbidden(reconciliation, forbiddenPrefixes);
-    }
-
-    /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
      * ConfigMap / CRD.
      *
-     * @param reconciliation  The reconciliation
-     * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenPrefixes   List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                           these prefixes will be ignored.
-     */
-    public AbstractConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes) {
-        options.addIterablePairs(jsonOptions);
-        filterForbidden(reconciliation, forbiddenPrefixes);
-    }
-
-    /**
-     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
-     * ConfigMap / CRD.
-     *
-     * @param reconciliation  The reconciliation
-     * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenPrefixes  List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                           these prefixes will be ignored.
-     * @param forbiddenPrefixExceptions Exceptions excluded from forbidden prefix options checking
-     */
-    public AbstractConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions) {
-        options.addIterablePairs(jsonOptions);
-        filterForbidden(reconciliation, forbiddenPrefixes, forbiddenPrefixExceptions);
-    }
-
-    /**
-     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
-     * ConfigMap / CRD.
-     *
-     * @param reconciliation  The reconciliation
-     * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenPrefixes   List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                           these prefixes will be ignored.
-     * @param defaults          Properties object with default options
-     */
-    public AbstractConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, Map<String, String> defaults) {
-        options.addMapPairs(defaults);
-        options.addIterablePairs(jsonOptions);
-        filterForbidden(reconciliation, forbiddenPrefixes);
-    }
-
-    /**
-     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
-     * ConfigMap / CRD.
-     *
-     * @param reconciliation  The reconciliation
-     * @param jsonOptions     Json object with configuration options as key ad value pairs.
-     * @param forbiddenPrefixes  List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                           these prefixes will be ignored.
+     * @param reconciliation             The reconciliation
+     * @param jsonOptions                Json object with configuration options as key ad value pairs.
+     * @param forbiddenPrefixes          List with configuration key prefixes which are not allowed. All keys which
+     *                                   start with one of these prefixes will be ignored.
      * @param forbiddenPrefixExceptions  Exceptions excluded from forbidden prefix options checking
-     * @param defaults          Properties object with default options
+     * @param forbiddenOptions           List with the exact configuration options (not prefixes) that should not be used
+     * @param defaults                   Properties object with default options
      */
-    public AbstractConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions, Map<String, String> defaults) {
+    public AbstractConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions, List<String> forbiddenOptions, Map<String, String> defaults) {
         options.addMapPairs(defaults);
         options.addIterablePairs(jsonOptions);
-        filterForbidden(reconciliation, forbiddenPrefixes, forbiddenPrefixExceptions);
+        filterForbidden(reconciliation, forbiddenPrefixes, forbiddenPrefixExceptions, forbiddenOptions);
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param reconciliation             The reconciliation
+     * @param configuration              Configuration in String format. Should contain zero or more lines with
+     *                                   key=value pairs.
+     * @param forbiddenPrefixes          List with configuration key prefixes which are not allowed. All keys which
+     *                                   start with one of these prefixes will be ignored.
+     * @param forbiddenPrefixExceptions  Exceptions excluded from forbidden prefix options checking
+     * @param forbiddenOptions           List with the exact configuration options (not prefixes) that should not be used
+     * @param defaults                   Properties object with default options
+     */
+    public AbstractConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions, List<String> forbiddenOptions, Map<String, String> defaults) {
+        options.addMapPairs(defaults);
+        options.addStringPairs(configuration);
+        filterForbidden(reconciliation, forbiddenPrefixes, forbiddenPrefixExceptions, forbiddenOptions);
     }
 
     /**
      * Filters forbidden values from the configuration.
      *
-     * @param reconciliation    The reconciliation
-     * @param forbiddenPrefixes List with configuration key prefixes which are not allowed. All keys which start with one of
-     *                          these prefixes will be ignored.
+     * @param reconciliation            The reconciliation
+     * @param forbiddenPrefixes         List with configuration key prefixes which are not allowed. All keys which start
+     *                                  with one of these prefixes will be ignored.
      * @param forbiddenPrefixExceptions Exceptions excluded from forbidden prefix options checking
+     * @param forbiddenOptions          List with the exact configuration options (not prefixes) that should not be used
      */
-    private void filterForbidden(Reconciliation reconciliation, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions)   {
+    private void filterForbidden(Reconciliation reconciliation, List<String> forbiddenPrefixes, List<String> forbiddenPrefixExceptions, List<String> forbiddenOptions)   {
+        // We filter the prefixes first
         options.filter(k -> forbiddenPrefixes.stream().anyMatch(s -> {
             boolean forbidden = k.toLowerCase(Locale.ENGLISH).startsWith(s);
+
             if (forbidden) {
                 if (forbiddenPrefixExceptions.contains(k))
                     forbidden = false;
             }
+
             if (forbidden) {
                 LOGGER.warnCr(reconciliation, "Configuration option \"{}\" is forbidden and will be ignored", k);
             } else {
                 LOGGER.traceCr(reconciliation, "Configuration option \"{}\" is allowed and will be passed to the assembly", k);
             }
+
             return forbidden;
         }));
-    }
 
-    private void filterForbidden(Reconciliation reconciliation, List<String> forbiddenPrefixes)   {
-        this.filterForbidden(reconciliation, forbiddenPrefixes, Collections.emptyList());
+        // Then we filter the forbidden options
+        if (!forbiddenOptions.isEmpty()) {
+            options.filter(k -> forbiddenOptions.stream().anyMatch(s -> {
+                boolean forbidden = k.toLowerCase(Locale.ENGLISH).equals(s);
+
+                if (forbidden) {
+                    LOGGER.warnCr(reconciliation, "Configuration option \"{}\" is forbidden and will be ignored", k);
+                } else {
+                    LOGGER.traceCr(reconciliation, "Configuration option \"{}\" is allowed and will be passed to the assembly", k);
+                }
+
+                return forbidden;
+            }));
+        }
     }
 
     /**
@@ -208,8 +166,9 @@ public abstract class AbstractConfiguration {
     }
 
     /**
-     * Get access to underlying key-value pairs.  Any changes to OrderedProperties will be reflected in
-     * in value returned by subsequent calls to getConfiguration()
+     * Get access to underlying key-value pairs. Any changes to OrderedProperties will be reflected in value returned
+     * by subsequent calls to getConfiguration()
+     *
      * @return A map of keys to values.
      */
     public OrderedProperties asOrderedProperties() {
@@ -222,7 +181,7 @@ public abstract class AbstractConfiguration {
      * @param prefixes  String with comma-separated items
      * @return          List with the values as separate items
      */
-    protected static List<String> splitPrefixesToList(String prefixes) {
+    protected static List<String> splitPrefixesOrOptionsToList(String prefixes) {
         return asList(prefixes.split("\\s*,+\\s*"));
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeAdminClientConfiguration.java
@@ -22,8 +22,8 @@ public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeAdminClientSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeAdminClientConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeAdminClientConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeConsumerConfiguration.java
@@ -22,8 +22,8 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeConsumerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeConsumerConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBridgeProducerConfiguration.java
@@ -22,8 +22,8 @@ public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaBridgeProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 
@@ -35,6 +35,6 @@ public class KafkaBridgeProducerConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaBridgeProducerConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -49,8 +49,8 @@ public class KafkaConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaClusterSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
     }
 
     /**
@@ -212,11 +212,11 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), Map.of());
     }
 
     private KafkaConfiguration(Reconciliation reconciliation, String configuration, List<String> forbiddenPrefixes) {
-        super(reconciliation, configuration, forbiddenPrefixes);
+        super(reconciliation, configuration, forbiddenPrefixes, List.of(), List.of(), Map.of());
     }
 
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -21,8 +21,8 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaConnectSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaConnectSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaConnectSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
         DEFAULTS = new HashMap<>(6);
         DEFAULTS.put("group.id", "connect-cluster");
@@ -41,6 +41,6 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConnectConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectorConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectorConfiguration.java
@@ -8,7 +8,6 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.api.kafka.model.connector.AbstractConnectorSpec;
 import io.strimzi.operator.common.Reconciliation;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,14 +15,10 @@ import java.util.Map;
  * Class for handling KafkaConnector configuration passed by the user
  */
 public class KafkaConnectorConfiguration extends AbstractConfiguration {
-    private static final List<String> FORBIDDEN_PREFIXES;
-    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS;
-    private static final Map<String, String> DEFAULTS;
+    private static final List<String> FORBIDDEN_OPTIONS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(AbstractConnectorSpec.FORBIDDEN_PARAMETERS);
-        FORBIDDEN_PREFIX_EXCEPTIONS = List.of();
-        DEFAULTS = new HashMap<>(0);
+        FORBIDDEN_OPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(AbstractConnectorSpec.FORBIDDEN_PARAMETERS);
     }
 
     /**
@@ -34,6 +29,6 @@ public class KafkaConnectorConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaConnectorConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, List.of(), List.of(), FORBIDDEN_OPTIONS, Map.of());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaListenerCustomAuthConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaListenerCustomAuthConfiguration.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class KafkaListenerCustomAuthConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_PREFIXES;
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaListenerAuthenticationCustom.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaListenerAuthenticationCustom.FORBIDDEN_PREFIXES);
     }
 
     /**
@@ -27,6 +27,6 @@ public class KafkaListenerCustomAuthConfiguration extends AbstractConfiguration 
      * @param jsonOptions       Configuration options
      */
     public KafkaListenerCustomAuthConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, List.of(), List.of(), Map.of());
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -21,8 +21,8 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMaker2ClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
         DEFAULTS = new HashMap<>(9);
         DEFAULTS.put("group.id", "mirrormaker2-cluster");
@@ -45,6 +45,6 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
      *                    pairs.
      */
     public KafkaMirrorMaker2Configuration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerConsumerConfiguration.java
@@ -21,8 +21,8 @@ public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMakerConsumerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerConsumerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerConsumerConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerProducerConfiguration.java
@@ -21,8 +21,8 @@ public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration
     private static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(KafkaMirrorMakerProducerSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
         DEFAULTS = new HashMap<>(0);
     }
 
@@ -34,6 +34,6 @@ public class KafkaMirrorMakerProducerConfiguration extends AbstractConfiguration
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public KafkaMirrorMakerProducerConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -23,8 +23,8 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
     protected static final Map<String, String> DEFAULTS;
 
     static {
-        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES);
-        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+        FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(ZookeeperClusterSpec.FORBIDDEN_PREFIXES);
+        FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(ZookeeperClusterSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
         Map<String, String> config = new HashMap<>(5);
         config.put("tickTime", "2000");
@@ -43,6 +43,6 @@ public class ZookeeperConfiguration extends AbstractConfiguration {
      * @param jsonOptions     Json object with configuration options as key ad value pairs.
      */
     public ZookeeperConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, DEFAULTS);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), DEFAULTS);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
@@ -102,8 +102,8 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             Map.entry(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue(), CruiseControlConfigurationParameters.DEFAULT_METRIC_REPORTER_TOPIC_NAME)
     )));
 
-    private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
-    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesToList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
+    private static final List<String> FORBIDDEN_PREFIXES = AbstractConfiguration.splitPrefixesOrOptionsToList(CruiseControlSpec.FORBIDDEN_PREFIXES);
+    private static final List<String> FORBIDDEN_PREFIX_EXCEPTIONS = AbstractConfiguration.splitPrefixesOrOptionsToList(CruiseControlSpec.FORBIDDEN_PREFIX_EXCEPTIONS);
 
     /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
@@ -114,7 +114,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
      * @param defaults        Default configuration values
      */
     public CruiseControlConfiguration(Reconciliation reconciliation, Iterable<Map.Entry<String, Object>> jsonOptions, Map<String, String> defaults) {
-        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, defaults);
+        super(reconciliation, jsonOptions, FORBIDDEN_PREFIXES, FORBIDDEN_PREFIX_EXCEPTIONS, List.of(), defaults);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, we use forbidden prefixes to block users from setting various configurations managed directly by the Strimzi Cluster Operator. When a user configures any option starting with the prefix (apart from the defined exceptions), the option will be ignored and removed from the config. This worked fine so far for most operands which have mostly a static set of configuration options.

But it does not work well for Kafka Connectors. In Kafka Connectors, we block three options: `name`, `connector.class`, and `tasks.max`. These are all important options to block as they would cause errors if they were set by users (especially the `name` option). But in Kafka Connectors, each connector has different configuration options. And therefore the likelihood of a conflict when blocking the whole prefix is not impossible, especially with a generic option such as `name`. #10500 describes one such conflict.

This PR improves how we handle the forbidden prefixes. It keeps the original logic, but it also adds support for forbidden options to the `AbstractConfiguration`. That allows us to keep the existing logic where it suits (for example blocking whole range of security-related options). But it allows to also block individual options such as those in Kafka Connectors instead of treating them as prefixes. That allows us to use options such as `namespace.mapper` while blocking the option `name`

I considered some other alternatives as well. For example
* Using regular expressions in the forbidden prefixes -> that way one can specify whether it blocks a particular name or a prefix
* Doing the validation differently for Kafka Connector configs

But the approach used in the PR (and described above) seemed best to me.

----

Apart from the actual fix, this PR also cleans up the various methods in `AbstractConfiguration`. It keeps only 3 constructors (one copy constructor and two regular ones) and makes it much easier to test this class as there are only two execution paths and not 8 of them.

----

This should resolve #10500.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging