### PR TITLE
[ST] Bump Test-Frame to 0.6.1 and add handling of the new metric types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <kroxylicious-testing.version>0.9.0</kroxylicious-testing.version>
         <kindcontainer.version>1.4.6</kindcontainer.version>
         <junit4.version>4.13.2</junit4.version>
-        <skodjob.version>0.1.1</skodjob.version>
+        <skodjob.test-frame.version>0.6.1</skodjob.test-frame.version>
 
         <!-- properties to skip surefire tests during failsafe execution -->
         <skipTests>false</skipTests>
@@ -732,9 +732,13 @@
             <dependency>
                 <groupId>io.skodjob</groupId>
                 <artifactId>test-frame-metrics-collector</artifactId>
-                <version>${skodjob.version}</version>
+                <version>${skodjob.test-frame.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>test-frame-common</artifactId>
+                <version>${skodjob.test-frame.version}</version>
+            </dependency>
             <!-- Test dependencies -->
             <dependency>
                 <groupId>io.strimzi</groupId>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -221,6 +221,10 @@
             <groupId>io.skodjob</groupId>
             <artifactId>test-frame-metrics-collector</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>test-frame-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -256,6 +260,7 @@
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
                                 <!-- Needed for logging in tests using the Kubernetes Client (uses SLF4J) -->
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.skodjob:test-frame-common</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/MetricsUtils.java
@@ -5,9 +5,14 @@
 package io.strimzi.systemtest.utils.specific;
 
 import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.skodjob.testframe.MetricsCollector;
+import io.skodjob.testframe.metrics.Counter;
+import io.skodjob.testframe.metrics.Gauge;
+import io.skodjob.testframe.metrics.Histogram;
+import io.skodjob.testframe.metrics.Metric;
+import io.skodjob.testframe.metrics.Summary;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.metrics.ClusterOperatorMetricsComponent;
+import io.strimzi.systemtest.performance.gather.collectors.BaseMetricsCollector;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.Exec;
@@ -17,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
@@ -58,50 +64,50 @@ public class MetricsUtils {
         return exec.out();
     }
 
-    public static MetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace, String coScraperName) {
+    public static BaseMetricsCollector setupCOMetricsCollectorInNamespace(String coName, String coNamespace, String coScraperName) {
         LabelSelector scraperDeploymentPodLabel = new LabelSelector(null, Map.of(TestConstants.APP_POD_LABEL, coScraperName));
         String coScraperPodName = ResourceManager.kubeClient().listPods(coNamespace, scraperDeploymentPodLabel).get(0).getMetadata().getName();
 
-        return new MetricsCollector.Builder()
+        return new BaseMetricsCollector.Builder()
             .withScraperPodName(coScraperPodName)
             .withNamespaceName(coNamespace)
             .withComponent(ClusterOperatorMetricsComponent.create(coNamespace, coName))
             .build();
     }
 
-    public static void assertCoMetricResourceNotNull(MetricsCollector collector, String metric, String kind) {
+    public static void assertCoMetricResourceNotNull(BaseMetricsCollector collector, String metric, String kind) {
         assertMetricResourceNotNull(collector, metric, kind);
     }
 
-    public static void assertMetricResourceNotNull(MetricsCollector collector, String metric, String kind) {
+    public static void assertMetricResourceNotNull(BaseMetricsCollector collector, String metric, String kind) {
         String metrics = metric + "\\{kind=\"" + kind + "\",.*}";
         assertMetricValueNotNull(collector, metrics);
     }
 
-    public static void assertCoMetricResourceStateNotExists(MetricsCollector collector, String kind, String name, String namespace) {
+    public static void assertCoMetricResourceStateNotExists(BaseMetricsCollector collector, String kind, String name, String namespace) {
         String metric = "strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",resource_namespace=\"" + namespace + "\",}";
-        ArrayList<Double> values = createPatternAndCollectWithoutWait(collector, metric);
+        List<Double> values = createPatternAndCollectWithoutWait(collector, metric);
         assertThat(values.isEmpty(), is(true));
     }
 
-    public static void assertCoMetricResourceState(MetricsCollector collector, String kind, String name, String namespace, int value, String reason) {
+    public static void assertCoMetricResourceState(BaseMetricsCollector collector, String kind, String name, String namespace, int value, String reason) {
         assertMetricResourceState(collector, kind, name, namespace, value, reason);
     }
 
-    public static void assertMetricResourceState(MetricsCollector collector, String kind, String name, String namespace, int value, String reason) {
+    public static void assertMetricResourceState(BaseMetricsCollector collector, String kind, String name, String namespace, int value, String reason) {
         String metric = "strimzi_resource_state\\{kind=\"" + kind + "\",name=\"" + name + "\",reason=\"" + reason + ".*\",resource_namespace=\"" + namespace + "\",}";
         assertMetricValue(collector, metric, value);
     }
 
-    public static void assertCoMetricResources(MetricsCollector collector, String kind, String namespace, int value) {
+    public static void assertCoMetricResources(BaseMetricsCollector collector, String kind, String namespace, int value) {
         assertMetricResources(collector, kind, namespace, value);
     }
 
-    public static void assertMetricResources(MetricsCollector collector, String kind, String namespace, int value) {
+    public static void assertMetricResources(BaseMetricsCollector collector, String kind, String namespace, int value) {
         assertMetricValue(collector, getResourceMetricPattern(kind, namespace), value);
     }
 
-    public static void assertCoMetricResourcesNullOrZero(MetricsCollector collector, String kind, String namespace) {
+    public static void assertCoMetricResourcesNullOrZero(BaseMetricsCollector collector, String kind, String namespace) {
         Pattern pattern = Pattern.compile(getResourceMetricPattern(kind, namespace));
         if (!collector.collectSpecificMetric(pattern).isEmpty()) {
             assertThat(String.format("metric %s doesn't contain 0 value!", pattern), createPatternAndCollectWithoutWait(collector, pattern.toString()).stream().mapToDouble(i -> i).sum(), is(0.0));
@@ -114,72 +120,91 @@ public class MetricsUtils {
         return metric;
     }
 
-    public static void assertMetricResourcesHigherThanOrEqualTo(MetricsCollector collector, String kind, int expectedValue) {
+    public static void assertMetricResourcesHigherThanOrEqualTo(BaseMetricsCollector collector, String kind, int expectedValue) {
         Predicate<Double> higherOrEqualToExpected = actual -> actual >= expectedValue;
         String metricConditionDescription = "higher or equal to expected value: (%s)".formatted(expectedValue);
         assertMetricResourcesIs(collector, kind, higherOrEqualToExpected, metricConditionDescription);
     }
 
-    public static void assertMetricResourcesLowerThanOrEqualTo(MetricsCollector collector, String kind, int expectedValue) {
+    public static void assertMetricResourcesLowerThanOrEqualTo(BaseMetricsCollector collector, String kind, int expectedValue) {
         Predicate<Double> lowerOrEqualToExpected = actual -> actual <= expectedValue;
         String metricConditionDescription = "lower or equal to expected value: (%s)".formatted(expectedValue);
         assertMetricResourcesIs(collector, kind, lowerOrEqualToExpected, metricConditionDescription);
     }
 
-    public static void assertMetricResourcesIs(MetricsCollector collector, String kind, Predicate<Double> predicate, String message) {
+    public static void assertMetricResourcesIs(BaseMetricsCollector collector, String kind, Predicate<Double> predicate, String message) {
         String metric = "strimzi_resources\\{kind=\"" + kind + "\",.*}";
         TestUtils.waitFor("metric " + metric + "is " + message, TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS, TestConstants.GLOBAL_TIMEOUT_SHORT, () -> {
             collector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
-            ArrayList<Double> values = createPatternAndCollect(collector, metric);
+            List<Double> values = createPatternAndCollect(collector, metric);
             double actualValue = values.stream().mapToDouble(i -> i).sum();
             return predicate.test(actualValue);
         });
     }
 
-    public static void assertMetricValueNotNull(MetricsCollector collector, String metric) {
-        ArrayList<Double> values = createPatternAndCollect(collector, metric);
+    public static void assertMetricValueNotNull(BaseMetricsCollector collector, String metric) {
+        List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).count();
         assertThat(String.format("metric '%s' doesn't exist", metric), actualValue, notNullValue());
     }
 
-    public static void assertMetricValueNullOrZero(MetricsCollector collector, String metric) {
+    public static void assertMetricValueNullOrZero(BaseMetricsCollector collector, String metric) {
         Pattern pattern = Pattern.compile(metric + " ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         if (!collector.collectSpecificMetric(pattern).isEmpty()) {
             assertThat(String.format("metric %s doesn't contain 0 value!", pattern), createPatternAndCollectWithoutWait(collector, pattern.toString()).stream().mapToDouble(i -> i).sum(), is(0.0));
         }
     }
 
-    public static void assertMetricValue(MetricsCollector collector, String metric, int expectedValue) {
-        ArrayList<Double> values = createPatternAndCollect(collector, metric);
+    public static void assertMetricValue(BaseMetricsCollector collector, String metric, int expectedValue) {
+        List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).sum();
         assertThat(String.format("metric '%s' actual value %s is different than expected %s", metric, actualValue, expectedValue), actualValue, is((double) expectedValue));
     }
 
-    public static void assertMetricValueCount(MetricsCollector collector, String metric, long expectedValue) {
-        ArrayList<Double> values = createPatternAndCollect(collector, metric);
+    public static void assertMetricValueCount(BaseMetricsCollector collector, String metric, long expectedValue) {
+        List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).count();
         assertThat(String.format("metric '%s' actual value %s is different than expected %s", actualValue, expectedValue, metric), actualValue, is((double) expectedValue));
     }
 
-    public static void assertMetricCountHigherThan(MetricsCollector collector, String metric, long expectedValue) {
-        ArrayList<Double> values = createPatternAndCollect(collector, metric);
+    public static void assertMetricCountHigherThan(BaseMetricsCollector collector, String metric, long expectedValue) {
+        List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).count();
         assertThat(String.format("metric '%s' actual value %s not is higher than expected %s", metric, actualValue, expectedValue), actualValue > expectedValue);
     }
 
-    public static void assertMetricValueHigherThan(MetricsCollector collector, String metric, int expectedValue) {
-        ArrayList<Double> values = createPatternAndCollect(collector, metric);
+    public static void assertMetricValueHigherThan(BaseMetricsCollector collector, String metric, int expectedValue) {
+        List<Double> values = createPatternAndCollect(collector, metric);
         double actualValue = values.stream().mapToDouble(i -> i).sum();
         assertThat(String.format("metric '%s' actual value %s is different than expected %s", metric, actualValue, expectedValue), actualValue > expectedValue);
     }
 
-    private static ArrayList<Double> createPatternAndCollect(MetricsCollector collector, String metric) {
+    public static void assertContainsMetric(List<Metric> metrics, String metricName) {
+        boolean containsMetric = metrics.stream().anyMatch(metric -> metric.getName().contains(metricName));
+        assertThat(String.format("metric '%s' is not present in the list of metrics", metricName), containsMetric, is(true));
+    }
+
+    private static List<Double> createPatternAndCollect(BaseMetricsCollector collector, String metric) {
         Pattern pattern = Pattern.compile(metric + " ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         return collector.waitForSpecificMetricAndCollect(pattern);
     }
 
-    private static ArrayList<Double> createPatternAndCollectWithoutWait(MetricsCollector collector, String metric) {
+    private static List<Double> createPatternAndCollectWithoutWait(BaseMetricsCollector collector, String metric) {
         Pattern pattern = Pattern.compile(metric + " ([\\d.][^\\n]+)", Pattern.CASE_INSENSITIVE);
         return collector.collectSpecificMetric(pattern);
+    }
+
+    public static Double getDoubleMetricValueBasedOnType(Metric metric) {
+        if (metric instanceof Gauge gauge) {
+            return gauge.getValue();
+        } else if (metric instanceof Histogram histogram) {
+            return histogram.getSum();
+        } else if (metric instanceof Counter counter) {
+            return counter.getValue();
+        } else if (metric instanceof Summary summary) {
+            return summary.getSum();
+        }
+
+        return null;
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/MultipleClusterOperatorsST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.operators;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
-import io.skodjob.testframe.MetricsCollector;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -19,6 +18,7 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
+import io.strimzi.systemtest.performance.gather.collectors.BaseMetricsCollector;
 import io.strimzi.systemtest.resources.NamespaceManager;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -143,9 +143,9 @@ public class MultipleClusterOperatorsST extends AbstractST {
 
         LOGGER.info("Setting up metric collectors targeting Cluster Operators: {}, {}", FIRST_CO_NAME, SECOND_CO_NAME);
         String firstCOScraper = FIRST_NAMESPACE + "-" + TestConstants.SCRAPER_NAME;
-        MetricsCollector firstCoMetricsCollector = setupCOMetricsCollectorInNamespace(FIRST_CO_NAME, FIRST_NAMESPACE, firstCOScraper);
+        BaseMetricsCollector firstCoMetricsCollector = setupCOMetricsCollectorInNamespace(FIRST_CO_NAME, FIRST_NAMESPACE, firstCOScraper);
         String secondCOScraper = SECOND_NAMESPACE + "-" + TestConstants.SCRAPER_NAME;
-        MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE, secondCOScraper);
+        BaseMetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, SECOND_NAMESPACE, secondCOScraper);
 
         // allowing NetworkPolicies for all scraper Pods to all CO Pods
         NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(FIRST_NAMESPACE);
@@ -269,7 +269,7 @@ public class MultipleClusterOperatorsST extends AbstractST {
 
         LOGGER.info("Setting up metric collectors targeting Cluster Operator: {}", SECOND_CO_NAME);
         String coScraperName = testStorage.getNamespaceName() + "-" + TestConstants.SCRAPER_NAME;
-        MetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, testStorage.getNamespaceName(), coScraperName);
+        BaseMetricsCollector secondCoMetricsCollector = setupCOMetricsCollectorInNamespace(SECOND_CO_NAME, testStorage.getNamespaceName(), coScraperName);
         // allowing NetworkPolicies for all scraper Pods to all CO Pods
         NetworkPolicyResource.allowNetworkPolicySettingsForClusterOperator(testStorage.getNamespaceName());
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/topic/TopicST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.operators.topic;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
-import io.skodjob.testframe.MetricsCollector;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
@@ -22,6 +21,7 @@ import io.strimzi.systemtest.enums.CustomResourceStatus;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.admin.AdminClient;
 import io.strimzi.systemtest.metrics.TopicOperatorMetricsComponent;
+import io.strimzi.systemtest.performance.gather.collectors.BaseMetricsCollector;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -313,15 +313,14 @@ public class TopicST extends AbstractST {
             LOGGER.info("{}: {}", KafkaTopic.RESOURCE_KIND, item);
         });
 
-        MetricsCollector toMetricsCollector = new MetricsCollector.Builder()
+        BaseMetricsCollector toMetricsCollector = new BaseMetricsCollector.Builder()
             .withNamespaceName(Environment.TEST_SUITE_NAMESPACE)
             .withScraperPodName(scraperPodName)
             .withComponent(TopicOperatorMetricsComponent.create(Environment.TEST_SUITE_NAMESPACE, sharedTestStorage.getClusterName()))
             .build();
 
         assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_successful_total", KafkaTopic.RESOURCE_KIND);
-        assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_duration_seconds_count", KafkaTopic.RESOURCE_KIND);
-        assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_duration_seconds_sum", KafkaTopic.RESOURCE_KIND);
+        assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_duration_seconds_bucket", KafkaTopic.RESOURCE_KIND);
         assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_duration_seconds_max", KafkaTopic.RESOURCE_KIND);
         assertMetricResourceNotNull(toMetricsCollector, "strimzi_reconciliations_total", KafkaTopic.RESOURCE_KIND);
         assertMetricResourcesHigherThanOrEqualTo(toMetricsCollector, KafkaTopic.RESOURCE_KIND, expectedNumOfTopics);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -867,8 +867,8 @@ class RollingUpdateST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), testStorage.getBrokerSelector(), 3, brokerPods);
 
         LOGGER.info("Check if metrics do not exist in Pods");
-        kafkaCollector.collectMetricsFromPodsWithoutWait().values().forEach(value -> assertThat(value, is("")));
-        zkCollector.collectMetricsFromPodsWithoutWait().values().forEach(value -> assertThat(value, is("")));
+        kafkaCollector.collectMetricsFromPodsWithoutWait().values().forEach(value -> assertThat(value.isEmpty(), is(true)));
+        zkCollector.collectMetricsFromPodsWithoutWait().values().forEach(value -> assertThat(value.isEmpty(), is(true)));
     }
 
     /**

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/NetworkPoliciesST.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.skodjob.testframe.MetricsCollector;
+import io.skodjob.testframe.metrics.Metric;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.exporter.KafkaExporterResources;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
@@ -35,6 +36,7 @@ import io.strimzi.systemtest.templates.crd.KafkaUserTemplates;
 import io.strimzi.systemtest.templates.specific.ScraperTemplates;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Tag;
@@ -229,11 +231,11 @@ public class NetworkPoliciesST extends AbstractST {
 
         metricsCollector.collectMetricsFromPods(TestConstants.METRICS_COLLECT_TIMEOUT);
         assertThat("KafkaExporter metrics should be non-empty", metricsCollector.getCollectedData().size() > 0);
-        for (Map.Entry<String, String> entry : metricsCollector.getCollectedData().entrySet()) {
+        for (Map.Entry<String, List<Metric>> entry : metricsCollector.getCollectedData().entrySet()) {
             assertThat("Value from collected metric should be non-empty", !entry.getValue().isEmpty());
-            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_consumergroup_current_offset"));
-            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_topic_partitions{topic=\"" + topicNameAccessedTls + "\"} 1"));
-            assertThat("Metrics doesn't contain specific values", entry.getValue().contains("kafka_topic_partitions{topic=\"" + topicNameAccessedPlain + "\"} 1"));
+            MetricsUtils.assertContainsMetric(entry.getValue(), "kafka_consumergroup_current_offset");
+            MetricsUtils.assertContainsMetric(entry.getValue(), "kafka_topic_partitions{topic=\"" + topicNameAccessedTls + "\"} 1");
+            MetricsUtils.assertContainsMetric(entry.getValue(), "kafka_topic_partitions{topic=\"" + topicNameAccessedPlain + "\"} 1");
         }
 
         checkNetworkPoliciesInNamespace(testStorage.getClusterName(), Environment.TEST_SUITE_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -53,6 +53,7 @@ import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
+import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.WaitException;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -82,8 +83,6 @@ import static io.strimzi.systemtest.TestConstants.OAUTH;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Tag(OAUTH)
@@ -792,7 +791,7 @@ public class OauthPlainST extends OauthAbstractST {
         for (final String podName : collector.getCollectedData().keySet()) {
             for (final String expectedMetric : expectedOauthMetrics) {
                 LOGGER.info("Searching value from Pod with IP {} for metric {}", podName, expectedMetric);
-                assertThat(collector.getCollectedData().get(podName), containsString(expectedMetric));
+                MetricsUtils.assertContainsMetric(collector.getCollectedData().get(podName), expectedMetric);
             }
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates version of Skodjob's Test-Frame, from where we are using MetricsCollector. But, from the 0.4.0 the MetricsCollector has completely changed, so in this PR I'm editing the ST code to reflect the changes. Before, the metrics where collected and stored in one String value (containing the whole output of the `curl` command).
But now, each metric is parsed into separate `Metric`-like object.

This PR also adds the `test-frame-common` module, which is needed for the `WaitException` and `Wait` classes.

Finally, because of the changes, I'm changing some of the metrics in the tests, as now we have them collected in `Histogram` with `_bucket` suffix, instead of `sum/max/min` suffixes.

### Checklist

- [ ] Make sure all tests pass

