### PR TITLE
fix: Correct the order of generating default and overridden broker capacities in Capacity.processCapacityEntries

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -376,14 +376,14 @@ public class Capacity {
 
         // Override default capacities
         if (brokerCapacity != null) {
-            // For checking for duplicate brokerIds
-            Set<Integer> overrideIds = new HashSet<>();
             List<BrokerCapacityOverride> overrides = brokerCapacity.getOverrides();
             // Override broker entries
             if (overrides != null) {
                 if (overrides.isEmpty()) {
                     LOGGER.warnCr(reconciliation, "Ignoring empty overrides list");
                 } else {
+                    // For checking for duplicate brokerIds
+                    Set<Integer> overrideIds = new HashSet<>();
                     for (BrokerCapacityOverride override : overrides) {
                         List<Integer> ids = override.getBrokers();
                         inboundNetwork = processInboundNetwork(brokerCapacity, override);


### PR DESCRIPTION
### Type of change


- Bugfix


### Description

Correct the order of generating default and overridden broker capacities in Capacity.processCapacityEntries. The order after the change will be:

1. Initialize the broker capacities based on `spec.cruiseControl.brokerCapacity`.
2. Override the default capacities base on `spec.cruiseControl.brokerCapacity.overrides`.

This reduces the unneeded loop when generating broker capacity configurations and will resolve issue https://github.com/strimzi/strimzi-kafka-operator/issues/10465 

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

I ran and passed test class `io.strimzi.operator.cluster.model.CruiseControlTest` for this change.
