### PR TITLE
Improve the `TestSeparator` to indicate if the test failed or succeeded

### DIFF
--- a/test/src/main/java/io/strimzi/test/interfaces/TestSeparator.java
+++ b/test/src/main/java/io/strimzi/test/interfaces/TestSeparator.java
@@ -21,12 +21,17 @@ public interface TestSeparator {
     @BeforeEach
     default void beforeEachTest(ExtensionContext testContext) {
         LOGGER.info(String.join("", Collections.nCopies(76, SEPARATOR_CHAR)));
-        LOGGER.info(String.format("%s.%s-STARTED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));
+        LOGGER.info("{}.{}-STARTED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName());
     }
 
     @AfterEach
     default void afterEachTest(ExtensionContext testContext) {
-        LOGGER.info(String.format("%s.%s-FINISHED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName()));
+        if (testContext.getExecutionException().isPresent()) {
+            LOGGER.info("{}.{}-FAILED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName());
+        } else {
+            LOGGER.info("{}.{}-SUCCEEDED", testContext.getRequiredTestClass().getName(), testContext.getRequiredTestMethod().getName());
+        }
+
         LOGGER.info(String.join("", Collections.nCopies(76, SEPARATOR_CHAR)));
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `TestSeparator` makes it easier to spot where one test ends / another one starts. But sometimes - especially with system tests - the success or failure is not always obvious from the log while the test is still running. This PR checks the result and instead of just indicating that the test `FINISHED` it suggests that it `FAILED` or `SUCCEEDED`.

### Checklist

- [x] Make sure all tests pass