### PR TITLE
Allow configuring advertised.listeners for controllers with Kafka version 3.9.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1775,6 +1775,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                         .withRackId(rack)
                         .withLogDirs(VolumeUtils.createVolumeMounts(pool.storage, false))
                         .withListeners(cluster,
+                                kafkaVersion,
                                 namespace,
                                 listeners,
                                 listenerId -> advertisedHostnames.get(node.nodeId()).get(listenerId),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -28,6 +28,7 @@ public class KafkaVersionTestUtils {
     public static final String LATEST_ZOOKEEPER_VERSION = "3.8.4";
     public static final String LATEST_CHECKSUM = "ABCD1234";
     public static final String LATEST_THIRD_PARTY_VERSION = "3.8.x";
+    public static final String KAFKA_390_VERSION = "3.9.0";
     public static final String LATEST_KAFKA_IMAGE = KAFKA_IMAGE_STR + LATEST_KAFKA_VERSION;
     public static final String LATEST_KAFKA_CONNECT_IMAGE = KAFKA_CONNECT_IMAGE_STR + LATEST_KAFKA_VERSION;
     public static final String LATEST_KAFKA_MIRROR_MAKER_IMAGE = KAFKA_MIRROR_MAKER_IMAGE_STR + LATEST_KAFKA_VERSION;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

When Kafka 3.9.0 is released and supported with Strimzi, the advertised.listeners will have to be configured for KRaft controllers, which is a forbidden configuration for the previous versions. While we still support an older version such as 3.8.0, we need to gate this configuration using the Kafka version. 

Related issue: https://github.com/strimzi/strimzi-kafka-operator/issues/10458. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

