### PR TITLE
Possibility to override kaniko executor image in systemtest

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -219,7 +219,7 @@ public class Environment {
     public static final String IP_FAMILY_DUAL_STACK = "dual";
 
     public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka:latest-kafka-" + ST_KAFKA_VERSION_DEFAULT;
-    public static final String KANIKO_IMAGE_DEFAULT = "gcr.io/kaniko-project/executor:latest";
+    public static final String KANIKO_IMAGE_DEFAULT = "gcr.io/kaniko-project/executor:v1.23.2";
 
     /**
      * Set values

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -184,6 +184,7 @@ public class Environment {
      * Env var for specify base image for building Kafka with tiered storage in system tests
      */
     public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE_ENV = "KAFKA_TIERED_STORAGE_BASE_IMAGE";
+    public static final String KANIKO_IMAGE_ENV = "KANIKO_IMAGE";
 
     /**
      * Defaults
@@ -218,6 +219,7 @@ public class Environment {
     public static final String IP_FAMILY_DUAL_STACK = "dual";
 
     public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + STRIMZI_ORG_DEFAULT + "/kafka:latest-kafka-" + ST_KAFKA_VERSION_DEFAULT;
+    public static final String KANIKO_IMAGE_DEFAULT = "gcr.io/kaniko-project/executor:latest";
 
     /**
      * Set values
@@ -275,6 +277,7 @@ public class Environment {
     public static final String IP_FAMILY = getOrDefault(IP_FAMILY_ENV, IP_FAMILY_DEFAULT);
 
     public static final String KAFKA_TIERED_STORAGE_BASE_IMAGE = getOrDefault(KAFKA_TIERED_STORAGE_BASE_IMAGE_ENV, KAFKA_TIERED_STORAGE_BASE_IMAGE_DEFAULT);
+    public static final String KANIKO_IMAGE = getOrDefault(KANIKO_IMAGE_ENV, KANIKO_IMAGE_DEFAULT);
 
     private Environment() { }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/imageBuild/ImageBuild.java
@@ -32,9 +32,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static io.strimzi.systemtest.Environment.KANIKO_IMAGE;
+
 public class ImageBuild {
     private static final Logger LOGGER = LogManager.getLogger(ImageBuild.class);
-    private static final String KANIKO_IMAGE = "gcr.io/kaniko-project/executor:latest";
 
     /**
      * Build a specific image from passed Dockerfile and push it into internal registry.


### PR DESCRIPTION
### Type of change
- Test Refactoring

### Description

Moved the kaniko image constant (used in tiered storage test) into Environment and made it possible to override via env var.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

