### PR TITLE
Refactor KafkaCluster tests to not use internal methods

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -591,7 +591,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
     }
 
-    protected static void validateIntConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec, long numberOfBrokers) {
+    private static void validateIntConfigProperty(String propertyName, KafkaClusterSpec kafkaClusterSpec, long numberOfBrokers) {
         String orLess = numberOfBrokers > 1 ? " or less" : "";
         if (kafkaClusterSpec.getConfig() != null && kafkaClusterSpec.getConfig().get(propertyName) != null) {
             try {
@@ -672,7 +672,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  JSON with discovery annotation
      */
-    /*test*/ Map<String, String> getInternalDiscoveryAnnotation() {
+    private Map<String, String> getInternalDiscoveryAnnotation() {
         JsonArray anno = new JsonArray();
 
         for (GenericKafkaListener listener : listeners) {
@@ -1231,7 +1231,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of container ports
      */
-    /* test */ List<ContainerPort> getContainerPortList(KafkaPool pool) {
+    private List<ContainerPort> getContainerPortList(KafkaPool pool) {
         List<ContainerPort> ports = new ArrayList<>(listeners.size() + 3);
 
         ports.add(ContainerUtils.createContainerPort(KAFKA_AGENT_PORT_NAME, KAFKA_AGENT_PORT));
@@ -1313,7 +1313,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return List of non-data volumes used by the ZooKeeper pods
      */
-    /* test */ List<Volume> getNonDataVolumes(boolean isOpenShift, String podName, PodTemplate templatePod) {
+    private List<Volume> getNonDataVolumes(boolean isOpenShift, String podName, PodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
         if (rack != null || isExposedWithNodePort()) {
@@ -1459,7 +1459,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  Combined affinity
      */
-    protected Affinity getMergedAffinity(KafkaPool pool) {
+    private Affinity getMergedAffinity(KafkaPool pool) {
         Affinity userAffinity = pool.templatePod != null && pool.templatePod.getAffinity() != null ? pool.templatePod.getAffinity() : new Affinity();
         AffinityBuilder builder = new AffinityBuilder(userAffinity);
         if (rack != null) {
@@ -1484,7 +1484,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         return builder.build();
     }
 
-    protected List<EnvVar> getInitContainerEnvVars(KafkaPool pool) {
+    private List<EnvVar> getInitContainerEnvVars(KafkaPool pool) {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVarFromFieldRef(ENV_VAR_KAFKA_INIT_NODE_NAME, "spec.nodeName"));
 
@@ -1504,7 +1504,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         return varList;
     }
 
-    /* test */ Container createInitContainer(ImagePullPolicy imagePullPolicy, KafkaPool pool) {
+    private Container createInitContainer(ImagePullPolicy imagePullPolicy, KafkaPool pool) {
         if (rack != null || !ListenersUtils.nodePortListeners(listeners).isEmpty()) {
             return ContainerUtils.createContainer(
                     INIT_NAME,
@@ -1532,7 +1532,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  Kafka container
      */
-    /* test */ Container createContainer(ImagePullPolicy imagePullPolicy, KafkaPool pool) {
+    private Container createContainer(ImagePullPolicy imagePullPolicy, KafkaPool pool) {
         return ContainerUtils.createContainer(
                 KAFKA_NAME,
                 image,
@@ -1555,7 +1555,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of environment variables
      */
-    protected List<EnvVar> getEnvVars(KafkaPool pool) {
+    private  List<EnvVar> getEnvVars(KafkaPool pool) {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(metrics.isEnabled())));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(pool.gcLoggingEnabled)));
@@ -1706,24 +1706,6 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     private boolean isExposedWithNodePort() {
         return ListenersUtils.hasNodePortListener(listeners);
-    }
-
-    /**
-     * Returns true when the Kafka cluster is exposed to the outside of Kubernetes using Ingress
-     *
-     * @return true when the Kafka cluster is exposed using Kubernetes Ingress.
-     */
-    /* test */ boolean isExposedWithIngress() {
-        return ListenersUtils.hasIngressListener(listeners);
-    }
-
-    /**
-     * Returns true when the Kafka cluster is exposed to the outside of Kubernetes using ClusterIP services
-     *
-     * @return true when the Kafka cluster is exposed using Kubernetes Ingress with TCP mode.
-     */
-    /* test */ boolean isExposedWithClusterIP() {
-        return ListenersUtils.hasClusterIPListener(listeners);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -32,6 +32,7 @@ import io.strimzi.api.kafka.model.kafka.listener.NodeAddressType;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
+import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Reconciliation;
@@ -42,6 +43,7 @@ import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -753,17 +755,16 @@ public class KafkaClusterListenersTest {
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
-
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
-
-            if (!"controllers".equals(pool.poolName))   {
-                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
-            } else {
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
+        
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
@@ -982,17 +983,17 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> Map.of());
 
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
-            } else {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
@@ -1365,17 +1366,17 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
+        
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
-
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
-            } else {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
@@ -1495,21 +1496,22 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
-
-        for (KafkaPool pool : pools) {
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
+        
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             // Check Init container
-            Container initCont = kc.createInitContainer(null, pool);
+            Container initCont = pod.getSpec().getInitContainers().stream().findAny().orElseThrow();
 
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(initCont, is(notNullValue()));
-                assertThat(initCont.getEnv().stream().filter(env -> KafkaCluster.ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS.equals(env.getName()))
-                        .map(EnvVar::getValue).findFirst().orElse(null), is("TRUE"));
-            } else {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(initCont, is(notNullValue()));
                 assertThat(initCont.getEnv().stream().filter(env -> KafkaCluster.ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS.equals(env.getName()))
                         .map(EnvVar::getValue).findFirst().orElse(null), is(nullValue()));
+            } else {
+                assertThat(initCont, is(notNullValue()));
+                assertThat(initCont.getEnv().stream().filter(env -> KafkaCluster.ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS.equals(env.getName()))
+                        .map(EnvVar::getValue).findFirst().orElse(null), is("TRUE"));
             }
-        }
+        }));
     }
 
     @ParallelTest
@@ -1543,17 +1545,17 @@ public class KafkaClusterListenersTest {
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> Map.of());
+        
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
-
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
-            } else {
+            if ((CLUSTER + "-controllers").equals(podSet.getMetadata().getName())) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         Service ext = kc.generateExternalBootstrapServices().get(0);
@@ -1823,18 +1825,18 @@ public class KafkaClusterListenersTest {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
 
-        assertThat(kc.isExposedWithIngress(), is(true));
+        assertThat(kc.getListeners().stream().findFirst().orElseThrow().getType(), is(KafkaListenerType.INGRESS));
 
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> Map.of());
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
-            } else {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort(ListenersUtils.BACKWARDS_COMPATIBLE_EXTERNAL_PORT_NAME, 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
@@ -2056,19 +2058,20 @@ public class KafkaClusterListenersTest {
 
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        
+        assertThat(kc.getListeners().stream().findFirst().orElseThrow().getType(), is(KafkaListenerType.CLUSTER_IP));
+        
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> Map.of());
 
-        assertThat(kc.isExposedWithClusterIP(), is(true));
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            List<ContainerPort> ports = pod.getSpec().getContainers().stream().findAny().orElseThrow().getPorts();
 
-        for (KafkaPool pool : pools) {
-            // Check port
-            List<ContainerPort> ports = kc.getContainerPortList(pool);
-
-            if (!"controllers".equals(pool.poolName)) {
-                assertThat(ports.contains(ContainerUtils.createContainerPort("tcp-clusterip", 9094)), is(true));
-            } else {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-controllers")) {
                 assertThat(ports.contains(ContainerUtils.createContainerPort("tcp-clusterip", 9094)), is(false));
+            } else {
+                assertThat(ports.contains(ContainerUtils.createContainerPort("tcp-clusterip", 9094)), is(true));
             }
-        }
+        }));
 
         // Check external bootstrap service
         List<Service> bootstrapServices = kc.generateExternalBootstrapServices();
@@ -2206,15 +2209,16 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
 
-        for (KafkaPool pool : pools) {
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
             // Volume mounts
-            Container cont = kc.createContainer(null, pool);
+            Container cont = pod.getSpec().getContainers().stream().findFirst().orElseThrow();
             assertThat(cont.getVolumeMounts().stream().filter(mount -> "custom-listener-plain-9092-0".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.CUSTOM_AUTHN_SECRETS_VOLUME_MOUNT + "/custom-listener-plain-9092/test"));
             assertThat(cont.getVolumeMounts().stream().filter(mount -> "custom-listener-plain-9092-1".equals(mount.getName())).findFirst().orElseThrow().getMountPath(), is(KafkaCluster.CUSTOM_AUTHN_SECRETS_VOLUME_MOUNT + "/custom-listener-plain-9092/test2"));
 
             // Volumes
-            List<Volume> volumes = kc.getNonDataVolumes(false, "foo-brokers-6", null);
+            List<Volume> volumes = pod.getSpec().getVolumes();
 
             assertThat(volumes.stream().filter(vol -> "custom-listener-plain-9092-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
             assertThat(volumes.stream().filter(vol -> "custom-listener-plain-9092-0".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("foo"));
@@ -2223,7 +2227,7 @@ public class KafkaClusterListenersTest {
             assertThat(volumes.stream().filter(vol -> "custom-listener-plain-9092-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().size(), is(1));
             assertThat(volumes.stream().filter(vol -> "custom-listener-plain-9092-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getKey(), is("bar"));
             assertThat(volumes.stream().filter(vol -> "custom-listener-plain-9092-1".equals(vol.getName())).findFirst().orElseThrow().getSecret().getItems().get(0).getPath(), is("bar"));
-        }
+        }));
     }
 
     @ParallelTest
@@ -2253,27 +2257,28 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
 
-        // Test volumes
-        List<Volume> volumes = kc.getNonDataVolumes(false, "foo-brokers-6", null);
-        Volume vol = volumes.stream().filter(v -> "custom-external-9094-certs".equals(v.getName())).findFirst().orElse(null);
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            // Test volumes
+            List<Volume> volumes = pod.getSpec().getVolumes();
+            Volume vol = volumes.stream().filter(v -> "custom-external-9094-certs".equals(v.getName())).findFirst().orElse(null);
 
-        assertThat(vol, is(notNullValue()));
-        assertThat(vol.getSecret().getSecretName(), is(secret));
-        assertThat(vol.getSecret().getItems().get(0).getKey(), is(key));
-        assertThat(vol.getSecret().getItems().get(0).getPath(), is("tls.key"));
-        assertThat(vol.getSecret().getItems().get(1).getKey(), is(cert));
-        assertThat(vol.getSecret().getItems().get(1).getPath(), is("tls.crt"));
+            assertThat(vol, is(notNullValue()));
+            assertThat(vol.getSecret().getSecretName(), is(secret));
+            assertThat(vol.getSecret().getItems().get(0).getKey(), is(key));
+            assertThat(vol.getSecret().getItems().get(0).getPath(), is("tls.key"));
+            assertThat(vol.getSecret().getItems().get(1).getKey(), is(cert));
+            assertThat(vol.getSecret().getItems().get(1).getPath(), is("tls.crt"));
 
-        for (KafkaPool pool : pools) {
             // Test volume mounts
-            Container cont = kc.createContainer(null, pool);
-            VolumeMount mount = cont.getVolumeMounts().stream().filter(v -> "custom-external-9094-certs".equals(v.getName())).findFirst().orElse(null);
+            Container container = pod.getSpec().getContainers().stream().findFirst().orElseThrow();
+            VolumeMount mount = container.getVolumeMounts().stream().filter(v -> "custom-external-9094-certs".equals(v.getName())).findFirst().orElse(null);
 
             assertThat(mount, is(notNullValue()));
             assertThat(mount.getName(), is("custom-external-9094-certs"));
             assertThat(mount.getMountPath(), is("/opt/kafka/certificates/custom-external-9094-certs"));
-        }
+        }));
     }
 
     @ParallelTest
@@ -2303,26 +2308,27 @@ public class KafkaClusterListenersTest {
                 .build();
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, brokerId -> new HashMap<>());
 
-        // Test volumes
-        List<Volume> volumes = kc.getNonDataVolumes(false, "foo-brokers-6", null);
-        Volume vol = volumes.stream().filter(v -> "custom-tls-9093-certs".equals(v.getName())).findFirst().orElse(null);
+        podSets.stream().forEach(podSet -> PodSetUtils.podSetToPods(podSet).stream().forEach(pod -> {
+            // Test volumes
+            List<Volume> volumes = pod.getSpec().getVolumes();
+            Volume vol = volumes.stream().filter(v -> "custom-tls-9093-certs".equals(v.getName())).findFirst().orElse(null);
 
-        assertThat(vol, is(notNullValue()));
-        assertThat(vol.getSecret().getSecretName(), is(secret));
-        assertThat(vol.getSecret().getItems().get(0).getKey(), is(key));
-        assertThat(vol.getSecret().getItems().get(0).getPath(), is("tls.key"));
-        assertThat(vol.getSecret().getItems().get(1).getKey(), is(cert));
-        assertThat(vol.getSecret().getItems().get(1).getPath(), is("tls.crt"));
+            assertThat(vol, is(notNullValue()));
+            assertThat(vol.getSecret().getSecretName(), is(secret));
+            assertThat(vol.getSecret().getItems().get(0).getKey(), is(key));
+            assertThat(vol.getSecret().getItems().get(0).getPath(), is("tls.key"));
+            assertThat(vol.getSecret().getItems().get(1).getKey(), is(cert));
+            assertThat(vol.getSecret().getItems().get(1).getPath(), is("tls.crt"));
 
-        for (KafkaPool pool : pools) {
             // Test volume mounts
-            Container cont = kc.createContainer(null, pool);
-            VolumeMount mount = cont.getVolumeMounts().stream().filter(v -> "custom-tls-9093-certs".equals(v.getName())).findFirst().orElse(null);
+            Container container = pod.getSpec().getContainers().stream().findAny().orElseThrow();
+            VolumeMount mount = container.getVolumeMounts().stream().filter(v -> "custom-tls-9093-certs".equals(v.getName())).findFirst().orElse(null);
 
             assertThat(mount, is(notNullValue()));
             assertThat(mount.getName(), is("custom-tls-9093-certs"));
             assertThat(mount.getMountPath(), is("/opt/kafka/certificates/custom-tls-9093-certs"));
-        }
+        }));
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Change methods in KafkaCluster.java to private that were previously exposed for unit test purposes and refactor related test cases.

Closes #10531 

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

