### PR TITLE
[ST] Upgrade tests removal of resources from co-namespace

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -67,7 +67,9 @@ public class ExecutionListener implements TestExecutionListener {
             TestConstants.DYNAMIC_CONFIGURATION, // Dynamic configuration also because in DynamicConfSharedST we use @TestFactory
             TestConstants.TRACING,  // Tracing, because we deploy Jaeger operator inside additional namespace
             TestConstants.KAFKA_SMOKE, // KafkaVersionsST, MigrationST because here we use @ParameterizedTest
-            TestConstants.MIGRATION
+            TestConstants.MIGRATION,
+            TestConstants.UPGRADE,
+            TestConstants.KRAFT_UPGRADE
         );
 
         for (TestIdentifier testIdentifier : testCases) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/ResourceManager.java
@@ -517,13 +517,13 @@ public class ResourceManager {
         coDeploymentName = newName;
     }
 
-    public static void waitForResourceReadiness(String resourceType, String resourceName) {
+    public static void waitForResourceReadiness(String namespaceName, String resourceType, String resourceName) {
         LOGGER.info("Waiting for " + resourceType + "/" + resourceName + " readiness");
 
         TestUtils.waitFor("readiness of resource " + resourceType + "/" + resourceName,
                 TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_CMD_CLIENT_TIMEOUT,
-            () -> ResourceManager.cmdKubeClient().getResourceReadiness(resourceType, resourceName));
-        LOGGER.info("Resource " + resourceType + "/" + resourceName + " is ready");
+            () -> ResourceManager.cmdKubeClient().namespace(namespaceName).getResourceReadiness(resourceType, resourceName));
+        LOGGER.info("Resource " + resourceType + "/" + resourceName + " in namespace:" + namespaceName + " is ready");
     }
 
     public static <T extends CustomResource<? extends Spec, ? extends Status>> boolean waitForResourceStatusMessage(MixedOperation<T, ?, ?> operation, T resource, String message) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -362,8 +362,8 @@ public class SetupClusterOperator {
      * Upgrade cluster operator by updating subscription and obtaining new install plan,
      * which has not been used yet and also approves the installation
      */
-    public void upgradeClusterOperator(OlmConfiguration olmConfiguration) {
-        if (kubeClient().listPodsByPrefixInName(ResourceManager.getCoDeploymentName()).isEmpty()) {
+    public void upgradeClusterOperator(String namespaceName, OlmConfiguration olmConfiguration) {
+        if (kubeClient(namespaceName).listPodsByPrefixInName(ResourceManager.getCoDeploymentName()).isEmpty()) {
             throw new RuntimeException("We can not perform upgrade! Cluster Operator Pod is not present.");
         }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/ClientUtils.java
@@ -115,6 +115,16 @@ public class ClientUtils {
     }
 
     /**
+     * Waits for the instant producer client to succeed with explicitly specified namespace automatically deleting the associated job afterward.
+     *
+     * @param namespaceName Explicit namespace name.
+     * @param testStorage The {@link TestStorage} instance containing details about the client's name.
+     */
+    public static void waitForInstantProducerClientSuccess(String namespaceName, TestStorage testStorage) {
+        waitForClientSuccess(testStorage.getProducerName(), namespaceName, testStorage.getMessageCount());
+    }
+
+    /**
      * Waits for the instant producer client to succeed, automatically deleting the associated job afterward.
      * {@link TestStorage#getProducerName()} is used for identifying producer Job and
      * {@link TestStorage#getConsumerName()} for identifying consumer Job.

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -324,11 +324,10 @@ public class StUtils {
      * Change Deployment configuration before applying it. We set different namespace, log level and image pull policy.
      * It's mostly used for use cases where we use direct kubectl command instead of fabric8 calls to api.
      * @param deploymentFile loaded Strimzi deployment file
-     * @param namespace Namespace where Strimzi should be installed
      * @param strimziFeatureGatesValue feature gates value
      * @return deployment file content as String
      */
-    public static String changeDeploymentConfiguration(File deploymentFile, String namespace, final String strimziFeatureGatesValue) {
+    public static String changeDeploymentConfiguration(String namespaceName, File deploymentFile, final String strimziFeatureGatesValue) {
         YAMLMapper mapper = new YAMLMapper();
         try {
             JsonNode node = mapper.readTree(deploymentFile);
@@ -339,7 +338,7 @@ public class StUtils {
                 if (varName.matches("STRIMZI_NAMESPACE")) {
                     // Replace all the default images with ones from the $DOCKER_ORG org and with the $DOCKER_TAG tag
                     ((ObjectNode) envVar).remove("valueFrom");
-                    ((ObjectNode) envVar).put("value", namespace);
+                    ((ObjectNode) envVar).put("value", namespaceName);
                 }
 
                 if (varName.matches("STRIMZI_LOG_LEVEL")) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -116,10 +116,10 @@ public class KafkaUtils {
             });
     }
 
-    public static void waitUntilStatusKafkaVersionMatchesExpectedVersion(String clusterName, String namespace, String expectedKafkaVersion) {
+    public static void waitUntilStatusKafkaVersionMatchesExpectedVersion(String namespaceName, String clusterName, String expectedKafkaVersion) {
         TestUtils.waitFor("Kafka version '" + expectedKafkaVersion + "' in Kafka cluster '" + clusterName + "' to match",
             TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_STATUS_TIMEOUT, () -> {
-                String kafkaVersionInStatus = KafkaResource.kafkaClient().inNamespace(namespace).withName(clusterName).get().getStatus().getKafkaVersion();
+                String kafkaVersionInStatus = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getKafkaVersion();
                 return expectedKafkaVersion.equals(kafkaVersionInStatus);
             });
     }
@@ -409,9 +409,9 @@ public class KafkaUtils {
         return clusterName + "-" + RANDOM.nextInt(Integer.MAX_VALUE);
     }
 
-    public static String getVersionFromKafkaPodLibs(String kafkaPodName) {
+    public static String getVersionFromKafkaPodLibs(String namespaceName, String kafkaPodName) {
         String command = "ls libs | grep -Po 'kafka_\\d+.\\d+-\\K(\\d+.\\d+.\\d+)(?=.*jar)' | head -1 | cut -d \"-\" -f2";
-        return cmdKubeClient().execInPodContainer(
+        return cmdKubeClient(namespaceName).execInPodContainer(
             kafkaPodName,
             "kafka",
             "/bin/bash",

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -125,11 +125,11 @@ public class AbstractUpgradeST extends AbstractST {
         return upgradeTopicCount + btoKafkaTopicsOnlyCount;
     }
 
-    protected void makeComponentsSnapshots(String namespaceName) {
-        controllerPods = PodUtils.podSnapshot(namespaceName, controllerSelector);
-        brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
-        eoPods = DeploymentUtils.depSnapshot(namespaceName, KafkaResources.entityOperatorDeploymentName(clusterName));
-        connectPods = PodUtils.podSnapshot(namespaceName, connectLabelSelector);
+    protected void makeComponentsSnapshots(String componentsNamespaceName) {
+        controllerPods = PodUtils.podSnapshot(componentsNamespaceName, controllerSelector);
+        brokerPods = PodUtils.podSnapshot(componentsNamespaceName, brokerSelector);
+        eoPods = DeploymentUtils.depSnapshot(componentsNamespaceName, KafkaResources.entityOperatorDeploymentName(clusterName));
+        connectPods = PodUtils.podSnapshot(componentsNamespaceName, connectLabelSelector);
     }
 
     @SuppressWarnings("CyclomaticComplexity")

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftKafkaUpgradeDowngradeST.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Tag;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.KRAFT_UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
 import static org.hamcrest.CoreMatchers.is;
@@ -43,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @Tag(KRAFT_UPGRADE)
 public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftKafkaUpgradeDowngradeST.class);
-    private final int continuousClientsMessageCount = 500;
+    private final int continuousClientsMessageCount = 300;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {
@@ -57,13 +56,13 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // If it is an upgrade test we keep the metadata version as the lower version number
             String metadataVersion = initialVersion.metadataVersion();
 
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, metadataVersion, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, metadataVersion, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -78,13 +77,13 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
             // If it is a downgrade then we make sure that we are using the lowest metadataVersion from the whole list
             String metadataVersion = sortedVersions.get(0).metadataVersion();
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, metadataVersion, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, metadataVersion, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -97,13 +96,13 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, null, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, null, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -116,17 +115,17 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(String namespaceName, TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initMetadataVersion, int controllerReplicas, int brokerReplicas) {
+    void runVersionChange(TestStorage testStorage, TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String initMetadataVersion, int controllerReplicas, int brokerReplicas) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> controllerPods;
         Map<String, String> brokerPods;
 
         boolean sameMinorVersion = initialVersion.metadataVersion().equals(newVersion.metadataVersion());
 
-        if (KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get() == null) {
+        if (KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get() == null) {
             LOGGER.info("Deploying initial Kafka version {} with metadataVersion={}", initialVersion.version(), initMetadataVersion);
 
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(namespaceName, clusterName, controllerReplicas, brokerReplicas)
+            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(testStorage.getNamespaceName(), clusterName, controllerReplicas, brokerReplicas)
                 .editMetadata()
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
                     .addToAnnotations(Annotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
@@ -149,8 +148,8 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             }
 
             resourceManager.createResourceWithWait(
-                KafkaNodePoolTemplates.controllerPoolPersistentStorage(namespaceName, CONTROLLER_NODE_NAME, clusterName, controllerReplicas).build(),
-                KafkaNodePoolTemplates.brokerPoolPersistentStorage(namespaceName, BROKER_NODE_NAME, clusterName, brokerReplicas).build(),
+                KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), CONTROLLER_NODE_NAME, clusterName, controllerReplicas).build(),
+                KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), BROKER_NODE_NAME, clusterName, brokerReplicas).build(),
                 kafka.build()
             );
 
@@ -158,12 +157,12 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(namespaceName, testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
+            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
             // 40s is used within TF environment to make upgrade/downgrade more stable on slow env
             String producerAdditionConfiguration = "delivery.timeout.ms=300000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
-                .withNamespaceName(namespaceName)
+                .withNamespaceName(testStorage.getNamespaceName())
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
                 .withMessageCount(continuousClientsMessageCount)
                 .withAdditionalConfig(producerAdditionConfiguration)
@@ -176,47 +175,47 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
 
         LOGGER.info("Deployment of initial Kafka version (" + initialVersion.version() + ") complete");
 
-        String controllerVersionResult = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getKafkaVersion();
+        String controllerVersionResult = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get().getStatus().getKafkaVersion();
         LOGGER.info("Pre-change Kafka version: " + controllerVersionResult);
 
-        controllerPods = PodUtils.podSnapshot(namespaceName, controllerSelector);
-        brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
+        controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), controllerSelector);
+        brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), brokerSelector);
 
         LOGGER.info("Updating Kafka CR version field to " + newVersion.version());
 
         // Change the version in Kafka CR
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             kafka.getSpec().getKafka().setVersion(newVersion.version());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
         LOGGER.info("Waiting for readiness of new Kafka version (" + newVersion.version() + ") to complete");
 
         // Wait for the controllers' version change roll
-        controllerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, controllerSelector, controllerReplicas, controllerPods);
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), controllerSelector, controllerReplicas, controllerPods);
         LOGGER.info("1st Controllers roll (image change) is complete");
 
         // Wait for the brokers' version change roll
-        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, brokerReplicas, brokerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerReplicas, brokerPods);
         LOGGER.info("1st Brokers roll (image change) is complete");
 
-        String currentMetadataVersion = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getKafka().getMetadataVersion();
+        String currentMetadataVersion = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get().getSpec().getKafka().getMetadataVersion();
 
         LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");
 
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, clusterName);
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);
 
-        String controllerPodName = kubeClient().listPodsByPrefixInName(namespaceName, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
-        String brokerPodName = kubeClient().listPodsByPrefixInName(namespaceName, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
+        String controllerPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
+        String brokerPodName = kubeClient().listPodsByPrefixInName(testStorage.getNamespaceName(), KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
 
         // Extract the Kafka version number from the jars in the lib directory
-        controllerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(namespaceName, controllerPodName);
+        controllerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(testStorage.getNamespaceName(), controllerPodName);
         LOGGER.info("Post-change Kafka version query returned: " + controllerVersionResult);
 
         assertThat("Kafka container had version " + controllerVersionResult + " where " + newVersion.version() +
             " was expected", controllerVersionResult, is(newVersion.version()));
 
         // Extract the Kafka version number from the jars in the lib directory
-        String brokerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(namespaceName, brokerPodName);
+        String brokerVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(testStorage.getNamespaceName(), brokerPodName);
         LOGGER.info("Post-change Kafka version query returned: " + brokerVersionResult);
 
         assertThat("Kafka container had version " + brokerVersionResult + " where " + newVersion.version() +
@@ -231,27 +230,27 @@ public class KRaftKafkaUpgradeDowngradeST extends AbstractKRaftUpgradeST {
                 kafka.getSpec().getKafka().setMetadataVersion(newVersion.metadataVersion());
 
                 LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().toString());
-            }, namespaceName);
+            }, testStorage.getNamespaceName());
 
             LOGGER.info("Metadata version changed, it doesn't require rolling update, so the Pods should be stable");
-            PodUtils.verifyThatRunningPodsAreStable(namespaceName, clusterName);
-            assertFalse(RollingUpdateUtils.componentHasRolled(namespaceName, controllerSelector, controllerPods));
-            assertFalse(RollingUpdateUtils.componentHasRolled(namespaceName, brokerSelector, brokerPods));
+            PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);
+            assertFalse(RollingUpdateUtils.componentHasRolled(testStorage.getNamespaceName(), controllerSelector, controllerPods));
+            assertFalse(RollingUpdateUtils.componentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerPods));
         }
 
         if (!isUpgrade) {
             LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", initMetadataVersion);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                 .get().getStatus().getKafkaMetadataVersion().contains(initMetadataVersion), is(true));
         } else {
             if (currentMetadataVersion != null) {
                 LOGGER.info("Verifying that metadataVersion attribute updated correctly to version {}", newVersion.metadataVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                     .get().getStatus().getKafkaMetadataVersion().contains(newVersion.metadataVersion()), is(true));
             }
         }
 
