### PR TITLE
docs(ports): adds a description of port 8443 used by KafkaAgent

### DIFF
--- a/documentation/assemblies/security/assembly-security.adoc
+++ b/documentation/assemblies/security/assembly-security.adoc
@@ -50,10 +50,16 @@ image::secure_communication_zookeeper.png[Secure Communication]
 
 The ZooKeeper ports are used as follows:
 
-ZooKeeper Port (2181):: ZooKeeper port for connection to Kafka brokers.
+ZooKeeper port (2181):: ZooKeeper port for connection to Kafka brokers.
 Additionally, the Cluster Operator communicates with ZooKeeper through this port.
 ZooKeeper internodal communication port (2888):: ZooKeeper port for internodal communication between ZooKeeper nodes.
 ZooKeeper leader election port (3888):: ZooKeeper port for leader election among ZooKeeper nodes in a ZooKeeper cluster.
+
+.Node status monitoring using the `KafkaAgent` (8443)
+
+Strimzi includes a component called `KafkaAgent` that runs inside each Kafka node. 
+The agent is responsible for collecting and providing node-specific information, such as current state and readiness, to the Cluster Operator. 
+It listens on port 8443 for secure HTTPS connections and exposes this information through a REST API, which the Cluster Operator uses to retrieve data from the nodes.
 
 include::../../modules/security/con-certificate-authorities.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Documentation**

Adds a description of port 8443 used by KafkaAgent on nodes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

