### PR TITLE
Improve handling of custom Cruise Control topic configurations

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporter.java
@@ -9,7 +9,6 @@ import io.strimzi.operator.cluster.model.KafkaConfiguration;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 
-
 /**
  * Represents a model for the Cruise Control Metrics Reporter
  *
@@ -49,22 +48,31 @@ public record CruiseControlMetricsReporter(String topicName, Integer numPartitio
                 topicName = kafka.getSpec().getCruiseControl().getConfig().get(CruiseControlConfigurationParameters.METRIC_REPORTER_TOPIC_NAME.getValue()).toString();
             }
 
-            Integer numPartitions = null;
+            int numPartitions;
             if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()) == null) {
                 numPartitions = Integer.parseInt(configuration.getConfigOption(KAFKA_NUM_PARTITIONS_CONFIG_FIELD, "1"));
+            } else {
+                numPartitions = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue()));
+                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS.getValue());
             }
 
-            Integer replicationFactor = null;
+            int replicationFactor;
             if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) == null) {
                 replicationFactor = Integer.parseInt(configuration.getConfigOption(KAFKA_REPLICATION_FACTOR_CONFIG_FIELD, "1"));
+            } else {
+                replicationFactor = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()));
+                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue());
             }
 
-            Integer minInSyncReplicas = null;
+            int minInSyncReplicas;
             if (configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()) == null) {
                 minInSyncReplicas = 1;
+            } else {
+                minInSyncReplicas = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()));
+                configuration.removeConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue());
             }
 
-            validateCruiseControl(kafka, configuration, numberOfBrokers, replicationFactor, minInSyncReplicas);
+            validateCruiseControl(kafka, numberOfBrokers, replicationFactor, minInSyncReplicas);
 
             return new CruiseControlMetricsReporter(topicName, numPartitions, replicationFactor, minInSyncReplicas);
         } else {
@@ -77,33 +85,28 @@ public record CruiseControlMetricsReporter(String topicName, Integer numPartitio
      * Validates the different values of the Cruise Control configuration such as number of replicas for the Metrics Reporter topic etc.
      *
      * @param kafka                 The Kafka custom resource
-     * @param configuration         The user-provider configuration of the Kafka cluster
      * @param numberOfBrokers       Number of broker nodes in the Kafka cluster
      * @param replicationFactor     The replication factor of the Metrics Reporter topic
      * @param minInSyncReplicas     The minimal number of in-sync replicas of the Metrics Reporter topic
      */
-    private static void validateCruiseControl(Kafka kafka, KafkaConfiguration configuration, long numberOfBrokers, Integer replicationFactor, Integer minInSyncReplicas)  {
+    private static void validateCruiseControl(Kafka kafka, long numberOfBrokers, int replicationFactor, int minInSyncReplicas)  {
         if (numberOfBrokers < 2) {
             throw new InvalidResourceException("Kafka " + kafka.getMetadata().getNamespace() + "/" + kafka.getMetadata().getName() +
                     " has invalid configuration. Cruise Control cannot be deployed with a Kafka cluster which has only one broker. It requires at least two Kafka brokers.");
         }
 
-        if (replicationFactor == null // When it is null, we validate the value from the user configuration. If it is not null, it is either 1 or it was already validated in the KafkaCluster class
-                && Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue())) > numberOfBrokers) {
+        // Validates that the replication factor is not higher than the number of brokers
+        if (replicationFactor > numberOfBrokers) {
             throw new InvalidResourceException("Kafka " + kafka.getMetadata().getNamespace() + "/" + kafka.getMetadata().getName() +
-                    " has invalid configuration. Cruise Control metrics reporter replication factor (" + configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()) + ") cannot be higher than number of brokers (" + numberOfBrokers + ").");
+                    " has invalid configuration. Cruise Control metrics reporter replication factor (" + replicationFactor + ") cannot be higher than number of brokers (" + numberOfBrokers + ").");
         }
 
