### PR TITLE
Promote `ContinueReconciliationOnManualRollingUpdateFailure` feature gate to beta

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_jobs.yaml
@@ -5,7 +5,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -17,7 +17,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -29,7 +29,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -41,7 +41,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -53,7 +53,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -65,7 +65,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
@@ -77,7 +77,7 @@ jobs:
       display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -8,7 +8,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -22,7 +22,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -36,7 +36,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -50,7 +50,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -64,7 +64,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -78,7 +78,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
@@ -92,7 +92,7 @@ jobs:
       cluster_operator_install_type: 'bundle'
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
-      strimzi_feature_gates: '+ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
       strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.44.0
 
 * Add the "Unmanaged" KafkaTopic status update.
+* The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate moves to beta stage and is enabled by default.
+  If needed, `ContinueReconciliationOnManualRollingUpdateFailure` can be disabled in the feature gates configuration in the Cluster Operator.
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorConfigTest.java
@@ -44,7 +44,7 @@ public class ClusterOperatorConfigTest {
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMakerImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString());
         ENV_VARS.put(ClusterOperatorConfig.OPERATOR_NAMESPACE.key(), "operator-namespace");
-        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "+ContinueReconciliationOnManualRollingUpdateFailure");
+        ENV_VARS.put(ClusterOperatorConfig.FEATURE_GATES.key(), "-ContinueReconciliationOnManualRollingUpdateFailure");
         ENV_VARS.put(ClusterOperatorConfig.DNS_CACHE_TTL.key(), "10");
         ENV_VARS.put(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.key(), "my.package.CustomPodSecurityProvider");
     }
@@ -100,7 +100,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(30_000L));
         assertThat(config.getConnectBuildTimeoutMs(), is(40_000L));
         assertThat(config.getOperatorNamespace(), is("operator-namespace"));
-        assertThat(config.featureGates().continueOnManualRUFailureEnabled(), is(true));
+        assertThat(config.featureGates().continueOnManualRUFailureEnabled(), is(false));
         assertThat(config.getDnsCacheTtlSec(), is(10));
         assertThat(config.getPodSecurityProviderClass(), is("my.package.CustomPodSecurityProvider"));
     }
