### PR TITLE
[ST] acceptance profile test count reduction

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Tag;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.strimzi.systemtest.TestConstants.ACCEPTANCE;
 import static io.strimzi.systemtest.TestConstants.CRUISE_CONTROL;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.systemtest.utils.specific.CruiseControlUtils.CRUISE_CONTROL_DEFAULT_PORT;
@@ -32,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @Tag(REGRESSION)
 @Tag(CRUISE_CONTROL)
-@Tag(ACCEPTANCE)
 public class CruiseControlApiST extends AbstractST {
 
     private static final Logger LOGGER = LogManager.getLogger(CruiseControlApiST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -237,6 +237,7 @@ public class MetricsST extends AbstractST {
     @ParallelTest
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
+    @Tag(ACCEPTANCE)
     void testKafkaConnectAndConnectorMetrics() {
         resourceManager.createResourceWithWait(
             KafkaConnectTemplates.connectMetricsConfigMap(namespaceFirst, kafkaClusterFirstName),
@@ -286,6 +287,7 @@ public class MetricsST extends AbstractST {
      *  - kafka-exporter-metrics
      */
     @IsolatedTest
+    @Tag(ACCEPTANCE)
     void testKafkaExporterMetrics() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final String kafkaStrimziPodSetName = StrimziPodSetResource.getBrokerComponentName(kafkaClusterFirstName);
@@ -342,6 +344,7 @@ public class MetricsST extends AbstractST {
      *  - kafka-exporter-metrics
      */
     @ParallelTest
+    @Tag(ACCEPTANCE)
     void testKafkaExporterDifferentSetting() throws InterruptedException, ExecutionException, IOException {
         String consumerOffsetsTopicName = "__consumer_offsets";
         LabelSelector exporterSelector = kubeClient().getDeploymentSelectors(namespaceFirst, KafkaExporterResources.componentName(kafkaClusterFirstName));
@@ -392,6 +395,7 @@ public class MetricsST extends AbstractST {
      *  - cluster-operator-metrics
      */
     @ParallelTest
+    @Tag(ACCEPTANCE)
     void testClusterOperatorMetrics() {
         // Expected PodSet counts per component
         int podSetCount = 2;
@@ -437,6 +441,7 @@ public class MetricsST extends AbstractST {
      *  - user-operator-metrics
      */
     @ParallelTest
+    @Tag(ACCEPTANCE)
     void testUserOperatorMetrics() {
         BaseMetricsCollector userOperatorCollector = kafkaCollector.toBuilder()
             .withComponent(UserOperatorMetricsComponent.create(namespaceFirst, kafkaClusterFirstName))
@@ -475,6 +480,7 @@ public class MetricsST extends AbstractST {
     @ParallelTest
     @Tag(MIRROR_MAKER2)
     @Tag(CONNECT_COMPONENTS)
+    @Tag(ACCEPTANCE)
     void testMirrorMaker2Metrics() {
         resourceManager.createResourceWithWait(
             KafkaMirrorMaker2Templates.mirrorMaker2MetricsConfigMap(namespaceFirst, mm2ClusterName),
@@ -520,6 +526,7 @@ public class MetricsST extends AbstractST {
      */
     @ParallelTest
     @Tag(BRIDGE)
+    @Tag(ACCEPTANCE)
     void testKafkaBridgeMetrics() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
@@ -580,6 +587,7 @@ public class MetricsST extends AbstractST {
      *  - cruise-control-metrics
      */
     @ParallelTest
+    @Tag(ACCEPTANCE)
     void testCruiseControlMetrics() {
         String cruiseControlMetrics = CruiseControlUtils.callApiWithAdminCredentials(namespaceFirst, CruiseControlUtils.HttpMethod.GET, CruiseControlUtils.Scheme.HTTP,
                 CruiseControlUtils.CRUISE_CONTROL_METRICS_PORT, "/metrics", "").getResponseText();

--- a/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/metrics/MetricsST.java
@@ -142,7 +142,6 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
  * @updated 2023-17-04
  */
 @Tag(SANITY)
-@Tag(ACCEPTANCE)
 @Tag(REGRESSION)
 @Tag(METRICS)
 @Tag(CRUISE_CONTROL)
@@ -202,7 +201,6 @@ public class MetricsST extends AbstractST {
      *  - zookeeper-metrics
      */
     @ParallelTest
-    @Tag(ACCEPTANCE)
     @KRaftNotSupported("ZooKeeper is not supported by KRaft mode and is used in this test case")
     void testZookeeperMetrics() {
         assertMetricValueNotNull(zookeeperCollector, "zookeeper_quorumsize");

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMakerST.java
@@ -51,7 +51,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.systemtest.TestConstants.ACCEPTANCE;
 import static io.strimzi.systemtest.TestConstants.COMPONENT_SCALING;
 import static io.strimzi.systemtest.TestConstants.MIRROR_MAKER;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
@@ -144,7 +143,6 @@ public class MirrorMakerST extends AbstractST {
      * Test mirroring messages by MirrorMaker over tls transport using mutual tls auth
      */
     @ParallelNamespaceTest
-    @Tag(ACCEPTANCE)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testMirrorMakerTlsAuthenticated() {
         TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/LeaderElectionST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/LeaderElectionST.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 
-import static io.strimzi.systemtest.TestConstants.ACCEPTANCE;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.systemtest.resources.ResourceManager.kubeClient;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -60,7 +59,6 @@ public class LeaderElectionST extends AbstractST {
     private static final String LEADER_MESSAGE = "I'm the new leader";
 
     @IsolatedTest
-    @Tag(ACCEPTANCE)
     void testLeaderElection() {
         // create CO with 2 replicas, wait for Deployment readiness and leader election
         clusterOperator = clusterOperator.defaultInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/PodSecurityProfilesST.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Tag;
 import java.util.Collections;
 import java.util.List;
 
-import static io.strimzi.systemtest.TestConstants.ACCEPTANCE;
 import static io.strimzi.systemtest.TestConstants.POD_SECURITY_PROFILES_RESTRICTED;
 import static io.strimzi.systemtest.TestConstants.REGRESSION;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;
@@ -93,7 +92,6 @@ public class PodSecurityProfilesST extends AbstractST {
      * @usecase
      *  - security-profiles
      */
-    @Tag(ACCEPTANCE)
     @ParallelNamespaceTest
     @RequiredMinKubeOrOcpBasedKubeVersion(kubeVersion = 1.23, ocpBasedKubeVersion = 1.24)
     void testOperandsWithRestrictedSecurityProfile() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -78,7 +78,6 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @Tag(OAUTH)
 @Tag(REGRESSION)
-@Tag(ACCEPTANCE)
 @FIPSNotSupported("Keycloak is not customized to run on FIPS env - https://github.com/strimzi/strimzi-kafka-operator/issues/8331")
 public class OauthTlsST extends OauthAbstractST {
     protected static final Logger LOGGER = LogManager.getLogger(OauthTlsST.class);
@@ -119,6 +118,7 @@ public class OauthTlsST extends OauthAbstractST {
     @ParallelTest
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
+    @Tag(ACCEPTANCE)
     void testProducerConsumerConnect() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
@@ -192,6 +192,7 @@ public class OauthTlsST extends OauthAbstractST {
     @Description("As a OAuth bridge, i am able to send messages to bridge endpoint using encrypted communication")
     @ParallelTest
     @Tag(BRIDGE)
+    @Tag(ACCEPTANCE)
     void testProducerConsumerBridge() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         String producerName = OAUTH_PRODUCER_NAME + "-" + testStorage.getClusterName();
@@ -263,6 +264,7 @@ public class OauthTlsST extends OauthAbstractST {
     @IsolatedTest("Using more tha one Kafka cluster in one Namespace")
     @Tag(MIRROR_MAKER)
     @Tag(NODEPORT_SUPPORTED)
+    @Tag(ACCEPTANCE)
     @SuppressWarnings({"checkstyle:MethodLength"})
     void testMirrorMaker() {
         // Nodeport needs cluster wide rights to work properly which is not possible with STRIMZI_RBAC_SCOPE=NAMESPACE

--- a/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/tracing/OpenTelemetryST.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
-import static io.strimzi.systemtest.TestConstants.ACCEPTANCE;
 import static io.strimzi.systemtest.TestConstants.BRIDGE;
 import static io.strimzi.systemtest.TestConstants.CONNECT;
 import static io.strimzi.systemtest.TestConstants.CONNECT_COMPONENTS;
@@ -72,7 +71,6 @@ public class OpenTelemetryST extends AbstractST {
 
     private final Tracing otelTracing = new OpenTelemetryTracing();
 
-    @Tag(ACCEPTANCE)
     @ParallelNamespaceTest
     void testProducerConsumerStreamsService() {
         final TestStorage testStorage = deployInitialResourcesAndGetTestStorage();


### PR DESCRIPTION
### Type of change

- Enhancement 
- Refactoring


### Description

Acceptance profile contained a bit large number of tests to run.  The total number is now reduced by crossed ~~tests/classes~~

### **suite**/tests included in Acceptance: 

- **HttpBridgeTlsST**
  - testSendSimpleMessageTls
  - testReceiveSimpleMessageTls
  - testTlsScramShaAuthWithWeirdUsername
  - testTlsAuthWithWeirdUsername
- ~~**CruiseControlApiST**~~
  - ~~testCruiseControlBasicAPIRequestsWithSecurityDisabled~~
  - ~~testCruiseControlAPIUsers~~
- **OauthTlsST**
  - ~~testProducerConsumer~~
  - testProducerConsumerConnect
  - testProducerConsumerBridge
  - ~~testMirrorMaker~~
  - testMirrorMaker2
  - ~~testIntrospectionEndpoint~~
- **MetricsST**
  - testKafkaMetrics
  - ~~testZookeeperMetrics~~
  - testKafkaConnectAndConnectorMetrics
  - testKafkaExporterMetrics
  - testKafkaExporterDifferentSetting
  - testClusterOperatorMetrics
  - testUserOperatorMetrics
  - testMirrorMaker2Metrics
  - testKafkaBridgeMetrics
  - testCruiseControlMetrics
  - ~~testKafkaMetricsSettings~~
- **MultipleListenersST**#testCombinationOfInternalAndExternalListeners
- **MirrorMaker2ST**#testMirrorMaker2TlsAndTlsClientAuth
- ~~**MirrorMakerST**#testMirrorMakerTlsAuthenticated~~
- ~~**LeaderElectionST**#testLeaderElection~~
- **UserST**#testUpdateUser
- **RollingUpdateST**#testKafkaScaleUpScaleDown
- ~~**PodSecurityProfilesST**#testOperandsWithRestrictedSecurityProfile~~
- **SecurityST**#testAutoRenewAllCaCertsTriggeredByAnno
- ~~**OpenTelemetryST**#testProducerConsumerStreamsService~~
- **ConnectBuilderST**#testBuildPluginUsingMavenCoordinatesArtifacts
- **ConnectST**#testMultiNodeKafkaConnectWithConnectorCreation
- **CruiseControlST**#testCruiseControlWithRebalanceResourceAndRefreshAnnotation
- **ListenerST**
	- testSendMessagesTlsScramSha
	- testSendMessagesCustomListenerTlsScramSha
	- testLoadBalancerTls
	- testCustomSoloCertificatesForRoute





