### PR TITLE
[ST] Use the KafkaConnect with Connector upgrade/downgrade scenario as the main one

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
@@ -58,6 +58,10 @@ public class UpgradeKafkaVersion {
         this.version = version;
     }
 
+    public void setLogMessageVersion(String logMessageVersion) {
+        this.logMessageVersion = logMessageVersion;
+    }
+
     public String getVersion() {
         return version;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/UpgradeKafkaVersion.java
@@ -62,6 +62,10 @@ public class UpgradeKafkaVersion {
         this.logMessageVersion = logMessageVersion;
     }
 
+    public void setMetadataVersion(String metadataVersion) {
+        this.metadataVersion = metadataVersion;
+    }
+
     public String getVersion() {
         return version;
     }

--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -187,7 +187,7 @@ public class VersionModificationDataLoader {
 
             downgradeData = updateUpgradeDataWithFeatureGates(downgradeData, featureGates);
 
-            parameters.add(Arguments.of(downgradeData.getFromVersion(), downgradeData.getToVersion(), downgradeData));
+            parameters.add(Arguments.of(downgradeData.getFromVersion(), downgradeData.getToVersion(), downgradeData.getFeatureGatesBefore(), downgradeData.getFeatureGatesAfter(), downgradeData));
         });
 
         return parameters.stream();

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -212,6 +212,16 @@ public class AbstractUpgradeST extends AbstractST {
         }
     }
 
+    protected void changeKafkaVersionInKafkaConnect(String componentsNamespaceName, CommonVersionModificationData versionModificationData) {
+        UpgradeKafkaVersion upgradeToKafkaVersion = new UpgradeKafkaVersion(versionModificationData.getProcedures().getVersion());
+
+        LOGGER.info(String.format("Setting Kafka version to %s in Kafka Connect", upgradeToKafkaVersion.getVersion()));
+        cmdKubeClient(componentsNamespaceName).patchResource(getResourceApiVersion(KafkaConnect.RESOURCE_PLURAL), clusterName, "/spec/version", upgradeToKafkaVersion.getVersion());
+
+        LOGGER.info("Waiting for KafkaConnect rolling update to finish");
+        connectPods = RollingUpdateUtils.waitTillComponentHasRolled(componentsNamespaceName, connectLabelSelector, 1, connectPods);
+    }
+
     protected void logComponentsPodImagesWithConnect(String componentsNamespaceName) {
         logPodImages(componentsNamespaceName, controllerSelector, brokerSelector, eoSelector, connectLabelSelector);
     }
@@ -550,7 +560,11 @@ public class AbstractUpgradeST extends AbstractST {
         }
     }
 