@@ -117,6 +117,7 @@ public class ClusterOperatorConfigTest {
         assertThat(config.getOperationTimeoutMs(), is(Long.parseLong(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.defaultValue())));
         assertThat(config.getOperatorNamespace(), is(nullValue()));
         assertThat(config.getOperatorNamespaceLabels(), is(nullValue()));
+        assertThat(config.featureGates().continueOnManualRUFailureEnabled(), is(true));
         assertThat(config.getDnsCacheTtlSec(), is(Integer.parseInt(ClusterOperatorConfig.DNS_CACHE_TTL.defaultValue())));
         assertThat(config.getPodSecurityProviderClass(), is(ClusterOperatorConfig.POD_SECURITY_PROVIDER_CLASS.defaultValue()));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -785,14 +785,14 @@ public class EntityOperatorTest {
     @ParallelTest
     public void testFeatureGateEnvVars() {
         ClusterOperatorConfig config = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS)
-                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "+ContinueReconciliationOnManualRollingUpdateFailure")
+                .with(ClusterOperatorConfig.FEATURE_GATES.key(), "-ContinueReconciliationOnManualRollingUpdateFailure")
                 .build();
 
         EntityOperator eo = EntityOperator.fromCrd(new Reconciliation("test", KAFKA.getKind(), KAFKA.getMetadata().getNamespace(), KAFKA.getMetadata().getName()), KAFKA, SHARED_ENV_PROVIDER, config);
         Deployment dep = eo.generateDeployment(Map.of(), false, null, null);
 
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+ContinueReconciliationOnManualRollingUpdateFailure"));
-        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(1).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("+ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("-ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(dep.getSpec().getTemplate().getSpec().getContainers().get(1).getEnv().stream().filter(env -> "STRIMZI_FEATURE_GATES".equals(env.getName())).map(EnvVar::getValue).findFirst().orElseThrow(), is("-ContinueReconciliationOnManualRollingUpdateFailure"));
     }
 
     ////////////////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesTest.java
@@ -357,12 +357,12 @@ public class KafkaAssemblyOperatorManualRollingUpdatesTest {
 
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError1(VertxTestContext context) {
-        testManualPodRollingUpdateWithPodSetsWithErrorConditions(context, "", true);
+        testManualPodRollingUpdateWithPodSetsWithErrorConditions(context, "-ContinueReconciliationOnManualRollingUpdateFailure", true);
     }
 
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError3(VertxTestContext context) {
-        testManualPodRollingUpdateWithPodSetsWithErrorConditions(context, "+ContinueReconciliationOnManualRollingUpdateFailure", false);
+        testManualPodRollingUpdateWithPodSetsWithErrorConditions(context, "", false);
     }
 
     private void testManualPodRollingUpdateWithPodSetsWithErrorConditions(VertxTestContext context, String featureGates, boolean expectError) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorManualRollingUpdatesZooBasedTest.java
@@ -433,25 +433,25 @@ public class KafkaAssemblyOperatorManualRollingUpdatesZooBasedTest {
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError1(VertxTestContext context) {
         testManualPodRollingUpdateWithPodSetsWithErrorConditions(
-            context, false, true, "", true);
+            context, false, true, "-ContinueReconciliationOnManualRollingUpdateFailure", true);
     }
 
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError2(VertxTestContext context) {
         testManualPodRollingUpdateWithPodSetsWithErrorConditions(
-            context, true, false, "", true);
+            context, true, false, "-ContinueReconciliationOnManualRollingUpdateFailure", true);
     }
 
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError3(VertxTestContext context) {
         testManualPodRollingUpdateWithPodSetsWithErrorConditions(
-            context, false, true, "+ContinueReconciliationOnManualRollingUpdateFailure", false);
+            context, false, true, "", false);
     }
 
     @Test
     public void testManualPodRollingUpdateWithPodSetsWithError4(VertxTestContext context) {
         testManualPodRollingUpdateWithPodSetsWithErrorConditions(
-            context, true, false, "+ContinueReconciliationOnManualRollingUpdateFailure", false);
+            context, true, false, "", false);
     }
 
     private void testManualPodRollingUpdateWithPodSetsWithErrorConditions(VertxTestContext context,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -2230,11 +2230,12 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
         ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
         when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
 
+        ClusterOperatorConfig coConfig = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS).with(ClusterOperatorConfig.FEATURE_GATES.key(), "-ContinueReconciliationOnManualRollingUpdateFailure").build();
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,
                 new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
                 supplier,
-                ResourceUtils.dummyClusterOperatorConfig()
+                coConfig
         );
 
         Checkpoint async = context.checkpoint();
@@ -2320,12 +2321,11 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
         ArgumentCaptor<KafkaConnect> connectCaptor = ArgumentCaptor.forClass(KafkaConnect.class);
         when(mockConnectOps.updateStatusAsync(any(), connectCaptor.capture())).thenReturn(Future.succeededFuture());
 
-        ClusterOperatorConfig coConfig = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS).with(ClusterOperatorConfig.FEATURE_GATES.key(), "+ContinueReconciliationOnManualRollingUpdateFailure").build();
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,
                 new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
                 supplier,
-                coConfig
+                ResourceUtils.dummyClusterOperatorConfig()
         );
 
         Checkpoint async = context.checkpoint();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -1523,11 +1523,12 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
         when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
+        ClusterOperatorConfig coConfig = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS).with(ClusterOperatorConfig.FEATURE_GATES.key(), "-ContinueReconciliationOnManualRollingUpdateFailure").build();
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
                 new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
                 supplier,
-                ResourceUtils.dummyClusterOperatorConfig(),
+                coConfig,
                 x -> mockConnectClient
         );
 
@@ -1619,12 +1620,11 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
         when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
         when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
 
-        ClusterOperatorConfig coConfig = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS).with(ClusterOperatorConfig.FEATURE_GATES.key(), "+ContinueReconciliationOnManualRollingUpdateFailure").build();
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
                 new PlatformFeaturesAvailability(false, KUBERNETES_VERSION),
                 supplier,
-                coConfig,
+                ResourceUtils.dummyClusterOperatorConfig(),
                 x -> mockConnectClient
         );
 

--- a/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
+++ b/documentation/modules/managing/proc-manual-rolling-update-pods.adoc
@@ -71,6 +71,6 @@ kubectl annotate pod <cluster_name>-mirrormaker2-<index_number> strimzi.io/manua
 A rolling update of the annotated `Pod` is triggered, as long as the annotation was detected by the reconciliation process.
 When the rolling update of a pod is complete, the annotation is automatically removed from the `Pod`.
 
