### PR TITLE
Pin the `upload-sarif` GitHub action in the Scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,6 +58,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### Type of change

- Task

### Description

The Scorecard workflow seems to have one unpinned GitHub action (which is one of the things the Scorecard checks and uses to calculate the score). This PR pins it.