-        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", namespaceName, clusterName, newVersion.version());
-        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(namespaceName, clusterName, newVersion.version());
+        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", testStorage.getNamespaceName(), clusterName, newVersion.version());
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(testStorage.getNamespaceName(), clusterName, newVersion.version());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -57,7 +57,7 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeVersionData.getDeployKafkaVersion());
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, TEST_SUITE_NAMESPACE, bundleDowngradeVersionData, testStorage, upgradeKafkaVersion);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, bundleDowngradeVersionData, testStorage, upgradeKafkaVersion);
     }
 
     private void performDowngrade(String clusterOperatorNamespaceName, String componentsNamespaceName, BundleVersionModificationData downgradeData) throws IOException {
@@ -70,7 +70,7 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
         // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
         // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
 
-        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, downgradeData, testStorage, testUpgradeKafkaVersion);
+        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, downgradeData, testStorage, testUpgradeKafkaVersion);
         logClusterOperatorPodImage(clusterOperatorNamespaceName);
 
         boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(componentsNamespaceName, eoSelector);
@@ -97,12 +97,20 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+
+        if (!CO_NAMESPACE.equals(TEST_SUITE_NAMESPACE)) {
+            NamespaceManager.getInstance().createNamespaceAndPrepare(TEST_SUITE_NAMESPACE);
+        }
     }
 
     @AfterEach
     void afterEach() {
-        cleanUpKafkaTopics();
+        cleanUpKafkaTopics(TEST_SUITE_NAMESPACE);
         deleteInstalledYamls(CO_NAMESPACE, TEST_SUITE_NAMESPACE, coDir);
         NamespaceManager.getInstance().deleteNamespaceWithWait(CO_NAMESPACE);
+
+        if (!CO_NAMESPACE.equals(TEST_SUITE_NAMESPACE)) {
+            NamespaceManager.getInstance().deleteNamespaceWithWait(TEST_SUITE_NAMESPACE);
+        }
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.upgrade.kraft;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KindIPv6NotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
@@ -33,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.KRAFT_UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -53,11 +53,11 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
     @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>) ")
     @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeDataForKRaft")
-    void testUpgradeStrimziVersion(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws Exception {
+    void testUpgradeStrimziVersion(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData) throws Exception {
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(upgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(upgradeData.getEnvMaxK8sVersion()));
 
-        performUpgrade(upgradeData, extensionContext);
+        performUpgrade(CO_NAMESPACE, TEST_SUITE_NAMESPACE, upgradeData);
     }
 
     @IsolatedTest
@@ -68,167 +68,157 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(acrossUpgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+        setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage, upgradeKafkaVersion);
 
-        Map<String, String> controllerSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
-        Map<String, String> brokerSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
-        Map<String, String> eoSnapshot = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, eoSelector);
+        Map<String, String> controllerSnapshot = PodUtils.podSnapshot(TEST_SUITE_NAMESPACE, controllerSelector);
+        Map<String, String> brokerSnapshot = PodUtils.podSnapshot(TEST_SUITE_NAMESPACE, brokerSelector);
+        Map<String, String> eoSnapshot = PodUtils.podSnapshot(TEST_SUITE_NAMESPACE, eoSelector);
 
         // Make snapshots of all Pods
-        makeSnapshots();
+        makeComponentsSnapshots(TEST_SUITE_NAMESPACE);
 
         // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TestConstants.CO_NAMESPACE, eoSelector);
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TEST_SUITE_NAMESPACE, eoSelector);
 
         // Upgrade CO
-        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        changeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData);
+        logClusterOperatorPodImage(CO_NAMESPACE);
+        logComponentsPodImages(TEST_SUITE_NAMESPACE);
 
-        logPodImages(TestConstants.CO_NAMESPACE);
-
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerSnapshot);
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerSnapshot);
-        DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoSnapshot);
-
-        logPodImages(TestConstants.CO_NAMESPACE);
-        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TEST_SUITE_NAMESPACE, controllerSelector, 3, controllerSnapshot);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TEST_SUITE_NAMESPACE, brokerSelector, 3, brokerSnapshot);
+        DeploymentUtils.waitTillDepHasRolled(TEST_SUITE_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoSnapshot);
+        checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
 
         // Verify that Pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        PodUtils.verifyThatRunningPodsAreStable(TEST_SUITE_NAMESPACE, clusterName);
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
 
-        String controllerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
-        String brokerPodName = kubeClient().listPodsByPrefixInName(TestConstants.CO_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
+        String controllerPodName = kubeClient().listPodsByPrefixInName(TEST_SUITE_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, CONTROLLER_NODE_NAME)).get(0).getMetadata().getName();
+        String brokerPodName = kubeClient().listPodsByPrefixInName(TEST_SUITE_NAMESPACE, KafkaResource.getStrimziPodSetName(clusterName, BROKER_NODE_NAME)).get(0).getMetadata().getName();
 
