### PR TITLE
Add `OneOf` constraint to Connect external configuration

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnvVarSource.java
@@ -12,6 +12,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.OneOf;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -28,14 +29,13 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"secretKeyRef", "configMapKeyRef"})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("secretKeyRef")), @OneOf.Alternative(@OneOf.Alternative.Property("configMapKeyRef"))})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnvVarSource implements UnknownPropertyPreserving {
     private SecretKeySelector secretKeyRef;
     private ConfigMapKeySelector configMapKeyRef;
     private Map<String, Object> additionalProperties;
-
-    // TODO: We should make it possible to generate a CRD configuring that exactly one of secretKeyRef and configMapKeyRef has to be defined.
 
     @Description("Reference to a key in a Secret.")
     @KubeLink(group = "core", version = "v1", kind = "secretkeyselector")

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.OneOf;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -29,6 +30,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"name", "secret", "configMap"})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("secret")), @OneOf.Alternative(@OneOf.Alternative.Property("configMap"))})
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationVolumeSource implements UnknownPropertyPreserving {
@@ -46,8 +48,6 @@ public class ExternalConfigurationVolumeSource implements UnknownPropertyPreserv
     public void setName(String name) {
         this.name = name;
     }
-
-    // TODO: We should make it possible to generate a CRD configuring that exactly one of secret and configMap has to be defined.
 
     @Description("Reference to a key in a Secret. " +
             "Exactly one Secret or ConfigMap has to be specified.")

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -2213,6 +2213,15 @@ spec:
                                   optional:
                                     type: boolean
                                 description: Reference to a key in a ConfigMap.
+                            oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                  - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                  - configMapKeyRef
                             description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                         required:
                           - name
@@ -2268,6 +2277,15 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                        oneOf:
+                          - properties:
+                              secret: {}
+                            required:
+                              - secret
+                          - properties:
+                              configMap: {}
+                            required:
+                              - configMap
                         required:
                           - name
                       description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -2358,6 +2358,15 @@ spec:
                                   optional:
                                     type: boolean
                                 description: Reference to a key in a ConfigMap.
+                            oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                  - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                  - configMapKeyRef
                             description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                         required:
                           - name
@@ -2413,6 +2422,15 @@ spec:
                               optional:
                                 type: boolean
                             description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                        oneOf:
+                          - properties:
+                              secret: {}
+                            required:
+                              - secret
+                          - properties:
+                              configMap: {}
+                            required:
+                              - configMap
                         required:
                           - name
                       description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -2212,6 +2212,15 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a ConfigMap.
+                          oneOf:
+                          - properties:
+                              secretKeyRef: {}
+                            required:
+                            - secretKeyRef
+                          - properties:
+                              configMapKeyRef: {}
+                            required:
+                            - configMapKeyRef
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -2267,6 +2276,15 @@ spec:
                             optional:
                               type: boolean
                           description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                      oneOf:
+                      - properties:
+                          secret: {}
+                        required:
+                        - secret
+                      - properties:
+                          configMap: {}
+                        required:
+                        - configMap
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -2357,6 +2357,15 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a ConfigMap.
+                          oneOf:
+                          - properties:
+                              secretKeyRef: {}
+                            required:
+                            - secretKeyRef
+                          - properties:
+                              configMapKeyRef: {}
+                            required:
+                            - configMapKeyRef
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -2412,6 +2421,15 @@ spec:
                             optional:
                               type: boolean
                           description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                      oneOf:
+                      - properties:
+                          secret: {}
+                        required:
+                        - secret
+                      - properties:
+                          configMap: {}
+                        required:
+                        - configMap
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the `OneOf` constraint to the external configuration in the COnnect / MM2 custom resources. This helps to validate that the environment variables or volumes use either ConfigMap or Secret but not both (or none of them).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally