### PR TITLE
[system test] Run DOCs STs generator only in install goal not verify (during tests)

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -280,7 +280,7 @@
                 <version>${skodjob-doc.version}</version>
                 <executions>
                     <execution>
-                        <phase>post-integration-test</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>test-docs-generator</goal>
                         </goals>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR changes the way how we run DOCs STs generator. Currently we run it also when one runs 
```java
mvn verify...  (i.e, during tests)
```
and we do not want it. Instead of this we want to run it during build process
```java
mvn clean install
```
### Checklist

- [x] Make sure all tests pass


