### PR TITLE
Increase minio secret key length for FIPS

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/minio/SetupMinio.java
@@ -25,7 +25,7 @@ public class SetupMinio {
     private static final Logger LOGGER = LogManager.getLogger(SetupMinio.class);
 
     public static final String MINIO = "minio";
-    public static final String ADMIN_CREDS = "minioadmin";
+    public static final String ADMIN_CREDS = "minioadminLongerThan16BytesForFIPS";
     public static final String MINIO_STORAGE_ALIAS = "local";
     public static final int MINIO_PORT = 9000;
     private static final String MINIO_IMAGE = "quay.io/minio/minio:latest";

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -9,7 +9,6 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.systemtest.annotations.FIPSNotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.annotations.ParallelTest;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -55,7 +54,6 @@ import static io.strimzi.systemtest.TestConstants.TIERED_STORAGE;
  *  - tiered-storage-integration
  */
 @MicroShiftNotSupported("We are using Kaniko and OpenShift builds to build Kafka image with TS. To make it working on Microshift we will invest much time with not much additional value.")
-@FIPSNotSupported("Aiven TieredStorage plugin doesn't work with FIPS - https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/issues/573")
 @Tag(REGRESSION)
 @Tag(TIERED_STORAGE)
 public class TieredStorageST extends AbstractST {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

We disabled FIPS test for tiered storage system test because of the issue: https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/issues/573 . After investigation, I found it's because the secret key length we set is too short, which is not compatible with FIPS compliance. After increasing the secret key size, the test passes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [V] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