-NOTE: If the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is enabled, reconciliation continues even if the manual rolling update of the cluster fails.
+NOTE: Unless the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is disabled, reconciliation continues even if the manual rolling update of the cluster fails.
 This allows the Cluster Operator to recover from certain rectifiable situations that can be addressed later in the reconciliation. 
 For example, it can recreate a missing Persistent Volume Claim (PVC) or Persistent Volume (PV) that caused the update to fail.

--- a/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gate-releases.adoc
@@ -30,7 +30,8 @@ Alpha and beta stage features are removed if they do not prove to be useful.
 * The `UseKRaft` feature gate moved to GA stage in Strimzi 0.42.
   It is now permanently enabled and cannot be disabled.
   To use KRaft (ZooKeeper-less Apache Kafka), you still need to use the `strimzi.io/kraft: enabled` annotation on the `Kafka` custom resources or migrate from an existing ZooKeeper-based cluster.
-* The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and is disabled by default.
+* The `ContinueReconciliationOnManualRollingUpdateFailure` feature was introduced in Strimzi 0.41 and moved to beta stage in Strimzi 0.44.0.
+  It is now enabled by default, but can be disabled if needed.
 
 NOTE: Feature gates might be removed when they reach GA. This means that the feature was incorporated into the Strimzi core features and can no longer be disabled.
 
@@ -80,8 +81,8 @@ NOTE: Feature gates might be removed when they reach GA. This means that the fea
 
 ¦`ContinueReconciliationOnManualRollingUpdateFailure`
 ¦0.41
-¦0.43 (planned)
-¦n/a
+¦0.44
+¦0.47 (planned)
 
 |===
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -104,12 +104,6 @@ For more information on using KRraft, see xref:assembly-kraft-mode-{context}[].
 
 Stable feature gates have reached a beta level of maturity, and are generally enabled by default for all users.
 Stable feature gates are production-ready, but they can still be disabled.
-Currently, there are no beta level feature gates.
-
-== Early access feature gates (Alpha)
-
-Early access feature gates have not yet reached the beta stage, and are disabled by default. 
-An early access feature gate provides an opportunity for assessment before its functionality is permanently incorporated into Strimzi.
 
 [id='ref-operator-continue-reconciliation-on-manual-ru-failure-feature-gate-{context}']
 === ContinueReconciliationOnManualRollingUpdateFailure feature gate