-        if (minInSyncReplicas == null) { // When it is null, we validate the value from the user configuration
-            int userConfiguredMinInSync = Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR.getValue()));
-            int configuredCcReplicationFactor = replicationFactor != null ? replicationFactor : Integer.parseInt(configuration.getConfigOption(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR.getValue()));
-            if (userConfiguredMinInSync > configuredCcReplicationFactor) {
-                throw new IllegalArgumentException(
-                        "The Cruise Control metric topic minISR was set to a value (" + userConfiguredMinInSync + ") " +
-                                "which is higher than the number of replicas for that topic (" + configuredCcReplicationFactor + "). " +
-                                "Please ensure that the Cruise Control metrics topic minISR is <= to the topic's replication factor."
-                );
-            }
+        if (minInSyncReplicas > replicationFactor) {
+            throw new IllegalArgumentException(
+                    "The Cruise Control metric topic minISR was set to a value (" + minInSyncReplicas + ") " +
+                            "which is higher than the number of replicas for that topic (" + replicationFactor + "). " +
+                            "Please ensure that the Cruise Control metrics topic minISR is <= to the topic's replication factor."
+            );
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -2114,10 +2114,10 @@ public class KafkaClusterTest {
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
 
         String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(1, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
-        // Due to a bug, this is set when custom values are configured even in controllers
-        assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=" + partitions));
-        assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR + "=" + replicationFactor));
-        assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=" + minInSync));
+        // The metrics reporter is not configured in a controller only node
+        assertThat(brokerConfig, not(CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=" + partitions)));
+        assertThat(brokerConfig, not(CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_REPLICATION_FACTOR + "=" + replicationFactor)));
+        assertThat(brokerConfig, not(CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=" + minInSync)));
 
         brokerConfig = kafkaCluster.generatePerBrokerConfiguration(3, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
         assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_NUM_PARTITIONS + "=" + partitions));
@@ -2149,8 +2149,8 @@ public class KafkaClusterTest {
         KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
 
         String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(1, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
-        // Due to a bug, this is set when custom values are configured even in controllers
-        assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=" + minInSync));
+        // The metrics reporter is not configured in a controller only node
+        assertThat(brokerConfig, not(CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=" + minInSync)));
 
         brokerConfig = kafkaCluster.generatePerBrokerConfiguration(3, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
         assertThat(brokerConfig, CoreMatchers.containsString(CruiseControlConfigurationParameters.METRICS_TOPIC_MIN_ISR + "=" + minInSync));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlMetricsReporterTest.java
@@ -104,14 +104,20 @@ public class CruiseControlMetricsReporterTest {
         userConfiguration.put("default.replication.factor", 3);
         userConfiguration.put("min.insync.replicas", 2);
         userConfiguration.put("num.partitions", 20);
+        KafkaConfiguration configuration = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
 
-        CruiseControlMetricsReporter ccmr = CruiseControlMetricsReporter.fromCrd(kafka, new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet()), 5);
+        CruiseControlMetricsReporter ccmr = CruiseControlMetricsReporter.fromCrd(kafka, configuration, 5);
 
         assertThat(ccmr, is(notNullValue()));
-        assertThat(ccmr.numPartitions(), is(nullValue()));
-        assertThat(ccmr.replicationFactor(), is(nullValue()));
-        assertThat(ccmr.minInSyncReplicas(), is(nullValue())); // This does not inherit the Kafka value
+        assertThat(ccmr.numPartitions(), is(50));
+        assertThat(ccmr.replicationFactor(), is(5));
+        assertThat(ccmr.minInSyncReplicas(), is(4)); // This does not inherit the Kafka value
         assertThat(ccmr.topicName(), is("my-custom-topic"));
+
+        // Values were removed from the Kafka configuration
+        assertThat(configuration.getConfigOption("cruise.control.metrics.topic.num.partitions"), is(nullValue()));
+        assertThat(configuration.getConfigOption("cruise.control.metrics.topic.replication.factor"), is(nullValue()));
+        assertThat(configuration.getConfigOption("cruise.control.metrics.topic.min.insync.replicas"), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently, we set the Cruise Control configuration only on broker nodes. But when a user provides custom topic configuration for the Cruise Control metrics reporter topic (e.g. `cruise.control.metrics.topic.replication.factor` or `cruise.control.metrics.topic.min.insync.replicas`), this ends up in the user configuration. And through the user configuration, it is also passed to controller-only nodes. It does not cause any problems, but it seems strange.

This PR updates the `CruiseControlMetricsReporter` record to swallow the custom user configuration values and remove them from the user configuration instead. That:
* Makes sure this config is in the broker nodes only
* Simplifies the validation as the values are now only in a one place
* Makes it easier to read to configuration of Cruise Control metrics reporter as it is all in one place (I guess this depends on the point of view - one might of course say that it is confusing that a user provided configuration is not in the user configuration section anymore 🤷‍♂️)

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally