### PR TITLE
Use init container for Kafka nodes only when needed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -158,14 +158,14 @@ public class KafkaBrokerConfigurationBuilder {
 
     /**
      * Adds the template for the {@code rack.id}. The rack ID will be set in the container based on the value of the
-     * {@code STRIMZI_RACK_ID} env var. It is set only if user enabled the rack awareness-
+     * {@code STRIMZI_RACK_ID} env var. It is set only for broker nodes and only if user enabled the rack awareness.
      *
      * @param rack The Rack Awareness configuration from the Kafka CR
      *
      * @return Returns the builder instance
      */
     public KafkaBrokerConfigurationBuilder withRackId(Rack rack)   {
-        if (rack != null) {
+        if (node.broker() && rack != null) {
             printSectionHeader("Rack ID");
             writer.println("broker.rack=" + PLACEHOLDER_RACK_ID);
             writer.println();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -238,14 +238,32 @@ public class KafkaBrokerConfigurationBuilderTest {
     }
 
     @ParallelTest
-    public void testRackAndBrokerId()  {
-        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)
+    public void testRackIdInKRaftBrokers()  {
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.KRAFT)
                 .withRackId(new Rack("failure-domain.kubernetes.io/zone"))
                 .build();
 
-        assertThat(configuration, isEquivalent("broker.id=2",
-                "node.id=2",
+        assertThat(configuration, isEquivalent("node.id=2",
                 "broker.rack=${STRIMZI_RACK_ID}"));
+    }
+
+    @ParallelTest
+    public void testRackIdInKRaftMixedNode()  {
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, new NodeRef("my-cluster-kafka-1", 1, "kafka", true, true), KafkaMetadataConfigurationState.KRAFT)
+                .withRackId(new Rack("failure-domain.kubernetes.io/zone"))
+                .build();
+
+        assertThat(configuration, isEquivalent("node.id=1",
+                "broker.rack=${STRIMZI_RACK_ID}"));
+    }
+
+    @ParallelTest
+    public void testRackIdInKRaftControllers()  {
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, new NodeRef("my-cluster-controllers-1", 1, "controllers", true, false), KafkaMetadataConfigurationState.KRAFT)
+                .withRackId(new Rack("failure-domain.kubernetes.io/zone"))
+                .build();
+
+        assertThat(configuration, isEquivalent("node.id=1"));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Strimzi uses init container to gather additional information about the running Kafka node. This is done in two situations:
* For node port listeners, we need to find out the node address to use it as advertised address
* For rack awareness, we need to find the corresponding label to configure the rack

Right now, we configure the init container for all Kafka nodes. But it is really needed only for broker or mixed nodes. Controller-only nodes do not need it because:
* They are never exposed through node ports
* Rack awareness does not make sense for them since they have only the metadata topic with replicas on each controller - so there is nothing to distribute.

This PR cleans up the code and configures the init container, the related volumes and volume mounts only when the node has the broker role. It does not affect the Cluster Role Binding to access the Kuberetes API because all Kafka nodes share the same service account.

I also decided to keep the affinity. While the rack does not need to be configured in the controller nodes, they should ideally be still distributed across the zones/racks and the best-effort affinity might help with it.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally