### PR TITLE
Run AZP in KRaft mode and create ZK regression pipeline

### DIFF
--- a/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/feature_gates_regression_namespace_rbac_jobs.yaml
@@ -9,7 +9,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -23,7 +22,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -37,7 +35,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -51,7 +48,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -65,7 +61,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -79,7 +74,6 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
@@ -93,6 +87,5 @@ jobs:
       timeout: 360
       strimzi_rbac_scope: NAMESPACE
       strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
-      strimzi_use_node_pools_in_tests: "false"
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/zookeeper_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/zookeeper_regression_jobs.yaml
@@ -1,77 +1,84 @@
 jobs:
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_kafka_oauth'
-      display_name: 'feature-gates-regression-bundle I. - kafka + oauth'
+      name: 'zookeeper_regression_kafka_oauth'
+      display_name: 'zookeeper-regression-bundle I. - kafka + oauth'
       profile: 'azp_kafka_oauth'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_security'
-      display_name: 'feature-gates-regression-bundle II. - security'
+      name: 'zookeeper_regression_security'
+      display_name: 'zookeeper-regression-bundle II. - security'
       profile: 'azp_security'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_dynconfig_listeners_tracing_watcher'
-      display_name: 'feature-gates-regression-bundle III. - dynconfig + tracing + watcher'
+      name: 'zookeeper_regression_dynconfig_listeners_tracing_watcher'
+      display_name: 'zookeeper-regression-bundle III. - dynconfig + tracing + watcher'
       profile: 'azp_dynconfig_listeners_tracing_watcher'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_operators'
-      display_name: 'feature-gates-regression-bundle IV. - operators'
+      name: 'zookeeper_regression_operators'
+      display_name: 'zookeeper-regression-bundle IV. - operators'
       profile: 'azp_operators'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_rollingupdate_bridge'
-      display_name: 'feature-gates-regression-bundle V. - rollingupdate'
+      name: 'zookeeper_regression_rollingupdate_bridge'
+      display_name: 'zookeeper-regression-bundle V. - rollingupdate'
       profile: 'azp_rolling_update_bridge'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_connect_mirrormaker'
-      display_name: 'feature-gates-regression-bundle VI. - connect + mirrormaker'
+      name: 'zookeeper_regression_connect_mirrormaker'
+      display_name: 'zookeeper-regression-bundle VI. - connect + mirrormaker'
       profile: 'azp_connect_mirrormaker'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'
 
   - template: '../../steps/system_test_general.yaml'
     parameters:
-      name: 'feature_gates_regression_all_remaining'
-      display_name: 'feature-gates-regression-bundle VII. - remaining system tests'
+      name: 'zookeeper_regression_all_remaining'
+      display_name: 'zookeeper-regression-bundle VII. - remaining system tests'
       profile: 'azp_remaining'
       cluster_operator_install_type: 'bundle'
-      strimzi_feature_gates: '-ContinueReconciliationOnManualRollingUpdateFailure'
+      strimzi_use_node_pools_in_tests: "false"
+      strimzi_use_kraft_in_tests: "false"
       timeout: 360
       releaseVersion: '${{ parameters.releaseVersion }}'
       kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -12,7 +12,7 @@ parameters:
   parallel: '1'
   run_parallel: false
   releaseVersion: "latest"
-  strimzi_use_kraft_in_tests: "false"
+  strimzi_use_kraft_in_tests: "true"
   strimzi_use_node_pools_in_tests: "true"
 
 jobs:

--- a/.azure/zookeeper-regression-pipeline.yaml
+++ b/.azure/zookeeper-regression-pipeline.yaml
@@ -1,0 +1,28 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then images will be built as part of the pipeline
+    default: "latest"
+  - name: kafkaVersion
+    displayName: Kafka Version
+    type: string
+    # If kafkaVersion == latest, the latest supported version of Kafka is used
+    default: "latest"
+
+# Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
+jobs:
+  - template: 'templates/jobs/system-tests/zookeeper_regression_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -234,7 +234,7 @@ public class Environment {
     public static final boolean SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, Boolean::parseBoolean, false);
     public static final String STRIMZI_RBAC_SCOPE = getOrDefault(STRIMZI_RBAC_SCOPE_ENV, STRIMZI_RBAC_SCOPE_DEFAULT);
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
-    public static final boolean STRIMZI_USE_KRAFT_IN_TESTS = getOrDefault(STRIMZI_USE_KRAFT_IN_TESTS_ENV, Boolean::parseBoolean, false);
+    public static final boolean STRIMZI_USE_KRAFT_IN_TESTS = getOrDefault(STRIMZI_USE_KRAFT_IN_TESTS_ENV, Boolean::parseBoolean, true);
     public static final boolean STRIMZI_USE_NODE_POOLS_IN_TESTS = getOrDefault(STRIMZI_USE_NODE_POOLS_IN_TESTS_ENV, Boolean::parseBoolean, true);
     public static final NodePoolsRoleMode STRIMZI_NODE_POOLS_ROLE_MODE = getOrDefault(STRIMZI_NODE_POOLS_ROLE_MODE_ENV, value -> NodePoolsRoleMode.valueOf(value.toUpperCase(Locale.ENGLISH)), NodePoolsRoleMode.SEPARATE);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -496,7 +496,7 @@ public class AbstractUpgradeST extends AbstractST {
             // Deploy a Kafka cluster
             if (upgradeData.getFromExamples().equals("HEAD")) {
                 resourceManager.createResourceWithWait(KafkaNodePoolTemplates.brokerPoolPersistentStorage(componentsNamespaceName, poolName, clusterName, 3).build());
-                resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistent(componentsNamespaceName, clusterName, 3, 3)
+                resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistentNodePools(componentsNamespaceName, clusterName, 3, 3)
                     .editSpec()
                         .editKafka()
                             .withVersion(upgradeKafkaVersion.getVersion())

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/KafkaUpgradeDowngradeST.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
@@ -42,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Metadata for upgrade/downgrade procedure are loaded from kafka-versions.yaml in root dir of this repository.
  */
 @Tag(UPGRADE)
-@KRaftNotSupported("Strimzi and Kafka downgrade is not supported with KRaft mode")
 public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaUpgradeDowngradeST.class);
@@ -168,7 +166,7 @@ public class KafkaUpgradeDowngradeST extends AbstractUpgradeST {
 
         if (KafkaResource.kafkaClient().inNamespace(testStorage.getNamespaceName()).withName(clusterName).get() == null) {
             LOGGER.info("Deploying initial Kafka version {} with logMessageFormat={} and interBrokerProtocol={}", initialVersion.version(), initLogMsgFormat, initInterBrokerProtocol);
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistent(testStorage.getNamespaceName(), clusterName, kafkaReplicas, zkReplicas)
+            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentNodePools(testStorage.getNamespaceName(), clusterName, kafkaReplicas, zkReplicas)
                 .editSpec()
                     .editKafka()
                         .withVersion(initialVersion.version())

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
@@ -10,7 +10,6 @@ import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.api.kafka.model.topic.KafkaTopicBuilder;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -49,11 +48,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests in this class use OLM for install cluster operator.
  */
 @Tag(OLM_UPGRADE)
-@KRaftNotSupported("Strimzi and Kafka downgrade is not supported with KRaft mode")
 public class OlmUpgradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(OlmUpgradeST.class);
     private final OlmVersionModificationData olmUpgradeData = new VersionModificationDataLoader(ModificationType.OLM_UPGRADE).getOlmUpgradeData();
+
     @IsolatedTest
     void testStrimziUpgrade() throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext(), CO_NAMESPACE);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -5,7 +5,6 @@
 package io.strimzi.systemtest.upgrade.regular;
 
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.annotations.KindIPv6NotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.resources.NamespaceManager;
@@ -39,7 +38,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Kafka upgrade is done as part of those tests as well, but the tests for Kafka upgrade/downgrade are in {@link KafkaUpgradeDowngradeST}.
  */
 @Tag(UPGRADE)
-@KRaftNotSupported("Strimzi and Kafka downgrade is not supported with KRaft mode")
 public class StrimziDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(StrimziDowngradeST.class);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -6,7 +6,6 @@ package io.strimzi.systemtest.upgrade.regular;
 
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.annotations.IsolatedTest;
-import io.strimzi.systemtest.annotations.KRaftNotSupported;
 import io.strimzi.systemtest.annotations.KindIPv6NotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.resources.NamespaceManager;
@@ -47,7 +46,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Kafka upgrade is done as part of those tests as well, but the tests for Kafka upgrade/downgrade are in {@link KafkaUpgradeDowngradeST}.
  */
 @Tag(UPGRADE)
-@KRaftNotSupported("Strimzi and Kafka upgrade is not supported with KRaft mode")
 public class StrimziUpgradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(StrimziUpgradeST.class);


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR changes the default mode in which we are running AZP. 
It:
- changes the default mode to KRaft
- creates the `zookeeper-regression` pipeline, which runs without KRaft and NodePools
- changes the default of the `STRIMZI_USE_KRAFT_IN_TESTS` environment variable to `true`

From now on, when we run STs, they will be run in KRaft mode. In order to test ZK mode in AZP, we will need to run the `zookeeper-regression` pipeline.

### Checklist

- [x] Make sure all tests pass
