### PR TITLE
Deprecate the External Configuration Volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   Kubernetes 1.23 and 1.24 are not supported anymore.
 * When finalizers are enabled (default), the Topic Operator will no longer restore finalizers on unmanaged `KafkaTopic` resources if they are removed, aligning the behavior with paused topics, where finalizers are also not restored.
   This change matches user expectations.
+* The External Configuration Volumes (`.spec.externalConfiguration.volumes`) in `KafkaConnect` and `KafkaMirrorMaker2` resources are deprecated and will be removed in the future.
+  Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps.
 
 ## 0.43.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -49,8 +49,8 @@ public class ExternalConfiguration implements UnknownPropertyPreserving {
     @Description("Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     @Deprecated
-    @DeprecatedProperty(description = "The External Configuration Volumes are deprecated and will be removed in the future. " +
-            "Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps.")
+    @DeprecatedProperty(description = "The external configuration volumes are deprecated and will be removed in the future. " +
+            "Please use the additional volumes and volume mounts in pod and container templates instead to mount additional secrets or config maps.")
     public List<ExternalConfigurationVolumeSource> getVolumes() {
         return volumes;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -6,6 +6,7 @@ package io.strimzi.api.kafka.model.connect;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -47,6 +48,9 @@ public class ExternalConfiguration implements UnknownPropertyPreserving {
 
     @Description("Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Deprecated
+    @DeprecatedProperty(description = "The External Configuration Volumes are deprecated and will be removed in the future. " +
+            "Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps.")
     public List<ExternalConfigurationVolumeSource> getVolumes() {
         return volumes;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationVolumeSource.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
 import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.api.kafka.model.common.template.AdditionalVolume;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.OneOf;
@@ -31,6 +33,8 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"name", "secret", "configMap"})
 @OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("secret")), @OneOf.Alternative(@OneOf.Alternative.Property("configMap"))})
