### PR TITLE
Use different image for RegistryProxy to workaround minikube startup failures

### DIFF
--- a/.azure/scripts/setup-kubernetes.sh
+++ b/.azure/scripts/setup-kubernetes.sh
@@ -110,7 +110,8 @@ if [ "$TEST_CLUSTER" = "minikube" ]; then
         minikube addons enable registry --images="Registry=arm64v8/registry:2.8.2,KubeRegistryProxy=google_containers/kube-registry-proxy:0.5-SNAPSHOT"
         rm -rf kubernetes
     else
-        minikube addons enable registry
+
+        minikube addons enable registry --images="KubeRegistryProxy=gcr.io/google_containers/kube-registry-proxy:0.4"
     fi
 
     minikube addons enable registry-aliases


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It seems there are some issues with `gcr.io/k8s-minikube` org that contains Minikube registry images. The problem with our build-pipeline should be resolved by this workaround.

Some more info is available here https://github.com/kubernetes/minikube/issues/19535 for example

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

