### PR TITLE
Suppress deprecatios in `KafkaMirrorMakerCrdIT`

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerCrdIT.java
@@ -80,6 +80,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
         createDeleteCustomResource("KafkaMirrorMaker-with-commit-and-abort.yaml");
     }
 
+    @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
@@ -87,6 +88,7 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
+    @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
     @AfterAll
     void teardownEnvironment() {
         TestUtils.deleteCrd(client, KafkaMirrorMaker.CRD_NAME);


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR does a minor fix and suppresses the deprecation warnings in `KafkaMirrorMakerCrdIT`. This should lead to cleaner build log without the warnings being raised by Java.

### Checklist

- [x] Make sure all tests pass