-    protected void deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(final TestStorage testStorage, final BundleVersionModificationData acrossUpgradeData, final UpgradeKafkaVersion upgradeKafkaVersion) {
+    protected void deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(
+        final TestStorage testStorage,
+        final BundleVersionModificationData acrossUpgradeData,
+        final UpgradeKafkaVersion upgradeKafkaVersion
+    ) {
         // setup KafkaConnect + KafkaConnector
         if (!cmdKubeClient(testStorage.getNamespaceName()).getResources(getResourceApiVersion(KafkaConnect.RESOURCE_PLURAL)).contains(clusterName)) {
             if (acrossUpgradeData.getFromVersion().equals("HEAD")) {
@@ -625,14 +639,17 @@ public class AbstractUpgradeST extends AbstractST {
         }
     }
 
-    protected void doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(final String clusterOperatorNamespaceName,
-                                                                              final TestStorage testStorage,
-                                                                              final BundleVersionModificationData bundleDowngradeDataWithFeatureGates,
-                                                                              final UpgradeKafkaVersion upgradeKafkaVersion) throws IOException {
-        this.deployCoWithWaitForReadiness(clusterOperatorNamespaceName, testStorage.getNamespaceName(), bundleDowngradeDataWithFeatureGates);
-        this.deployKafkaClusterWithWaitForReadiness(testStorage.getNamespaceName(), bundleDowngradeDataWithFeatureGates, upgradeKafkaVersion);
-        this.deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(testStorage, bundleDowngradeDataWithFeatureGates, upgradeKafkaVersion);
-        this.deployKafkaUserWithWaitForReadiness(testStorage.getNamespaceName(), bundleDowngradeDataWithFeatureGates);
+    protected void doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(
+        final String clusterOperatorNamespaceName,
+        final TestStorage testStorage,
+        final BundleVersionModificationData upgradeDowngradeData,
+        final UpgradeKafkaVersion upgradeKafkaVersion
+    ) throws IOException {
+        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, testStorage, upgradeDowngradeData, upgradeKafkaVersion);
+        this.deployKafkaConnectAndKafkaConnectorWithWaitForReadiness(testStorage, upgradeDowngradeData, upgradeKafkaVersion);
+
+        // Check if UTO is used before changing the CO -> used for check for KafkaTopics
+        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(testStorage.getNamespaceName(), eoSelector);
 
         final KafkaClients clients = ClientUtils.getInstantTlsClientBuilder(testStorage, KafkaResources.tlsBootstrapAddress(clusterName))
             .withNamespaceName(testStorage.getNamespaceName())
@@ -651,23 +668,39 @@ public class AbstractUpgradeST extends AbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // Upgrade CO to HEAD and wait for readiness of ClusterOperator
-        changeClusterOperator(clusterOperatorNamespaceName, testStorage.getNamespaceName(), bundleDowngradeDataWithFeatureGates);
+        changeClusterOperator(clusterOperatorNamespaceName, testStorage.getNamespaceName(), upgradeDowngradeData);
 
-        // Verify that Kafka and Connect Pods Rolled
-        waitForKafkaClusterRollingUpdate(testStorage.getNamespaceName());
-        RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), connectLabelSelector, 1, connectPods);
-        KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), clusterName);
+        if (TestKafkaVersion.supportedVersionsContainsVersion(upgradeKafkaVersion.getVersion())) {
+            // Verify that Kafka and Connect Pods Rolled
+            waitForKafkaClusterRollingUpdate(testStorage.getNamespaceName());
+            connectPods = RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), connectLabelSelector, 1, connectPods);
+            KafkaConnectorUtils.waitForConnectorReady(testStorage.getNamespaceName(), clusterName);
+        }
+
+        logComponentsPodImagesWithConnect(testStorage.getNamespaceName());
+
+        // Upgrade kafka
+        changeKafkaAndLogFormatVersion(testStorage.getNamespaceName(), upgradeDowngradeData);
+        changeKafkaVersionInKafkaConnect(testStorage.getNamespaceName(), upgradeDowngradeData);
+
+        logComponentsPodImagesWithConnect(testStorage.getNamespaceName());
+        checkAllComponentsImages(testStorage.getNamespaceName(), upgradeDowngradeData);
 
         // send again new messages
         resourceManager.createResourceWithWait(clients.producerTlsStrimzi(clusterName));
+
         // Verify that Producer finish successfully
         ClientUtils.waitForInstantProducerClientSuccess(testStorage.getNamespaceName(), testStorage);
+
         // Verify FileSink KafkaConnector
         connectorPodName = kubeClient().listPods(testStorage.getNamespaceName(), Collections.singletonMap(Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND)).get(0).getMetadata().getName();
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(testStorage.getNamespaceName(), connectorPodName, DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
 
         // Verify that pods are stable
         PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);
+
+        // Verify upgrade
+        verifyProcedure(testStorage.getNamespaceName(), upgradeDowngradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
     }
 
     protected String downloadExamplesAndGetPath(CommonVersionModificationData versionModificationData) throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -133,7 +133,7 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     @SuppressWarnings("CyclomaticComplexity")
-    protected void changeKafkaAndLogFormatVersion(String componentsNamespaceName, CommonVersionModificationData versionModificationData) throws IOException {
+    protected void changeKafkaVersion(String componentsNamespaceName, CommonVersionModificationData versionModificationData) throws IOException {
         // Get Kafka configurations
         String currentLogMessageFormat = cmdKubeClient(componentsNamespaceName).getResourceJsonPath(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, ".spec.kafka.config.log\\.message\\.format\\.version");
         String currentInterBrokerProtocol = cmdKubeClient(componentsNamespaceName).getResourceJsonPath(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, ".spec.kafka.config.inter\\.broker\\.protocol\\.version");
@@ -679,8 +679,8 @@ public class AbstractUpgradeST extends AbstractST {
 
         logComponentsPodImagesWithConnect(testStorage.getNamespaceName());
 
-        // Upgrade kafka
-        changeKafkaAndLogFormatVersion(testStorage.getNamespaceName(), upgradeDowngradeData);
+        // Upgrade/Downgrade kafka
+        changeKafkaVersion(testStorage.getNamespaceName(), upgradeDowngradeData);
         changeKafkaVersionInKafkaConnect(testStorage.getNamespaceName(), upgradeDowngradeData);
 
         logComponentsPodImagesWithConnect(testStorage.getNamespaceName());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
@@ -118,8 +118,8 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
         DeploymentUtils.waitForDeploymentAndPodsReady(componentsNamespaceName, KafkaResources.entityOperatorDeploymentName(clusterName), 1);
     }
 
-    protected void changeKafkaAndMetadataVersion(final String componentsNamespaceName, CommonVersionModificationData versionModificationData) throws IOException {
-        changeKafkaAndMetadataVersion(componentsNamespaceName, versionModificationData, false);
+    protected void changeKafkaVersion(final String componentsNamespaceName, CommonVersionModificationData versionModificationData) throws IOException {
+        changeKafkaVersion(componentsNamespaceName, versionModificationData, false);
     }
 
     /**
@@ -131,7 +131,7 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
      * @throws IOException exception during application of YAML files
      */
     @SuppressWarnings("CyclomaticComplexity")
-    protected void changeKafkaAndMetadataVersion(final String componentsNamespaceName, CommonVersionModificationData versionModificationData, boolean replaceEvenIfMissing) throws IOException {
+    protected void changeKafkaVersion(final String componentsNamespaceName, CommonVersionModificationData versionModificationData, boolean replaceEvenIfMissing) throws IOException {
         // Get Kafka version
         String kafkaVersionFromCR = cmdKubeClient(componentsNamespaceName).getResourceJsonPath(getResourceApiVersion(Kafka.RESOURCE_PLURAL), clusterName, ".spec.kafka.version");
         kafkaVersionFromCR = kafkaVersionFromCR.equals("") ? null : kafkaVersionFromCR;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -42,9 +42,9 @@ public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeDataForKRaft")
     void testDowngradeOfKafkaKafkaConnectAndKafkaConnector(String from, String to, String fgBefore, String fgAfter, BundleVersionModificationData downgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        UpgradeKafkaVersion downgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(downgradeData.getFromKafkaVersionsUrl(), downgradeData.getDeployKafkaVersion());
-        // setting log message version to null, similarly to the examples, which are not configuring LMFV
-        downgradeKafkaVersion.setLogMessageVersion(null);
+        String lowerMetadataVersion = downgradeData.getProcedures().getMetadataVersion();
+
+        UpgradeKafkaVersion downgradeKafkaVersion = new UpgradeKafkaVersion(downgradeData.getDeployKafkaVersion(), lowerMetadataVersion);
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(downgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(downgradeData.getEnvMaxK8sVersion()));

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziDowngradeST.java
@@ -11,15 +11,12 @@ import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
 import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
-import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -38,61 +35,23 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @Tag(KRAFT_UPGRADE)
 public class KRaftStrimziDowngradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziDowngradeST.class);
-    private final BundleVersionModificationData bundleDowngradeVersionData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_DOWNGRADE).buildDataForDowngradeUsingFirstScenarioForKRaft();
-
-    @ParameterizedTest(name = "testDowngradeStrimziVersion-{0}-{1}")
-    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeDataForKRaft")
-    void testDowngradeStrimziVersion(String from, String to, BundleVersionModificationData parameters) throws Exception {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getEnvFlakyVariable()));
-        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getEnvMaxK8sVersion()));
-
-        LOGGER.debug("Running downgrade test from version {} to {}", from, to);
-        performDowngrade(CO_NAMESPACE, testStorage.getNamespaceName(), parameters);
-    }
 
     @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
     @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
-    @Test
-    void testDowngradeOfKafkaConnectAndKafkaConnector() throws IOException {
+    @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>)")
+    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeDataForKRaft")
+    void testDowngradeOfKafkaKafkaConnectAndKafkaConnector(String from, String to, String fgBefore, String fgAfter, BundleVersionModificationData downgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeVersionData.getDeployKafkaVersion());
+        UpgradeKafkaVersion downgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(downgradeData.getFromKafkaVersionsUrl(), downgradeData.getDeployKafkaVersion());
+        // setting log message version to null, similarly to the examples, which are not configuring LMFV
+        downgradeKafkaVersion.setLogMessageVersion(null);
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, bundleDowngradeVersionData, upgradeKafkaVersion);
-    }
+        assumeTrue(StUtils.isAllowOnCurrentEnvironment(downgradeData.getEnvFlakyVariable()));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(downgradeData.getEnvMaxK8sVersion()));
 
-    private void performDowngrade(String clusterOperatorNamespaceName, String componentsNamespaceName, BundleVersionModificationData downgradeData) throws IOException {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
+        LOGGER.debug("Running downgrade test from version {} to {} (FG: {} -> {})", from, to, fgBefore, fgAfter);
 
-        String lowerMetadataVersion = downgradeData.getProcedures().getMetadataVersion();
-        UpgradeKafkaVersion testUpgradeKafkaVersion = new UpgradeKafkaVersion(downgradeData.getDeployKafkaVersion(), lowerMetadataVersion);
-
-        // Setup env
-        // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
-        // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
-
-        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, testStorage, downgradeData, testUpgradeKafkaVersion);
-        logClusterOperatorPodImage(clusterOperatorNamespaceName);
-
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(componentsNamespaceName, eoSelector);
-
-        // Downgrade CO
-        changeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, downgradeData);
-
-        // Wait for Kafka cluster rolling update
-        waitForKafkaClusterRollingUpdate(componentsNamespaceName);
-        logComponentsPodImages(componentsNamespaceName);
-
-        // Downgrade kafka
-        changeKafkaAndMetadataVersion(componentsNamespaceName, downgradeData);
-
-        // Verify that pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(componentsNamespaceName, clusterName);
-
-        checkAllComponentsImages(componentsNamespaceName, downgradeData);
-
-        // Verify upgrade
-        verifyProcedure(componentsNamespaceName, downgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, downgradeData, downgradeKafkaVersion);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -57,8 +57,8 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
     void testUpgradeOfKafkaKafkaConnectAndKafkaConnector(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(upgradeData.getOldestKafka());
-        // setting log message version to null, similarly to the examples, which are not configuring LMFV
-        upgradeKafkaVersion.setLogMessageVersion(null);
+        // setting metadata version to null, similarly to the examples, which are not configuring metadataVersion
+        upgradeKafkaVersion.setMetadataVersion(null);
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(upgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(upgradeData.getEnvMaxK8sVersion()));
@@ -132,7 +132,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         logPodImages(CO_NAMESPACE);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(testStorage.getNamespaceName(), acrossUpgradeData, true);
+        changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData, true);
 
         logPodImages(CO_NAMESPACE);
 
@@ -167,7 +167,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         logPodImages(CO_NAMESPACE);
 
         // Upgrade kafka
-        changeKafkaAndMetadataVersion(testStorage.getNamespaceName(), acrossUpgradeData);
+        changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData);
         logComponentsPodImages(testStorage.getNamespaceName());
         checkAllComponentsImages(testStorage.getNamespaceName(), acrossUpgradeData);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -52,7 +52,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
     @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
     @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
-    @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>) ")
+    @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>)")
     @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeDataForKRaft")
     void testUpgradeOfKafkaKafkaConnectAndKafkaConnector(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -17,7 +17,6 @@ import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
 import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.RollingUpdateUtils;
 import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.systemtest.utils.TestKafkaVersion;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
@@ -26,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -52,14 +50,22 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
     private static final Logger LOGGER = LogManager.getLogger(KRaftStrimziUpgradeST.class);
     private final BundleVersionModificationData acrossUpgradeData = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_UPGRADE).buildDataForUpgradeAcrossVersionsForKRaft();
 
+    @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
+    @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
     @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>) ")
     @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlUpgradeDataForKRaft")
-    void testUpgradeStrimziVersion(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData) throws Exception {
+    void testUpgradeOfKafkaKafkaConnectAndKafkaConnector(String fromVersion, String toVersion, String fgBefore, String fgAfter, BundleVersionModificationData upgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
+        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(upgradeData.getOldestKafka());
+        // setting log message version to null, similarly to the examples, which are not configuring LMFV
+        upgradeKafkaVersion.setLogMessageVersion(null);
+
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(upgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(upgradeData.getEnvMaxK8sVersion()));
 
-        performUpgrade(CO_NAMESPACE, testStorage.getNamespaceName(), upgradeData);
+        LOGGER.debug("Running upgrade test from version {} to {} (FG: {} -> {})",
+            fromVersion, toVersion, fgBefore, fgAfter);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, upgradeData, upgradeKafkaVersion);
     }
 
     @IsolatedTest
