### PR TITLE
Roll controller nodes on `num.partitions` change

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -122,6 +122,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
             "node.id",
             "num.io.threads",
             "num.network.threads",
+            "num.partitions",
             "offsets.topic.replication.factor",
             "principal.builder.class",
             "process.roles",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Currently, we do not roll the controller-only nodes when `num.partitions` option changes. But this option seems to be used by the controller nodes and not brokers. So any changes to it are ignored unless the controllers are rolled. This PR adds it to the list of _controller relevant options_, so that we roll the controllers when it is changed.

This was raised up in https://cloud-native.slack.com/archives/CMH3Q3SNP/p1726561281223539

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally