### PR TITLE
Add current Raft state metric to the exported metrics

### DIFF
--- a/packaging/examples/metrics/kafka-metrics.yaml
+++ b/packaging/examples/metrics/kafka-metrics.yaml
@@ -202,6 +202,12 @@ data:
     - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
       name: kafka_server_raftmetrics_$1
       type: COUNTER
+    - pattern: "kafka.server<type=raft-metrics><>(current-state): (.+)"
+      name: kafka_server_raftmetrics_$1
+      value: 1
+      type: UNTYPED
+      labels:
+        $1: "$2"
     - pattern: "kafka.server<type=raft-metrics><>(.+):"
       name: kafka_server_raftmetrics_$1
       type: GAUGE


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the _current raft state_ metric to the exported metrics. It lists the state of the Kafka node: leader, observer, follower etc. which seems like it might be useful.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally