### PR TITLE
Use LockSupport.parkNanos instead of Thread.sleep in systemtests

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -278,11 +280,7 @@ public class KafkaTopicUtils {
 
         while (System.currentTimeMillis() < endTime) {
             assertThat(KafkaCmdClient.listTopicsUsingPodCli(namespaceName, queryingPodName, KafkaResources.plainBootstrapAddress(clusterName)), not(hasItems(absentTopicName)));
-            try {
-                Thread.sleep(TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(TestConstants.POLL_INTERVAL_FOR_RESOURCE_READINESS));
         }
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -73,6 +73,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -763,7 +765,7 @@ public class MetricsST extends AbstractST {
         // wait some time for metrics to be stable - at least reconciliation interval + 10s
         LOGGER.info("Sleeping for {} to give operators and operands some time to stable the metrics values before collecting",
                 TestConstants.SAFETY_RECONCILIATION_INTERVAL);
-        Thread.sleep(TestConstants.SAFETY_RECONCILIATION_INTERVAL);
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(TestConstants.SAFETY_RECONCILIATION_INTERVAL));
 
         kafkaCollector = new MetricsCollector.Builder()
             .withScraperPodName(scraperPodName)

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -55,6 +55,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
@@ -187,11 +188,7 @@ public final class TestUtils {
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("{} not ready, will try again in {} ms ({}ms till timeout)", description, sleepTime, timeLeft);
             }
-            try {
-                Thread.sleep(sleepTime);
-            } catch (InterruptedException e) {
-                return deadline - System.currentTimeMillis();
-            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(sleepTime));
         }
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Use LockSupport.parkNanos instead of Thread.sleep when we need to wait in systemtests. 

The use of LockSupport.parkNanos is more consistent with modern concurrency practices in Java, where fine-grained control over thread states is often required. This change aligns the codebase with best practices for implementing efficient concurrency mechanisms.

Unlike Thread.sleep, LockSupport.parkNanos does not throw an InterruptedException but instead returns immediately if the thread is interrupted. 

And also my IDE does not warn me with Thread.sleep  :D  

### Checklist

- [x] Make sure all tests pass

