### PR TITLE
Add current raft state to grafana dashboard

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-kraft.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kraft.json
@@ -1075,6 +1075,83 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
+      "description": "The role of the node in KRaft",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 122,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "max(kafka_server_raftmetrics_current_state) by (kubernetes_pod_name, current_state)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current KRaft State",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 3,
+              "current_state": 2,
+              "kubernetes_pod_name": 1
+            },
+            "renameByName": {
+              "current_state": "Current State",
+              "kubernetes_pod_name": "Pod Name"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
       "description": "The current quorum leader's id; -1 indicates unknown",
       "fieldConfig": {
         "defaults": {
@@ -1134,8 +1211,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 23
       },
       "id": 104,
@@ -1228,8 +1305,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 23
       },
       "id": 105,
@@ -1322,8 +1399,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 23
       },
       "id": 113,

--- a/examples/metrics/grafana-dashboards/strimzi-kraft.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kraft.json
@@ -1075,83 +1075,6 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "description": "The role of the node in KRaft",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": null,
-            "filterable": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 23
-      },
-      "id": 122,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "7.4.5",
-      "targets": [
-        {
-          "expr": "max(kafka_server_raftmetrics_current_state) by (kubernetes_pod_name, current_state)",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Current KRaft State",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value": 3,
-              "current_state": 2,
-              "kubernetes_pod_name": 1
-            },
-            "renameByName": {
-              "current_state": "Current State",
-              "kubernetes_pod_name": "Pod Name"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
       "description": "The current quorum leader's id; -1 indicates unknown",
       "fieldConfig": {
         "defaults": {
@@ -1211,8 +1134,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 0,
         "y": 23
       },
       "id": 104,
@@ -1305,8 +1228,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 23
       },
       "id": 105,
@@ -1399,8 +1322,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
+        "w": 8,
+        "x": 16,
         "y": 23
       },
       "id": 113,

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
@@ -1075,6 +1075,83 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
+      "description": "The role of the node in KRaft",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 122,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "max(kafka_server_raftmetrics_current_state) by (kubernetes_pod_name, current_state)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current Raft State",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 3,
+              "current_state": 2,
+              "kubernetes_pod_name": 1
+            },
+            "renameByName": {
+              "current_state": "Current State",
+              "kubernetes_pod_name": "Pod Name"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
       "description": "The current quorum leader's id; -1 indicates unknown",
       "fieldConfig": {
         "defaults": {
@@ -1134,8 +1211,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 23
       },
       "id": 104,
@@ -1228,8 +1305,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 23
       },
       "id": 105,
@@ -1322,8 +1399,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 23
       },
       "id": 113,

--- a/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/examples/metrics/grafana-dashboards/strimzi-kraft.json
@@ -1111,7 +1111,13 @@
       },
       "id": 122,
       "options": {
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pod Name"
+          }
+        ]
       },
       "pluginVersion": "7.4.5",
       "targets": [

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
@@ -1075,6 +1075,83 @@
     },
     {
       "datasource": "${DS_PROMETHEUS}",
+      "description": "The role of the node in KRaft",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 122,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "expr": "max(kafka_server_raftmetrics_current_state) by (kubernetes_pod_name, current_state)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current Raft State",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 3,
+              "current_state": 2,
+              "kubernetes_pod_name": 1
+            },
+            "renameByName": {
+              "current_state": "Current State",
+              "kubernetes_pod_name": "Pod Name"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
       "description": "The current quorum leader's id; -1 indicates unknown",
       "fieldConfig": {
         "defaults": {
@@ -1134,8 +1211,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 23
       },
       "id": 104,
@@ -1228,8 +1305,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 23
       },
       "id": 105,
@@ -1322,8 +1399,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 23
       },
       "id": 113,

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/files/grafana-dashboards/strimzi-kraft.json
@@ -1111,7 +1111,13 @@
       },
       "id": 122,
       "options": {
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Pod Name"
+          }
+        ]
       },
       "pluginVersion": "7.4.5",
       "targets": [


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds the current Raft state metric to the grafana dashboard as a table as per screenshot below

![image](https://github.com/user-attachments/assets/5c359ee8-2170-4f36-8709-0aabd15f35ca)

Closes #10538 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [X] Supply screenshots for visual changes, such as Grafana dashboards