@@ -170,53 +176,6 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
         // Verify upgrade
         verifyProcedure(testStorage.getNamespaceName(), acrossUpgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
-    }
-
-    @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
-    @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
-    @IsolatedTest
-    void testUpgradeOfKafkaConnectAndKafkaConnector(final ExtensionContext extensionContext) throws IOException {
-        final TestStorage testStorage = new TestStorage(extensionContext);
-        final UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(acrossUpgradeData.getDefaultKafka());
-
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, acrossUpgradeData, upgradeKafkaVersion);
-    }
-
-    private void performUpgrade(String clusterOperatorNamespaceName, String componentsNamespaceName, BundleVersionModificationData upgradeData) throws IOException {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-
-        // leave empty, so the original Kafka version from appropriate Strimzi's yaml will be used
-        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion();
-
-        // Setup env
-        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, testStorage, upgradeData, upgradeKafkaVersion);
-
-        // Upgrade CO to HEAD
-        logClusterOperatorPodImage(clusterOperatorNamespaceName);
-        logComponentsPodImages(componentsNamespaceName);
-
-        // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(componentsNamespaceName, eoSelector);
-
-        changeClusterOperator(clusterOperatorNamespaceName, componentsNamespaceName, upgradeData);
-
-        if (TestKafkaVersion.supportedVersionsContainsVersion(upgradeData.getDefaultKafkaVersionPerStrimzi())) {
-            waitForKafkaClusterRollingUpdate(componentsNamespaceName);
-        }
-
-        logClusterOperatorPodImage(clusterOperatorNamespaceName);
-        logComponentsPodImages(componentsNamespaceName);
-
-        // Upgrade kafka
-        changeKafkaAndMetadataVersion(componentsNamespaceName, upgradeData, true);
-        logComponentsPodImages(componentsNamespaceName);
-        checkAllComponentsImages(componentsNamespaceName, upgradeData);
-
-        // Verify that Pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(componentsNamespaceName, clusterName);
-
-        // Verify upgrade
-        verifyProcedure(componentsNamespaceName, upgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/OlmUpgradeST.java
@@ -140,7 +140,7 @@ public class OlmUpgradeST extends AbstractUpgradeST {
 
         // ======== Kafka upgrade starts ========
         logComponentsPodImages(CO_NAMESPACE);
-        changeKafkaAndLogFormatVersion(CO_NAMESPACE, olmUpgradeData);
+        changeKafkaVersion(CO_NAMESPACE, olmUpgradeData);
         logComponentsPodImages(CO_NAMESPACE);
         // ======== Kafka upgrade ends ========
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest.upgrade.regular;
 
-import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.KindIPv6NotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.resources.NamespaceManager;
@@ -13,9 +12,7 @@ import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.upgrade.AbstractUpgradeST;
 import io.strimzi.systemtest.upgrade.BundleVersionModificationData;
 import io.strimzi.systemtest.upgrade.UpgradeKafkaVersion;
-import io.strimzi.systemtest.upgrade.VersionModificationDataLoader;
 import io.strimzi.systemtest.utils.StUtils;
-import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -25,7 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.List;
 
 import static io.strimzi.systemtest.Environment.TEST_SUITE_NAMESPACE;
 import static io.strimzi.systemtest.TestConstants.CO_NAMESPACE;
@@ -41,58 +37,23 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class StrimziDowngradeST extends AbstractUpgradeST {
 
     private static final Logger LOGGER = LogManager.getLogger(StrimziDowngradeST.class);
-    private final List<BundleVersionModificationData> bundleDowngradeMetadata = new VersionModificationDataLoader(VersionModificationDataLoader.ModificationType.BUNDLE_DOWNGRADE).getBundleUpgradeOrDowngradeDataList();
-
-    @ParameterizedTest(name = "testDowngradeStrimziVersion-{0}-{1}")
-    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeData")
-    void testDowngradeStrimziVersion(String from, String to, BundleVersionModificationData parameters) throws Exception {
-        final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        assumeTrue(StUtils.isAllowOnCurrentEnvironment(parameters.getEnvFlakyVariable()));
-        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(parameters.getEnvMaxK8sVersion()));
-
-        LOGGER.debug("Running downgrade test from version {} to {}", from, to);
-        performDowngrade(CO_NAMESPACE, testStorage, parameters);
-    }
 
     @MicroShiftNotSupported("Due to lack of Kafka Connect build feature")
     @KindIPv6NotSupported("Our current CI setup doesn't allow pushing into internal registries that is needed in this test")
-    @IsolatedTest
-    void testDowngradeOfKafkaConnectAndKafkaConnector() throws IOException {
+    @ParameterizedTest(name = "from: {0} (using FG <{2}>) to: {1} (using FG <{3}>)")
+    @MethodSource("io.strimzi.systemtest.upgrade.VersionModificationDataLoader#loadYamlDowngradeData")
+    void testDowngradeOfKafkaKafkaConnectAndKafkaConnector(String from, String to, String fgBefore, String fgAfter, BundleVersionModificationData downgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        final BundleVersionModificationData bundleDowngradeDataWithFeatureGates = bundleDowngradeMetadata.stream()
-                .filter(bundleMetadata -> bundleMetadata.getFeatureGatesBefore() != null && !bundleMetadata.getFeatureGatesBefore().isEmpty() ||
-                        bundleMetadata.getFeatureGatesAfter() != null && !bundleMetadata.getFeatureGatesAfter().isEmpty()).toList().get(0);
-        UpgradeKafkaVersion upgradeKafkaVersion = new UpgradeKafkaVersion(bundleDowngradeDataWithFeatureGates.getDeployKafkaVersion());
+        UpgradeKafkaVersion downgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(downgradeData.getFromKafkaVersionsUrl(), downgradeData.getDeployKafkaVersion());
+        // setting log message version to null, similarly to the examples, which are not configuring LMFV
+        downgradeKafkaVersion.setLogMessageVersion(null);
 
-        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, bundleDowngradeDataWithFeatureGates, upgradeKafkaVersion);
-    }
+        assumeTrue(StUtils.isAllowOnCurrentEnvironment(downgradeData.getEnvFlakyVariable()));
+        assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(downgradeData.getEnvMaxK8sVersion()));
 
-    private void performDowngrade(String clusterOperatorNamespaceName, TestStorage testStorage, BundleVersionModificationData downgradeData) throws IOException {
-        UpgradeKafkaVersion testUpgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(downgradeData.getFromKafkaVersionsUrl(), downgradeData.getDeployKafkaVersion());
+        LOGGER.debug("Running downgrade test from version {} to {} (FG: {} -> {})", from, to, fgBefore, fgAfter);
 
-        // Setup env
-        // We support downgrade only when you didn't upgrade to new inter.broker.protocol.version and log.message.format.version
-        // https://strimzi.io/docs/operators/latest/full/deploying.html#con-target-downgrade-version-str
-        setupEnvAndUpgradeClusterOperator(clusterOperatorNamespaceName, testStorage, downgradeData, testUpgradeKafkaVersion);
-
-        logClusterOperatorPodImage(clusterOperatorNamespaceName);
-        logComponentsPodImages(testStorage.getNamespaceName());
-
-        // Check if UTO is used before changing the CO -> used for check for KafkaTopics
-        boolean wasUTOUsedBefore = StUtils.isUnidirectionalTopicOperatorUsed(testStorage.getNamespaceName(), eoSelector);
-
-        // Downgrade CO
-        changeClusterOperator(clusterOperatorNamespaceName, testStorage.getNamespaceName(), downgradeData);
-        // Wait for Kafka cluster rolling update
-        waitForKafkaClusterRollingUpdate(testStorage.getNamespaceName());
-        logComponentsPodImages(testStorage.getNamespaceName());
-        // Downgrade kafka
-        changeKafkaAndLogFormatVersion(testStorage.getNamespaceName(), downgradeData);
-        // Verify that pods are stable
-        PodUtils.verifyThatRunningPodsAreStable(testStorage.getNamespaceName(), clusterName);
-        checkAllComponentsImages(testStorage.getNamespaceName(), downgradeData);
-        // Verify upgrade
-        verifyProcedure(testStorage.getNamespaceName(), downgradeData, testStorage.getContinuousProducerName(), testStorage.getContinuousConsumerName(), wasUTOUsedBefore);
+        doKafkaConnectAndKafkaConnectorUpgradeOrDowngradeProcedure(CO_NAMESPACE, testStorage, downgradeData, downgradeKafkaVersion);
     }
 
     @BeforeEach

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -125,7 +125,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         changeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData);
         logPodImages(CO_NAMESPACE);
         //  Upgrade kafka
-        changeKafkaAndLogFormatVersion(TEST_SUITE_NAMESPACE, acrossUpgradeData);
+        changeKafkaVersion(TEST_SUITE_NAMESPACE, acrossUpgradeData);
         logPodImages(TEST_SUITE_NAMESPACE);
         checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
         // Verify that Pods are stable
@@ -153,7 +153,7 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         LOGGER.info("Rolling to new images has finished!");
         logPodImages(CO_NAMESPACE);
         //  Upgrade kafka
-        changeKafkaAndLogFormatVersion(testStorage.getNamespaceName(), acrossUpgradeData);
+        changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData);
         logPodImages(CO_NAMESPACE);
         checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
         // Verify that Pods are stable

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -44,7 +44,7 @@
     userOperator: strimzi/operator:0.43.0
   deployKafkaVersion: 3.8.0
   client:
-    continuousClientsMessages: 300
+    continuousClientsMessages: 400
   environmentInfo:
     maxK8sVersion: latest
     status: stable
@@ -72,7 +72,7 @@
     userOperator: strimzi/operator:0.43.0
   deployKafkaVersion: 3.8.0
   client:
-    continuousClientsMessages: 300
+    continuousClientsMessages: 400
   environmentInfo:
     maxK8sVersion: latest
     status: stable

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -57,31 +57,3 @@
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
     kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
     kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"
