### PR TITLE
Update the Kindcontainer used in MockKube tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <javax.json.version>1.1.4</javax.json.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <kroxylicious-testing.version>0.9.0</kroxylicious-testing.version>
-        <kindcontainer.version>1.4.6</kindcontainer.version>
+        <kindcontainer.version>1.4.7</kindcontainer.version>
         <junit4.version>4.13.2</junit4.version>
         <skodjob.test-frame.version>0.6.1</skodjob.test-frame.version>
         <skodjob-doc.version>0.3.0</skodjob-doc.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the KindContainer dependency used by the MockKube for mock tests. This brings support for Kubernetes 1.31.

### Checklist

- [x] Make sure all tests pass