-        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(controllerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
-        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(brokerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(TEST_SUITE_NAMESPACE, controllerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
+        assertThat(KafkaUtils.getVersionFromKafkaPodLibs(TEST_SUITE_NAMESPACE, brokerPodName), containsString(acrossUpgradeData.getProcedures().getVersion()));
     }
 
     @IsolatedTest
-    void testUpgradeAcrossVersionsWithUnsupportedKafkaVersion(ExtensionContext extensionContext) throws IOException {
+    void testUpgradeAcrossVersionsWithUnsupportedKafkaVersion() throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         UpgradeKafkaVersion upgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(acrossUpgradeData.getFromKafkaVersionsUrl(), acrossUpgradeData.getStartingKafkaVersion());
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(acrossUpgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+        setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage, upgradeKafkaVersion);
 
         // Make snapshots of all Pods
-        makeSnapshots();
+        makeComponentsSnapshots(TEST_SUITE_NAMESPACE);
 
         // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TestConstants.CO_NAMESPACE, eoSelector);
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TEST_SUITE_NAMESPACE, eoSelector);
 
         // Upgrade CO
-        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        changeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData);
 
-        waitForKafkaClusterRollingUpdate();
+        waitForKafkaClusterRollingUpdate(TEST_SUITE_NAMESPACE);
 
-        logPodImages(TestConstants.CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(acrossUpgradeData, true);
+        changeKafkaAndMetadataVersion(TEST_SUITE_NAMESPACE, acrossUpgradeData, true);
 
-        logPodImages(TestConstants.CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE);
 
-        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
 
         // Verify that Pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        PodUtils.verifyThatRunningPodsAreStable(TEST_SUITE_NAMESPACE, clusterName);
 
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
     }
 
     @IsolatedTest
-    void testUpgradeAcrossVersionsWithNoKafkaVersion(ExtensionContext extensionContext) throws IOException {
+    void testUpgradeAcrossVersionsWithNoKafkaVersion() throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(acrossUpgradeData, testStorage, null, TestConstants.CO_NAMESPACE);
+        setupEnvAndUpgradeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage, null);
 
         // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TestConstants.CO_NAMESPACE, eoSelector);
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TEST_SUITE_NAMESPACE, eoSelector);
 
         // Upgrade CO
-        changeClusterOperator(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        changeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData);
 
         // Wait till first upgrade finished
-        controllerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, 3, controllerPods);
-        brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, 3, brokerPods);
-        eoPods = DeploymentUtils.waitTillDepHasRolled(TestConstants.CO_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
+        controllerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TEST_SUITE_NAMESPACE, controllerSelector, 3, controllerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TEST_SUITE_NAMESPACE, brokerSelector, 3, brokerPods);
+        eoPods = DeploymentUtils.waitTillDepHasRolled(TEST_SUITE_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
 
         LOGGER.info("Rolling to new images has finished!");
-        logPodImages(TestConstants.CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(acrossUpgradeData);
-
-        logPodImages(TestConstants.CO_NAMESPACE);
-
-        checkAllImages(acrossUpgradeData, TestConstants.CO_NAMESPACE);
+        changeKafkaAndMetadataVersion(TEST_SUITE_NAMESPACE, acrossUpgradeData);
+        logComponentsPodImages(TEST_SUITE_NAMESPACE);
+        checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
 
         // Verify that Pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        PodUtils.verifyThatRunningPodsAreStable(TEST_SUITE_NAMESPACE, clusterName);
 
         // Verify upgrade
-        verifyProcedure(acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
     }
 
     @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
     @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
     @IsolatedTest
     void testUpgradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
-        final TestStorage testStorage = new TestStorage(extensionContext, TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(extensionContext);
         final UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(acrossUpgradeData.getDefaultKafka());
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(acrossUpgradeData, testStorage, upgradeKafkaVersion);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData, testStorage, upgradeKafkaVersion);
     }
 
-    private void performUpgrade(BundleVersionModificationData upgradeData, ExtensionContext extensionContext) throws IOException {
+    private void performUpgrade(String clusterOperatorNamespaceName, String componentsNamespaceName, BundleVersionModificationData upgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
         // leave empty, so the original Kafka version from appropriate Strimzi's yaml will be used
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion();
 
         // Setup env
-        setupEnvAndUpgradeClusterOperator(upgradeData, testStorage, upgradeKafkaVersion, TestConstants.CO_NAMESPACE);
+        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, upgradeData, testStorage, upgradeKafkaVersion);
 
         // Upgrade CO to HEAD
-        logPodImages(TestConstants.CO_NAMESPACE);
+        logClusterOperatorPodImage(clusterOperatorNamespaceName);
+        logComponentsPodImages(componentsNamespaceName);
 
         // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(TestConstants.CO_NAMESPACE, eoSelector);
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(componentsNamespaceName, eoSelector);
 
-        changeClusterOperator(upgradeData, TestConstants.CO_NAMESPACE);
+        changeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, upgradeData);
 
         if (TestKafkaVersion.supportedVersionsContainsVersion(upgradeData.getDefaultKafkaVersionPerStrimzi())) {
-            waitForKafkaClusterRollingUpdate();
+            waitForKafkaClusterRollingUpdate(componentsNamespaceName);
         }
 
-        logPodImages(TestConstants.CO_NAMESPACE);
+        logClusterOperatorPodImage(clusterOperatorNamespaceName);
+        logComponentsPodImages(componentsNamespaceName);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(upgradeData, true);
-
-        logPodImages(TestConstants.CO_NAMESPACE);
-
-        checkAllImages(upgradeData, TestConstants.CO_NAMESPACE);
+        changeKafkaAndMetadataVersion(componentsNamespaceName, upgradeData, true);
+        logComponentsPodImages(componentsNamespaceName);
+        checkAllComponentsImages(componentsNamespaceName, upgradeData);
 
         // Verify that Pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, clusterName);
+        PodUtils.verifyThatRunningPodsAreStable(componentsNamespaceName, clusterName);
 
         // Verify upgrade
-        verifyProcedure(upgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, wasUTOUsedBefore);
+        verifyProcedure(componentsNamespaceName, upgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
     }
 
     @BeforeEach
     void setupEnvironment() {
         NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
-    }
-
-    protected void afterEachMayOverride(ExtensionContext extensionContext) {
-        cleanUpKafkaTopics();
-        ResourceManager.getInstance().deleteResources();
-        NamespaceManager.getInstance().deleteNamespaceWithWait(CO_NAMESPACE);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -7,7 +7,6 @@ package io.strimzi.systemtest.upgrade.regular;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -31,6 +30,7 @@ import org.junit.jupiter.api.Tag;
 import java.util.List;
 import java.util.Map;
 
+import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -47,11 +47,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
-    private final int continuousClientsMessageCount = 500;
+    private final int continuousClientsMessageCount = 300;
 
     @IsolatedTest
     void testKafkaClusterUpgrade() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
@@ -61,19 +61,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is an upgrade test we keep the message format as the lower version number
             String logMsgFormat = initialVersion.messageVersion();
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testKafkaClusterDowngrade() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = sortedVersions.size() - 1; x > 0; x--) {
@@ -83,19 +83,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is a downgrade then we make sure to use the lower version number for the message format
             String logMsgFormat = newVersion.messageVersion();
             String interBrokerProtocol = newVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testKafkaClusterDowngradeToOlderMessageFormat() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         String initLogMsgFormat = sortedVersions.get(0).messageVersion();
@@ -105,38 +105,38 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x - 1);
 
-            runVersionChange(initialVersion, newVersion, testStorage, initLogMsgFormat, initInterBrokerProtocol, 3, 3);
+            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, initLogMsgFormat, initInterBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testUpgradeWithNoMessageAndProtocolVersionsSet() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(initialVersion, newVersion, testStorage, null, null, 3, 3);
+            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, null, null, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousProducerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousProducerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
     @IsolatedTest
     void testUpgradeWithoutLogMessageFormatVersionSet() {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), TestConstants.CO_NAMESPACE);
+        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
 
         for (int x = 0; x < sortedVersions.size() - 1; x++) {
@@ -145,13 +145,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
             // If it is an upgrade test we keep the message format as the lower version number
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(initialVersion, newVersion, testStorage, null, interBrokerProtocol, 3, 3);
+            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, null, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TestConstants.CO_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
         // ##############################
     }
 
@@ -161,15 +161,15 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
+    void runVersionChange(String namespaceName, TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> brokerPods;
 
         boolean sameMinorVersion = initialVersion.protocolVersion().equals(newVersion.protocolVersion());
 
-        if (KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get() == null) {
+        if (KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get() == null) {
             LOGGER.info("Deploying initial Kafka version {} with logMessageFormat={} and interBrokerProtocol={}", initialVersion.version(), initLogMsgFormat, initInterBrokerProtocol);
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(TestConstants.CO_NAMESPACE, clusterName, kafkaReplicas, zkReplicas)
+            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(namespaceName, clusterName, kafkaReplicas, zkReplicas)
                 .editSpec()
                     .editKafka()
                         .withVersion(initialVersion.version())
@@ -195,18 +195,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                         .endKafka()
                     .endSpec();
             }
-            resourceManager.createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(TestConstants.CO_NAMESPACE, poolName, clusterName, kafkaReplicas).build());
+            resourceManager.createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(namespaceName, poolName, clusterName, kafkaReplicas).build());
             resourceManager.createResourceWithWait(kafka.build());
 
             // ##############################
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(TestConstants.CO_NAMESPACE, testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
+            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(namespaceName, testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
             String producerAdditionConfiguration = "delivery.timeout.ms=300000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
+                .withNamespaceName(namespaceName)
                 .withMessageCount(continuousClientsMessageCount)
                 .withAdditionalConfig(producerAdditionConfiguration)
                 .build();
@@ -217,7 +218,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
         } else {
             LOGGER.info("Initial Kafka version (" + initialVersion.version() + ") is already ready");
-            brokerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+            brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
 
             // Wait for log.message.format.version and inter.broker.protocol.version change
             if (!sameMinorVersion
@@ -232,65 +233,65 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                     config.put("inter.broker.protocol.version", newVersion.protocolVersion());
                     kafka.getSpec().getKafka().setConfig(config);
                     LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().getConfig().toString());
-                }, TestConstants.CO_NAMESPACE);
+                }, namespaceName);
 
-                RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, kafkaReplicas, brokerPods);
+                RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
             }
         }
 
         LOGGER.info("Deployment of initial Kafka version (" + initialVersion.version() + ") complete");
 
         String zkVersionCommand = "ls libs | grep -Po 'zookeeper-\\K\\d+.\\d+.\\d+' | head -1";
-        String zkResult = cmdKubeClient().execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
+        String zkResult = cmdKubeClient(namespaceName).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Pre-change ZooKeeper version query returned: " + zkResult);
 
-        String kafkaVersionResult = KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get().getStatus().getKafkaVersion();
+        String kafkaVersionResult = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getKafkaVersion();
         LOGGER.info("Pre-change Kafka version: " + kafkaVersionResult);
 
-        Map<String, String> controllerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, controllerSelector);
-        brokerPods = PodUtils.podSnapshot(TestConstants.CO_NAMESPACE, brokerSelector);
+        Map<String, String> controllerPods = PodUtils.podSnapshot(namespaceName, controllerSelector);
+        brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
         LOGGER.info("Updating Kafka CR version field to " + newVersion.version());
 
         // Change the version in Kafka CR
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             kafka.getSpec().getKafka().setVersion(newVersion.version());
-        }, TestConstants.CO_NAMESPACE);
+        }, namespaceName);
 
         LOGGER.info("Waiting for readiness of new Kafka version (" + newVersion.version() + ") to complete");
 
         // Wait for the zk version change roll
-        controllerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, controllerSelector, zkReplicas, controllerPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, controllerSelector, zkReplicas, controllerPods);
         LOGGER.info("1st ZooKeeper roll (image change) is complete");
 
         // Wait for the kafka broker version change roll
-        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, brokerPods);
         LOGGER.info("1st Kafka roll (image change) is complete");
 
-        Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
-        Object currentInterBrokerProtocol = KafkaResource.kafkaClient().inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName).get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version");
+        Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
+        Object currentInterBrokerProtocol = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version");
 
         if (isUpgrade && !sameMinorVersion) {
             LOGGER.info("Kafka version is increased, two RUs remaining for increasing IBPV and LMFV");
 
             if (currentInterBrokerProtocol == null) {
-                brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerPods);
+                brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, brokerPods);
                 LOGGER.info("Kafka roll (inter.broker.protocol.version) is complete");
             }
 
             // Only Kafka versions before 3.0.0 require the second roll
             if (currentLogMessageFormat == null && TestKafkaVersion.compareDottedVersions(newVersion.protocolVersion(), "3.0") < 0) {
-                brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, kafkaReplicas, brokerPods);
+                brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
                 LOGGER.info("Kafka roll (log.message.format.version) is complete");
             }
         }
 
         LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");
 
-        PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, KafkaResources.kafkaComponentName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaComponentName(clusterName));
 
         // Extract the zookeeper version number from the jars in the lib directory
-        zkResult = cmdKubeClient().execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
+        zkResult = cmdKubeClient(namespaceName).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Post-change ZooKeeper version query returned: " + zkResult);
 
@@ -298,8 +299,8 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 " was expected", zkResult, is(newVersion.zookeeperVersion()));
 
         // Extract the Kafka version number from the jars in the lib directory
-        String brokerPodName = kubeClient().listPods(TestConstants.CO_NAMESPACE, brokerSelector).get(0).getMetadata().getName();
-        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(brokerPodName);
+        String brokerPodName = kubeClient().listPods(namespaceName, brokerSelector).get(0).getMetadata().getName();
+        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(namespaceName, brokerPodName);
         LOGGER.info("Post-change Kafka version query returned: " + kafkaVersionResult);
 
         assertThat("Kafka container had version " + kafkaVersionResult + " where " + newVersion.version() +
@@ -316,39 +317,39 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 config.put("inter.broker.protocol.version", newVersion.protocolVersion());
                 kafka.getSpec().getKafka().setConfig(config);
                 LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().getConfig().toString());
-            }, TestConstants.CO_NAMESPACE);
+            }, namespaceName);
 
             if (currentLogMessageFormat != null || currentInterBrokerProtocol != null) {
                 LOGGER.info("Change of configuration is done manually - rolling update");
                 // Wait for the kafka broker version of log.message.format.version change roll
-                RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(TestConstants.CO_NAMESPACE, brokerSelector, kafkaReplicas, brokerPods);
+                RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
                 LOGGER.info("Kafka roll (log.message.format.version change) is complete");
             } else {
                 LOGGER.info("Cluster Operator already changed the configuration, there should be no rolling update");
-                PodUtils.verifyThatRunningPodsAreStable(TestConstants.CO_NAMESPACE, KafkaResources.kafkaComponentName(clusterName));
-                assertFalse(RollingUpdateUtils.componentHasRolled(TestConstants.CO_NAMESPACE, brokerSelector, brokerPods));
+                PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaComponentName(clusterName));
+                assertFalse(RollingUpdateUtils.componentHasRolled(namespaceName, brokerSelector, brokerPods));
             }
         }
 
         if (!isUpgrade) {
             LOGGER.info("Verifying that log.message.format attribute updated correctly to version {}", initLogMsgFormat);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
                     .get().getSpec().getKafka().getConfig().get("log.message.format.version"), is(initLogMsgFormat));
             LOGGER.info("Verifying that inter.broker.protocol.version attribute updated correctly to version {}", initInterBrokerProtocol);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
                     .get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version"), is(initInterBrokerProtocol));
         } else {
             if (currentLogMessageFormat != null && currentInterBrokerProtocol != null) {
                 LOGGER.info("Verifying that log.message.format attribute updated correctly to version {}", newVersion.messageVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
                         .get().getSpec().getKafka().getConfig().get("log.message.format.version"), is(newVersion.messageVersion()));
                 LOGGER.info("Verifying that inter.broker.protocol.version attribute updated correctly to version {}", newVersion.protocolVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(TestConstants.CO_NAMESPACE).withName(clusterName)
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
                         .get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version"), is(newVersion.protocolVersion()));
             }
         }
 
-        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", TestConstants.CO_NAMESPACE, clusterName, newVersion.version());
-        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(clusterName, TestConstants.CO_NAMESPACE, newVersion.version());
+        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", namespaceName, clusterName, newVersion.version());
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(namespaceName, clusterName, newVersion.version());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Tag;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.UPGRADE;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -61,13 +60,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is an upgrade test we keep the message format as the lower version number
             String logMsgFormat = initialVersion.messageVersion();
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -83,13 +82,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             // If it is a downgrade then we make sure to use the lower version number for the message format
             String logMsgFormat = newVersion.messageVersion();
             String interBrokerProtocol = newVersion.protocolVersion();
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, logMsgFormat, interBrokerProtocol, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, logMsgFormat, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -105,13 +104,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x - 1);
 
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, initLogMsgFormat, initInterBrokerProtocol, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, initLogMsgFormat, initInterBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -124,13 +123,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
             TestKafkaVersion initialVersion = sortedVersions.get(x);
             TestKafkaVersion newVersion = sortedVersions.get(x + 1);
 
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, null, null, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, null, null, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousProducerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousProducerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -145,13 +144,13 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
             // If it is an upgrade test we keep the message format as the lower version number
             String interBrokerProtocol = initialVersion.protocolVersion();
-            runVersionChange(TEST_SUITE_NAMESPACE, initialVersion, newVersion, testStorage, null, interBrokerProtocol, 3, 3);
+            runVersionChange(testStorage, initialVersion, newVersion, null, interBrokerProtocol, 3, 3);
         }
 
         // ##############################
         // Validate that continuous clients finished successfully
         // ##############################
-        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), TEST_SUITE_NAMESPACE, continuousClientsMessageCount);
+        ClientUtils.waitForClientsSuccess(testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), testStorage.getNamespaceName(), continuousClientsMessageCount);
         // ##############################
     }
 
@@ -161,15 +160,15 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
     }
 
     @SuppressWarnings({"checkstyle:MethodLength"})