-- fromVersion: HEAD
-  toVersion: 0.43.0
-  fromExamples: HEAD
-  toExamples: strimzi-0.43.0
-  fromUrl: HEAD
-  toUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.43.0/strimzi-0.43.0.zip
-  fromKafkaVersionsUrl: HEAD
-  additionalTopics: 2
-  imagesAfterOperations:
-    zookeeper: strimzi/kafka:0.43.0-kafka-3.7.0
-    kafka: strimzi/kafka:0.43.0-kafka-3.7.0
-    topicOperator: strimzi/operator:0.43.0
-    userOperator: strimzi/operator:0.43.0
-  deployKafkaVersion: 3.8.0
-  client:
-    continuousClientsMessages: 400
-  environmentInfo:
-    maxK8sVersion: latest
-    status: stable
-    flakyEnvVariable: none
-    reason: Test is working on all environment used by QE.
-  featureGatesBefore: "+ContinueReconciliationOnManualRollingUpdateFailure"
-  featureGatesAfter: "-ContinueReconciliationOnManualRollingUpdateFailure"
-  filePaths:
-    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
-    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
-    kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
-    kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -41,7 +41,7 @@
     topicOperator: strimzi/operator:latest
     userOperator: strimzi/operator:latest
   client:
-    continuousClientsMessages: 300
+    continuousClientsMessages: 400
   environmentInfo:
     maxK8sVersion: latest
     status: stable


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates the upgrade/downgrade scenarios to run the parametrized tests together with Connect and the KafkaConnector resources.
Until now, we had first upgrade/downgrade scenarios that took the testcases from particular YAML files (with FG and other stuff) that checked upgrade of Strimzi just with Kafka cluster. Then, we have other scenarios with just Kafka cluster (like upgrading with unsupported Kafka version or empty version etc.). And finally, there is scenario for upgrade/downgrade of Strimzi with Kafka and KafkaConnect + KafkaConnector. The issue is that for example for downgrade, the logic is to pick the version from the BundleDowngrade.yaml, where we have FGs (same for upgrade IIRC). So in case that there are no scenarios with FGs, it's skipped or it ends up in error.

Because the scenario is more or less (the Kafka cluster upgrade/downgrade part) covered in the parametrized test, the KafkaConnect + KafkaConnector scenario adds value just in the KafkaConnect case.

To save some time and test exactly the same thing, it's better to "remove" the scenario just with Kafka cluster upgrade/downgrade, and add the scenario with Kafka + KafkaConnect + KafkaConnector. Thanks to that, the test scenario will be wider, we will test more and also save some time (and the KafkaConnect scenario will not be fixed).

The PR updates the code to handle this kind of upgrade/downgrade, adds possibility to also upgrade the KafkaConnect's Kafka version inside the KafkaConnect's `.spec.version` field, removes not needed methods (which were used for the previous parametrized tests), changes the parametrized name of the tests (downgrade ones), and bumps the number of messages that should be sent/received throughout the test.

### Checklist

- [x] Make sure all tests pass