@@ -134,6 +128,13 @@ It is ignored by the User and Topic Operators.
 
 .Disabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
 To disable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `-ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+
+
+== Early access feature gates (Alpha)
+
+Early access feature gates have not yet reached the beta stage, and are disabled by default. 
+An early access feature gate provides an opportunity for assessment before its functionality is permanently incorporated into Strimzi.
+Currently, there are no alpha level feature gates.
 
 == Enabling feature gates
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -114,7 +114,7 @@ An early access feature gate provides an opportunity for assessment before its f
 [id='ref-operator-continue-reconciliation-on-manual-ru-failure-feature-gate-{context}']
 === ContinueReconciliationOnManualRollingUpdateFailure feature gate
 
-The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate has a default state of _disabled_.
+The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate has a default state of _enabled_.
 
 The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate allows the Cluster Operator to continue a reconciliation if the manual rolling update of the operands fails.
 It applies to the following operands that support manual rolling updates using the `strimzi.io/manual-rolling-update` annotation:
@@ -132,8 +132,8 @@ By continuing the reconciliation after this failure, the process can recreate th
 The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate is used by the Cluster Operator.
 It is ignored by the User and Topic Operators.
 
-.Enabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
-To enable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `+ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
+.Disabling the ContinueReconciliationOnManualRollingUpdateFailure feature gate
+To disable the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate, specify `-ContinueReconciliationOnManualRollingUpdateFailure` in the `STRIMZI_FEATURE_GATES` environment variable in the Cluster Operator configuration.
 
 == Enabling feature gates
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/featuregates/FeatureGates.java
@@ -22,7 +22,7 @@ public class FeatureGates {
 
     // When adding new feature gates, do not forget to add them to allFeatureGates(), toString(), equals(), and `hashCode() methods
     private final FeatureGate continueOnManualRUFailure =
-        new FeatureGate(CONTINUE_ON_MANUAL_RU_FAILURE, false);
+        new FeatureGate(CONTINUE_ON_MANUAL_RU_FAILURE, true);
 
     /**
      * Constructs the feature gates configuration.

--- a/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/featuregates/FeatureGatesTest.java
@@ -117,7 +117,7 @@ public class FeatureGatesTest {
     @ParallelTest
     public void testEnvironmentVariable()   {
         assertThat(new FeatureGates("").toEnvironmentVariable(), is(""));
-        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is(""));
-        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is("+ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(new FeatureGates("-ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is("-ContinueReconciliationOnManualRollingUpdateFailure"));
+        assertThat(new FeatureGates("+ContinueReconciliationOnManualRollingUpdateFailure").toEnvironmentVariable(), is(""));
     }
 }

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -57,3 +57,31 @@
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
     kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
     kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"
+- fromVersion: HEAD
+  toVersion: 0.43.0
+  fromExamples: HEAD
+  toExamples: strimzi-0.43.0
+  fromUrl: HEAD
+  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.43.0/strimzi-0.43.0.zip
+  fromKafkaVersionsUrl: HEAD
+  additionalTopics: 2
+  imagesAfterOperations:
+    zookeeper: strimzi/kafka:0.43.0-kafka-3.7.0
+    kafka: strimzi/kafka:0.43.0-kafka-3.7.0
+    topicOperator: strimzi/operator:0.43.0
+    userOperator: strimzi/operator:0.43.0
+  deployKafkaVersion: 3.8.0
+  client:
+    continuousClientsMessages: 500
+  environmentInfo:
+    maxK8sVersion: latest
+    status: stable
+    flakyEnvVariable: none
+    reason: Test is working on all environment used by QE.
+  featureGatesBefore: "+ContinueReconciliationOnManualRollingUpdateFailure"
+  featureGatesAfter: "-ContinueReconciliationOnManualRollingUpdateFailure"
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
+    kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -57,31 +57,3 @@
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
     kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
     kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"
-- fromVersion: HEAD
-  toVersion: 0.43.0
-  fromExamples: HEAD
-  toExamples: strimzi-0.43.0
-  fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.43.0/strimzi-0.43.0.zip
-  fromKafkaVersionsUrl: HEAD
-  additionalTopics: 2
-  imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.43.0-kafka-3.7.0
-    kafka: strimzi/kafka:0.43.0-kafka-3.7.0
-    topicOperator: strimzi/operator:0.43.0
-    userOperator: strimzi/operator:0.43.0
-  deployKafkaVersion: 3.8.0
-  client:
-    continuousClientsMessages: 500
-  environmentInfo:
-    maxK8sVersion: latest
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on all environment used by QE.
-  featureGatesBefore: "+ContinueReconciliationOnManualRollingUpdateFailure"
-  featureGatesAfter: "-ContinueReconciliationOnManualRollingUpdateFailure"
-  filePaths:
-    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
-    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
-    kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
-    kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -54,28 +54,3 @@
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
     kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
     kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"
-- fromVersion: 0.43.0
-  fromExamples: strimzi-0.43.0
-  oldestKafka: 3.7.0
-  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.43.0/strimzi-0.43.0.zip
-  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.43.0/kafka-versions.yaml
-  additionalTopics: 2
-  imagesAfterOperations:
-    zookeeper: strimzi/kafka:latest-kafka-3.8.0
-    kafka: strimzi/kafka:latest-kafka-3.8.0
-    topicOperator: strimzi/operator:latest
-    userOperator: strimzi/operator:latest
-  client:
-    continuousClientsMessages: 500
-  environmentInfo:
-    maxK8sVersion: latest
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on environment, where k8s server version is < 1.22
-  featureGatesBefore: "-ContinueReconciliationOnManualRollingUpdateFailure"
-  featureGatesAfter: "+ContinueReconciliationOnManualRollingUpdateFailure"
-  filePaths:
-    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
-    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
-    kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
-    kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR promotes the `ContinueReconciliationOnManualRollingUpdateFailure` feature gate to beta and enables it by default. It also removes it from the upgrade/downgrade tests as this feature gate does not really have any influence on them.

This was originally supposed to be done in 0.43, but we forgot about it :-/

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md