-    void runVersionChange(String namespaceName, TestKafkaVersion initialVersion, TestKafkaVersion newVersion, TestStorage testStorage, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
+    void runVersionChange(TestStorage testStorage, TestKafkaVersion initialVersion, TestKafkaVersion newVersion, String initLogMsgFormat, String initInterBrokerProtocol, int kafkaReplicas, int zkReplicas) {
         boolean isUpgrade = initialVersion.isUpgrade(newVersion);
         Map<String, String> brokerPods;
 
         boolean sameMinorVersion = initialVersion.protocolVersion().equals(newVersion.protocolVersion());
 
-        if (KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get() == null) {
+        if (KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get() == null) {
             LOGGER.info("Deploying initial Kafka version {} with logMessageFormat={} and interBrokerProtocol={}", initialVersion.version(), initLogMsgFormat, initInterBrokerProtocol);
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(namespaceName, clusterName, kafkaReplicas, zkReplicas)
+            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(testStorage.getNamespaceName(), clusterName, kafkaReplicas, zkReplicas)
                 .editSpec()
                     .editKafka()
                         .withVersion(initialVersion.version())
@@ -195,19 +194,19 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                         .endKafka()
                     .endSpec();
             }
-            resourceManager.createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(namespaceName, poolName, clusterName, kafkaReplicas).build());
+            resourceManager.createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(testStorage.getNamespaceName(), poolName, clusterName, kafkaReplicas).build());
             resourceManager.createResourceWithWait(kafka.build());
 
             // ##############################
             // Attach clients which will continuously produce/consume messages to/from Kafka brokers during rolling update
             // ##############################
             // Setup topic, which has 3 replicas and 2 min.isr to see if producer will be able to work during rolling update
-            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(namespaceName, testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
+            resourceManager.createResourceWithWait(KafkaTopicTemplates.topic(testStorage.getNamespaceName(), testStorage.getContinuousTopicName(), clusterName, 3, 3, 2).build());
             String producerAdditionConfiguration = "delivery.timeout.ms=300000\nrequest.timeout.ms=20000";
 
             KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
                 .withBootstrapAddress(KafkaResources.plainBootstrapAddress(clusterName))
-                .withNamespaceName(namespaceName)
+                .withNamespaceName(testStorage.getNamespaceName())
                 .withMessageCount(continuousClientsMessageCount)
                 .withAdditionalConfig(producerAdditionConfiguration)
                 .build();
@@ -218,7 +217,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
         } else {
             LOGGER.info("Initial Kafka version (" + initialVersion.version() + ") is already ready");
-            brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
+            brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), brokerSelector);
 
             // Wait for log.message.format.version and inter.broker.protocol.version change
             if (!sameMinorVersion
@@ -233,65 +232,65 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                     config.put("inter.broker.protocol.version", newVersion.protocolVersion());
                     kafka.getSpec().getKafka().setConfig(config);
                     LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().getConfig().toString());
-                }, namespaceName);
+                }, testStorage.getNamespaceName());
 
-                RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
+                RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), brokerSelector, kafkaReplicas, brokerPods);
             }
         }
 
         LOGGER.info("Deployment of initial Kafka version (" + initialVersion.version() + ") complete");
 
         String zkVersionCommand = "ls libs | grep -Po 'zookeeper-\\K\\d+.\\d+.\\d+' | head -1";
-        String zkResult = cmdKubeClient(namespaceName).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
+        String zkResult = cmdKubeClient(testStorage.getNamespaceName()).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Pre-change ZooKeeper version query returned: " + zkResult);
 
-        String kafkaVersionResult = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getStatus().getKafkaVersion();
+        String kafkaVersionResult = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get().getStatus().getKafkaVersion();
         LOGGER.info("Pre-change Kafka version: " + kafkaVersionResult);
 
-        Map<String, String> controllerPods = PodUtils.podSnapshot(namespaceName, controllerSelector);
-        brokerPods = PodUtils.podSnapshot(namespaceName, brokerSelector);
+        Map<String, String> controllerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), controllerSelector);
+        brokerPods = PodUtils.podSnapshot(testStorage.getNamespaceName(), brokerSelector);
         LOGGER.info("Updating Kafka CR version field to " + newVersion.version());
 
         // Change the version in Kafka CR
         KafkaResource.replaceKafkaResourceInSpecificNamespace(clusterName, kafka -> {
             kafka.getSpec().getKafka().setVersion(newVersion.version());
-        }, namespaceName);
+        }, testStorage.getNamespaceName());
 
         LOGGER.info("Waiting for readiness of new Kafka version (" + newVersion.version() + ") to complete");
 
         // Wait for the zk version change roll
-        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, controllerSelector, zkReplicas, controllerPods);
+        RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controllerSelector, zkReplicas, controllerPods);
         LOGGER.info("1st ZooKeeper roll (image change) is complete");
 
         // Wait for the kafka broker version change roll
-        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, brokerPods);
+        brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerPods);
         LOGGER.info("1st Kafka roll (image change) is complete");
 
-        Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
-        Object currentInterBrokerProtocol = KafkaResource.kafkaClient().inNamespace(namespaceName).withName(clusterName).get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version");
+        Object currentLogMessageFormat = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get().getSpec().getKafka().getConfig().get("log.message.format.version");
+        Object currentInterBrokerProtocol = KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version");
 
         if (isUpgrade && !sameMinorVersion) {
             LOGGER.info("Kafka version is increased, two RUs remaining for increasing IBPV and LMFV");
 
             if (currentInterBrokerProtocol == null) {
-                brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(namespaceName, brokerSelector, brokerPods);
+                brokerPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerPods);
                 LOGGER.info("Kafka roll (inter.broker.protocol.version) is complete");
             }
 
             // Only Kafka versions before 3.0.0 require the second roll
             if (currentLogMessageFormat == null && TestKafkaVersion.compareDottedVersions(newVersion.protocolVersion(), "3.0") < 0) {
-                brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
+                brokerPods = RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, kafkaReplicas, brokerPods);
                 LOGGER.info("Kafka roll (log.message.format.version) is complete");
             }
         }
 
         LOGGER.info("Deployment of Kafka (" + newVersion.version() + ") complete");
 
-        PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaComponentName(clusterName));
+        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaComponentName(clusterName));
 
         // Extract the zookeeper version number from the jars in the lib directory
-        zkResult = cmdKubeClient(namespaceName).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
+        zkResult = cmdKubeClient(testStorage.getNamespaceName()).execInPodContainer(KafkaResources.zookeeperPodName(clusterName, 0),
                 "zookeeper", "/bin/bash", "-c", zkVersionCommand).out().trim();
         LOGGER.info("Post-change ZooKeeper version query returned: " + zkResult);
 
@@ -299,8 +298,8 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 " was expected", zkResult, is(newVersion.zookeeperVersion()));
 
         // Extract the Kafka version number from the jars in the lib directory
-        String brokerPodName = kubeClient().listPods(namespaceName, brokerSelector).get(0).getMetadata().getName();
-        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(namespaceName, brokerPodName);
+        String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), brokerSelector).get(0).getMetadata().getName();
+        kafkaVersionResult = KafkaUtils.getVersionFromKafkaPodLibs(testStorage.getNamespaceName(), brokerPodName);
         LOGGER.info("Post-change Kafka version query returned: " + kafkaVersionResult);
 
         assertThat("Kafka container had version " + kafkaVersionResult + " where " + newVersion.version() +
@@ -317,39 +316,39 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
                 config.put("inter.broker.protocol.version", newVersion.protocolVersion());
                 kafka.getSpec().getKafka().setConfig(config);
                 LOGGER.info("Kafka config after updating '{}'", kafka.getSpec().getKafka().getConfig().toString());
-            }, namespaceName);
+            }, testStorage.getNamespaceName());
 
             if (currentLogMessageFormat != null || currentInterBrokerProtocol != null) {
                 LOGGER.info("Change of configuration is done manually - rolling update");
                 // Wait for the kafka broker version of log.message.format.version change roll
-                RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(namespaceName, brokerSelector, kafkaReplicas, brokerPods);
+                RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, kafkaReplicas, brokerPods);
                 LOGGER.info("Kafka roll (log.message.format.version change) is complete");
             } else {
                 LOGGER.info("Cluster Operator already changed the configuration, there should be no rolling update");
-                PodUtils.verifyThatRunningPodsAreStable(namespaceName, KafkaResources.kafkaComponentName(clusterName));
-                assertFalse(RollingUpdateUtils.componentHasRolled(namespaceName, brokerSelector, brokerPods));
+                PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), KafkaResources.kafkaComponentName(clusterName));
+                assertFalse(RollingUpdateUtils.componentHasRolled(testStorage.getNamespaceName(), brokerSelector, brokerPods));
             }
         }
 
         if (!isUpgrade) {
             LOGGER.info("Verifying that log.message.format attribute updated correctly to version {}", initLogMsgFormat);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                     .get().getSpec().getKafka().getConfig().get("log.message.format.version"), is(initLogMsgFormat));
             LOGGER.info("Verifying that inter.broker.protocol.version attribute updated correctly to version {}", initInterBrokerProtocol);
-            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+            assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                     .get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version"), is(initInterBrokerProtocol));
         } else {
             if (currentLogMessageFormat != null && currentInterBrokerProtocol != null) {
                 LOGGER.info("Verifying that log.message.format attribute updated correctly to version {}", newVersion.messageVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                         .get().getSpec().getKafka().getConfig().get("log.message.format.version"), is(newVersion.messageVersion()));
                 LOGGER.info("Verifying that inter.broker.protocol.version attribute updated correctly to version {}", newVersion.protocolVersion());
-                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(namespaceName).withName(clusterName)
+                assertThat(Crds.kafkaOperation(kubeClient().getClient()).inNamespace(testStorage.getNamespaceName()).withName(clusterName)
                         .get().getSpec().getKafka().getConfig().get("inter.broker.protocol.version"), is(newVersion.protocolVersion()));
             }
         }
 
-        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", namespaceName, clusterName, newVersion.version());
-        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(namespaceName, clusterName, newVersion.version());
+        LOGGER.info("Waiting till Kafka Cluster {}/{} with specified version {} has the same version in status and specification", testStorage.getNamespaceName(), clusterName, newVersion.version());
+        KafkaUtils.waitUntilStatusKafkaVersionMatchesExpectedVersion(testStorage.getNamespaceName(), clusterName, newVersion.version());
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -65,7 +65,7 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
                         bundleMetadata.getFeatureGatesAfter() != null && !bundleMetadata.getFeatureGatesAfter().isEmpty()).toList().get(0);
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeDataWithFeatureGates.getDeployKafkaVersion());
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, TEST_SUITE_NAMESPACE, bundleDowngradeDataWithFeatureGates, testStorage, upgradeKafkaVersion);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, bundleDowngradeDataWithFeatureGates, testStorage, upgradeKafkaVersion);
     }
 
     private void performDowngrade(String clusterOperatorNamespaceName, String componentsNamespaceName, BundleVersionModificationData downgradeData) throws IOException {
@@ -75,7 +75,7 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
         // Setup env
         // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
         // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
-        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, downgradeData, testStorage, testUpgradeKafkaVersion);
+        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, downgradeData, testStorage, testUpgradeKafkaVersion);
 
         logClusterOperatorPodImage(clusterOperatorNamespaceName);
         logComponentsPodImages(componentsNamespaceName);
@@ -100,16 +100,20 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
     @BeforeEach
     void setupEnvironment() {
         NamespaceManager.getInstance().createNamespaceAndPrepare(CO_NAMESPACE);
+
+        if (!CO_NAMESPACE.equals(TEST_SUITE_NAMESPACE)) {
+            NamespaceManager.getInstance().createNamespaceAndPrepare(TEST_SUITE_NAMESPACE);
+        }
     }
 
     @AfterEach
     void afterEach() {
-        cleanUpKafkaTopics();
+        cleanUpKafkaTopics(TEST_SUITE_NAMESPACE);
         deleteInstalledYamls(CO_NAMESPACE, TEST_SUITE_NAMESPACE, coDir);
         NamespaceManager.getInstance().deleteNamespaceWithWait(CO_NAMESPACE);
-        if (!TEST_SUITE_NAMESPACE.equals(CO_NAMESPACE)) {
+
+        if (!CO_NAMESPACE.equals(TEST_SUITE_NAMESPACE)) {
             NamespaceManager.getInstance().deleteNamespaceWithWait(TEST_SUITE_NAMESPACE);
         }
-
     }
 }

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -44,7 +44,7 @@
     userOperator: strimzi/operator:0.43.0
   deployKafkaVersion: 3.8.0
   client:
-    continuousClientsMessages: 500
+    continuousClientsMessages: 300
   environmentInfo:
     maxK8sVersion: latest
     status: stable
@@ -72,7 +72,7 @@
     userOperator: strimzi/operator:0.43.0
   deployKafkaVersion: 3.8.0
   client:
-    continuousClientsMessages: 500
+    continuousClientsMessages: 300
   environmentInfo:
     maxK8sVersion: latest
     status: stable

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -41,7 +41,7 @@
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
-    continuousClientsMessages: 500
+    continuousClientsMessages: 300
   environmentInfo:
     maxK8sVersion: latest
     status: stable


### PR DESCRIPTION
### Type of change

refactor

### Description

`co-namespace` will not be used for creation of any resources also in upgrade/donwgrade system tests (the only exception will now be in OLM tests). 

### Detailed changes
- methods used in modified parts will now have namespace as first parameter with name `namespaceName`. 
- number of created topics is decreased to 20 (from 40) as each creation can take even 6+ seconds making the test unneccesarry slow. 
- helper method `copyModifyApply` is now modified so it reflects exactly steps from documentation how to deploy cluster operator which watch multiple namesapces. 
- `TestConstants.CO_NAMESPACE` and `TEST_SUITE_NAMESPACE` are not used if they can be passed as argument. 
- `TestConstants.CO_NAMESPACE` occurences replaced with simple `CO_NAMESPACE` as both were used in different places so for at least so-so consistency. 