+@Deprecated
+@DeprecatedType(replacedWithType = AdditionalVolume.class)
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationVolumeSource implements UnknownPropertyPreserving {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -133,6 +133,8 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
 
     protected String bootstrapServers;
     protected List<ExternalConfigurationEnv> externalEnvs = Collections.emptyList();
+
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     protected List<ExternalConfigurationVolumeSource> externalVolumes = Collections.emptyList();
     protected Tracing tracing;
     protected JmxModel jmx;
@@ -384,6 +386,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         return volumeList;
     }
 
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     private List<Volume> getExternalConfigurationVolumes(boolean isOpenShift)  {
         int mode = 0444;
         if (isOpenShift) {
@@ -454,6 +457,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         return volumeMountList;
     }
 
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     private List<VolumeMount> getExternalConfigurationVolumeMounts()    {
         List<VolumeMount> volumeMountList = new ArrayList<>(0);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -980,6 +980,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationSecretVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1013,6 +1014,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationSecretVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -1046,6 +1048,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationConfigVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1079,6 +1082,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationConfigVolumesWithDots() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my.volume")
@@ -1112,6 +1116,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationInvalidVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1142,6 +1147,7 @@ public class KafkaConnectClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testNoExternalConfigurationVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -1124,6 +1124,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationSecretVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1157,6 +1158,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationConfigVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1190,6 +1192,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testExternalConfigurationInvalidVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")
@@ -1220,6 +1223,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     @ParallelTest
+    @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
     public void testNoExternalConfigurationVolumes() {
         ExternalConfigurationVolumeSource volume = new ExternalConfigurationVolumeSourceBuilder()
                 .withName("my-volume")

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2754,7 +2754,7 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 |Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
 |volumes
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
-|**The `volumes` property has been deprecated.** The External Configuration Volumes are deprecated and will be removed in the future. Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
+|**The `volumes` property has been deprecated.** The external configuration volumes are deprecated and will be removed in the future. Please use the additional volumes and volume mounts in pod and container templates instead to mount additional secrets or config maps. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
 |====
 
 [id='type-ExternalConfigurationEnv-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2754,7 +2754,7 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 |Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
 |volumes
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
-|Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
+|**The `volumes` property has been deprecated.** The External Configuration Volumes are deprecated and will be removed in the future. Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
 |====
 
 [id='type-ExternalConfigurationEnv-{context}']
@@ -2793,6 +2793,9 @@ Used in: xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`
 
 [id='type-ExternalConfigurationVolumeSource-{context}']
 = `ExternalConfigurationVolumeSource` schema reference
+
+*The type `ExternalConfigurationVolumeSource` has been deprecated.*
+Please use xref:type-AdditionalVolume-{context}[`AdditionalVolume`] instead.
 
 Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 

--- a/documentation/modules/configuring/proc-loading-config-from-file.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-file.adoc
@@ -103,7 +103,7 @@ spec:
   config:
     database.hostname: 192.168.99.1
     database.port: "3306"
-    database.user: "${file:/mnt//mysecret/connector.properties:dbUsername}"
+    database.user: "${file:/mnt/mysecret/connector.properties:dbUsername}"
     database.password: "${file:/mnt/mysecret/connector.properties:dbPassword}"
     database.server.id: "184054"
     #...

--- a/documentation/modules/configuring/proc-loading-config-from-file.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-file.adoc
@@ -7,12 +7,12 @@
 
 [role="_abstract"]
 Use the `FileConfigProvider` to provide configuration properties from a file within a directory.
-Files can be config maps or secrets.
+Files can be stored in config maps or secrets.
 
 In this procedure, a file provides configuration properties for a connector.
 A database name and password are specified as properties of a secret.
 The secret is mounted to the Kafka Connect pod as a volume. 
-Volumes are mounted on the path `/opt/kafka/external-configuration/<volume-name>`.
+Volumes are mounted on the path `/mnt/<volume-name>`.
 
 .Prerequisites
 
@@ -42,7 +42,7 @@ stringData:
 +
 --
 * Enable the `FileConfigProvider`
-* Specify the file using the `externalConfiguration` property.
+* Specify the additional volume using the `template` property.
 --
 +
 .Example Kafka Connect configuration to use an external property file
@@ -58,17 +58,26 @@ spec:
     config.providers: file # <1>
     config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider # <2>
   #...
-  externalConfiguration:
-    volumes:
-      - name: connector-config # <3>
-        secret:
-          secretName: mysecret # <4>
+  template:
+    pod:
+      volumes:
+        - name: connector-config-volume # <3>
+          secret:
+            secretName: mysecret # <4>
+    kafkaContainer:
+      volumeMounts:
+        - name: connector-config-volume # <5>
+          mountPath: /mnt/mysecret # <6>
 ----
 <1> The alias for the configuration provider is used to define other configuration parameters.
 <2> `FileConfigProvider` provides values from properties files.
 The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
 <3> The name of the volume containing the secret.
 <4> The name of the secret.
+<5> The name of the volume that will be mounted.
+Has to be the same as the name of the volume.
+<6> The path where the Secret will be mounted.
+Has to start with `/mnt/`.
 
 . Create or update the resource to enable the provider.
 +
@@ -94,8 +103,8 @@ spec:
   config:
     database.hostname: 192.168.99.1
     database.port: "3306"
-    database.user: "${file:/opt/kafka/external-configuration/connector-config/mysecret:dbUsername}"
-    database.password: "${file:/opt/kafka/external-configuration/connector-config/mysecret:dbPassword}"
+    database.user: "${file:/mnt//mysecret/connector.properties:dbUsername}"
+    database.password: "${file:/mnt/mysecret/connector.properties:dbPassword}"
     database.server.id: "184054"
     #...
 ----

--- a/documentation/modules/configuring/proc-loading-config-from-file.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-file.adoc
@@ -74,10 +74,8 @@ spec:
 The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
 <3> The name of the volume containing the secret.
 <4> The name of the secret.
-<5> The name of the volume that will be mounted.
-Has to be the same as the name of the volume in the volumes list in <3>.
-<6> The path where the Secret will be mounted.
-Has to start with `/mnt/`.
+<5> The name of the mounted volume, which must match the volume name in the `volumes` list.
+<6> The path where the secret is mounted, which must start with `/mnt/`.
 
 . Create or update the resource to enable the provider.
 +

--- a/documentation/modules/configuring/proc-loading-config-from-file.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-file.adoc
@@ -75,7 +75,7 @@ The parameter uses the alias from `config.providers`, taking the form `config.pr
 <3> The name of the volume containing the secret.
 <4> The name of the secret.
 <5> The name of the volume that will be mounted.
-Has to be the same as the name of the volume.
+Has to be the same as the name of the volume in the volumes list in <3>.
 <6> The path where the Secret will be mounted.
 Has to start with `/mnt/`.
 

--- a/documentation/modules/configuring/proc-loading-config-from-files.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-files.adoc
@@ -93,10 +93,8 @@ spec:
 <2> `DirectoryConfigProvider` provides values from files in a directory. The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
 <3> The name of the volume containing the secret.
 <4> The name of the secret.
-<5> The name of the volume that will be mounted.
-Has to be the same as the name of the volume in the volumes list in <3>.
-<6> The path where the Secret will be mounted.
-Has to start with `/mnt/`.
+<5> The name of the mounted volume, which must match the volume name in the `volumes` list.
+<6> The path where the secret is mounted, which must start with `/mnt/`.
 
 . Create or update the resource to enable the provider.
 +

--- a/documentation/modules/configuring/proc-loading-config-from-files.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-files.adoc
@@ -94,7 +94,7 @@ spec:
 <3> The name of the volume containing the secret.
 <4> The name of the secret.
 <5> The name of the volume that will be mounted.
-Has to be the same as the name of the volume.
+Has to be the same as the name of the volume in the volumes list in <3>.
 <6> The path where the Secret will be mounted.
 Has to start with `/mnt/`.
 

--- a/documentation/modules/configuring/proc-loading-config-from-files.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-files.adoc
@@ -11,8 +11,8 @@ Files can be config maps or secrets.
 
 In this procedure, a secret provides the TLS keystore and truststore user credentials for a connector.
 The credentials are in separate files.
-The secrets are mounted into the Kafka Connect pod as volumes. 
-Volumes are mounted on the path `/opt/kafka/external-configuration/<volume-name>`.
+The secrets are mounted into the Kafka Connect pod as volumes.
+Volumes are mounted on the path `/mnt/<volume-name>`.
 
 .Prerequisites
 
@@ -49,7 +49,7 @@ The `<cluster_name>-cluster-ca-cert` secret generated when deploying the Kafka c
 +
 --
 * Enable the `DirectoryConfigProvider`
-* Specify the files using the `externalConfiguration` property.
+* Specify the additional volume using the `template` property.
 --
 +
 .Example Kafka Connect configuration to use external property files
@@ -65,6 +65,21 @@ spec:
     config.providers: directory # <1>
     config.providers.directory.class: org.apache.kafka.common.config.provider.DirectoryConfigProvider # <2>
   #...
+  template:
+    pod:
+      volumes:
+        - name: my-user-volume # <3>
+          secret:
+            secretName: my-user # <4>
+        - name: cluster-ca-volume
+          secret:
+            secretName: my-cluster-cluster-ca-cert
+    kafkaContainer:
+      volumeMounts:
+        - name: my-user-volume # <5>
+          mountPath: /mnt/my-user # <6>
+        - name: cluster-ca-volume
+          mountPath: /mnt/cluster-ca
   externalConfiguration:
     volumes: # <3>
       - name: cluster-ca # <4>
@@ -76,9 +91,12 @@ spec:
 ----
 <1> The alias for the configuration provider is used to define other configuration parameters.
 <2> `DirectoryConfigProvider` provides values from files in a directory. The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.
-<3> The names of the volumes containing the secrets. 
-<4> The name of the secret for the cluster CA certificate to supply truststore configuration.
-<5> The name of the secret for the user to supply keystore configuration.
+<3> The name of the volume containing the secret.
+<4> The name of the secret.
+<5> The name of the volume that will be mounted.
+Has to be the same as the name of the volume.
+<6> The path where the Secret will be mounted.
+Has to start with `/mnt/`.
 
 . Create or update the resource to enable the provider.
 +
@@ -105,10 +123,10 @@ spec:
     # ...
     database.history.producer.security.protocol: SSL
     database.history.producer.ssl.truststore.type: PEM
-    database.history.producer.ssl.truststore.certificates: "${directory:/opt/kafka/external-configuration/cluster-ca:ca.crt}"
+    database.history.producer.ssl.truststore.certificates: "${directory:/mtn/cluster-ca:ca.crt}"
     database.history.producer.ssl.keystore.type: PEM
-    database.history.producer.ssl.keystore.certificate.chain: "${directory:/opt/kafka/external-configuration/my-user:user.crt}"
-    database.history.producer.ssl.keystore.key: "${directory:/opt/kafka/external-configuration/my-user:user.key}"
+    database.history.producer.ssl.keystore.certificate.chain: "${directory:/mnt/my-user:user.crt}"
+    database.history.producer.ssl.keystore.key: "${directory:/mnt/my-user:user.key}"
     #...
 ----
 +


### PR DESCRIPTION
### Type of change

- Task

### Description

In Strimzi 0.43, we added the [additional volumes feature](https://strimzi.io/docs/operators/latest/full/configuring.html#type-AdditionalVolume-reference) -> it can be used with any container to mount new volumes based on Secret, ConfigMap, EmptyDir or PVC.

But already previously, in Kafka Connect, we had the External configuration volumes that allow to mount additional Secret or ConfigMaps as a volume to the [Connect containers](https://strimzi.io/docs/operators/latest/full/configuring.html#type-ExternalConfigurationVolumeSource-reference). So this now duplicates the newly added additional volumes feature.

This PR deprecates the External Configuration volumes. Reducing a duplicate functionality would simplify the code maintenance and testing going forward. It also updates the documentation to also use the additional volumes instead of the external configuration volumes. The API will be still present and used until it is removed in `v1` API.

### Checklist

- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md