### PR TITLE
Fix various JavaDoc style issues

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/OpenSslCertManager.java
@@ -124,8 +124,10 @@ public class OpenSslCertManager implements CertManager {
      * Add basic constraints and subject alt names section to the provided openssl configuration file
      *
      * @param sbj subject information
+     *
      * @return openssl configuration file with subject alt names added
-     * @throws IOException
+     *
+     * @throws IOException  Throws IOException when IO operations fail
      */
     private Path buildConfigFile(Subject sbj, boolean isCa) throws IOException {
         Path sna = createDefaultConfig();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -185,7 +185,7 @@ public class ClusterOperator extends AbstractVerticle {
     }
 
     /**
-      Periodical reconciliation (in case we lost some event)
+     * Periodical reconciliation (in case we lost some event)
      */
     private void reconcileAll(String trigger) {
         if (!config.isPodSetReconciliationOnly()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -281,7 +281,7 @@ public class CertUtils {
      *
      * @param certSecretSource      Represents a certificate inside a Secret
      * @param prefix                Prefix used to generate the volume name
-
+     *
      * @return  The generated volume name
      */
     private static String trustedCertificateVolumeName(CertSecretSource certSecretSource, String prefix)    {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -880,7 +880,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         return logging;
     }
 
-     /**
+    /**
      * @return  Returns the preferred Deployment Strategy. This is used for the migration form Deployment to
      * StrimziPodSet or the other way around
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaVersion.java
@@ -336,7 +336,7 @@ public class KafkaVersion implements Comparable<KafkaVersion> {
             validateImages(versions, kafkaMirrorMakerImages);
         }
 
-       /**
+        /**
          * The Kafka MirrorMaker 2 image to use for a Kafka MirrorMaker 2 cluster.
          * @param image The image given in the CR.
          * @param version The version given in the CR.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -723,7 +723,7 @@ public class ListenersUtils {
                 : null;
     }
 
-     /**
+    /**
      * Returns broker service external IPs
      * 
      * @param listener  Listener for which the external IPs should be found

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/MetricsAndLogging.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/MetricsAndLogging.java
@@ -8,5 +8,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 
 /**
  * Holder record for ConfigMaps with Metrics and Logging configuration
+ *
+ * @param metricsCm     Config Map with metrics configuration
+ * @param loggingCm     Config Map with logging configuration
  */
 public record MetricsAndLogging(ConfigMap metricsCm, ConfigMap loggingCm) { }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/CruiseControlConfiguration.java
@@ -81,10 +81,10 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
             String.join(",", CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS_LIST);
 
     /**
-    * Map containing default values for required configuration properties. The map needs to be sorted so that the order
-    * of the entries in the Cruise Control configuration is deterministic and does not cause unnecessary rolling updates
-    * of Cruise Control deployment.
-    */
+     * Map containing default values for required configuration properties. The map needs to be sorted so that the order
+     * of the entries in the Cruise Control configuration is deterministic and does not cause unnecessary rolling updates
+     * of Cruise Control deployment.
+     */
     private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP = Collections.unmodifiableSortedMap(new TreeMap<>(Map.ofEntries(
             Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_MS_CONFIG_KEY.getValue(), Integer.toString(300_000)),
             Map.entry(CruiseControlConfigurationParameters.PARTITION_METRICS_WINDOW_NUM_CONFIG_KEY.getValue(), "1"),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -39,6 +39,13 @@ import java.util.List;
  *
  * <p>This class manages a per-assembly locking strategy so only one operation per assembly
  * can proceed at once.</p>
+ *
+ * @param <C>   Kubernetes Client type
+ * @param <T>   Type representing the custom resource
+ * @param <R>   Type extending the Fabric8 Resource class
+ * @param <P>   Type representing the .spec section of the custom resource
+ * @param <S>   Type representing the .status section of the custom resource
+ * @param <L>   Type representing the custom resource list
  */
 public abstract class AbstractAssemblyOperator<C extends KubernetesClient, T extends CustomResource<P, S>,
         L extends KubernetesResourceList<T>, R extends Resource<T>, P extends Spec, S extends Status>

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -473,7 +473,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
      * @param connectorName                 Name of the connector
      * @param status                        The new/future status of the connector
      * @param previousAutoRestartStatus     Previous auto-restart status used to generate the new status (increment the restart counter etc.)
-
+     *
      * @return  Future with connector status and conditions which completes when the connector is restarted
      */
     private Future<ConnectorStatusAndConditions> autoRestartConnector(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, ConnectorStatusAndConditions status, AutoRestartStatus previousAutoRestartStatus) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -56,9 +56,11 @@ import java.util.stream.Collectors;
  *
  * <li>add support for operator-side {@linkplain StatusUtils#validate(Reconciliation, CustomResource)} validation}.
  *     This can be used to automatically log warnings about source resources which used deprecated part of the CR API.
- *ą
  * </ul>
+ *
  * @param <T> The Java representation of the Kubernetes resource, e.g. {@code Kafka} or {@code KafkaConnect}
+ * @param <P> The Java representation of the Kubernetes resource .spec section
+ * @param <S> The Java representation of the Kubernetes resource .status section
  * @param <O> The "Resource Operator" for the source resource type. Typically, this will be some instantiation of
  *           {@link io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator}.
  */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -344,7 +344,7 @@ public class CaReconciler {
      * Kafka and ZooKeeper anymore.
      *
      * @param clock    The clock for supplying the reconciler with the time instant of each reconciliation cycle.
-                       That time is used for checking maintenance windows
+     *                 That time is used for checking maintenance windows
      */
     Future<Void> reconcileClusterOperatorSecret(Clock clock) {
         return secretOperator.getAsync(reconciliation.namespace(), KafkaResources.clusterOperatorCertsSecretName(reconciliation.name()))
@@ -622,6 +622,9 @@ public class CaReconciler {
 
     /**
      * Helper class to pass both Cluster and Clients CA as a result of the reconciliation
+     *
+     * @param clusterCa     The Cluster CA instance
+     * @param clientsCa     The Clients CA instance
      */
     public record CaReconciliationResult(ClusterCa clusterCa, ClientsCa clientsCa) { }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -212,10 +212,10 @@ public class ConnectBuildOperator {
     /**
      * Checks if the builder Pod finished the build
      *
-     @param namespace               Namespace of the Connect cluster
-     * @param podName               The name of the Pod which should be checked whether it finished
+     * @param namespace     Namespace of the Connect cluster
+     * @param podName       The name of the Pod which should be checked whether it finished
      *
-     * @return                      True if the build already finished, false if it is still building
+     * @return      True if the build already finished, false if it is still building
      */
     private boolean kubernetesBuildPodFinished(String namespace, String podName, String containerName)   {
         Pod buildPod = podOperator.get(namespace, podName);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -124,7 +124,7 @@ public class CruiseControlReconciler {
      * @param imagePullPolicy   Image pull policy
      * @param imagePullSecrets  List of Image pull secrets
      * @param clock             The clock for supplying the reconciler with the time instant of each reconciliation cycle.
- *                              That time is used for checking maintenance windows
+     *                          That time is used for checking maintenance windows
      *
      * @return                  Future which completes when the reconciliation completes
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperEraser.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperEraser.java
@@ -170,7 +170,7 @@ public class ZooKeeperEraser {
      * If deleteClaim is set to true (PVCs have Kafka CR as owner), this method deletes the PVCs.
      * If deleteClaim is set to false (PVCs don't have Kafka CR as owner), this method doesn't delete the PVCs (user has to do it manually).
      *
-      @return  Future which completes when the PVCs which should be deleted
+     * @return  Future which completes when the PVCs which should be deleted
      */
     protected Future<Void> deletePersistentClaims() {
         Labels zkSelectorLabels = Labels.EMPTY

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/DefaultZookeeperScalerProvider.java
@@ -25,6 +25,7 @@ public class DefaultZookeeperScalerProvider implements ZookeeperScalerProvider {
      * @param zkNodeAddress                 Function for generating the Zookeeper node addresses
      * @param tlsPemIdentity                Trust set and identity for TLS client authentication for connecting to ZooKeeper
      * @param operationTimeoutMs            Operation timeout
+     * @param zkAdminSessionTimeoutMs       Session timeout for the ZooKeeper connection
      *
      * @return  ZookeeperScaler instance
      */

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- The algorithm:
+ * The algorithm:
  *  1. Create a map from the supplied desired String
  *  2. Fill placeholders (e.g. ${BROKER_ID}) in desired map as the broker's {@code kafka_config_generator.sh} would
  *  3a. Loop over all entries. If the entry is in IGNORABLE_PROPERTIES or entry.value from desired is equal to entry.value from current, do nothing

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/VersionRange.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/VersionRange.java
@@ -81,7 +81,8 @@ public class VersionRange<Version extends Comparable<Version>> {
 
     /**
      * Abstracts the parsing of a version.
-     * @param <Version>
+     *
+     * @param <Version> Custom Resource API Version
      */
     interface VersionParser<Version extends Comparable<Version>> {
         Version parse(String version) throws IllegalArgumentException;

--- a/operator-common/src/main/java/io/strimzi/operator/common/ReconciliationLogger.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/ReconciliationLogger.java
@@ -226,7 +226,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void offOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, OFF, marker, message, params);
@@ -238,7 +237,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0) {
@@ -252,7 +251,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -267,7 +266,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -283,7 +282,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -301,7 +300,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -320,7 +319,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -340,7 +339,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -361,7 +360,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -384,7 +383,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -408,7 +407,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -504,7 +503,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void offOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, OFF, null, message, params);
@@ -515,7 +513,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0) {
@@ -528,7 +526,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1) {
@@ -542,7 +540,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -557,7 +555,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -574,7 +572,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -592,7 +590,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -611,7 +609,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -631,7 +629,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -653,7 +651,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -676,7 +674,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void offOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -910,7 +908,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void fatalOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, FATAL, marker, message, params);
@@ -922,7 +919,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0) {
@@ -936,7 +933,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -951,7 +948,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -967,7 +964,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -985,7 +982,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1004,7 +1001,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1024,7 +1021,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1045,7 +1042,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1068,7 +1065,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1092,7 +1089,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1188,7 +1185,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void fatalOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, FATAL, null, message, params);
@@ -1199,7 +1195,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0) {
@@ -1212,7 +1208,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1) {
@@ -1226,7 +1222,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -1241,7 +1237,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1258,7 +1254,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1276,7 +1272,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1295,7 +1291,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1315,7 +1311,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1337,7 +1333,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1360,7 +1356,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void fatalOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1594,7 +1590,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void errorOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, ERROR, marker, message, params);
@@ -1606,7 +1601,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0) {
@@ -1620,7 +1615,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -1635,7 +1630,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -1651,7 +1646,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1669,7 +1664,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1688,7 +1683,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1708,7 +1703,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1729,7 +1724,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1752,7 +1747,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1776,7 +1771,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -1872,7 +1867,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void errorOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, ERROR, null, message, params);
@@ -1883,7 +1877,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0) {
@@ -1896,7 +1890,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1) {
@@ -1910,7 +1904,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -1925,7 +1919,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1942,7 +1936,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1960,7 +1954,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1979,7 +1973,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -1999,7 +1993,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2021,7 +2015,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2044,7 +2038,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void errorOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2278,7 +2272,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void warnOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, WARN, marker, message, params);
@@ -2290,7 +2283,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0) {
@@ -2304,7 +2297,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -2319,7 +2312,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -2335,7 +2328,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2353,7 +2346,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2372,7 +2365,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2392,7 +2385,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2413,7 +2406,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2436,7 +2429,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2460,7 +2453,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -2556,7 +2549,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void warnOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, WARN, null, message, params);
@@ -2567,7 +2559,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0) {
@@ -2580,7 +2572,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1) {
@@ -2594,7 +2586,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -2609,7 +2601,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2626,7 +2618,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2644,7 +2636,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2663,7 +2655,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2683,7 +2675,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2705,7 +2697,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2728,7 +2720,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void warnOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -2962,7 +2954,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void infoOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, INFO, marker, message, params);
@@ -2974,7 +2965,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0) {
@@ -2988,7 +2979,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -3003,7 +2994,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -3019,7 +3010,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3037,7 +3028,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3056,7 +3047,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3076,7 +3067,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3097,7 +3088,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3120,7 +3111,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3144,7 +3135,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3240,7 +3231,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void infoOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, INFO, null, message, params);
@@ -3251,7 +3241,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0) {
@@ -3264,7 +3254,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1) {
@@ -3278,7 +3268,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -3293,7 +3283,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3310,7 +3300,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3328,7 +3318,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3347,7 +3337,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3367,7 +3357,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3389,7 +3379,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3412,7 +3402,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void infoOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3646,7 +3636,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void debugOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, DEBUG, marker, message, params);
@@ -3658,7 +3647,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0) {
@@ -3672,7 +3661,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -3687,7 +3676,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -3703,7 +3692,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3721,7 +3710,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3740,7 +3729,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3760,7 +3749,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3781,7 +3770,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3804,7 +3793,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3828,7 +3817,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -3924,7 +3913,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void debugOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, DEBUG, null, message, params);
@@ -3935,7 +3923,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0) {
@@ -3948,7 +3936,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1) {
@@ -3962,7 +3950,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -3977,7 +3965,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -3994,7 +3982,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4012,7 +4000,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4031,7 +4019,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4051,7 +4039,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4073,7 +4061,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4096,7 +4084,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void debugOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4330,7 +4318,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void traceOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, TRACE, marker, message, params);
@@ -4342,7 +4329,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0) {
@@ -4356,7 +4343,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -4371,7 +4358,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -4387,7 +4374,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4405,7 +4392,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4424,7 +4411,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4444,7 +4431,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4465,7 +4452,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4488,7 +4475,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4512,7 +4499,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -4608,7 +4595,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void traceOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, TRACE, null, message, params);
@@ -4619,7 +4605,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0) {
@@ -4632,7 +4618,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1) {
@@ -4646,7 +4632,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -4661,7 +4647,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4678,7 +4664,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4696,7 +4682,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4715,7 +4701,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4735,7 +4721,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4757,7 +4743,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -4780,7 +4766,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void traceOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5014,7 +5000,6 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void allOp(final Marker marker, final String message, final Object... params) {
         logger.logIfEnabled(FQCN, ALL, marker, message, params);
@@ -5026,7 +5011,7 @@ public class ReconciliationLogger implements Serializable {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0) {
@@ -5040,7 +5025,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1) {
@@ -5055,7 +5040,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
@@ -5071,7 +5056,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5089,7 +5074,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5108,7 +5093,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5128,7 +5113,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5149,7 +5134,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5172,7 +5157,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5196,7 +5181,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
@@ -5292,7 +5277,6 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param params parameters to the message.
-
      */
     public void allOp(final String message, final Object... params) {
         logger.logIfEnabled(FQCN, ALL, null, message, params);
@@ -5303,7 +5287,7 @@ public class ReconciliationLogger implements Serializable {
      * 
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0) {
@@ -5316,7 +5300,7 @@ public class ReconciliationLogger implements Serializable {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1) {
@@ -5330,7 +5314,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2) {
@@ -5345,7 +5329,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5362,7 +5346,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5380,7 +5364,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5399,7 +5383,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5419,7 +5403,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5441,7 +5425,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,
@@ -5464,7 +5448,7 @@ public class ReconciliationLogger implements Serializable {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
-
+     *
      * @since Log4j-2.6
      */
     public void allOp(final String message, final Object p0, final Object p1, final Object p2,

--- a/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/config/ConfigParameterParser.java
@@ -25,6 +25,8 @@ import static java.util.Arrays.asList;
 
 /**
  * Abstraction for things which convert a single configuration parameter value from a String to some specific type.
+ *
+ * @param <T> Configuration type that will be parsed
  */
 public interface ConfigParameterParser<T> {
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -102,9 +102,11 @@ public abstract class Ca {
         }
 
         /**
+         * Checks whether the key has the desired suffix based on the entry.
          *
-         * @param key to check the type of
-         * @return whether this key has the correct suffix for the entry
+         * @param key   The key that will be checked whether it matches
+         *
+         * @return  True if the key matches. False otherwise.
          */
         private boolean matchesType(String key) {
             return key.endsWith(suffix);

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -474,7 +474,6 @@ public class Labels extends ResourceLabels {
     }
 
     /**
-     *
      * When adding new labels, ensure the names of any resources are truncated for sanitization purposes to be compatible with Kubernetes
      * Note: Valid label values must be a maximum length of 63 characters
      * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/OrderedProperties.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/OrderedProperties.java
@@ -466,9 +466,11 @@ public class OrderedProperties {
 
         /**
          * Write comment to a Writer, handling newlines embedded in the comment
+         *
          * @param bufferedWriter BufferedWriter to write.
          * @param comment A comment to be written
-         * @throws IOException
+         *
+         * @throws IOException  Throws IOException when IO operations fail
          */
         private static void writeComment(BufferedWriter bufferedWriter, String comment) throws IOException {
             for (String line : LINE_SPLITTER.split(comment)) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -146,7 +146,7 @@ public class BatchingTopicController {
      *
      * @param admin The {@link Admin} client used to interact with the Kafka cluster.
      * @param name The name of the configuration to retrieve.
-     * @return An {@link Optional<String>} containing the value of the requested configuration if found, or an empty Optional if not.
+     * @return An {@link Optional} {@link String} containing the value of the requested configuration if found, or an empty Optional if not.
      * @throws RuntimeException if there is an error during the operation. This exception wraps the underlying exception's message.
      */
     private static Optional<String> getClusterConfig(Admin admin, String name) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -50,14 +50,15 @@ import static io.strimzi.operator.common.config.ConfigParameterParser.strictlyPo
  * @param saslEnabled                           Whether the Admin client should be configured to use SASL.
  * @param saslMechanism                         The SASL mechanism for the Admin client.
  * @param saslCustomConfigJson                  The SASL custom values for the Admin client when using alternate auth mechanisms.
- * @param saslUsername,                         The SASL username for the Admin client.
- * @param saslPassword,                         The SASL password for the Admin client.
+ * @param saslUsername                          The SASL username for the Admin client.
+ * @param saslPassword                          The SASL password for the Admin client.
  * @param securityProtocol                      The security protocol for the Admin client.
  * @param useFinalizer                          Whether to use finalizers.
  * @param maxQueueSize                          The capacity of the queue.
  * @param maxBatchSize                          The maximum size of a reconciliation batch.
  * @param maxBatchLingerMs                      The maximum time to wait for a reconciliation batch to contain {@code maxBatchSize} items.
  * @param enableAdditionalMetrics               Whether to enable additional metrics.
+ * @param featureGates                          Configured feature gates.
  * @param cruiseControlEnabled                  Whether Cruise Control integration is enabled.
  * @param cruiseControlRackEnabled              Whether the target Kafka cluster has rack awareness.
  * @param cruiseControlHostname                 Cruise Control hostname.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/model/KubeRef.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/model/KubeRef.java
@@ -13,6 +13,10 @@ import java.util.Objects;
  * Reference to a resource in Kube.
  * Equality is based on {@link #namespace()} and {@link #name()}.
  * {@link #creationTime()} is present to allow disambiguation of multiple KafkaTopics managing the same topic in Kafka.
+ *
+ * @param namespace     The namespace of the resource
+ * @param name          The name of the resource
+ * @param creationTime  The creation time of the resource
  */
 public record KubeRef(String namespace, String name, long creationTime) {
     /**

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/model/Pair.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/model/Pair.java
@@ -7,6 +7,10 @@ package io.strimzi.operator.topic.model;
 /**
  * A key-value pair.
  * We can't use Map.entry because it forbids null values, which we want to allow.
+ *
+ * @param getKey    The key
+ * @param getValue  The value
+ *
  * @param <K> Type of key.
  * @param <V> Type of value.
  */

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/AdminApiOperator.java
@@ -13,6 +13,9 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * Interface for operators using the Kafka Admin API
+ *
+ * @param <T>   The type that is being reconciled by the operator instance
+ * @param <S>   Collection type that is used by given operator instance
  */
 public interface AdminApiOperator<T, S extends Collection<String>> {
     /**

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/AbstractBatchReconciler.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/batching/AbstractBatchReconciler.java
@@ -18,6 +18,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Abstract class for collecting Kafka Admin API requests and sending them to Kafka in batches. The batches are sent
  * when we collect some (configurable) amount of requests or after some (configurable) time interval
+ *
+ * @param <T>   The type that is reconciled by given batch reconciler instance
  */
 public abstract class AbstractBatchReconciler<T> {
     private final static Logger LOGGER = LogManager.getLogger(AbstractBatchReconciler.class);

--- a/user-operator/src/main/java/io/strimzi/operator/user/operator/cache/AbstractCache.java
+++ b/user-operator/src/main/java/io/strimzi/operator/user/operator/cache/AbstractCache.java
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Abstract cache provides a periodically refreshed cache. The cache is based around ConcurrentHashMap and a scheduled
  * periodical timer which regularly updates the cache. It also provides method to access the cache and its data.
+ *
+ * @param <T> Type of the resource that will be cached
  */
 public abstract class AbstractCache<T> {
     private final static Logger LOGGER = LogManager.getLogger(AbstractCache.class);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR fixes various Javadoc issues. Some of them are related to the style (bad alignment, missing asterics). Other are related to missing parameters.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally