### PR TITLE
Continue refactoring of the `test` module

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -39,7 +39,7 @@
     <!-- The api module is currently not ready or Javadoc checks-->
     <suppress checks="(JavadocMethod|JavadocType|JavadocVariable|MissingJavadocType|MissingJavadocMethod)" files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]strimzi[/\\].*"/>
 
-    <!-- The test module is currently not ready or Javadoc checks-->
-    <suppress checks="(JavadocMethod|JavadocType|JavadocVariable|MissingJavadocType|MissingJavadocMethod)" files="test[/\\]src[/\\]main[/\\]java[/\\]io[/\\]strimzi[/\\].*"/>
+    <!-- The systemtest module is currently not ready or Javadoc checks-->
+    <suppress checks="(JavadocMethod|JavadocType|JavadocVariable|MissingJavadocType|MissingJavadocMethod)" files="systemtest[/\\]src[/\\]main[/\\]java[/\\]io[/\\]strimzi[/\\].*"/>
 
 </suppressions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -63,11 +63,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.sundr</groupId>
             <artifactId>builder-annotations</artifactId>
             <scope>provided</scope>

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdIT.java
@@ -6,7 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.interfaces.TestSeparator;
 import org.junit.jupiter.api.TestInstance;
 
@@ -62,11 +62,11 @@ public abstract class AbstractCrdIT implements TestSeparator {
     }
 
     protected <T extends CustomResource> void createScaleDelete(Class<T> resourceClass, String resource) {
-        T model = TestUtils.fromYaml(resource, resourceClass);
+        T model = ReadWriteUtils.readObjectFromYamlFileInResources(resource, resourceClass);
         String apiVersion = model.getApiVersion();
         String kind = model.getKind();
         String resourceName = model.getMetadata().getName();
-        String resourceYamlAsString = TestUtils.toYamlString(model);
+        String resourceYamlAsString = ReadWriteUtils.writeObjectToYamlString(model);
         createScaleDelete(apiVersion, kind, resourceName, resourceYamlAsString);
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/AbstractCrdTest.java
@@ -6,7 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -24,23 +24,23 @@ public abstract class AbstractCrdTest<R extends CustomResource> {
     }
 
     protected void assertDesiredResource(R actual, String expectedResource) {
-        String content = TestUtils.readResource(getClass(), expectedResource);
+        String content = ReadWriteUtils.readFileFromResources(getClass(), expectedResource);
         assertThat("The resource " + expectedResource + " does not exist", content, is(notNullValue()));
 
-        String ssStr = TestUtils.toYamlString(actual);
+        String ssStr = ReadWriteUtils.writeObjectToYamlString(actual);
         assertThat(ssStr.trim(), is(content.trim()));
     }
 
     @Test
     public void roundTrip() {
         String resourceName = crdClass.getSimpleName() + ".yaml";
-        R model = TestUtils.fromYaml(resourceName, crdClass);
+        R model = ReadWriteUtils.readObjectFromYamlFileInResources(resourceName, crdClass);
         assertThat("The classpath resource " + resourceName + " does not exist", model, is(notNullValue()));
 
         ObjectMeta metadata = model.getMetadata();
         assertThat(metadata, is(notNullValue()));
         assertDesiredResource(model, crdClass.getSimpleName() + ".out.yaml");
-        assertDesiredResource(TestUtils.fromYamlString(TestUtils.toYamlString(model), crdClass), crdClass.getSimpleName() + ".out.yaml");
+        assertDesiredResource(ReadWriteUtils.readObjectFromYamlString(ReadWriteUtils.writeObjectToYamlString(model), crdClass), crdClass.getSimpleName() + ".out.yaml");
     }
 
 }

--- a/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/ExamplesTest.java
@@ -5,11 +5,10 @@
 package io.strimzi.api.kafka.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinitionSpec;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,6 @@ import java.util.Stack;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.fail;
-
 
 /**
  * The purpose of this test is to check that all the resources in the
@@ -57,8 +55,7 @@ public class ExamplesTest {
 
     private void validate(File f) {
         try {
-            ObjectMapper mapper = new YAMLMapper();
-            final String content = TestUtils.readFile(f);
+            final String content = ReadWriteUtils.readFile(f);
             validate(content);
         } catch (Exception | AssertionError e) {
             throw new AssertionError("Invalid example yaml in " + f.getPath() + ": " + e.getMessage(), e);

--- a/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/JvmOptionsTest.java
@@ -5,16 +5,19 @@
 package io.strimzi.api.kafka.model;
 
 import io.strimzi.api.kafka.model.common.JvmOptions;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 public class JvmOptionsTest {
     @Test
     public void testSetXmxXms() {
-        JvmOptions opts = TestUtils.fromYamlString("-Xmx: 2g\n" +
+        JvmOptions opts = ReadWriteUtils.readObjectFromYamlString("-Xmx: 2g\n" +
                                                    "-Xms: 1g",
                 JvmOptions.class);
 
@@ -24,7 +27,7 @@ public class JvmOptionsTest {
 
     @Test
     public void testEmptyXmxXms() {
-        JvmOptions opts = TestUtils.fromYamlString("{}", JvmOptions.class);
+        JvmOptions opts = ReadWriteUtils.readObjectFromYamlString("{}", JvmOptions.class);
 
         assertThat(opts.getXms(), is(nullValue()));
         assertThat(opts.getXmx(), is(nullValue()));
@@ -32,7 +35,7 @@ public class JvmOptionsTest {
 
     @Test
     public void testXx() {
-        JvmOptions opts = TestUtils.fromYamlString("-XX:\n" +
+        JvmOptions opts = ReadWriteUtils.readObjectFromYamlString("-XX:\n" +
                                                    "  key1: value1\n" +
                                                    "  key2: value2\n" +
                                                    "  key3: true\n" +
@@ -40,9 +43,9 @@ public class JvmOptionsTest {
                                                    "  key5: 10\n",
                 JvmOptions.class);
 
-        assertThat(opts.getXx(), is(TestUtils.map("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10")));
+        assertThat(opts.getXx(), is(Map.of("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10")));
 
-        opts = TestUtils.fromYamlString("{}", JvmOptions.class);
+        opts = ReadWriteUtils.readObjectFromYamlString("{}", JvmOptions.class);
 
         assertThat(opts.getXx(), is(nullValue()));
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaJmxOptionsTest.java
@@ -6,7 +6,7 @@ package io.strimzi.api.kafka.model;
 
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPassword;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -20,7 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class KafkaJmxOptionsTest {
     @Test
     public void testAuthentication() {
-        KafkaJmxOptions opts = TestUtils.fromYamlString(
+        KafkaJmxOptions opts = ReadWriteUtils.readObjectFromYamlString(
                 "authentication:\n" +
                 "  type: password",
                 KafkaJmxOptions.class);
@@ -31,7 +31,7 @@ public class KafkaJmxOptionsTest {
 
     @Test
     public void testNoJmxOpts() {
-        KafkaJmxOptions opts = TestUtils.fromYamlString("{}", KafkaJmxOptions.class);
+        KafkaJmxOptions opts = ReadWriteUtils.readObjectFromYamlString("{}", KafkaJmxOptions.class);
 
         assertThat(opts.getAuthentication(),  is(nullValue()));
         assertThat(opts.getAdditionalProperties(),  is(Collections.emptyMap()));

--- a/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/StructuralCrdIT.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.api.annotations.ApiVersion;
 import io.strimzi.api.annotations.VersionRange;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,10 +60,10 @@ public class StructuralCrdIT extends AbstractCrdIT {
 
     private void assertApiVersionsAreStructural(String crdName, String crdPath, VersionRange<ApiVersion> shouldBeStructural) {
         try {
-            TestUtils.createCrd(client, crdName, crdPath);
+            CrdUtils.createCrd(client, crdName, crdPath);
             assertApiVersionsAreStructuralInApiextensionsV1(crdName, shouldBeStructural);
         } finally {
-            TestUtils.deleteCrd(client, crdName);
+            CrdUtils.deleteCrd(client, crdName);
         }
     }
 

--- a/api/src/test/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/bridge/KafkaBridgeCrdIT.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -85,7 +87,7 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     void testLoadKafkaBridgeWithWrongTracingType() {
         Throwable exception = assertThrows(
             RuntimeException.class,
-            () -> TestUtils.fromYaml("KafkaBridge-with-wrong-tracing-type.yaml", KafkaBridge.class));
+            () -> ReadWriteUtils.readObjectFromYamlFileInResources("KafkaBridge-with-wrong-tracing-type.yaml", KafkaBridge.class));
 
         assertThat(exception.getMessage(), allOf(
                 containsStringIgnoringCase("Could not resolve type id 'wrongtype'"),
@@ -119,13 +121,13 @@ public class KafkaBridgeCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaBridge.CRD_NAME, TestUtils.CRD_KAFKA_BRIDGE);
+        CrdUtils.createCrd(client, KafkaBridge.CRD_NAME, CrdUtils.CRD_KAFKA_BRIDGE);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaBridge.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaBridge.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/connect/KafkaConnectCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,13 +101,13 @@ public class KafkaConnectCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaConnect.CRD_NAME, TestUtils.CRD_KAFKA_CONNECT);
+        CrdUtils.createCrd(client, KafkaConnect.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECT);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/connector/KafkaConnectorCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/connector/KafkaConnectorCrdIT.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.connector;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,13 +35,13 @@ public class KafkaConnectorCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaConnector.CRD_NAME, TestUtils.CRD_KAFKA_CONNECTOR);
+        CrdUtils.createCrd(client, KafkaConnector.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECTOR);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaConnector.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaConnector.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -113,13 +114,13 @@ public class KafkaCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, Kafka.CRD_NAME, TestUtils.CRD_KAFKA);
+        CrdUtils.createCrd(client, Kafka.CRD_NAME, CrdUtils.CRD_KAFKA);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, Kafka.CRD_NAME);
+        CrdUtils.deleteCrd(client, Kafka.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaTest.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/kafka/KafkaTest.java
@@ -12,7 +12,7 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatus;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
@@ -80,7 +80,7 @@ public class KafkaTest extends AbstractCrdTest<Kafka> {
                 .build();
 
         String path = Objects.requireNonNull(this.getClass().getResource("Kafka-ca-ints.yaml")).toURI().getPath();
-        assertThat(TestUtils.toYamlString(kafka), is(TestUtils.getFileAsString(path)));
+        assertThat(ReadWriteUtils.writeObjectToYamlString(kafka), is(ReadWriteUtils.readFile(path)));
     }
 
     @Test
@@ -121,12 +121,12 @@ public class KafkaTest extends AbstractCrdTest<Kafka> {
                 .build();
 
         String path = Objects.requireNonNull(this.getClass().getResource("Kafka-new-listener-serialization.yaml")).toURI().getPath();
-        assertThat(TestUtils.toYamlString(kafka), is(TestUtils.getFileAsString(path)));
+        assertThat(ReadWriteUtils.writeObjectToYamlString(kafka), is(ReadWriteUtils.readFile(path)));
     }
 
     @Test
     public void testListeners()    {
-        Kafka model = TestUtils.fromYaml("Kafka" + ".yaml", Kafka.class);
+        Kafka model = ReadWriteUtils.readObjectFromYamlFileInResources("Kafka" + ".yaml", Kafka.class);
 
         assertThat(model.getSpec().getKafka().getListeners(), is(notNullValue()));
         assertThat(model.getSpec().getKafka().getListeners().size(), is(2));
@@ -188,12 +188,12 @@ public class KafkaTest extends AbstractCrdTest<Kafka> {
                 .build();
 
         String path = Objects.requireNonNull(this.getClass().getResource("Kafka-listener-name-and-status.yaml")).toURI().getPath();
-        assertThat(TestUtils.toYamlString(kafka), is(TestUtils.getFileAsString(path)));
+        assertThat(ReadWriteUtils.writeObjectToYamlString(kafka), is(ReadWriteUtils.readFile(path)));
     }
 
     @Test
     public void testListenersTypeAndName()    {
-        Kafka model = TestUtils.fromYaml("Kafka-listener-name-and-status" + ".yaml", Kafka.class);
+        Kafka model = ReadWriteUtils.readObjectFromYamlFileInResources("Kafka-listener-name-and-status" + ".yaml", Kafka.class);
 
         assertThat(model.getStatus().getListeners(), is(notNullValue()));
         assertThat(model.getStatus().getListeners().size(), is(2));

--- a/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -84,14 +85,14 @@ public class KafkaMirrorMakerCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaMirrorMaker.CRD_NAME, TestUtils.CRD_KAFKA_MIRROR_MAKER);
+        CrdUtils.createCrd(client, KafkaMirrorMaker.CRD_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @SuppressWarnings("deprecation") // Kafka Mirror Maker is deprecated
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaMirrorMaker.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaMirrorMaker.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2CrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2CrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,13 +101,13 @@ public class KafkaMirrorMaker2CrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        CrdUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,13 +46,13 @@ public class KafkaNodePoolCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaNodePool.CRD_NAME, TestUtils.CRD_KAFKA_NODE_POOL);
+        CrdUtils.createCrd(client, KafkaNodePool.CRD_NAME, CrdUtils.CRD_KAFKA_NODE_POOL);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaNodePool.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaNodePool.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/podset/StrimziPodSetCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/podset/StrimziPodSetCrdIT.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -71,13 +72,13 @@ public class StrimziPodSetCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, StrimziPodSet.CRD_NAME, TestUtils.CRD_STRIMZI_POD_SET);
+        CrdUtils.createCrd(client, StrimziPodSet.CRD_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
+        CrdUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -78,13 +79,13 @@ public class KafkaRebalanceCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaRebalance.CRD_NAME, TestUtils.CRD_KAFKA_REBALANCE);
+        CrdUtils.createCrd(client, KafkaRebalance.CRD_NAME, CrdUtils.CRD_KAFKA_REBALANCE);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaRebalance.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaRebalance.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/topic/KafkaTopicCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/topic/KafkaTopicCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,13 +48,13 @@ public class KafkaTopicCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaTopic.CRD_NAME, TestUtils.CRD_TOPIC);
+        CrdUtils.createCrd(client, KafkaTopic.CRD_NAME, CrdUtils.CRD_TOPIC);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaTopic.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaTopic.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/api/src/test/java/io/strimzi/api/kafka/model/user/KafkaUserCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/user/KafkaUserCrdIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.AbstractCrdIT;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,13 +48,13 @@ public class KafkaUserCrdIT extends AbstractCrdIT {
     @BeforeAll
     void setupEnvironment() {
         client = new KubernetesClientBuilder().withConfig(new ConfigBuilder().withNamespace(NAMESPACE).build()).build();
-        TestUtils.createCrd(client, KafkaUser.CRD_NAME, TestUtils.CRD_KAFKA_USER);
+        CrdUtils.createCrd(client, KafkaUser.CRD_NAME, CrdUtils.CRD_KAFKA_USER);
         TestUtils.createNamespace(client, NAMESPACE);
     }
 
     @AfterAll
     void teardownEnvironment() {
-        TestUtils.deleteCrd(client, KafkaUser.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaUser.CRD_NAME);
         TestUtils.deleteNamespace(client, NAMESPACE);
         client.close();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -83,7 +83,6 @@ import io.strimzi.operator.common.auth.PemAuthIdentity;
 import io.strimzi.operator.common.auth.PemTrustSet;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetClientOptions;
@@ -186,7 +185,7 @@ public class ResourceUtils {
         ObjectMeta meta = new ObjectMetaBuilder()
             .withNamespace(namespace)
             .withName(name)
-            .withLabels(Labels.fromMap(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests", "my-user-label", "cromulent")).toMap())
+            .withLabels(Labels.fromMap(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests", "my-user-label", "cromulent")).toMap())
             .build();
         result.setMetadata(meta);
 
@@ -245,7 +244,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .withAnnotations(emptyMap())
                         .build())
@@ -262,7 +261,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -280,7 +279,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -303,7 +302,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -327,7 +326,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()
@@ -350,7 +349,7 @@ public class ResourceUtils {
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(name)
                         .withNamespace(namespace)
-                        .withLabels(TestUtils.map(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
+                        .withLabels(Map.of(Labels.KUBERNETES_DOMAIN + "part-of", "tests",
                                 "my-user-label", "cromulent"))
                         .build())
                 .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -11,7 +11,7 @@ import io.strimzi.api.kafka.model.common.JvmOptions;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
@@ -37,11 +37,11 @@ public class AbstractModelTest {
 
     @ParallelTest
     public void testJvmPerformanceOptions() {
-        JvmOptions opts = TestUtils.fromYamlString("{}", JvmOptions.class);
+        JvmOptions opts = ReadWriteUtils.readObjectFromYamlString("{}", JvmOptions.class);
 
         assertThat(getPerformanceOptions(opts), is(nullValue()));
 
-        opts = TestUtils.fromYamlString("-XX:\n" +
+        opts = ReadWriteUtils.readObjectFromYamlString("-XX:\n" +
                                         "  key1: value1\n" +
                                         "  key2: true\n" +
                                         "  key3: false\n" +

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -564,17 +564,17 @@ public class CruiseControlTest {
     @SuppressWarnings("MethodLength")
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> depAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> depLabels = TestUtils.modifiableMap("l1", "v1", "l2", "v2");
+        Map<String, String> depAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = TestUtils.modifiableMap("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = TestUtils.modifiableMap("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> saLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> saAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> saLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> saAnnotations = Map.of("a7", "v7", "a8", "v8");
 
         Affinity affinity = new AffinityBuilder()
                 .withNewNodeAffinity()
@@ -1183,7 +1183,7 @@ public class CruiseControlTest {
     }
 
     private Map<String, String> expectedLabels(String name) {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME,
+        return TestUtils.modifiableMap(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND,
                 Labels.STRIMZI_NAME_LABEL, name,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityOperatorTest.java
@@ -206,21 +206,21 @@ public class EntityOperatorTest {
 
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> depLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedDepLabels = new HashMap<>(depLabels);
         expectedDepLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> depAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> depAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> saAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> saLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> saAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> rLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> rAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> rLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> rAnnotations = Map.of("a7", "v7", "a8", "v8");
 
         Toleration toleration = new TolerationBuilder()
                 .withEffect("NoSchedule")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityTopicOperatorTest.java
@@ -36,7 +36,6 @@ import static io.strimzi.operator.cluster.model.EntityTopicOperator.CRUISE_CONTR
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_PASSWORD_KEY;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_USERNAME;
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties.TOPIC_OPERATOR_USERNAME_KEY;
-import static io.strimzi.test.TestUtils.map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -250,7 +249,7 @@ public class EntityTopicOperatorTest {
         assertThat(container.getPorts().get(0).getContainerPort(), is(EntityTopicOperator.HEALTHCHECK_PORT));
         assertThat(container.getPorts().get(0).getName(), is(EntityTopicOperator.HEALTHCHECK_PORT_NAME));
         assertThat(container.getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(map(
+        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
                 EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,
@@ -318,7 +317,7 @@ public class EntityTopicOperatorTest {
         assertThat(entityTopicOperator.getEnvVars(), is(expectedEnvVars));
 
         Container container = entityTopicOperator.createContainer(null);
-        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(map(
+        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
             EntityTopicOperator.TOPIC_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
             "entity-topic-operator-metrics-and-logging", "/opt/topic-operator/custom-config/",
             EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/EntityUserOperatorTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static io.strimzi.test.TestUtils.map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -230,7 +229,7 @@ public class EntityUserOperatorTest {
         assertThat(container.getPorts().get(0).getContainerPort(), is(EntityUserOperator.HEALTHCHECK_PORT));
         assertThat(container.getPorts().get(0).getName(), is(EntityUserOperator.HEALTHCHECK_PORT_NAME));
         assertThat(container.getPorts().get(0).getProtocol(), is("TCP"));
-        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(map(
+        assertThat(EntityOperatorTest.volumeMounts(container.getVolumeMounts()), is(Map.of(
                 EntityUserOperator.USER_OPERATOR_TMP_DIRECTORY_DEFAULT_VOLUME_NAME, VolumeUtils.STRIMZI_TMP_DIRECTORY_DEFAULT_MOUNT_PATH,
                 "entity-user-operator-metrics-and-logging", "/opt/user-operator/custom-config/",
                 EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_NAME, EntityOperator.TLS_SIDECAR_CA_CERTS_VOLUME_MOUNT,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBridgeClusterTest.java
@@ -131,7 +131,7 @@ public class KafkaBridgeClusterTest {
     private final KafkaBridgeCluster kbc = KafkaBridgeCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resource, SHARED_ENV_PROVIDER);
 
     private Map<String, String> expectedLabels(String name)    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+        return TestUtils.modifiableMap(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaBridgeCluster.COMPONENT_TYPE,
@@ -425,24 +425,24 @@ public class KafkaBridgeClusterTest {
     @ParallelTest
     @SuppressWarnings({"checkstyle:methodlength"})
     public void testTemplate() {
-        Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> depLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedDepLabels = new HashMap<>(depLabels);
         expectedDepLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> depAnots = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> depAnots = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnots = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnots = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> pdbLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> pdbAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> pdbLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> pdbAnots = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> saLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> saAnots = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> saLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> saAnots = Map.of("a9", "v9", "a10", "v10");
 
         Affinity affinity = new AffinityBuilder()
                 .withNewNodeAffinity()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -142,29 +142,29 @@ public class KafkaClusterListenersTest {
     @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelTest
     public void testListenersTemplate() {
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> hSvcAnnotations = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> exSvcLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> exSvcAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> exSvcLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> exSvcAnnotations = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> perPodSvcLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> perPodSvcAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> perPodSvcLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> perPodSvcAnnotations = Map.of("a11", "v11", "a12", "v12");
 
-        Map<String, String> exRouteLabels = TestUtils.map("l13", "v13", "l14", "v14");
-        Map<String, String> exRouteAnnotations = TestUtils.map("a13", "v13", "a14", "v14");
+        Map<String, String> exRouteLabels = Map.of("l13", "v13", "l14", "v14");
+        Map<String, String> exRouteAnnotations = Map.of("a13", "v13", "a14", "v14");
 
-        Map<String, String> perPodRouteLabels = TestUtils.map("l15", "v15", "l16", "v16");
-        Map<String, String> perPodRouteAnnotations = TestUtils.map("a15", "v15", "a16", "v16");
+        Map<String, String> perPodRouteLabels = Map.of("l15", "v15", "l16", "v16");
+        Map<String, String> perPodRouteAnnotations = Map.of("a15", "v15", "a16", "v16");
 
-        Map<String, String> exIngressLabels = TestUtils.map("l17", "v17", "l18", "v18");
-        Map<String, String> exIngressAnnotations = TestUtils.map("a17", "v17", "a18", "v18");
+        Map<String, String> exIngressLabels = Map.of("l17", "v17", "l18", "v18");
+        Map<String, String> exIngressAnnotations = Map.of("a17", "v17", "a18", "v18");
 
-        Map<String, String> perPodIngressLabels = TestUtils.map("l19", "v19", "l20", "v20");
-        Map<String, String> perPodIngressAnnotations = TestUtils.map("a19", "v19", "a20", "v20");
+        Map<String, String> perPodIngressLabels = Map.of("l19", "v19", "l20", "v20");
+        Map<String, String> perPodIngressAnnotations = Map.of("a19", "v19", "a20", "v20");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -338,39 +338,39 @@ public class KafkaClusterListenersTest {
     @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelTest
     public void testListenersTemplateFromKafkaAndNodePools() {
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> hSvcAnnotations = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> exSvcLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> exSvcAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> exSvcLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> exSvcAnnotations = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> perPodSvcLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> perPodSvcAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> perPodSvcLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> perPodSvcAnnotations = Map.of("a11", "v11", "a12", "v12");
 
-        Map<String, String> exRouteLabels = TestUtils.map("l13", "v13", "l14", "v14");
-        Map<String, String> exRouteAnnotations = TestUtils.map("a13", "v13", "a14", "v14");
+        Map<String, String> exRouteLabels = Map.of("l13", "v13", "l14", "v14");
+        Map<String, String> exRouteAnnotations = Map.of("a13", "v13", "a14", "v14");
 
-        Map<String, String> perPodRouteLabels = TestUtils.map("l15", "v15", "l16", "v16");
-        Map<String, String> perPodRouteAnnotations = TestUtils.map("a15", "v15", "a16", "v16");
+        Map<String, String> perPodRouteLabels = Map.of("l15", "v15", "l16", "v16");
+        Map<String, String> perPodRouteAnnotations = Map.of("a15", "v15", "a16", "v16");
 
-        Map<String, String> exIngressLabels = TestUtils.map("l17", "v17", "l18", "v18");
-        Map<String, String> exIngressAnnotations = TestUtils.map("a17", "v17", "a18", "v18");
+        Map<String, String> exIngressLabels = Map.of("l17", "v17", "l18", "v18");
+        Map<String, String> exIngressAnnotations = Map.of("a17", "v17", "a18", "v18");
 
-        Map<String, String> perPodIngressLabels = TestUtils.map("l19", "v19", "l20", "v20");
-        Map<String, String> perPodIngressAnnotations = TestUtils.map("a19", "v19", "a20", "v20");
+        Map<String, String> perPodIngressLabels = Map.of("l19", "v19", "l20", "v20");
+        Map<String, String> perPodIngressAnnotations = Map.of("a19", "v19", "a20", "v20");
 
         // Node pool values
-        Map<String, String> perPodSvcLabels2 = TestUtils.map("l21", "v21", "l22", "v22");
-        Map<String, String> perPodSvcAnnotations2 = TestUtils.map("a21", "v21", "a22", "v22");
+        Map<String, String> perPodSvcLabels2 = Map.of("l21", "v21", "l22", "v22");
+        Map<String, String> perPodSvcAnnotations2 = Map.of("a21", "v21", "a22", "v22");
 
-        Map<String, String> perPodRouteLabels2 = TestUtils.map("l25", "v25", "l26", "v26");
-        Map<String, String> perPodRouteAnnotations2 = TestUtils.map("a25", "v25", "a26", "v26");
+        Map<String, String> perPodRouteLabels2 = Map.of("l25", "v25", "l26", "v26");
+        Map<String, String> perPodRouteAnnotations2 = Map.of("a25", "v25", "a26", "v26");
 
-        Map<String, String> perPodIngressLabels2 = TestUtils.map("l29", "v29", "l30", "v30");
-        Map<String, String> perPodIngressAnnotations2 = TestUtils.map("a29", "v29", "a30", "v30");
+        Map<String, String> perPodIngressLabels2 = Map.of("l29", "v29", "l30", "v30");
+        Map<String, String> perPodIngressAnnotations2 = Map.of("a29", "v29", "a30", "v30");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -597,14 +597,14 @@ public class KafkaClusterListenersTest {
     @ParallelTest
     public void testListenersTemplateFromNodePools() {
         // Node pool values
-        Map<String, String> perPodSvcLabels2 = TestUtils.map("l21", "v21", "l22", "v22");
-        Map<String, String> perPodSvcAnnotations2 = TestUtils.map("a21", "v21", "a22", "v22");
+        Map<String, String> perPodSvcLabels2 = Map.of("l21", "v21", "l22", "v22");
+        Map<String, String> perPodSvcAnnotations2 = Map.of("a21", "v21", "a22", "v22");
 
-        Map<String, String> perPodRouteLabels2 = TestUtils.map("l25", "v25", "l26", "v26");
-        Map<String, String> perPodRouteAnnotations2 = TestUtils.map("a25", "v25", "a26", "v26");
+        Map<String, String> perPodRouteLabels2 = Map.of("l25", "v25", "l26", "v26");
+        Map<String, String> perPodRouteAnnotations2 = Map.of("a25", "v25", "a26", "v26");
 
-        Map<String, String> perPodIngressLabels2 = TestUtils.map("l29", "v29", "l30", "v30");
-        Map<String, String> perPodIngressAnnotations2 = TestUtils.map("a29", "v29", "a30", "v30");
+        Map<String, String> perPodIngressLabels2 = Map.of("l29", "v29", "l30", "v30");
+        Map<String, String> perPodIngressAnnotations2 = Map.of("a29", "v29", "a30", "v30");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -993,17 +993,17 @@ public class KafkaClusterTest {
 
     @ParallelTest
     public void testAuxiliaryResourcesTemplate() {
-        Map<String, String> pdbLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> pdbAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> pdbLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> pdbAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> crbLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> crbAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> crbLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> crbAnnotations = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> saAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> saLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> saAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> jmxLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> jmxAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> jmxLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> jmxAnnotations = Map.of("a7", "v7", "a8", "v8");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -1889,8 +1889,8 @@ public class KafkaClusterTest {
 
     @ParallelTest
     public void testCustomizedPodDisruptionBudget()   {
-        Map<String, String> pdbLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> pdbAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> pdbLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> pdbAnnotations = Map.of("a1", "v1", "a2", "v2");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -3774,11 +3774,11 @@ public class KafkaClusterTest {
     @ParallelTest
     public void testCustomizedPodSet()   {
         // Prepare various template values
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> spsAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")
@@ -4040,17 +4040,17 @@ public class KafkaClusterTest {
     @ParallelTest
     public void testCustomizedPodSetInKafkaAndNodePool()   {
         // Prepare various template values
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> spsAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> poolSpsLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> poolSpsAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> poolSpsLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> poolSpsAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> poolPodLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> poolPodAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> poolPodLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> poolPodAnnotations = Map.of("a7", "v7", "a8", "v8");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")
@@ -4435,11 +4435,11 @@ public class KafkaClusterTest {
     @ParallelTest
     public void testCustomizedPodSetInNodePool()   {
         // Prepare various template values
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> spsAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
@@ -124,7 +124,6 @@ import java.util.stream.IntStream;
 
 import static io.strimzi.operator.cluster.model.jmx.JmxModel.JMX_PORT;
 import static io.strimzi.operator.cluster.model.jmx.JmxModel.JMX_PORT_NAME;
-import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -555,32 +554,32 @@ public class KafkaClusterZooBasedTest {
     @SuppressWarnings({"checkstyle:MethodLength"})
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> hSvcAnnotations = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> exSvcLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> exSvcAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> exSvcLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> exSvcAnnotations = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> perPodSvcLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> perPodSvcAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> perPodSvcLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> perPodSvcAnnotations = Map.of("a11", "v11", "a12", "v12");
 
-        Map<String, String> exRouteLabels = TestUtils.map("l13", "v13", "l14", "v14");
-        Map<String, String> exRouteAnnotations = TestUtils.map("a13", "v13", "a14", "v14");
+        Map<String, String> exRouteLabels = Map.of("l13", "v13", "l14", "v14");
+        Map<String, String> exRouteAnnotations = Map.of("a13", "v13", "a14", "v14");
 
-        Map<String, String> perPodRouteLabels = TestUtils.map("l15", "v15", "l16", "v16");
-        Map<String, String> perPodRouteAnnotations = TestUtils.map("a15", "v15", "a16", "v16");
+        Map<String, String> perPodRouteLabels = Map.of("l15", "v15", "l16", "v16");
+        Map<String, String> perPodRouteAnnotations = Map.of("a15", "v15", "a16", "v16");
 
-        Map<String, String> pdbLabels = TestUtils.map("l17", "v17", "l18", "v18");
-        Map<String, String> pdbAnnotations = TestUtils.map("a17", "v17", "a18", "v18");
+        Map<String, String> pdbLabels = Map.of("l17", "v17", "l18", "v18");
+        Map<String, String> pdbAnnotations = Map.of("a17", "v17", "a18", "v18");
 
-        Map<String, String> crbLabels = TestUtils.map("l19", "v19", "l20", "v20");
-        Map<String, String> crbAnnotations = TestUtils.map("a19", "v19", "a20", "v20");
+        Map<String, String> crbLabels = Map.of("l19", "v19", "l20", "v20");
+        Map<String, String> crbAnnotations = Map.of("a19", "v19", "a20", "v20");
 
-        Map<String, String> saLabels = TestUtils.map("l21", "v21", "l22", "v22");
-        Map<String, String> saAnnotations = TestUtils.map("a21", "v21", "a22", "v22");
+        Map<String, String> saLabels = Map.of("l21", "v21", "l22", "v22");
+        Map<String, String> saAnnotations = Map.of("a21", "v21", "a22", "v22");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -1520,7 +1519,7 @@ public class KafkaClusterZooBasedTest {
 
     @ParallelTest
     public void testPvcsWithSetStorageSelector() {
-        Map<String, String> selector = TestUtils.map("foo", "bar");
+        Map<String, String> selector = Map.of("foo", "bar");
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
@@ -2401,13 +2400,13 @@ public class KafkaClusterZooBasedTest {
     @ParallelTest
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateBrokerSecret(null, emptyMap());
-        assertThat(secret.getData().keySet(), is(set(
+        assertThat(secret.getData().keySet(), is(Set.of(
                 "foo-kafka-0.crt",  "foo-kafka-0.key",
                 "foo-kafka-1.crt", "foo-kafka-1.key",
                 "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
-        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(Set.of(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
                 asList(2, "foo-kafka-bootstrap"),
@@ -2428,13 +2427,13 @@ public class KafkaClusterZooBasedTest {
         externalAddresses.put(2, Collections.singleton("123.10.125.132"));
 
         Secret secret = generateBrokerSecret(Collections.singleton("123.10.125.140"), externalAddresses);
-        assertThat(secret.getData().keySet(), is(set(
+        assertThat(secret.getData().keySet(), is(Set.of(
                 "foo-kafka-0.crt",  "foo-kafka-0.key",
                 "foo-kafka-1.crt", "foo-kafka-1.key",
                 "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
-        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(Set.of(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
                 asList(2, "foo-kafka-bootstrap"),
@@ -2452,18 +2451,18 @@ public class KafkaClusterZooBasedTest {
     @ParallelTest
     public void testGenerateBrokerSecretExternalWithManyDNS() throws CertificateParsingException {
         Map<Integer, Set<String>> externalAddresses = new HashMap<>();
-        externalAddresses.put(0, TestUtils.set("123.10.125.130", "my-broker-0"));
-        externalAddresses.put(1, TestUtils.set("123.10.125.131", "my-broker-1"));
-        externalAddresses.put(2, TestUtils.set("123.10.125.132", "my-broker-2"));
+        externalAddresses.put(0, Set.of("123.10.125.130", "my-broker-0"));
+        externalAddresses.put(1, Set.of("123.10.125.131", "my-broker-1"));
+        externalAddresses.put(2, Set.of("123.10.125.132", "my-broker-2"));
 
-        Secret secret = generateBrokerSecret(TestUtils.set("123.10.125.140", "my-bootstrap"), externalAddresses);
-        assertThat(secret.getData().keySet(), is(set(
+        Secret secret = generateBrokerSecret(Set.of("123.10.125.140", "my-bootstrap"), externalAddresses);
+        assertThat(secret.getData().keySet(), is(Set.of(
                 "foo-kafka-0.crt",  "foo-kafka-0.key",
                 "foo-kafka-1.crt", "foo-kafka-1.key",
                 "foo-kafka-2.crt", "foo-kafka-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-kafka-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-kafka,O=io.strimzi"));
-        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(Set.of(
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc.cluster.local"),
                 asList(2, "foo-kafka-0.foo-kafka-brokers.test.svc"),
                 asList(2, "foo-kafka-bootstrap"),
@@ -2708,8 +2707,8 @@ public class KafkaClusterZooBasedTest {
 
     @ParallelTest
     public void testCustomizedPodDisruptionBudget()   {
-        Map<String, String> pdbLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> pdbAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> pdbLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> pdbAnnotations = Map.of("a1", "v1", "a2", "v2");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -4277,11 +4276,11 @@ public class KafkaClusterZooBasedTest {
     @ParallelTest
     public void testCustomizedPodSet()   {
         // Prepare various template values
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> spsAnnotations = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnotations = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnotations = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnotations = Map.of("a3", "v3", "a4", "v4");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectBuildTest.java
@@ -197,7 +197,7 @@ public class KafkaConnectBuildTest {
         assertThat(pod.getMetadata().getName(), is(KafkaConnectResources.buildPodName(cluster)));
         assertThat(pod.getMetadata().getNamespace(), is(namespace));
 
-        Map<String, String> expectedDeploymentLabels = TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
@@ -325,7 +325,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(cluster)));
         assertThat(bc.getMetadata().getNamespace(), is(namespace));
 
-        Map<String, String> expectedDeploymentLabels = TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
@@ -407,7 +407,7 @@ public class KafkaConnectBuildTest {
         assertThat(bc.getMetadata().getName(), is(KafkaConnectResources.buildConfigName(cluster)));
         assertThat(bc.getMetadata().getNamespace(), is(namespace));
 
-        Map<String, String> expectedDeploymentLabels = TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+        Map<String, String> expectedDeploymentLabels = Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 Labels.STRIMZI_NAME_LABEL, KafkaConnectResources.buildPodName(cluster),
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
                 Labels.STRIMZI_COMPONENT_TYPE_LABEL, KafkaConnectBuild.COMPONENT_TYPE,
@@ -425,14 +425,14 @@ public class KafkaConnectBuildTest {
 
     @ParallelTest
     public void testTemplate()   {
-        Map<String, String> buildPodLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> buildPodAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> buildPodLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> buildPodAnnos = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> buildConfigLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> buildConfigAnnos = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> buildConfigLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> buildConfigAnnos = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> saAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> saLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> saAnots = Map.of("a5", "v5", "a6", "v6");
 
         SecretVolumeSource secret = new SecretVolumeSourceBuilder()
                 .withSecretName("secret1")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -77,6 +77,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -141,7 +142,7 @@ public class KafkaConnectClusterTest {
 
     private final KafkaConnect resource = new KafkaConnectBuilder(ResourceUtils.createEmptyKafkaConnect(namespace, clusterName))
             .withNewSpec()
-                .withConfig((Map<String, Object>) TestUtils.fromYamlString(configurationJson, Map.class))
+                .withConfig((Map<String, Object>) ReadWriteUtils.readObjectFromYamlString(configurationJson, Map.class))
                 .withImage(image)
                 .withReplicas(replicas)
                 .withReadinessProbe(new Probe(healthDelay, healthTimeout))
@@ -169,7 +170,7 @@ public class KafkaConnectClusterTest {
     }
 
     private Map<String, String> expectedLabels(String name)    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.clusterName,
+        return TestUtils.modifiableMap(Labels.STRIMZI_CLUSTER_LABEL, this.clusterName,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.STRIMZI_KIND_LABEL, KafkaConnect.RESOURCE_KIND,
@@ -716,27 +717,27 @@ public class KafkaConnectClusterTest {
     @ParallelTest
     @SuppressWarnings({"checkstyle:methodlength"})
     public void testTemplate() {
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedDepLabels = new HashMap<>(spsLabels);
         expectedDepLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> spsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsAnnos = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnots = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnots = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> pdbLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> pdbAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> pdbLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> pdbAnots = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> crbLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> crbAnots = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> crbLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> crbAnots = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> saLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> saAnots = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> saLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> saAnots = Map.of("a11", "v11", "a12", "v12");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaExporterTest.java
@@ -298,18 +298,18 @@ public class KafkaExporterTest {
 
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> depLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedDepLabels = new HashMap<>(depLabels);
         expectedDepLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> depAnots = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> depAnots = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnots = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> saLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> saAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> saLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> saAnots = Map.of("a5", "v5", "a6", "v6");
 
         Affinity affinity = new AffinityBuilder()
                 .withNewNodeAffinity()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -72,6 +72,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -132,7 +133,7 @@ public class KafkaMirrorMaker2ClusterTest {
     private final KafkaMirrorMaker2ClusterSpec targetCluster = new KafkaMirrorMaker2ClusterSpecBuilder()
             .withAlias(targetClusterAlias)
             .withBootstrapServers(bootstrapServers)
-            .withConfig((Map<String, Object>) TestUtils.fromYamlString(configurationJson, Map.class))
+            .withConfig((Map<String, Object>) ReadWriteUtils.readObjectFromYamlString(configurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMaker2 resource = new KafkaMirrorMaker2Builder(ResourceUtils.createEmptyKafkaMirrorMaker2(namespace, clusterName))
@@ -171,7 +172,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     private Map<String, String> expectedLabels(String name)    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.clusterName,
+        return Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.clusterName,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_NAME_LABEL, name,
                 Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker2.RESOURCE_KIND,
@@ -901,27 +902,27 @@ public class KafkaMirrorMaker2ClusterTest {
     @ParallelTest
     @SuppressWarnings({"checkstyle:methodlength"})
     public void testTemplate() {
-        Map<String, String> podSetLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> podSetLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedPodSetLabels = new HashMap<>(podSetLabels);
         expectedPodSetLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> podSetAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> podSetAnnos = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnots = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnots = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> pdbLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> pdbAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> pdbLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> pdbAnots = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> crbLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> crbAnots = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> crbLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> crbAnots = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> saLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> saAnots = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> saLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> saAnots = Map.of("a11", "v11", "a12", "v12");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMakerClusterTest.java
@@ -50,6 +50,7 @@ import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
 import io.strimzi.plugin.security.profiles.impl.RestrictedPodSecurityProvider;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
@@ -104,7 +105,7 @@ public class KafkaMirrorMakerClusterTest {
     private final KafkaMirrorMakerProducerSpec producer = new KafkaMirrorMakerProducerSpecBuilder()
             .withBootstrapServers(producerBootstrapServers)
             .withAbortOnSendFailure(abortOnSendFailure)
-            .withConfig((Map<String, Object>) TestUtils.fromYamlString(producerConfigurationJson, Map.class))
+            .withConfig((Map<String, Object>) ReadWriteUtils.readObjectFromYamlString(producerConfigurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMakerConsumerSpec consumer = new KafkaMirrorMakerConsumerSpecBuilder()
@@ -112,7 +113,7 @@ public class KafkaMirrorMakerClusterTest {
             .withGroupId(groupId)
             .withNumStreams(numStreams)
             .withOffsetCommitInterval(offsetCommitInterval)
-            .withConfig((Map<String, Object>) TestUtils.fromYamlString(consumerConfigurationJson, Map.class))
+            .withConfig((Map<String, Object>) ReadWriteUtils.readObjectFromYamlString(consumerConfigurationJson, Map.class))
             .build();
 
     private final KafkaMirrorMaker resource = new KafkaMirrorMakerBuilder(ResourceUtils.createEmptyKafkaMirrorMaker(namespace, cluster))
@@ -144,7 +145,7 @@ public class KafkaMirrorMakerClusterTest {
     }
 
     private Map<String, String> expectedLabels(String name)    {
-        return TestUtils.map(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+        return Map.of(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
                 "my-user-label", "cromulent",
                 Labels.STRIMZI_KIND_LABEL, KafkaMirrorMaker.RESOURCE_KIND,
                 Labels.STRIMZI_NAME_LABEL, name,
@@ -563,21 +564,21 @@ public class KafkaMirrorMakerClusterTest {
 
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> depLabels = TestUtils.map("l1", "v1", "l2", "v2",
+        Map<String, String> depLabels = Map.of("l1", "v1", "l2", "v2",
                 Labels.KUBERNETES_PART_OF_LABEL, "custom-part",
                 Labels.KUBERNETES_MANAGED_BY_LABEL, "custom-managed-by");
         Map<String, String> expectedDepLabels = new HashMap<>(depLabels);
         expectedDepLabels.remove(Labels.KUBERNETES_MANAGED_BY_LABEL);
-        Map<String, String> depAnots = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> depAnots = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnots = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnots = Map.of("a3", "v3", "a4", "v4");
 
-        Map<String, String> pdbLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> pdbAnots = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> pdbLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> pdbAnots = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> saLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> saAnots = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> saLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> saAnots = Map.of("a7", "v7", "a8", "v8");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterPodSetTest.java
@@ -142,11 +142,11 @@ public class ZookeeperClusterPodSetTest {
     @ParallelTest
     public void testCustomizedPodSet()   {
         // Prepare various template values
-        Map<String, String> spsLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> spsAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> spsLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> spsAnnos = Map.of("a1", "v1", "a2", "v2");
 
-        Map<String, String> podLabels = TestUtils.map("l3", "v3", "l4", "v4");
-        Map<String, String> podAnnos = TestUtils.map("a3", "v3", "a4", "v4");
+        Map<String, String> podLabels = Map.of("l3", "v3", "l4", "v4");
+        Map<String, String> podAnnos = Map.of("a3", "v3", "a4", "v4");
 
         HostAlias hostAlias1 = new HostAliasBuilder()
                 .withHostnames("my-host-1", "my-host-2")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -64,10 +64,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.strimzi.operator.cluster.model.jmx.JmxModel.JMX_PORT;
 import static io.strimzi.operator.cluster.model.jmx.JmxModel.JMX_PORT_NAME;
-import static io.strimzi.test.TestUtils.set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -405,13 +405,13 @@ public class ZookeeperClusterTest {
     @ParallelTest
     public void testGenerateBrokerSecret() throws CertificateParsingException {
         Secret secret = generateCertificatesSecret();
-        assertThat(secret.getData().keySet(), is(set(
+        assertThat(secret.getData().keySet(), is(Set.of(
                 "foo-zookeeper-0.crt",  "foo-zookeeper-0.key",
                 "foo-zookeeper-1.crt", "foo-zookeeper-1.key",
                 "foo-zookeeper-2.crt", "foo-zookeeper-2.key")));
         X509Certificate cert = Ca.cert(secret, "foo-zookeeper-0.crt");
         assertThat(cert.getSubjectX500Principal().getName(), is("CN=foo-zookeeper,O=io.strimzi"));
-        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(set(
+        assertThat(new HashSet<Object>(cert.getSubjectAlternativeNames()), is(Set.of(
                 asList(2, "foo-zookeeper-0"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc"),
                 asList(2, "foo-zookeeper-0.foo-zookeeper-nodes.test.svc.cluster.local"),
@@ -427,17 +427,17 @@ public class ZookeeperClusterTest {
 
     @ParallelTest
     public void testTemplate() {
-        Map<String, String> svcLabels = TestUtils.map("l5", "v5", "l6", "v6");
-        Map<String, String> svcAnnotations = TestUtils.map("a5", "v5", "a6", "v6");
+        Map<String, String> svcLabels = Map.of("l5", "v5", "l6", "v6");
+        Map<String, String> svcAnnotations = Map.of("a5", "v5", "a6", "v6");
 
-        Map<String, String> hSvcLabels = TestUtils.map("l7", "v7", "l8", "v8");
-        Map<String, String> hSvcAnnotations = TestUtils.map("a7", "v7", "a8", "v8");
+        Map<String, String> hSvcLabels = Map.of("l7", "v7", "l8", "v8");
+        Map<String, String> hSvcAnnotations = Map.of("a7", "v7", "a8", "v8");
 
-        Map<String, String> pdbLabels = TestUtils.map("l9", "v9", "l10", "v10");
-        Map<String, String> pdbAnnotations = TestUtils.map("a9", "v9", "a10", "v10");
+        Map<String, String> pdbLabels = Map.of("l9", "v9", "l10", "v10");
+        Map<String, String> pdbAnnotations = Map.of("a9", "v9", "a10", "v10");
 
-        Map<String, String> saLabels = TestUtils.map("l11", "v11", "l12", "v12");
-        Map<String, String> saAnnotations = TestUtils.map("a11", "v11", "a12", "v12");
+        Map<String, String> saLabels = Map.of("l11", "v11", "l12", "v12");
+        Map<String, String> saAnnotations = Map.of("a11", "v11", "a12", "v12");
 
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -1009,8 +1009,8 @@ public class ZookeeperClusterTest {
 
     @ParallelTest
     public void testCustomizedPodDisruptionBudget()   {
-        Map<String, String> pdbLabels = TestUtils.map("l1", "v1", "l2", "v2");
-        Map<String, String> pdbAnnos = TestUtils.map("a1", "v1", "a2", "v2");
+        Map<String, String> pdbLabels = Map.of("l1", "v1", "l2", "v2");
+        Map<String, String> pdbAnnos = Map.of("a1", "v1", "a2", "v2");
 
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -45,6 +45,7 @@ import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -86,7 +87,6 @@ import static io.strimzi.operator.common.model.Ca.CA_CRT;
 import static io.strimzi.operator.common.model.Ca.CA_KEY;
 import static io.strimzi.operator.common.model.Ca.CA_STORE;
 import static io.strimzi.operator.common.model.Ca.CA_STORE_PASSWORD;
-import static io.strimzi.test.TestUtils.set;
 import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -301,12 +301,12 @@ public class CaReconcilerTest {
             .onComplete(context.succeeding(c -> context.verify(() -> {
                 assertThat(c.getAllValues(), hasSize(4));
 
-                assertThat(c.getAllValues().get(0).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(c.getAllValues().get(0).getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 assertThat(isCertInTrustStore(CA_CRT, c.getAllValues().get(0).getData()), is(true));
 
                 assertThat(c.getAllValues().get(1).getData().keySet(), is(singleton(CA_KEY)));
 
-                assertThat(c.getAllValues().get(2).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(c.getAllValues().get(2).getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 assertThat(isCertInTrustStore(CA_CRT, c.getAllValues().get(2).getData()), is(true));
 
                 assertThat(c.getAllValues().get(3).getData().keySet(), is(singleton(CA_KEY)));
@@ -351,7 +351,7 @@ public class CaReconcilerTest {
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
 
         Map<String, String> clusterCaCertData = initialClusterCaCertSecret.getData();
-        assertThat(clusterCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(clusterCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(clusterCaCertData.get(CA_CRT), is(notNullValue()));
         assertThat(clusterCaCertData.get(CA_STORE), is(notNullValue()));
         assertThat(clusterCaCertData.get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -366,7 +366,7 @@ public class CaReconcilerTest {
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
 
         Map<String, String> clientsCaCertData = initialClientsCaCertSecret.getData();
-        assertThat(clientsCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(clientsCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(clientsCaCertData.get(CA_CRT), is(notNullValue()));
         assertThat(clientsCaCertData.get(CA_STORE), is(notNullValue()));
         assertThat(clientsCaCertData.get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -386,18 +386,18 @@ public class CaReconcilerTest {
         reconcileCa(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.succeeding(c -> context.verify(() -> {
 
-                assertThat(c.getAllValues().get(0).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(c.getAllValues().get(0).getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 assertThat(c.getAllValues().get(0).getData().get(CA_CRT), is(initialClusterCaCertSecret.getData().get(CA_CRT)));
                 assertThat(x509Certificate(initialClusterCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, c.getAllValues().get(0).getData())));
 
-                assertThat(c.getAllValues().get(1).getData().keySet(), is(set(CA_KEY)));
+                assertThat(c.getAllValues().get(1).getData().keySet(), is(Set.of(CA_KEY)));
                 assertThat(c.getAllValues().get(1).getData().get(CA_KEY), is(initialClusterCaKeySecret.getData().get(CA_KEY)));
 
-                assertThat(c.getAllValues().get(2).getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(c.getAllValues().get(2).getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 assertThat(c.getAllValues().get(2).getData().get(CA_CRT), is(initialClientsCaCertSecret.getData().get(CA_CRT)));
                 assertThat(x509Certificate(initialClientsCaCertSecret.getData().get(CA_CRT)), is(getCertificateFromTrustStore(CA_CRT, c.getAllValues().get(2).getData())));
 
-                assertThat(c.getAllValues().get(3).getData().keySet(), is(set(CA_KEY)));
+                assertThat(c.getAllValues().get(3).getData().keySet(), is(Set.of(CA_KEY)));
                 assertThat(c.getAllValues().get(3).getData().get(CA_KEY), is(initialClientsCaKeySecret.getData().get(CA_KEY)));
                 async.flag();
             })));
@@ -437,7 +437,7 @@ public class CaReconcilerTest {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
-                assertThat(clusterCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clusterCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
 
                 X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
                 String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
@@ -458,7 +458,7 @@ public class CaReconcilerTest {
                 assertThat(newClusterCaKey, is(initialClusterCaKeySecret.getData().get(CA_KEY)));
 
                 Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
-                assertThat(clientsCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clientsCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
 
                 X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
                 String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
@@ -490,7 +490,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -501,7 +501,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -520,7 +520,7 @@ public class CaReconcilerTest {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
-                assertThat(clusterCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clusterCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
                 String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
                 String newClusterCaCertStore = clusterCaCertData.remove(CA_STORE);
@@ -540,7 +540,7 @@ public class CaReconcilerTest {
                 assertThat(newClusterCaKey, is(initialClusterCaKeySecret.getData().get(CA_KEY)));
 
                 Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
-                assertThat(clientsCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clientsCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
 
                 X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
                 String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
@@ -584,7 +584,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -595,7 +595,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -614,7 +614,7 @@ public class CaReconcilerTest {
                 assertThat(c.getAllValues(), hasSize(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
-                assertThat(clusterCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clusterCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
                 assertThat(c.getAllValues().get(0).getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
                 String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
@@ -636,7 +636,7 @@ public class CaReconcilerTest {
                 assertThat(newClusterCaKey, is(initialClusterCaKeySecret.getData().get(CA_KEY)));
 
                 Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
-                assertThat(clientsCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clientsCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
                 assertThat(c.getAllValues().get(2).getMetadata().getAnnotations().get(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION), is("0"));
                 String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
@@ -681,7 +681,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -692,7 +692,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -711,7 +711,7 @@ public class CaReconcilerTest {
                 assertThat(c.getAllValues().size(), is(4));
 
                 Map<String, String> clusterCaCertData = c.getAllValues().get(0).getData();
-                assertThat(clusterCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clusterCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 X509Certificate newX509ClusterCaCertStore = getCertificateFromTrustStore(CA_CRT, clusterCaCertData);
                 assertThat(c.getAllValues().get(0).getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
                 String newClusterCaCert = clusterCaCertData.remove(CA_CRT);
@@ -733,7 +733,7 @@ public class CaReconcilerTest {
                 assertThat(newClusterCaKey, is(initialClusterCaKeySecret.getData().get(CA_KEY)));
 
                 Map<String, String> clientsCaCertData = c.getAllValues().get(2).getData();
-                assertThat(clientsCaCertData.keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+                assertThat(clientsCaCertData.keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
                 X509Certificate newX509ClientsCaCertStore = getCertificateFromTrustStore(CA_CRT, clientsCaCertData);
                 assertThat(c.getAllValues().get(2).getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
                 String newClientsCaCert = clientsCaCertData.remove(CA_CRT);
@@ -770,7 +770,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -781,7 +781,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -881,7 +881,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -892,7 +892,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -977,7 +977,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -988,7 +988,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -1088,14 +1088,14 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
         assertThat(isCertInTrustStore(CA_CRT, initialClusterCaCertSecret.getData()), is(true));
 
         // add an expired certificate to the secret ...
-        String clusterCert = Objects.requireNonNull(TestUtils.readResource(getClass(), "cluster-ca.crt"));
+        String clusterCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "cluster-ca.crt"));
         String encodedClusterCert = Base64.getEncoder().encodeToString(clusterCert.getBytes(StandardCharsets.UTF_8));
         initialClusterCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClusterCert);
 
@@ -1116,14 +1116,14 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
         assertThat(isCertInTrustStore(CA_CRT, initialClientsCaCertSecret.getData()), is(true));
 
         // add an expired certificate to the secret ...
-        String clientCert = Objects.requireNonNull(TestUtils.readResource(getClass(), "clients-ca.crt"));
+        String clientCert = Objects.requireNonNull(ReadWriteUtils.readFileFromResources(getClass(), "clients-ca.crt"));
         String encodedClientCert = Base64.getEncoder().encodeToString(clientCert.getBytes(StandardCharsets.UTF_8));
         initialClientsCaCertSecret.getData().put("ca-2018-07-01T09-00-00.crt", encodedClientCert);
 
@@ -1187,7 +1187,7 @@ public class CaReconcilerTest {
         List<Secret> clusterCaSecrets = initialClusterCaSecrets(certificateAuthority);
         Secret initialClusterCaKeySecret = clusterCaSecrets.get(0);
         Secret initialClusterCaCertSecret = clusterCaSecrets.get(1);
-        assertThat(initialClusterCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClusterCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClusterCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClusterCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -1198,7 +1198,7 @@ public class CaReconcilerTest {
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
         Secret initialClientsCaKeySecret = clientsCaSecrets.get(0);
         Secret initialClientsCaCertSecret = clientsCaSecrets.get(1);
-        assertThat(initialClientsCaCertSecret.getData().keySet(), is(set(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
+        assertThat(initialClientsCaCertSecret.getData().keySet(), is(Set.of(CA_CRT, CA_STORE, CA_STORE_PASSWORD)));
         assertThat(initialClientsCaCertSecret.getData().get(CA_CRT), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE), is(notNullValue()));
         assertThat(initialClientsCaCertSecret.getData().get(CA_STORE_PASSWORD), is(notNullValue()));
@@ -1356,8 +1356,8 @@ public class CaReconcilerTest {
                     assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(1));
                     assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(1));
 
-                    assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
-                    assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
+                    TestUtils.checkOwnerReference(clientsCaCertSecret, kafka);
+                    TestUtils.checkOwnerReference(clientsCaKeySecret, kafka);
 
                     async.flag();
                 })));
@@ -1422,8 +1422,8 @@ public class CaReconcilerTest {
                     assertThat(clientsCaCertSecret.getMetadata().getOwnerReferences(), hasSize(0));
                     assertThat(clientsCaKeySecret.getMetadata().getOwnerReferences(), hasSize(0));
 
-                    assertThat(clusterCaCertSecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
-                    assertThat(clusterCaKeySecret.getMetadata().getOwnerReferences().get(0), is(ownerReference));
+                    TestUtils.checkOwnerReference(clusterCaCertSecret, kafka);
+                    TestUtils.checkOwnerReference(clusterCaKeySecret, kafka);
 
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/ConnectorMockTest.java
@@ -47,7 +47,7 @@ import io.strimzi.operator.common.metrics.MetricsHolder;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.mockkube3.MockKube3;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -78,9 +78,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static io.strimzi.test.TestUtils.map;
 import static io.strimzi.test.TestUtils.waitFor;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -187,7 +185,7 @@ public class ConnectorMockTest {
 
         setupMockConnectAPI();
 
-        ClusterOperatorConfig config = ClusterOperatorConfig.buildFromMap(map(
+        ClusterOperatorConfig config = ClusterOperatorConfig.buildFromMap(Map.of(
             ClusterOperatorConfig.STRIMZI_KAFKA_IMAGES, KafkaVersionTestUtils.getKafkaImagesEnvVarString(),
             ClusterOperatorConfig.STRIMZI_KAFKA_CONNECT_IMAGES, KafkaVersionTestUtils.getKafkaConnectImagesEnvVarString(),
             ClusterOperatorConfig.STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES, KafkaVersionTestUtils.getKafkaMirrorMaker2ImagesEnvVarString(),
@@ -268,10 +266,10 @@ public class ConnectorMockTest {
             if (connectorStatus == null) {
                 return Future.failedFuture(new ConnectRestException("GET", String.format("/connectors/%s", connectorName), 404, "Not Found", ""));
             }
-            return Future.succeededFuture(TestUtils.map(
+            return Future.succeededFuture(Map.of(
                     "name", connectorName,
                     "config", connectorStatus.config,
-                    "tasks", emptyMap()));
+                    "tasks", Map.of()));
         });
         when(api.createOrUpdatePutRequest(any(), any(), anyInt(), anyString(), any())).thenAnswer(invocation -> {
             LOGGER.info((String) invocation.getArgument(1) + invocation.getArgument(2) + invocation.getArgument(3) + invocation.getArgument(4));
@@ -466,7 +464,7 @@ public class ConnectorMockTest {
             Map<String, Object> connector = s.getStatus().getConnectorStatus();
             if (connector != null) {
                 @SuppressWarnings({ "rawtypes" })
-                Object connectorState = ((Map) connector.getOrDefault("connector", emptyMap())).get("state");
+                Object connectorState = ((Map) connector.getOrDefault("connector", Map.of())).get("state");
                 return connectorState instanceof String
                     && state.equals(connectorState);
             } else {
@@ -1380,7 +1378,7 @@ public class ConnectorMockTest {
                 "    level: INFO\n" +
                 "    topics: timer-topic";
 
-        KafkaConnector kcr = TestUtils.fromYamlString(yaml, KafkaConnector.class);
+        KafkaConnector kcr = ReadWriteUtils.readObjectFromYamlString(yaml, KafkaConnector.class);
         Crds.kafkaConnectorOperation(client).inNamespace(namespace).resource(kcr).create();
 
         waitForConnectorReady(connectorName);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -116,7 +116,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static io.strimzi.operator.common.model.Ca.x509Certificate;
-import static io.strimzi.test.TestUtils.set;
+import static io.strimzi.test.TestUtils.modifiableSet;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -527,7 +527,7 @@ public class KafkaAssemblyOperatorTest {
 
         // Secrets
         SecretOperator mockSecretOps = supplier.secretOperations;
-        Set<String> expectedSecrets = set(
+        Set<String> expectedSecrets = modifiableSet(
                 KafkaResources.clientsCaKeySecretName(CLUSTER_NAME),
                 KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME),
                 KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME),
@@ -687,7 +687,7 @@ public class KafkaAssemblyOperatorTest {
 
                 // Check routes
                 if (openShift) {
-                    Set<String> expectedRoutes = set(KafkaResources.bootstrapServiceName(CLUSTER_NAME));
+                    Set<String> expectedRoutes = modifiableSet(KafkaResources.bootstrapServiceName(CLUSTER_NAME));
                     for (NodeRef node : kafkaCluster.nodes()) {
                         if (node.broker()) {
                             expectedRoutes.add(node.podName());
@@ -883,13 +883,13 @@ public class KafkaAssemblyOperatorTest {
         when(mockCmOps.listAsync(NAMESPACE, updatedKafkaCluster.getSelectorLabels())).thenReturn(Future.succeededFuture(List.of()));
         when(mockCmOps.deleteAsync(any(), any(), any(), anyBoolean())).thenReturn(Future.succeededFuture());
 
-        Set<String> metricsCms = set();
+        Set<String> metricsCms = modifiableSet();
         doAnswer(invocation -> {
             metricsCms.add(invocation.getArgument(1));
             return Future.succeededFuture();
         }).when(mockCmOps).reconcile(any(), eq(NAMESPACE), any(), any());
 
-        Set<String> logCms = set();
+        Set<String> logCms = modifiableSet();
         doAnswer(invocation -> {
             logCms.add(invocation.getArgument(1));
             return Future.succeededFuture();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -322,7 +322,7 @@ public class KafkaBridgeAssemblyOperatorTest {
         when(mockCmOps.get(kbNamespace, KafkaBridgeResources.metricsAndLogConfigMapName(kbName))).thenReturn(metricsCm);
 
         // Mock CM patch
-        Set<String> metricsCms = TestUtils.set();
+        Set<String> metricsCms = TestUtils.modifiableSet();
         doAnswer(invocation -> {
             metricsCms.add(invocation.getArgument(1));
             return Future.succeededFuture();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -8,7 +8,6 @@ import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.strimzi.test.TestUtils;
 import io.strimzi.test.container.StrimziKafkaCluster;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -159,7 +158,7 @@ public class KafkaConnectApiIT {
             })))
             .compose(status -> client.getConnectorConfig(Reconciliation.DUMMY_RECONCILIATION, new BackOff(10), "localhost", port, "test"))
             .onComplete(context.succeeding(config -> context.verify(() -> {
-                assertThat(config, is(TestUtils.map("connector.class", "FileStreamSource",
+                assertThat(config, is(Map.of("connector.class", "FileStreamSource",
                         "file", "/dev/null",
                         "tasks.max", "1",
                         "name", "test",

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube3.MockKube3;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -144,7 +144,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withLabels(TestUtils.map("foo", "bar"))
+                    .withLabels(Map.of("foo", "bar"))
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(REPLICAS)
@@ -172,7 +172,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withLabels(TestUtils.map("foo", "bar"))
+                    .withLabels(Map.of("foo", "bar"))
                     .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", "true"))
                 .endMetadata()
                 .withNewSpec()
@@ -213,7 +213,7 @@ public class KafkaConnectAssemblyOperatorMockTest {
                             .withNewMetadata()
                                 .withName(CLUSTER_NAME)
                                 .withNamespace(namespace)
-                                .withLabels(TestUtils.map("foo", "bar"))
+                                .withLabels(Map.of("foo", "bar"))
                                 .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", "false"))
                             .endMetadata()
                             .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
@@ -61,7 +60,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest {
                 .withNewMetadata()
                     .withName("my-mm2")
                     .withNamespace("namespace")
-                    .withLabels(TestUtils.map("foo", "bar"))
+                    .withLabels(Map.of("foo", "bar"))
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(1)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -28,7 +28,6 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.OrderedProperties;
 import io.strimzi.platform.KubernetesVersion;
-import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube3.MockKube3;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -166,7 +166,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withLabels(TestUtils.map("foo", "bar"))
+                    .withLabels(Map.of("foo", "bar"))
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(REPLICAS)
@@ -197,7 +197,7 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 .withNewMetadata()
                     .withName(CLUSTER_NAME)
                     .withNamespace(namespace)
-                    .withLabels(TestUtils.map("foo", "bar"))
+                    .withLabels(Map.of("foo", "bar"))
                     .withAnnotations(singletonMap("strimzi.io/pause-reconciliation", "true"))
                 .endMetadata()
                 .withNewSpec()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -314,7 +314,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
         when(mockCmOps.get(kmmNamespace, KafkaMirrorMakerResources.metricsAndLogConfigMapName(kmmName))).thenReturn(metricsCm);
 
         // Mock CM patch
-        Set<String> metricsCms = TestUtils.set();
+        Set<String> metricsCms = TestUtils.modifiableSet();
         doAnswer(invocation -> {
             metricsCms.add(invocation.getArgument(1));
             return Future.succeededFuture();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -42,6 +42,7 @@ import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.platform.KubernetesVersion;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube3.MockKube3;
 import io.vertx.core.Vertx;
@@ -139,8 +140,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
         // Configure Cruise Control mock
         cruiseControlPort = TestUtils.getFreePort();
-        tlsKeyFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".key");
-        tlsCrtFile = TestUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".crt");
+        tlsKeyFile = ReadWriteUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".key");
+        tlsCrtFile = ReadWriteUtils.tempFile(KafkaRebalanceAssemblyOperatorTest.class.getSimpleName(), ".crt");
         
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);
@@ -1412,7 +1413,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 "spec:\n" +
                 "  unknown: \"value\"";
 
-        KafkaRebalance kr = TestUtils.fromYamlString(rebalanceString, KafkaRebalance.class);
+        KafkaRebalance kr = ReadWriteUtils.readObjectFromYamlString(rebalanceString, KafkaRebalance.class);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
         crdCreateKafka();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -30,6 +30,7 @@ import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -82,8 +83,8 @@ public class KafkaRebalanceStateMachineTest {
 
     @BeforeAll
     public static void before() throws IOException {
-        File tlsKeyFile = TestUtils.tempFile(KafkaRebalanceStateMachineTest.class.getSimpleName(), ".key");
-        File tlsCrtFile = TestUtils.tempFile(KafkaRebalanceStateMachineTest.class.getSimpleName(), ".crt");
+        File tlsKeyFile = ReadWriteUtils.tempFile(KafkaRebalanceStateMachineTest.class.getSimpleName(), ".key");
+        File tlsCrtFile = ReadWriteUtils.tempFile(KafkaRebalanceStateMachineTest.class.getSimpleName(), ".crt");
 
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetControllerIT.java
@@ -37,6 +37,7 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.StrimziPodSetOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
@@ -87,10 +88,10 @@ public class StrimziPodSetControllerIT {
         LOGGER.info("Created namespace");
 
         LOGGER.info("Creating CRDs");
-        TestUtils.createCrd(client, Kafka.CRD_NAME, TestUtils.CRD_KAFKA);
-        TestUtils.createCrd(client, KafkaConnect.CRD_NAME, TestUtils.CRD_KAFKA_CONNECT);
-        TestUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
-        TestUtils.createCrd(client, StrimziPodSet.CRD_NAME, TestUtils.CRD_STRIMZI_POD_SET);
+        CrdUtils.createCrd(client, Kafka.CRD_NAME, CrdUtils.CRD_KAFKA);
+        CrdUtils.createCrd(client, KafkaConnect.CRD_NAME, CrdUtils.CRD_KAFKA_CONNECT);
+        CrdUtils.createCrd(client, KafkaMirrorMaker2.CRD_NAME, CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
+        CrdUtils.createCrd(client, StrimziPodSet.CRD_NAME, CrdUtils.CRD_STRIMZI_POD_SET);
         LOGGER.info("Created CRDs");
 
         vertx = Vertx.vertx();
@@ -113,10 +114,10 @@ public class StrimziPodSetControllerIT {
         kafkaOp().inNamespace(NAMESPACE).withName(KAFKA_NAME).delete();
         kafkaOp().inNamespace(NAMESPACE).withName(OTHER_KAFKA_NAME).delete();
 
-        TestUtils.deleteCrd(client, Kafka.CRD_NAME);
-        TestUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
-        TestUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
-        TestUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
+        CrdUtils.deleteCrd(client, Kafka.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaConnect.CRD_NAME);
+        CrdUtils.deleteCrd(client, KafkaMirrorMaker2.CRD_NAME);
+        CrdUtils.deleteCrd(client, StrimziPodSet.CRD_NAME);
 
         TestUtils.deleteNamespace(client, NAMESPACE);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiffTest.java
@@ -9,7 +9,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -53,7 +53,7 @@ public class KafkaBrokerConfigurationDiffTest {
 
     private String getDesiredConfiguration(List<ConfigEntry> additional) {
         try (InputStream is = getClass().getClassLoader().getResourceAsStream("desired-kafka-broker.conf")) {
-            String desiredConfigString = TestUtils.readResource(is);
+            String desiredConfigString = ReadWriteUtils.readInputStream(is);
 
             for (ConfigEntry ce : additional) {
                 desiredConfigString += "\n" + ce.name() + "=" + ce.value();
@@ -71,7 +71,7 @@ public class KafkaBrokerConfigurationDiffTest {
 
         try (InputStream is = getClass().getClassLoader().getResourceAsStream("current-kafka-broker.conf")) {
 
-            List<String> configList = Arrays.asList(TestUtils.readResource(is).split(System.getProperty("line.separator")));
+            List<String> configList = Arrays.asList(ReadWriteUtils.readInputStream(is).split(System.getProperty("line.separator")));
             configList.forEach(entry -> {
                 String[] split = entry.split("=");
                 String val = split.length == 1 ? "" : split[1];

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -10,6 +10,7 @@ import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlRebalanceKeys;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlUserTaskStatus;
 import io.strimzi.operator.common.operator.MockCertManager;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -51,8 +52,8 @@ public class CruiseControlClientTest {
     @BeforeAll
     public static void setupServer() throws IOException {
         cruiseControlPort = TestUtils.getFreePort();
-        File tlsKeyFile = TestUtils.tempFile(CruiseControlClientTest.class.getSimpleName(), ".key");
-        File tlsCrtFile = TestUtils.tempFile(CruiseControlClientTest.class.getSimpleName(), ".crt");
+        File tlsKeyFile = ReadWriteUtils.tempFile(CruiseControlClientTest.class.getSimpleName(), ".key");
+        File tlsCrtFile = ReadWriteUtils.tempFile(CruiseControlClientTest.class.getSimpleName(), ".crt");
         
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -14,7 +14,7 @@ import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 import io.strimzi.operator.common.operator.MockCertManager;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
@@ -127,7 +127,7 @@ public class MockCruiseControl {
      */
     public void setupCCStateResponse() {
         // Non-verbose response
-        JsonBody jsonProposalNotReady = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-State-proposal-not-ready.json"));
+        JsonBody jsonProposalNotReady = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State-proposal-not-ready.json"));
 
         server
                 .when(
@@ -146,7 +146,7 @@ public class MockCruiseControl {
 
 
         // Non-verbose response
-        JsonBody json = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-State.json"));
+        JsonBody json = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State.json"));
 
         server
                 .when(
@@ -164,7 +164,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
 
         // Verbose response
-        JsonBody jsonVerbose = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-State-verbose.json"));
+        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State-verbose.json"));
 
         server
                 .when(
@@ -188,7 +188,7 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceNotEnoughDataError(CruiseControlEndpoints endpoint) {
         // Rebalance response with no goal that returns an error
-        JsonBody jsonError = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-NotEnoughValidWindows-error.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-NotEnoughValidWindows-error.json"));
 
         server
                 .when(
@@ -214,7 +214,7 @@ public class MockCruiseControl {
      */
     public void setupCCBrokerDoesNotExist(CruiseControlEndpoints endpoint) {
         // Add/remove broker response with no goal that returns an error
-        JsonBody jsonError = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Broker-not-exist.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Broker-not-exist.json"));
 
         server
                 .when(
@@ -248,7 +248,7 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceResponse(int pendingCalls, int responseDelay, CruiseControlEndpoints endpoint) {
         // Rebalance in progress response with no goals set - non-verbose
-        JsonBody pendingJson = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-no-goals-in-progress.json"));
+        JsonBody pendingJson = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-in-progress.json"));
         server
                 .when(
                         request()
@@ -269,7 +269,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, responseDelay));
 
         // Rebalance response with no goals set - non-verbose
-        JsonBody json = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-no-goals.json"));
+        JsonBody json = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals.json"));
 
         server
                 .when(
@@ -290,7 +290,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, responseDelay));
 
         // Rebalance response with no goals set - verbose
-        JsonBody jsonVerbose = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
+        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
 
         server
                 .when(
@@ -316,7 +316,7 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceBadGoalsError(CruiseControlEndpoints endpoint) {
         // Response if the user has set custom goals which do not include all configured hard.goals
-        JsonBody jsonError = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-bad-goals-error.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-bad-goals-error.json"));
 
         server
                 .when(
@@ -339,7 +339,7 @@ public class MockCruiseControl {
 
         // Response if the user has set custom goals which do not include all configured hard.goals
         // Note: This uses the no-goals example response but the difference between custom goals and default goals is not tested here
-        JsonBody jsonSummary = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
+        JsonBody jsonSummary = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
 
         server
                 .when(
@@ -372,9 +372,9 @@ public class MockCruiseControl {
      */
     public void setupCCUserTasksResponseNoGoals(int activeCalls, int inExecutionCalls) throws IOException, URISyntaxException {
         // User tasks response for the rebalance request with no goals set (non-verbose)
-        JsonBody jsonActive = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-Active.json"));
-        JsonBody jsonInExecution = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-inExecution.json"));
-        JsonBody jsonCompleted = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-completed.json"));
+        JsonBody jsonActive = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-Active.json"));
+        JsonBody jsonInExecution = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-inExecution.json"));
+        JsonBody jsonCompleted = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-completed.json"));
 
         // The first activeCalls times respond that with a status of "Active"
         server
@@ -431,9 +431,9 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
 
         // User tasks response for the rebalance request with no goals set (verbose)
-        JsonBody jsonActiveVerbose = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-Active.json"));
-        JsonBody jsonInExecutionVerbose = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-inExecution.json"));
-        JsonBody jsonCompletedVerbose = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-completed.json"));
+        JsonBody jsonActiveVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-Active.json"));
+        JsonBody jsonInExecutionVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-inExecution.json"));
+        JsonBody jsonCompletedVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-completed.json"));
 
         // The first activeCalls times respond that with a status of "Active"
         server
@@ -496,7 +496,7 @@ public class MockCruiseControl {
      */
     public void setupCCUserTasksCompletedWithError() throws IOException, URISyntaxException {
         // This simulates asking for the status of a task that has Complete with error and fetch_completed_task=true
-        JsonBody compWithErrorJson = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-status-completed-with-error.json"));
+        JsonBody compWithErrorJson = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-status-completed-with-error.json"));
 
         server
                 .when(
@@ -520,7 +520,7 @@ public class MockCruiseControl {
      */
     public void setupUserTasktoEmpty() {
         // This simulates asking for the status with empty user task
-        JsonBody jsonEmptyUserTask = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-User-task-status-empty.json"));
+        JsonBody jsonEmptyUserTask = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-status-empty.json"));
 
         server
                 .when(
@@ -543,7 +543,7 @@ public class MockCruiseControl {
      * Setup response of task being stopped.
      */
     public void setupCCStopResponse() {
-        JsonBody jsonStop = new JsonBody(TestUtils.jsonFromResource(CC_JSON_ROOT + "CC-Stop.json"));
+        JsonBody jsonStop = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Stop.json"));
 
         server
                 .when(

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractCustomResourceOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractCustomResourceOperatorIT.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -80,14 +81,14 @@ public abstract class AbstractCustomResourceOperatorIT<C extends KubernetesClien
         LOGGER.info("Created namespace");
 
         LOGGER.info("Creating CRD");
-        TestUtils.createCrd(client, getCrdName(), getCrd());
+        CrdUtils.createCrd(client, getCrdName(), getCrd());
         LOGGER.info("Created CRD");
     }
 
     @AfterAll
     public void after() {
         LOGGER.info("Deleting CRD");
-        TestUtils.deleteCrd(client, getCrdName());
+        CrdUtils.deleteCrd(client, getCrdName());
         TestUtils.deleteNamespace(client, getNamespace());
 
         client.close();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaBridgeCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaBridgeCrdOperatorIT.java
@@ -10,7 +10,7 @@ import io.strimzi.api.kafka.model.bridge.KafkaBridgeBuilder;
 import io.strimzi.api.kafka.model.bridge.KafkaBridgeList;
 import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.api.kafka.model.common.InlineLogging;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +37,7 @@ public class KafkaBridgeCrdOperatorIT extends AbstractCustomResourceOperatorIT<K
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_BRIDGE;
+        return CrdUtils.CRD_KAFKA_BRIDGE;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectCrdOperatorIT.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnectList;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +35,7 @@ public class KafkaConnectCrdOperatorIT extends AbstractCustomResourceOperatorIT<
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_CONNECT;
+        return CrdUtils.CRD_KAFKA_CONNECT;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectorCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaConnectorCrdOperatorIT.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorBuilder;
 import io.strimzi.api.kafka.model.connector.KafkaConnectorList;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +35,7 @@ public class KafkaConnectorCrdOperatorIT extends AbstractCustomResourceOperatorI
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_CONNECTOR;
+        return CrdUtils.CRD_KAFKA_CONNECTOR;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaCrdOperatorIT.java
@@ -10,7 +10,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaList;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +37,7 @@ public class KafkaCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kuberne
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA;
+        return CrdUtils.CRD_KAFKA;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMaker2CrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMaker2CrdOperatorIT.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2List;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +35,7 @@ public class KafkaMirrorMaker2CrdOperatorIT extends AbstractCustomResourceOperat
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_MIRROR_MAKER_2;
+        return CrdUtils.CRD_KAFKA_MIRROR_MAKER_2;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMakerCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/KafkaMirrorMakerCrdOperatorIT.java
@@ -9,7 +9,7 @@ import io.strimzi.api.kafka.model.common.InlineLogging;
 import io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMaker;
 import io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerBuilder;
 import io.strimzi.api.kafka.model.mirrormaker.KafkaMirrorMakerList;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -36,7 +36,7 @@ public class KafkaMirrorMakerCrdOperatorIT extends AbstractCustomResourceOperato
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_MIRROR_MAKER;
+        return CrdUtils.CRD_KAFKA_MIRROR_MAKER;
     }
 
     @Override

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/StrimziPodSetCrdOperatorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/kubernetes/StrimziPodSetCrdOperatorIT.java
@@ -16,7 +16,7 @@ import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.api.kafka.model.podset.StrimziPodSetList;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.vertx.core.Promise;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
@@ -55,7 +55,7 @@ public class StrimziPodSetCrdOperatorIT extends AbstractCustomResourceOperatorIT
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_STRIMZI_POD_SET;
+        return CrdUtils.CRD_STRIMZI_POD_SET;
     }
 
     @Override

--- a/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
+++ b/mockkube/src/main/java/io/strimzi/test/mockkube3/MockKube3.java
@@ -19,7 +19,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.mockkube3.controllers.AbstractMockController;
 import io.strimzi.test.mockkube3.controllers.MockDeletionController;
 import io.strimzi.test.mockkube3.controllers.MockDeploymentController;
@@ -260,7 +260,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA);
+            mock.registerCrd(CrdUtils.CRD_KAFKA);
             return this;
         }
 
@@ -270,7 +270,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaTopicCrd()  {
-            mock.registerCrd(TestUtils.CRD_TOPIC);
+            mock.registerCrd(CrdUtils.CRD_TOPIC);
             return this;
         }
 
@@ -280,7 +280,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaUserCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_USER);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_USER);
             return this;
         }
 
@@ -290,7 +290,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaConnectCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_CONNECT);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_CONNECT);
             return this;
         }
 
@@ -300,7 +300,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaConnectorCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_CONNECTOR);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_CONNECTOR);
             return this;
         }
 
@@ -310,7 +310,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaMirrorMaker2Crd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_MIRROR_MAKER_2);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_MIRROR_MAKER_2);
             return this;
         }
 
@@ -320,7 +320,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaRebalanceCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_REBALANCE);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_REBALANCE);
             return this;
         }
 
@@ -330,7 +330,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withKafkaNodePoolCrd()  {
-            mock.registerCrd(TestUtils.CRD_KAFKA_NODE_POOL);
+            mock.registerCrd(CrdUtils.CRD_KAFKA_NODE_POOL);
             return this;
         }
 
@@ -340,7 +340,7 @@ public class MockKube3 {
          * @return  MockKube builder instance
          */
         public MockKube3Builder withStrimziPodSetCrd()  {
-            mock.registerCrd(TestUtils.CRD_STRIMZI_POD_SET);
+            mock.registerCrd(CrdUtils.CRD_STRIMZI_POD_SET);
             return this;
         }
 

--- a/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/auth/PemAuthIdentityTest.java
@@ -10,7 +10,8 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.common.operator.MockCertManager;
 import org.junit.jupiter.api.Test;
 
-import static io.strimzi.test.TestUtils.map;
+import java.util.Map;
+
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -40,7 +41,7 @@ public class PemAuthIdentityTest {
                     .withName(KafkaResources.clusterOperatorCertsSecretName(CLUSTER))
                     .withNamespace(NAMESPACE)
                 .endMetadata()
-                .withData(map("cluster-operator.key", "key"))
+                .withData(Map.of("cluster-operator.key", "key"))
                 .build();
         Exception e = assertThrows(RuntimeException.class, () -> PemAuthIdentity.clusterOperator(secretWithMissingClusterOperatorKey));
         assertThat(e.getMessage(), is("The Secret testns/testcluster-cluster-operator-certs is missing the field cluster-operator.crt"));
@@ -53,7 +54,7 @@ public class PemAuthIdentityTest {
                     .withName(KafkaResources.clusterOperatorCertsSecretName(CLUSTER))
                     .withNamespace(NAMESPACE)
                 .endMetadata()
-                .withData(map("cluster-operator.key", MockCertManager.clusterCaKey(),
+                .withData(Map.of("cluster-operator.key", MockCertManager.clusterCaKey(),
                         "cluster-operator.crt", "bm90YWNlcnQ=", //notacert
                         "cluster-operator.p12", "bm90YXRydXN0c3RvcmU=", //notatruststore
                         "cluster-operator.password", "bm90YXBhc3N3b3Jk")) //notapassword

--- a/operator-common/src/test/java/io/strimzi/operator/common/auth/PemTrustSetTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/auth/PemTrustSetTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static io.strimzi.test.TestUtils.map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +26,7 @@ public class PemTrustSetTest {
                     .withName(KafkaResources.clusterOperatorCertsSecretName(CLUSTER))
                     .withNamespace(NAMESPACE)
                 .endMetadata()
-                .withData(map("ca.crt", "notacert"))
+                .withData(Map.of("ca.crt", "notacert"))
                 .build();
         PemTrustSet pemTrustSet = new PemTrustSet(secretWithBadCertificate);
         Exception e = assertThrows(RuntimeException.class, pemTrustSet::jksTrustStore);

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ResourceVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ResourceVisitorTest.java
@@ -6,7 +6,7 @@ package io.strimzi.operator.common.model;
 
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.AnnotatedElement;
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ResourceVisitorTest {
     @Test
     public void testDoesNotThrow() {
-        Kafka k = TestUtils.fromYaml("/example.yaml", Kafka.class, true);
+        Kafka k = ReadWriteUtils.readObjectFromYamlFileInResources("/example.yaml", Kafka.class, true);
         assertThat(k, is(notNullValue()));
         ResourceVisitor.visit(new Reconciliation("test", "kind", "namespace", "name"), k, new ResourceVisitor.Visitor() {
             @Override
@@ -38,7 +38,7 @@ public class ResourceVisitorTest {
 
     @Test
     public void testDoesNotThrowWithListenerList() {
-        Kafka k = TestUtils.fromYaml("/example2.yaml", Kafka.class, true);
+        Kafka k = ReadWriteUtils.readObjectFromYamlFileInResources("/example2.yaml", Kafka.class, true);
         assertThat(k, is(notNullValue()));
         ResourceVisitor.visit(new Reconciliation("test", "kind", "namespace", "name"), k, new ResourceVisitor.Visitor() {
             @Override

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/ValidationVisitorTest.java
@@ -9,7 +9,7 @@ import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.logging.TestLogger;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ValidationVisitorTest {
     @Test
     public void testValidationErrorsAreLogged() {
-        Kafka k = TestUtils.fromYaml("/example.yaml", Kafka.class, true);
+        Kafka k = ReadWriteUtils.readObjectFromYamlFileInResources("/example.yaml", Kafka.class, true);
         assertThat(k, is(notNullValue()));
         TestLogger logger = TestLogger.create(ValidationVisitorTest.class);
         HasMetadata resource = new KafkaBuilder()

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractCustomResourceOperatorIT.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.ConditionBuilder;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,13 +73,13 @@ public abstract class AbstractCustomResourceOperatorIT<
         LOGGER.info("Created namespace");
 
         LOGGER.info("Creating CRD");
-        TestUtils.createCrd(client, getCrdName(), getCrd());
+        CrdUtils.createCrd(client, getCrdName(), getCrd());
         LOGGER.info("Created CRD");
     }
 
     @AfterAll
     public void after() {
-        TestUtils.deleteCrd(client, getCrdName());
+        CrdUtils.deleteCrd(client, getCrdName());
         TestUtils.deleteNamespace(client, getNamespace());
 
         client.close();

--- a/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/KafkaUserCrdOperatorIT.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/operator/resource/concurrent/KafkaUserCrdOperatorIT.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.api.kafka.model.user.KafkaUser;
 import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
 import io.strimzi.api.kafka.model.user.KafkaUserList;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.CrdUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,7 +33,7 @@ public class KafkaUserCrdOperatorIT extends AbstractCustomResourceOperatorIT<Kub
 
     @Override
     protected String getCrd() {
-        return TestUtils.CRD_KAFKA_USER;
+        return CrdUtils.CRD_KAFKA_USER;
     }
 
     @Override

--- a/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/logs/LogCollector.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import static io.strimzi.test.TestUtils.writeFile;
+import static io.strimzi.test.ReadWriteUtils.writeFile;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 
 /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/draincleaner/SetupDrainCleaner.java
@@ -23,6 +23,7 @@ import io.strimzi.systemtest.security.CertAndKeyFiles;
 import io.strimzi.systemtest.security.SystemTestCertAndKey;
 import io.strimzi.systemtest.security.SystemTestCertManager;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
@@ -85,7 +86,7 @@ public class SetupDrainCleaner {
 
                 switch (resourceType) {
                     case TestConstants.ROLE:
-                        Role role = TestUtils.configFromYaml(file, Role.class);
+                        Role role = ReadWriteUtils.readObjectFromYamlFilepath(file, Role.class);
                         ResourceManager.getInstance().createResourceWithWait(new RoleBuilder(role)
                             .editMetadata()
                                 .withNamespace(TestConstants.DRAIN_CLEANER_NAMESPACE)
@@ -93,7 +94,7 @@ public class SetupDrainCleaner {
                             .build());
                         break;
                     case TestConstants.ROLE_BINDING:
-                        RoleBinding roleBinding = TestUtils.configFromYaml(file, RoleBinding.class);
+                        RoleBinding roleBinding = ReadWriteUtils.readObjectFromYamlFilepath(file, RoleBinding.class);
                         ResourceManager.getInstance().createResourceWithWait(new RoleBindingBuilder(roleBinding)
                             .editMetadata()
                                 .withNamespace(TestConstants.DRAIN_CLEANER_NAMESPACE)
@@ -104,11 +105,11 @@ public class SetupDrainCleaner {
                             .build());
                         break;
                     case TestConstants.CLUSTER_ROLE:
-                        ClusterRole clusterRole = TestUtils.configFromYaml(file, ClusterRole.class);
+                        ClusterRole clusterRole = ReadWriteUtils.readObjectFromYamlFilepath(file, ClusterRole.class);
                         ResourceManager.getInstance().createResourceWithWait(clusterRole);
                         break;
                     case TestConstants.SERVICE_ACCOUNT:
-                        ServiceAccount serviceAccount = TestUtils.configFromYaml(file, ServiceAccount.class);
+                        ServiceAccount serviceAccount = ReadWriteUtils.readObjectFromYamlFilepath(file, ServiceAccount.class);
                         ResourceManager.getInstance().createResourceWithWait(new ServiceAccountBuilder(serviceAccount)
                             .editMetadata()
                                 .withNamespace(TestConstants.DRAIN_CLEANER_NAMESPACE)
@@ -116,18 +117,18 @@ public class SetupDrainCleaner {
                             .build());
                         break;
                     case TestConstants.CLUSTER_ROLE_BINDING:
-                        ClusterRoleBinding clusterRoleBinding = TestUtils.configFromYaml(file, ClusterRoleBinding.class);
+                        ClusterRoleBinding clusterRoleBinding = ReadWriteUtils.readObjectFromYamlFilepath(file, ClusterRoleBinding.class);
                         ResourceManager.getInstance().createResourceWithWait(new ClusterRoleBindingBuilder(clusterRoleBinding).build());
                         break;
                     case TestConstants.SECRET:
                         ResourceManager.getInstance().createResourceWithWait(customDrainCleanerSecret);
                         break;
                     case TestConstants.SERVICE:
-                        Service service = TestUtils.configFromYaml(file, Service.class);
+                        Service service = ReadWriteUtils.readObjectFromYamlFilepath(file, Service.class);
                         ResourceManager.getInstance().createResourceWithWait(service);
                         break;
                     case TestConstants.VALIDATION_WEBHOOK_CONFIG:
-                        ValidatingWebhookConfiguration webhookConfiguration = TestUtils.configFromYaml(file, ValidatingWebhookConfiguration.class);
+                        ValidatingWebhookConfiguration webhookConfiguration = ReadWriteUtils.readObjectFromYamlFilepath(file, ValidatingWebhookConfiguration.class);
 
                         // in case that we are running on OpenShift-like cluster, we are not creating the Secret, thus this step is not needed
                         if (customDrainCleanerSecret != null) {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/jaeger/SetupJaeger.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/jaeger/SetupJaeger.java
@@ -13,11 +13,11 @@ import io.strimzi.systemtest.resources.ResourceItem;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.kubernetes.NetworkPolicyResource;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -174,7 +174,7 @@ public class SetupJaeger {
     public static void deployJaegerInstance(String namespaceName) {
         LOGGER.info("=== Applying jaeger instance install file ===");
 
-        String instanceYamlContent = TestUtils.getContent(new File(JAEGER_INSTANCE_PATH), TestUtils::toYamlString);
+        String instanceYamlContent = ReadWriteUtils.readFile(JAEGER_INSTANCE_PATH);
 
         TestUtils.waitFor("Jaeger Instance deploy", JAEGER_DEPLOYMENT_POLL, JAEGER_DEPLOYMENT_TIMEOUT, () -> {
             try {

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/ClusterRoleBindingResource.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,7 +69,7 @@ public class ClusterRoleBindingResource implements ResourceType<ClusterRoleBindi
     }
 
     private static ClusterRoleBinding getClusterRoleBindingFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, ClusterRoleBinding.class);
+        return ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, ClusterRoleBinding.class);
     }
 }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/DeploymentResource.java
@@ -10,7 +10,7 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 
 import java.util.function.Consumer;
 
@@ -51,6 +51,6 @@ public class DeploymentResource implements ResourceType<Deployment> {
     }
 
     public static Deployment getDeploymentFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, Deployment.class);
+        return ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, Deployment.class);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleBindingResource.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -60,6 +60,6 @@ public class RoleBindingResource implements ResourceType<RoleBinding> {
     }
 
     private static RoleBinding getRoleBindingFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, RoleBinding.class);
+        return ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, RoleBinding.class);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/kubernetes/RoleResource.java
@@ -9,7 +9,7 @@ import io.fabric8.kubernetes.api.model.rbac.RoleBuilder;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.ResourceType;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,6 +56,6 @@ public class RoleResource implements ResourceType<Role> {
     }
 
     private static Role getRoleFromYaml(String yamlPath) {
-        return TestUtils.configFromYaml(yamlPath, Role.class);
+        return ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, Role.class);
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/SetupClusterOperator.java
@@ -39,6 +39,7 @@ import io.strimzi.systemtest.resources.operator.specific.OlmResource;
 import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.specific.OlmUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.Exec;
 import io.strimzi.test.k8s.KubeClusterResource;
@@ -579,7 +580,7 @@ public class SetupClusterOperator {
 
                 switch (resourceEntry.getKey()) {
                     case TestConstants.ROLE:
-                        RoleBuilder roleBuilder = new RoleBuilder(TestUtils.configFromYaml(yamlPath, Role.class))
+                        RoleBuilder roleBuilder = new RoleBuilder(ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, Role.class))
                             .editMetadata()
                                 .withName(resourceName)
                             .endMetadata()
@@ -587,10 +588,10 @@ public class SetupClusterOperator {
                                 .withResourceNames(leaseEnvVar.getValue())
                             .endRule();
 
-                        tmpFileContent = TestUtils.toYamlString(roleBuilder.build());
+                        tmpFileContent = ReadWriteUtils.writeObjectToYamlString(roleBuilder.build());
                         break;
                     case TestConstants.CLUSTER_ROLE:
-                        ClusterRoleBuilder clusterRoleBuilder = new ClusterRoleBuilder(TestUtils.configFromYaml(yamlPath, ClusterRole.class))
+                        ClusterRoleBuilder clusterRoleBuilder = new ClusterRoleBuilder(ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, ClusterRole.class))
                             .editMetadata()
                                 .withName(resourceName)
                             .endMetadata()
@@ -599,10 +600,10 @@ public class SetupClusterOperator {
                                 .withResourceNames(leaseEnvVar.getValue())
                             .endRule();
 
-                        tmpFileContent = TestUtils.toYamlString(clusterRoleBuilder.build());
+                        tmpFileContent = ReadWriteUtils.writeObjectToYamlString(clusterRoleBuilder.build());
                         break;
                     case TestConstants.ROLE_BINDING:
-                        RoleBindingBuilder roleBindingBuilder = new RoleBindingBuilder(TestUtils.configFromYaml(yamlPath, RoleBinding.class))
+                        RoleBindingBuilder roleBindingBuilder = new RoleBindingBuilder(ReadWriteUtils.readObjectFromYamlFilepath(yamlPath, RoleBinding.class))
                             .editMetadata()
                                 .withName(resourceName)
                             .endMetadata()
@@ -610,13 +611,13 @@ public class SetupClusterOperator {
                                 .withName(resourceName)
                             .endRoleRef();
 
-                        tmpFileContent = TestUtils.toYamlString(roleBindingBuilder.build());
+                        tmpFileContent = ReadWriteUtils.writeObjectToYamlString(roleBindingBuilder.build());
                         break;
                     default:
                         return yamlPath;
                 }
 
-                TestUtils.writeFile(tmpFile.toPath(), tmpFileContent);
+                ReadWriteUtils.writeFile(tmpFile.toPath(), tmpFileContent);
                 return tmpFile.getAbsolutePath();
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -649,7 +650,7 @@ public class SetupClusterOperator {
             switch (resourceType) {
                 case TestConstants.ROLE:
                     if (!this.isRolesAndBindingsManagedByAnUser()) {
-                        Role role = TestUtils.configFromYaml(createFile, Role.class);
+                        Role role = ReadWriteUtils.readObjectFromYamlFilepath(createFile, Role.class);
                         ResourceManager.getInstance().createResourceWithWait(new RoleBuilder(role)
                             .editMetadata()
                                 .withNamespace(namespace)
@@ -659,12 +660,12 @@ public class SetupClusterOperator {
                     break;
                 case TestConstants.CLUSTER_ROLE:
                     if (!this.isRolesAndBindingsManagedByAnUser()) {
-                        ClusterRole clusterRole = TestUtils.configFromYaml(changeLeaseNameInResourceIfNeeded(createFile.getAbsolutePath()), ClusterRole.class);
+                        ClusterRole clusterRole = ReadWriteUtils.readObjectFromYamlFilepath(changeLeaseNameInResourceIfNeeded(createFile.getAbsolutePath()), ClusterRole.class);
                         ResourceManager.getInstance().createResourceWithWait(clusterRole);
                     }
                     break;
                 case TestConstants.SERVICE_ACCOUNT:
-                    ServiceAccount serviceAccount = TestUtils.configFromYaml(createFile, ServiceAccount.class);
+                    ServiceAccount serviceAccount = ReadWriteUtils.readObjectFromYamlFilepath(createFile, ServiceAccount.class);
                     ResourceManager.getInstance().createResourceWithWait(new ServiceAccountBuilder(serviceAccount)
                         .editMetadata()
                             .withNamespace(namespace)
@@ -672,7 +673,7 @@ public class SetupClusterOperator {
                         .build());
                     break;
                 case TestConstants.CONFIG_MAP:
-                    ConfigMap configMap = TestUtils.configFromYaml(createFile, ConfigMap.class);
+                    ConfigMap configMap = ReadWriteUtils.readObjectFromYamlFilepath(createFile, ConfigMap.class);
                     ResourceManager.getInstance().createResourceWithWait(new ConfigMapBuilder(configMap)
                         .editMetadata()
                             .withNamespace(namespace)
@@ -692,7 +693,7 @@ public class SetupClusterOperator {
                             .build());
                     break;
                 case TestConstants.CUSTOM_RESOURCE_DEFINITION_SHORT:
-                    CustomResourceDefinition customResourceDefinition = TestUtils.configFromYaml(createFile, CustomResourceDefinition.class);
+                    CustomResourceDefinition customResourceDefinition = ReadWriteUtils.readObjectFromYamlFilepath(createFile, CustomResourceDefinition.class);
                     ResourceManager.getInstance().createResourceWithWait(customResourceDefinition);
                     break;
                 default:
@@ -714,7 +715,7 @@ public class SetupClusterOperator {
                 fileNameArr[1] = "Role";
                 final String changeFileName = Arrays.stream(fileNameArr).map(item -> "-" + item).collect(Collectors.joining()).substring(1);
                 File tmpFile = Files.createTempFile(changeFileName.replace(".yaml", ""), ".yaml").toFile();
-                TestUtils.writeFile(tmpFile.toPath(), TestUtils.readFile(oldFile).replace("ClusterRole", "Role"));
+                ReadWriteUtils.writeFile(tmpFile.toPath(), ReadWriteUtils.readFile(oldFile).replace("ClusterRole", "Role"));
                 LOGGER.info("Replaced ClusterRole for Role in {}", oldFile.getAbsolutePath());
 
                 return tmpFile;

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -18,7 +18,7 @@ import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.test.ReadWriteUtils;
+import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,7 +68,7 @@ public class KafkaConnectTemplates {
     }
 
     public static ConfigMap connectMetricsConfigMap(String namespaceName, String kafkaConnectClusterName) {
-        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, ConfigMap.class))
+        return new ConfigMapBuilder(FileUtils.extractConfigMapFromYAMLWithResources(TestConstants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics"))
             .editOrNewMetadata()
                 .withNamespace(namespaceName)
                 .withName(getConfigMapName(kafkaConnectClusterName))

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaConnectTemplates.java
@@ -18,7 +18,7 @@ import io.strimzi.api.kafka.model.connect.build.PluginBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.k8s.KubeClusterResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,7 +68,7 @@ public class KafkaConnectTemplates {
     }
 
     public static ConfigMap connectMetricsConfigMap(String namespaceName, String kafkaConnectClusterName) {
-        return new ConfigMapBuilder(TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, "connect-metrics"))
+        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_CONNECT_METRICS_CONFIG, ConfigMap.class))
             .editOrNewMetadata()
                 .withNamespace(namespaceName)
                 .withName(getConfigMapName(kafkaConnectClusterName))

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -17,7 +17,7 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.storage.TestStorage;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 
 public class KafkaMirrorMaker2Templates {
 
@@ -66,7 +66,7 @@ public class KafkaMirrorMaker2Templates {
     }
 
     public static ConfigMap mirrorMaker2MetricsConfigMap(String namespaceName, String kafkaMirrorMaker2Name) {
-        return new ConfigMapBuilder(TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, "mirror-maker-2-metrics"))
+        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, ConfigMap.class))
             .editOrNewMetadata()
                 .withNamespace(namespaceName)
                 .withName(getConfigMapName(kafkaMirrorMaker2Name))

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaMirrorMaker2Templates.java
@@ -16,8 +16,8 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpecBuild
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.storage.TestStorage;
+import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
-import io.strimzi.test.ReadWriteUtils;
 
 public class KafkaMirrorMaker2Templates {
 
@@ -66,7 +66,7 @@ public class KafkaMirrorMaker2Templates {
     }
 
     public static ConfigMap mirrorMaker2MetricsConfigMap(String namespaceName, String kafkaMirrorMaker2Name) {
-        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, ConfigMap.class))
+        return new ConfigMapBuilder(FileUtils.extractConfigMapFromYAMLWithResources(TestConstants.PATH_TO_KAFKA_MIRROR_MAKER_2_METRICS_CONFIG, "mirror-maker-2-metrics"))
             .editOrNewMetadata()
                 .withNamespace(namespaceName)
                 .withName(getConfigMapName(kafkaMirrorMaker2Name))

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -18,8 +18,8 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
+import io.strimzi.systemtest.utils.FileUtils;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
-import io.strimzi.test.ReadWriteUtils;
 
 import java.util.Collections;
 
@@ -183,7 +183,7 @@ public class KafkaTemplates {
     public static ConfigMap kafkaMetricsConfigMap(String namespaceName, String kafkaClusterName) {
         String configMapName = kafkaClusterName + METRICS_KAFKA_CONFIG_MAP_SUFFIX;
 
-        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, ConfigMap.class))
+        return new ConfigMapBuilder(FileUtils.extractConfigMapFromYAMLWithResources(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics"))
             .editMetadata()
                 .withName(configMapName)
                 .withNamespace(namespaceName)

--- a/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/templates/crd/KafkaTemplates.java
@@ -19,7 +19,7 @@ import io.strimzi.operator.common.Annotations;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.utils.TestKafkaVersion;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 
 import java.util.Collections;
 
@@ -183,9 +183,7 @@ public class KafkaTemplates {
     public static ConfigMap kafkaMetricsConfigMap(String namespaceName, String kafkaClusterName) {
         String configMapName = kafkaClusterName + METRICS_KAFKA_CONFIG_MAP_SUFFIX;
 
-        ConfigMap kafkaMetricsCm = TestUtils.configMapFromYaml(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, "kafka-metrics");
-
-        return new ConfigMapBuilder(kafkaMetricsCm)
+        return new ConfigMapBuilder(ReadWriteUtils.readObjectFromYamlFilepath(TestConstants.PATH_TO_KAFKA_METRICS_CONFIG, ConfigMap.class))
             .editMetadata()
                 .withName(configMapName)
                 .withNamespace(namespaceName)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/BridgeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/BridgeUtils.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.systemtest.utils.specific;
 
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.vertx.core.http.HttpMethod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,6 +76,6 @@ public class BridgeUtils {
      */
     public static String getBridgeVersion() {
         InputStream bridgeVersionInputStream = BridgeUtils.class.getResourceAsStream("/bridge.version");
-        return TestUtils.readResource(bridgeVersionInputStream).replace("\n", "");
+        return ReadWriteUtils.readInputStream(bridgeVersionInputStream).replace("\n", "");
     }
 }

--- a/systemtest/src/main/java/io/strimzi/test/executor/ExecResult.java
+++ b/systemtest/src/main/java/io/strimzi/test/executor/ExecResult.java
@@ -6,6 +6,9 @@ package io.strimzi.test.executor;
 
 import java.io.Serializable;
 
+/**
+ * Result of an execution of an command
+ */
 public class ExecResult implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -20,18 +23,30 @@ public class ExecResult implements Serializable {
         this.stdErr = stdErr;
     }
 
+    /**
+     * @return True if the command succeeded. False otherwise.
+     */
     public boolean exitStatus() {
         return returnCode == 0;
     }
 
+    /**
+     * @return  The command return code
+     */
     public int returnCode() {
         return returnCode;
     }
 
+    /**
+     * @return  The standard output of the command
+     */
     public String out() {
         return stdOut;
     }
 
+    /**
+     * @return  The error output of the command
+     */
     public String err() {
         return stdErr;
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -64,6 +64,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -141,7 +142,7 @@ class ConnectST extends AbstractST {
         RollingUpdateUtils.waitTillComponentHasRolled(testStorage.getNamespaceName(), testStorage.getKafkaConnectSelector(), connectReplicasCount, connectPodsSnapshot);
 
         final String podName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), KafkaConnectResources.componentName(testStorage.getClusterName()));
-        final String kafkaPodJson = TestUtils.toJsonString(kubeClient(testStorage.getNamespaceName()).getPod(podName));
+        final String kafkaPodJson = ReadWriteUtils.writeObjectToJsonString(kubeClient(testStorage.getNamespaceName()).getPod(podName));
 
         assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0, "KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
                 hasItem(KafkaResources.tlsBootstrapAddress(testStorage.getClusterName()))));

--- a/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/log/LoggingChangeST.java
@@ -51,6 +51,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaConnectorUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -1410,7 +1411,7 @@ class LoggingChangeST extends AbstractST {
     @ParallelNamespaceTest
     void testNotExistingCMSetsDefaultLogging() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
-        final String defaultProps = TestUtils.getFileAsString(TestUtils.USER_PATH + "/../cluster-operator/src/main/resources/default-logging/KafkaCluster.properties");
+        final String defaultProps = ReadWriteUtils.readFile(TestUtils.USER_PATH + "/../cluster-operator/src/main/resources/default-logging/KafkaCluster.properties");
 
         String cmData = "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\n" +
             "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\n" +

--- a/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/mirrormaker/MirrorMaker2ST.java
@@ -54,6 +54,7 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -148,7 +149,7 @@ class MirrorMaker2ST extends AbstractST {
         ClientUtils.waitForInstantClientSuccess(testStorage);
 
         String podName = PodUtils.getPodNameByPrefix(testStorage.getNamespaceName(), KafkaMirrorMaker2Resources.componentName(testStorage.getClusterName()));
-        String kafkaPodJson = TestUtils.toJsonString(kubeClient().getPod(testStorage.getNamespaceName(), podName));
+        String kafkaPodJson = ReadWriteUtils.writeObjectToJsonString(kubeClient().getPod(testStorage.getNamespaceName(), podName));
 
         assertThat(kafkaPodJson, hasJsonPath(StUtils.globalVariableJsonPathBuilder(0, "KAFKA_CONNECT_BOOTSTRAP_SERVERS"),
                 hasItem(KafkaResources.plainBootstrapAddress(testStorage.getTargetClusterName()))));

--- a/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/operators/user/UserST.java
@@ -40,6 +40,7 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -105,7 +106,7 @@ class UserST extends AbstractST {
 
         resourceManager.createResourceWithWait(KafkaUserTemplates.tlsUser(Environment.TEST_SUITE_NAMESPACE, testStorage.getKafkaUsername(), sharedTestStorage.getClusterName()).build());
 
-        String kafkaUserSecret = TestUtils.toJsonString(kubeClient(Environment.TEST_SUITE_NAMESPACE).getSecret(testStorage.getKafkaUsername()));
+        String kafkaUserSecret = ReadWriteUtils.writeObjectToJsonString(kubeClient(Environment.TEST_SUITE_NAMESPACE).getSecret(testStorage.getKafkaUsername()));
         assertThat(kafkaUserSecret, hasJsonPath("$.data['ca.crt']", notNullValue()));
         assertThat(kafkaUserSecret, hasJsonPath("$.data['user.crt']", notNullValue()));
         assertThat(kafkaUserSecret, hasJsonPath("$.data['user.key']", notNullValue()));
@@ -113,7 +114,7 @@ class UserST extends AbstractST {
         assertThat(kafkaUserSecret, hasJsonPath("$.metadata.namespace", equalTo(Environment.TEST_SUITE_NAMESPACE)));
 
         KafkaUser kUser = KafkaUserResource.kafkaUserClient().inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getKafkaUsername()).get();
-        String kafkaUserAsJson = TestUtils.toJsonString(kUser);
+        String kafkaUserAsJson = ReadWriteUtils.writeObjectToJsonString(kUser);
 
         assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(testStorage.getKafkaUsername())));
         assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(Environment.TEST_SUITE_NAMESPACE)));
@@ -136,12 +137,12 @@ class UserST extends AbstractST {
         KafkaUserUtils.waitForKafkaUserIncreaseObserverGeneration(Environment.TEST_SUITE_NAMESPACE, observedGeneration, testStorage.getKafkaUsername());
         KafkaUserUtils.waitForKafkaUserCreation(Environment.TEST_SUITE_NAMESPACE, testStorage.getKafkaUsername());
 
-        String anotherKafkaUserSecret = TestUtils.toJsonString(kubeClient(Environment.TEST_SUITE_NAMESPACE).getSecret(Environment.TEST_SUITE_NAMESPACE, testStorage.getKafkaUsername()));
+        String anotherKafkaUserSecret = ReadWriteUtils.writeObjectToJsonString(kubeClient(Environment.TEST_SUITE_NAMESPACE).getSecret(Environment.TEST_SUITE_NAMESPACE, testStorage.getKafkaUsername()));
 
         assertThat(anotherKafkaUserSecret, hasJsonPath("$.data.password", notNullValue()));
 
         kUser = Crds.kafkaUserOperation(kubeClient().getClient()).inNamespace(Environment.TEST_SUITE_NAMESPACE).withName(testStorage.getKafkaUsername()).get();
-        kafkaUserAsJson = TestUtils.toJsonString(kUser);
+        kafkaUserAsJson = ReadWriteUtils.writeObjectToJsonString(kUser);
         assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.name", equalTo(testStorage.getKafkaUsername())));
         assertThat(kafkaUserAsJson, hasJsonPath("$.metadata.namespace", equalTo(Environment.TEST_SUITE_NAMESPACE)));
         assertThat(kafkaUserAsJson, hasJsonPath("$.spec.authentication.type", equalTo("scram-sha-512")));

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -57,6 +57,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
@@ -603,7 +604,7 @@ class SecurityST extends AbstractST {
 
         // 1. Create the Secrets already, and a certificate that's already expired
         InputStream secretInputStream = getClass().getClassLoader().getResourceAsStream("security-st-certs/expired-cluster-ca.crt");
-        String clusterCaCert = TestUtils.readResource(secretInputStream);
+        String clusterCaCert = ReadWriteUtils.readInputStream(secretInputStream);
         SecretUtils.createSecret(testStorage.getNamespaceName(), clusterCaCertificateSecretName(testStorage.getClusterName()), "ca.crt", clusterCaCert);
 
         // 2. Now create a cluster

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/SpecificST.java
@@ -24,7 +24,7 @@ import io.strimzi.systemtest.templates.crd.KafkaNodePoolTemplates;
 import io.strimzi.systemtest.templates.crd.KafkaTemplates;
 import io.strimzi.systemtest.templates.kubernetes.ClusterRoleBindingTemplates;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
@@ -53,27 +53,27 @@ public class SpecificST extends AbstractST {
         final String namespaceWhereCreationOfCustomResourcesIsApproved = "example-1";
 
         // --- a) defining Role and ClusterRoles
-        final Role strimziClusterOperator020 = TestUtils.configFromYaml(SetupClusterOperator.getInstance().switchClusterRolesToRolesIfNeeded(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml"), true), Role.class);
+        final Role strimziClusterOperator020 = ReadWriteUtils.readObjectFromYamlFilepath(SetupClusterOperator.getInstance().switchClusterRolesToRolesIfNeeded(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml"), true), Role.class);
 
         // specify explicit namespace for Role (for ClusterRole we do not specify namespace because ClusterRole is a non-namespaced resource
         strimziClusterOperator020.getMetadata().setNamespace(namespaceWhereCreationOfCustomResourcesIsApproved);
 
-        final ClusterRole strimziClusterOperator021 = TestUtils.configFromYaml(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
-        final ClusterRole strimziClusterOperator022 = TestUtils.configFromYaml(SetupClusterOperator.getInstance().changeLeaseNameInResourceIfNeeded(new File(
+        final ClusterRole strimziClusterOperator021 = ReadWriteUtils.readObjectFromYamlFilepath(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator022 = ReadWriteUtils.readObjectFromYamlFilepath(SetupClusterOperator.getInstance().changeLeaseNameInResourceIfNeeded(new File(
             TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/022-ClusterRole-strimzi-cluster-operator-role.yaml").getAbsolutePath()), ClusterRole.class);
-        final ClusterRole strimziClusterOperator023 = TestUtils.configFromYaml(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
-        final ClusterRole strimziClusterOperator030 = TestUtils.configFromYaml(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml"), ClusterRole.class);
-        final ClusterRole strimziClusterOperator031 = TestUtils.configFromYaml(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml"), ClusterRole.class);
-        final ClusterRole strimziClusterOperator033 = TestUtils.configFromYaml(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator023 = ReadWriteUtils.readObjectFromYamlFilepath(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/023-ClusterRole-strimzi-cluster-operator-role.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator030 = ReadWriteUtils.readObjectFromYamlFilepath(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/030-ClusterRole-strimzi-kafka-broker.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator031 = ReadWriteUtils.readObjectFromYamlFilepath(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/031-ClusterRole-strimzi-entity-operator.yaml"), ClusterRole.class);
+        final ClusterRole strimziClusterOperator033 = ReadWriteUtils.readObjectFromYamlFilepath(new File(TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/033-ClusterRole-strimzi-kafka-client.yaml"), ClusterRole.class);
 
         final List<Role> roles = Arrays.asList(strimziClusterOperator020);
         final List<ClusterRole> clusterRoles = Arrays.asList(strimziClusterOperator021, strimziClusterOperator022,
                 strimziClusterOperator023, strimziClusterOperator030, strimziClusterOperator031, strimziClusterOperator033);
 
         // ---- b) defining RoleBindings
-        final RoleBinding strimziClusterOperator020Namespaced = TestUtils.configFromYaml(SetupClusterOperator.getInstance().switchClusterRolesToRolesIfNeeded(new File(
+        final RoleBinding strimziClusterOperator020Namespaced = ReadWriteUtils.readObjectFromYamlFilepath(SetupClusterOperator.getInstance().switchClusterRolesToRolesIfNeeded(new File(
             TestConstants.PATH_TO_PACKAGING_INSTALL_FILES + "/cluster-operator/020-RoleBinding-strimzi-cluster-operator.yaml"), true), RoleBinding.class);
-        final RoleBinding strimziClusterOperator022LeaderElection = TestUtils.configFromYaml(SetupClusterOperator.getInstance().changeLeaseNameInResourceIfNeeded(new File(
+        final RoleBinding strimziClusterOperator022LeaderElection = ReadWriteUtils.readObjectFromYamlFilepath(SetupClusterOperator.getInstance().changeLeaseNameInResourceIfNeeded(new File(
             TestConstants.PATH_TO_LEASE_ROLE_BINDING).getAbsolutePath()), RoleBinding.class);
 
         // specify explicit namespace for RoleBindings

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -414,7 +414,7 @@ public class AbstractUpgradeST extends AbstractST {
 
                 kafkaTopicYaml = new File(dir, pathToTopicExamples);
                 cmdKubeClient(testStorage.getNamespaceName()).applyContent(ReadWriteUtils.readFile(kafkaTopicYaml)
-                        .replace("name: \"my-topic\"", "name: \"" + testStorage.getTopicName() + "\"")
+                        .replace("name: my-topic", "name: " + testStorage.getTopicName())
                         .replace("partitions: 1", "partitions: 3")
                         .replace("replicas: 1", "replicas: 3") +
                         "    min.insync.replicas: 2");
@@ -443,8 +443,8 @@ public class AbstractUpgradeST extends AbstractST {
     }
 
     private String getKafkaYamlWithName(String name) {
-        String initialName = "name: \"my-topic\"";
-        String newName =  "name: \"%s\"".formatted(name);
+        String initialName = "name: my-topic";
+        String newName =  "name: %s".formatted(name);
 
         return ReadWriteUtils.readFile(kafkaTopicYaml).replace(initialName, newName);
     }

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/AbstractKRaftUpgradeST.java
@@ -22,7 +22,7 @@ import io.strimzi.systemtest.utils.kafkaUtils.KafkaUserUtils;
 import io.strimzi.systemtest.utils.kafkaUtils.KafkaUtils;
 import io.strimzi.systemtest.utils.kubeUtils.controllers.DeploymentUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -218,7 +218,7 @@ public class AbstractKRaftUpgradeST extends AbstractUpgradeST {
 
         kafkaTopicYaml = new File(examplesPath + "/examples/topic/kafka-topic.yaml");
         LOGGER.info("Deploying KafkaTopic from: {}, in Namespace {}", kafkaTopicYaml.getPath(), namespaceName);
-        cmdKubeClient(namespaceName).applyContent(TestUtils.readFile(kafkaTopicYaml));
+        cmdKubeClient(namespaceName).applyContent(ReadWriteUtils.readFile(kafkaTopicYaml));
     }
 
     @BeforeEach

--- a/test/src/main/java/io/strimzi/test/CrdUtils.java
+++ b/test/src/main/java/io/strimzi/test/CrdUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class with methods and fields useful for testing CRD related things
+ */
+public final class CrdUtils {
+    /**
+     * Path to the KafkaTopic CRD definition YAML
+     */
+    public static final String CRD_TOPIC = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/043-Crd-kafkatopic.yaml";
+
+    /**
+     * Path to the Kafka CRD definition YAML
+     */
+    public static final String CRD_KAFKA = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/040-Crd-kafka.yaml";
+
+    /**
+     * Path to the KafkaConnect CRD definition YAML
+     */
+    public static final String CRD_KAFKA_CONNECT = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml";
+
+    /**
+     * Path to the KafkaUser CRD definition YAML
+     */
+    public static final String CRD_KAFKA_USER = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/044-Crd-kafkauser.yaml";
+
+    /**
+     * Path to the KafkaMirrorMaker CRD definition YAML
+     */
+    public static final String CRD_KAFKA_MIRROR_MAKER = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml";
+
+    /**
+     * Path to the KafkaBridge CRD definition YAML
+     */
+    public static final String CRD_KAFKA_BRIDGE = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/046-Crd-kafkabridge.yaml";
+
+    /**
+     * Path to the KafkaMirrorMaker2 CRD definition YAML
+     */
+    public static final String CRD_KAFKA_MIRROR_MAKER_2 = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml";
+
+    /**
+     * Path to the KafkaConnector CRD definition YAML
+     */
+    public static final String CRD_KAFKA_CONNECTOR = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/047-Crd-kafkaconnector.yaml";
+
+    /**
+     * Path to the KafkaRebalance CRD definition YAML
+     */
+    public static final String CRD_KAFKA_REBALANCE = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml";
+
+    /**
+     * Path to the KafkaNodePool CRD definition YAML
+     */
+    public static final String CRD_KAFKA_NODE_POOL = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml";
+
+    /**
+     * Path to the StrimziPodSet CRD definition YAML
+     */
+    public static final String CRD_STRIMZI_POD_SET = TestUtils.USER_PATH + "/../packaging/install/cluster-operator/042-Crd-strimzipodset.yaml";
+
+    private CrdUtils() { }
+
+    /**
+     * Creates a CRD resource in the Kubernetes cluster
+     *
+     * @param client    Kubernetes client
+     * @param crdName   Name of the CRD
+     * @param crdPath   Path to the CRD YAML
+     */
+    public static void createCrd(KubernetesClient client, String crdName, String crdPath)   {
+        if (client.apiextensions().v1().customResourceDefinitions().withName(crdName).get() != null) {
+            deleteCrd(client, crdName);
+        }
+
+        client.apiextensions().v1()
+                .customResourceDefinitions()
+                .load(crdPath)
+                .create();
+        client.apiextensions().v1()
+                .customResourceDefinitions()
+                .load(crdPath)
+                .waitUntilCondition(CrdUtils::isCrdEstablished, 10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Checks if the CRD has been established
+     *
+     * @param crd   The CRD resource
+     *
+     * @return  True if the CRD is established. False otherwise.
+     */
+    private static boolean isCrdEstablished(CustomResourceDefinition crd)   {
+        return crd.getStatus() != null
+                && crd.getStatus().getConditions() != null
+                && crd.getStatus().getConditions().stream().anyMatch(c -> "Established".equals(c.getType()) && "True".equals(c.getStatus()));
+    }
+
+    /**
+     * Deletes the CRD from the Kubernetes cluster
+     *
+     * @param client    Kubernetes client
+     * @param crdName   Name of the CRD
+     */
+    public static void deleteCrd(KubernetesClient client, String crdName)   {
+        if (client.apiextensions().v1().customResourceDefinitions().withName(crdName).get() != null) {
+            client.apiextensions().v1().customResourceDefinitions().withName(crdName).withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+            client.apiextensions().v1().customResourceDefinitions().withName(crdName).waitUntilCondition(Objects::isNull, 30_000, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/test/src/main/java/io/strimzi/test/ReadWriteUtils.java
+++ b/test/src/main/java/io/strimzi/test/ReadWriteUtils.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Class with various utility methods for reading and writing files and objects
+ */
+public final class ReadWriteUtils {
+    private static final Logger LOGGER = LogManager.getLogger(ReadWriteUtils.class);
+
+    private ReadWriteUtils() {
+        // All static methods
+    }
+
+    /**
+     * Reads file frm the disk and returns it as a String
+     *
+     * @param file  The file that should be read
+     *
+     * @return  String with file content
+     */
+    public static String readFile(File file) {
+        try {
+            if (file == null) {
+                return null;
+            } else {
+                return Files.readString(file.toPath());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads file frm the disk and returns it as a String
+     *
+     * @param filePath  Path to the file that should be read
+     *
+     * @return  String with file content
+     */
+    public static String readFile(String filePath) {
+        return readFile(new File(filePath));
+    }
+
+    /**
+     * Read the classpath resource with the given resourceName and return the content as a String
+     *
+     * @param cls           The class relative to which the resource will be loaded.
+     * @param resourceName  The name of the file stored in resources
+     *
+     * @return  The resource content
+     */
+    public static String readFileFromResources(Class<?> cls, String resourceName) {
+        try {
+            URL url = cls.getResource(resourceName);
+            if (url == null) {
+                return null;
+            } else {
+                return Files.readString(Paths.get(
+                        url.toURI()));
+            }
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads an InputStream and returns its content as a String
+     *
+     * @param stream    InputStreams that should be read
+     *
+     * @return  String with the InputStream content
+     */
+    public static String readInputStream(InputStream stream) {
+        StringBuilder textBuilder = new StringBuilder();
+        try (Reader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            int character;
+
+            while ((character = reader.read()) != -1) {
+                textBuilder.append((char) character);
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Failed to read from InputStream", e);
+        }
+
+        return textBuilder.toString();
+    }
+
+    /**
+     * Reads an object from a YAML file stored in resources
+     *
+     * @param resource  The name of the file in resources
+     * @param c         The class from which resource path should be the file loaded
+     *
+     * @return  An object instance read from the file
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> T readObjectFromYamlFileInResources(String resource, Class<T> c) {
+        return readObjectFromYamlFileInResources(resource, c, false);
+    }
+
+    /**
+     * Reads an object from a YAML file stored in resources
+     *
+     * @param resource                  The name of the file in resources
+     * @param c                         The class from which resource path should be the file loaded
+     * @param ignoreUnknownProperties   Defines whether unknown properties should be ignored or if this method should
+     *                                  fail with an exception
+     *
+     * @return  An object instance from the file
+     *
+     * @param <T>   Type of the resource
+     */
+    public static <T> T readObjectFromYamlFileInResources(String resource, Class<T> c, boolean ignoreUnknownProperties) {
+        URL url = c.getResource(resource);
+        if (url == null) {
+            return null;
+        }
+        ObjectMapper mapper = new YAMLMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !ignoreUnknownProperties);
+        try {
+            return mapper.readValue(url, c);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads an object from YAML string
+     *
+     * @param yamlContent   String with the YAML of the object
+     * @param c             The class representing the object
+     *
+     * @return  Returns the object instance based on the YAML
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> T readObjectFromYamlString(String yamlContent, Class<T> c) {
+        try {
+            ObjectMapper mapper = new YAMLMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+            return mapper.readValue(yamlContent, c);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads an object from a YAML file
+     *
+     * @param yamlFile   File with the YAML
+     * @param c          The class representing the object
+     *
+     * @return  Returns the object instance based on the YAML file
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> T readObjectFromYamlFilepath(File yamlFile, Class<T> c) {
+        try {
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            return mapper.readValue(yamlFile, c);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads an object from a path to a YAML file
+     *
+     * @param yamlPath   Path to a YAML file
+     * @param c          The class representing the object
+     *
+     * @return  Returns the object instance based on the YAML file path
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> T readObjectFromYamlFilepath(String yamlPath, Class<T> c) {
+        return readObjectFromYamlFilepath(new File(yamlPath), c);
+    }
+
+    /**
+     * Converts an object into YAML
+     *
+     * @param instance  The resource that should be converted to YAML
+     *
+     * @return  String with the YAML representation of the object
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> String writeObjectToYamlString(T instance) {
+        try {
+            ObjectMapper mapper = new YAMLMapper()
+                    .disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)
+                    .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+            return mapper.writeValueAsString(instance);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Converts an object into YAML
+     *
+     * @param instance  The resource that should be converted to YAML
+     *
+     * @return  String with the YAML representation of the object
+     *
+     * @param <T>   Type of the object
+     */
+    public static <T> String writeObjectToJsonString(T instance) {
+        try {
+            ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            return mapper.writeValueAsString(instance);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Writes text into a file
+     *
+     * @param filePath  Path of the file where the text will be written
+     * @param text      The text that will be written into the file
+     */
+    public static void writeFile(Path filePath, String text) {
+        try {
+            Files.writeString(filePath, text, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOGGER.warn("Exception during writing text in file", e);
+        }
+    }
+
+    /**
+     * Creates an empty file in the default temporary-file directory, using the given prefix and suffix.
+     *
+     * @param prefix    The prefix of the empty file (default: UUID).
+     * @param suffix    The suffix of the empty file (default: .tmp).
+     *
+     * @return The empty file just created.
+     */
+    public static File tempFile(String prefix, String suffix) {
+        File file;
+        prefix = prefix == null ? UUID.randomUUID().toString() : prefix;
+        suffix = suffix == null ? ".tmp" : suffix;
+        try {
+            file = Files.createTempFile(prefix, suffix).toFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        file.deleteOnExit();
+        return file;
+    }
+
+    /**
+     * Get JSON content as string from resource file.
+     *
+     * TODO: Does the special handling here really matter? Can't we just use redFileFromResources?
+     *
+     * @param resourcePath Resource path.
+     *
+     * @return JSON content as string.
+     */
+    public static String readSingleLineJsonStringFromResourceFile(String resourcePath) {
+        try {
+            URI resourceURI = Objects.requireNonNull(TestUtils.class.getClassLoader().getResource(resourcePath)).toURI();
+            try (Stream<String> lines = Files.lines(Paths.get(resourceURI), UTF_8)) {
+                Optional<String> content = lines.reduce((x, y) -> x + y);
+
+                if (content.isEmpty()) {
+                    throw new IOException(format("File %s from resources was empty", resourcePath));
+                }
+
+                return content.get();
+            }
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/test/src/main/java/io/strimzi/test/WaitException.java
+++ b/test/src/main/java/io/strimzi/test/WaitException.java
@@ -4,11 +4,24 @@
  */
 package io.strimzi.test;
 
+/**
+ * Exception used to indicate that waiting for an event failed
+ */
 public class WaitException extends RuntimeException {
+    /**
+     * Constructor
+     *
+     * @param message   Exception message
+     */
     public WaitException(String message) {
         super(message);
     }
 
+    /**
+     * Constructor
+     *
+     * @param cause     Cause of the exception
+     */
     public WaitException(Throwable cause) {
         super(cause);
     }

--- a/test/src/main/java/io/strimzi/test/annotations/IsolatedTest.java
+++ b/test/src/main/java/io/strimzi/test/annotations/IsolatedTest.java
@@ -26,5 +26,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @ResourceLock(mode = ResourceAccessMode.READ_WRITE, value = "global")
 @Test
 public @interface IsolatedTest {
+    /**
+     * @return  The description of why this test needs to run as isolated
+     */
     String value() default "";
 }

--- a/test/src/main/java/io/strimzi/test/interfaces/ExtensionContextParameterResolver.java
+++ b/test/src/main/java/io/strimzi/test/interfaces/ExtensionContextParameterResolver.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
+/**
+ * Extension context parameter resolver used in the Test separator
+ */
 public class ExtensionContextParameterResolver implements ParameterResolver {
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {

--- a/test/src/main/java/io/strimzi/test/interfaces/TestSeparator.java
+++ b/test/src/main/java/io/strimzi/test/interfaces/TestSeparator.java
@@ -13,17 +13,36 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Collections;
 
+/**
+ * Separates different tests in the log output
+ */
 @ExtendWith(ExtensionContextParameterResolver.class)
 public interface TestSeparator {
+    /**
+     * Logger used to log the separator message
+     */
     Logger LOGGER = LogManager.getLogger(TestSeparator.class);
+    /**
+     * Separator character used in the log output
+     */
     String SEPARATOR_CHAR = "#";
 
+    /**
+     * Prints the separator at the start of the test
+     *
+     * @param testContext   Test context
+     */
     @BeforeEach
     default void beforeEachTest(ExtensionContext testContext) {
         LOGGER.info(String.join("", Collections.nCopies(76, SEPARATOR_CHAR)));
         LOGGER.info(String.format("%s.%s-STARTED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));
     }
 
+    /**
+     * Prints the separator at the end of the test
+     *
+     * @param testContext   Test context
+     */
     @AfterEach
     default void afterEachTest(ExtensionContext testContext) {
         LOGGER.info(String.format("%s.%s-FINISHED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTestUtil.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTestUtil.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
+import io.strimzi.test.CrdUtils;
 import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,7 +53,7 @@ public class TopicOperatorTestUtil {
         createOrReplace(kubernetesClient, "file://" + TestUtils.USER_PATH + "/../packaging/install/topic-operator/01-ServiceAccount-strimzi-topic-operator.yaml", namespace);
         createOrReplace(kubernetesClient, "file://" + TestUtils.USER_PATH + "/../packaging/install/topic-operator/02-Role-strimzi-topic-operator.yaml", namespace);
         createOrReplace(kubernetesClient, "file://" + TestUtils.USER_PATH + "/../packaging/install/topic-operator/03-RoleBinding-strimzi-topic-operator.yaml", namespace);
-        createOrReplace(kubernetesClient, "file://" + TestUtils.CRD_TOPIC);
+        createOrReplace(kubernetesClient, "file://" + CrdUtils.CRD_TOPIC);
     }
 
     private static void createOrReplace(KubernetesClient kubernetesClient, String resourcesPath) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
@@ -22,6 +22,7 @@ import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsProvider;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
 import io.strimzi.operator.topic.model.Results;
+import io.strimzi.test.ReadWriteUtils;
 import io.strimzi.test.TestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,15 +62,15 @@ public class CruiseControlHandlerTest {
             new TopicOperatorMetricsProvider(new SimpleMeterRegistry()));
         
         serverPort = TestUtils.getFreePort();
-        File tlsKeyFile = TestUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".key");
-        tlsCrtFile = TestUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".crt");
+        File tlsKeyFile = ReadWriteUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".key");
+        tlsCrtFile = ReadWriteUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".crt");
         new MockCertManager().generateSelfSignedCert(tlsKeyFile, tlsCrtFile,
             new Subject.Builder().withCommonName("Trusted Test CA").build(), 365);
-        apiUserFile = TestUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".username");
+        apiUserFile = ReadWriteUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".username");
         try (PrintWriter out = new PrintWriter(apiUserFile.getAbsolutePath())) {
             out.print("topic-operator-admin");
         }
-        apiPassFile = TestUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".password");
+        apiPassFile = ReadWriteUtils.tempFile(CruiseControlHandlerTest.class.getSimpleName(), ".password");
         try (PrintWriter out = new PrintWriter(apiPassFile.getAbsolutePath())) {
             out.print("changeit");
         }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/MockCruiseControl.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/MockCruiseControl.java
@@ -8,7 +8,7 @@ import io.strimzi.operator.common.CruiseControlUtil;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 import io.strimzi.operator.topic.TopicOperatorTestUtil;
-import io.strimzi.test.TestUtils;
+import io.strimzi.test.ReadWriteUtils;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
@@ -87,7 +87,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -108,7 +108,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -126,7 +126,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -146,7 +146,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
@@ -168,7 +168,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/topic-config-failure.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-failure.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
@@ -225,7 +225,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // encryption and authentication enabled
@@ -243,7 +243,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // encryption only
@@ -258,7 +258,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // authentication only
@@ -275,7 +275,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
 
@@ -294,7 +294,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code())
-                    .withBody(new JsonBody(TestUtils.jsonFromResource("cruisecontrol/user-tasks-failure.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-failure.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
 

--- a/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
+++ b/user-operator/src/test/java/io/strimzi/operator/user/model/KafkaUserModelTest.java
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
-import static io.strimzi.test.TestUtils.set;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -141,7 +141,7 @@ public class KafkaUserModelTest {
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, Clock.systemUTC());
         Secret generatedSecret = model.generateSecret();
 
-        assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
+        assertThat(generatedSecret.getData().keySet(), is(Set.of("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
 
         assertThat(generatedSecret.getMetadata().getName(), is(ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
@@ -165,7 +165,7 @@ public class KafkaUserModelTest {
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, Clock.systemUTC());
         Secret generatedSecret = model.generateSecret();
 
-        assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
+        assertThat(generatedSecret.getData().keySet(), is(Set.of("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
 
         assertThat(generatedSecret.getMetadata().getName(), is(secretPrefix + ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
@@ -202,7 +202,7 @@ public class KafkaUserModelTest {
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, null, 365, 30, null, Clock.systemUTC());
         Secret generatedSecret = model.generateSecret();
 
-        assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
+        assertThat(generatedSecret.getData().keySet(), is(Set.of("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
 
         assertThat(generatedSecret.getMetadata().getName(), is(ResourceUtils.NAME));
         assertThat(generatedSecret.getMetadata().getNamespace(), is(ResourceUtils.NAMESPACE));
@@ -341,7 +341,7 @@ public class KafkaUserModelTest {
         model.maybeGenerateCertificates(Reconciliation.DUMMY_RECONCILIATION, mockCertManager, passwordGenerator, clientsCaCert, clientsCaKey, oldSecret, 365, 30, null, Clock.systemUTC());
         Secret generatedSecret = model.generateSecret();
 
-        assertThat(generatedSecret.getData().keySet(), is(set("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
+        assertThat(generatedSecret.getData().keySet(), is(Set.of("ca.crt", "user.crt", "user.key", "user.p12", "user.password")));
 
         assertThat(Util.decodeFromBase64(generatedSecret.getData().get("ca.crt")), is("clients-ca-crt"));
         assertThat(Util.decodeFromBase64(generatedSecret.getData().get("user.crt")), is(MockCertManager.userCert()));


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR continues the cleanup and refactoring of the `test` module:
* It splits the `TestUtils` into 3 different classes:
    * `CrdUtils` class with the methods and fields for working with CRDs
    * `ReadWriteUtils` for reading and writing various files and converting them tot he right types
    * The original `TestUtils` with the rest of the methods and fields that did not fit the other classes
* It tries to consolidate the methods, remove duplicates and keep really generic shared methods
* It adds Javadocs and enables the Javadoc validation for the `test` module

There are few more TODOs -> if this PR is approved, I will open issues to track them.

### Checklist

- [x] Make sure all tests pass