### PR TITLE
Allow templating of `host` and `advertisedHost` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * The `ContinueReconciliationOnManualRollingUpdateFailure` feature gate moves to beta stage and is enabled by default.
   If needed, `ContinueReconciliationOnManualRollingUpdateFailure` can be disabled in the feature gates configuration in the Cluster Operator.
 * Add support for managing connector offsets via KafkaConnector and KafkaMirrorMaker2 custom resources.
+* Add support for templating `host` and `advertisedHost` fields in listener configuration
 
 ### Changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -30,7 +30,8 @@ import java.util.Map;
 @DescriptionFile
 @JsonPropertyOrder({"brokerCertChainAndKey", "class", "preferredAddressType", "externalTrafficPolicy",
     "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService",
-    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType", "publishNotReadyAddresses"})
+    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType",
+    "publishNotReadyAddresses", "hostTemplate", "advertisedHostTemplate"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -54,6 +55,8 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private List<IpFamily> ipFamilies;
     private Boolean createBootstrapService = true;
     private Boolean publishNotReadyAddresses;
+    private String hostTemplate;
+    private String advertisedHostTemplate;
     private Map<String, Object> additionalProperties;
 
     @Description("Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. " +
@@ -254,6 +257,28 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
 
     public void setPublishNotReadyAddresses(Boolean publishNotReadyAddresses) {
         this.publishNotReadyAddresses = publishNotReadyAddresses;
+    }
+
+    @Description("Configures the template for generating the host names of the individual brokers. " +
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getHostTemplate() {
+        return hostTemplate;
+    }
+
+    public void setHostTemplate(String hostTemplate) {
+        this.hostTemplate = hostTemplate;
+    }
+
+    @Description("Configures the template for generating the advertisedHost names of the individual brokers. " +
+            "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getAdvertisedHostTemplate() {
+        return advertisedHostTemplate;
+    }
+
+    public void setAdvertisedHostTemplate(String advertisedHostTemplate) {
+        this.advertisedHostTemplate = advertisedHostTemplate;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -259,7 +259,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.publishNotReadyAddresses = publishNotReadyAddresses;
     }
 
-    @Description("Configures the template for generating the host names of the individual brokers. " +
+    @Description("Configures the template for generating the hostnames of the individual brokers. " +
             "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostTemplate() {
@@ -270,7 +270,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
         this.hostTemplate = hostTemplate;
     }
 
-    @Description("Configures the template for generating the advertisedHost names of the individual brokers. " +
+    @Description("Configures the template for generating the advertised hostnames of the individual brokers. " +
             "Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getAdvertisedHostTemplate() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -951,7 +951,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                                 .endSpec()
                                 .build();
 
-                        String host = ListenersUtils.brokerHost(listener, node.nodeId());
+                        String host = ListenersUtils.brokerHost(listener, node);
                         if (host != null) {
                             route.getSpec().setHost(host);
                         }
@@ -1040,7 +1040,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 if (pool.isBroker()) {
                     for (NodeRef node : pool.nodes()) {
                         String ingressName = ListenersUtils.backwardsCompatiblePerBrokerServiceName(pool.componentName, node.nodeId(), listener);
-                        String host = ListenersUtils.brokerHost(listener, node.nodeId());
+                        String host = ListenersUtils.brokerHost(listener, node);
                         String ingressClass = ListenersUtils.controllerClass(listener);
 
                         HTTPIngressPath path = new HTTPIngressPathBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -170,7 +170,7 @@ public class ListenersValidator {
 
             if (conf.getBootstrap() == null
                     || conf.getBootstrap().getHost() == null)   {
-                errors.add("listener " + listener.getName() + " is missing a bootstrap host name which is required for Ingress based listeners");
+                errors.add("listener " + listener.getName() + " is missing a bootstrap host property which is required for Ingress based listeners");
             }
 
             if (conf.getHostTemplate() != null) {
@@ -180,14 +180,14 @@ public class ListenersValidator {
                     GenericKafkaListenerConfigurationBroker broker = conf.getBrokers().stream().filter(b -> b.getBroker() == node.nodeId()).findFirst().orElse(null);
 
                     if (broker == null || broker.getHost() == null) {
-                        errors.add("listener " + listener.getName() + " is missing a broker host name for broker with ID " + node.nodeId() + " which is required for Ingress based listeners");
+                        errors.add("listener " + listener.getName() + " is missing a broker host property for broker with ID " + node.nodeId() + " which is required for Ingress based listeners");
                     }
                 }
             } else {
-                errors.add("listener " + listener.getName() + " is missing a broker configuration with host names which is required for Ingress based listeners");
+                errors.add("listener " + listener.getName() + " is missing a broker configuration with host properties which are required for Ingress based listeners");
             }
         } else {
-            errors.add("listener " + listener.getName() + " is missing a configuration with host names which is required for Ingress based listeners");
+            errors.add("listener " + listener.getName() + " is missing a configuration with host properties which are required for Ingress based listeners");
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1087,7 +1087,7 @@ public class KafkaReconciler {
                             Set<ListenerAddress> statusAddresses = new HashSet<>(brokerNodes.size());
 
                             for (Map.Entry<Integer, Node> entry : brokerNodes.entrySet())   {
-                                String advertisedHost = ListenersUtils.brokerAdvertisedHost(listener, entry.getKey());
+                                String advertisedHost = ListenersUtils.brokerAdvertisedHost(listener, kafka.nodePoolForNodeId(entry.getKey()).nodeRef(entry.getKey()));
                                 ListenerAddress address;
 
                                 if (advertisedHost != null)    {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
@@ -2462,7 +2462,7 @@ public class KafkaClusterZooBasedTest {
 
         assertThat(ListenersUtils.bootstrapNodePort(kc.getListeners().get(0)), is(32001));
         assertThat(ListenersUtils.brokerNodePort(kc.getListeners().get(0), 0), is(32101));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is("advertised.host"));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-0", 0, "kafka", false, true)), is("advertised.host"));
     }
 
     @ParallelTest
@@ -2884,13 +2884,13 @@ public class KafkaClusterZooBasedTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER);
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 0), is(10000));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is("my-host-0.cz"));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-0", 0, "kafka", false, true)), is("my-host-0.cz"));
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 1), is(10001));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 1), is("my-host-1.cz"));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-1", 1, "kafka", false, true)), is("my-host-1.cz"));
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 2), is(10002));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 2), is("my-host-2.cz"));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-2", 2, "kafka", false, true)), is("my-host-2.cz"));
     }
 
     @ParallelTest
@@ -2912,13 +2912,13 @@ public class KafkaClusterZooBasedTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER);
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 0), is(nullValue()));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 0), is(nullValue()));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-0", 0, "kafka", false, true)), is(nullValue()));
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 1), is(nullValue()));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 1), is(nullValue()));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-1", 1, "kafka", false, true)), is(nullValue()));
 
         assertThat(ListenersUtils.brokerAdvertisedPort(kc.getListeners().get(0), 2), is(nullValue()));
-        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), 2), is(nullValue()));
+        assertThat(ListenersUtils.brokerAdvertisedHost(kc.getListeners().get(0), new NodeRef("foo-kafka-2", 2, "kafka", false, true)), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -642,21 +642,21 @@ public class ListenersValidatorTest {
                 .withTls(true)
                 .build();
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host properties which are required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
-                "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host property which is required for Ingress based listeners",
+                "listener ingress is missing a broker configuration with host properties which are required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                         .withHostTemplate("my-host-{nodeIf}")
                         .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                         .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host property which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -669,9 +669,9 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
-                "listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners",
-                "listener ingress is missing a broker host name for broker with ID 1 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host property which is required for Ingress based listeners",
+                "listener ingress is missing a broker host property for broker with ID 0 which is required for Ingress based listeners",
+                "listener ingress is missing a broker host property for broker with ID 1 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -683,7 +683,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 0 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host property for broker with ID 0 which is required for Ingress based listeners"));
 
         // Valid configurations
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
@@ -735,14 +735,14 @@ public class ListenersValidatorTest {
                 .withTls(true)
                 .build();
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a configuration with host properties which are required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBrokers((List<GenericKafkaListenerConfigurationBroker>) null)
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
-                "listener ingress is missing a broker configuration with host names which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host property which is required for Ingress based listeners",
+                "listener ingress is missing a broker configuration with host properties which are required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -758,10 +758,10 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host name which is required for Ingress based listeners",
-                "listener ingress is missing a broker host name for broker with ID 1000 which is required for Ingress based listeners",
-                "listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners",
-                "listener ingress is missing a broker host name for broker with ID 2001 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a bootstrap host property which is required for Ingress based listeners",
+                "listener ingress is missing a broker host property for broker with ID 1000 which is required for Ingress based listeners",
+                "listener ingress is missing a broker host property for broker with ID 2000 which is required for Ingress based listeners",
+                "listener ingress is missing a broker host property for broker with ID 2001 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -777,7 +777,7 @@ public class ListenersValidatorTest {
                                 .build())
                 .build());
 
-        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host name for broker with ID 2000 which is required for Ingress based listeners"));
+        assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, NODE_POOL_NODES, List.of(listener)), containsInAnyOrder("listener ingress is missing a broker host property for broker with ID 2000 which is required for Ingress based listeners"));
 
         listener.setConfiguration(new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenerReconcilerTest.java
@@ -122,6 +122,8 @@ public class KafkaListenerReconcilerTest {
                 .endSpec()
                 .build();
 
+    // TODO: test advertised hostnames
+
     @Test
     public void testClusterIpWithoutTLS(VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
@@ -279,11 +281,6 @@ public class KafkaListenerReconcilerTest {
                 .withAdvertisedHost("my-address-0")
                 .build();
 
-        GenericKafkaListenerConfigurationBroker broker1 = new GenericKafkaListenerConfigurationBrokerBuilder()
-                .withBroker(11)
-                .withAdvertisedHost("my-address-1")
-                .build();
-
         GenericKafkaListenerConfigurationBroker broker2 = new GenericKafkaListenerConfigurationBrokerBuilder()
                 .withBroker(12)
                 .withAdvertisedHost("my-address-2")
@@ -299,7 +296,7 @@ public class KafkaListenerReconcilerTest {
                                 .withType(KafkaListenerType.CLUSTER_IP)
                                 .withNewConfiguration()
                                     .withCreateBootstrapService(true)
-                                    .withBrokers(broker0, broker1, broker2)
+                                    .withBrokers(broker0, broker2)
                                 .endConfiguration()
                                 .build())
                     .endKafka()
@@ -346,11 +343,11 @@ public class KafkaListenerReconcilerTest {
                     assertThat(res.bootstrapDnsNames.size(), is(4));
                     assertThat(res.bootstrapDnsNames, hasItems("my-kafka-kafka-external-bootstrap", "my-kafka-kafka-external-bootstrap.test", "my-kafka-kafka-external-bootstrap.test.svc", "my-kafka-kafka-external-bootstrap.test.svc.cluster.local"));
                     Set<String> allBrokersDnsNames = res.brokerDnsNames.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
-                    assertThat(allBrokersDnsNames.size(), is(6));
-                    assertThat(allBrokersDnsNames, hasItems("my-address-0", "my-address-1", "my-address-2", "my-kafka-brokers-11.test.svc", "my-kafka-brokers-12.test.svc", "my-kafka-brokers-10.test.svc"));
+                    assertThat(allBrokersDnsNames.size(), is(5));
+                    assertThat(allBrokersDnsNames, hasItems("my-address-0", "my-address-2", "my-kafka-brokers-11.test.svc", "my-kafka-brokers-12.test.svc", "my-kafka-brokers-10.test.svc"));
                     Set<String> allBrokersAdvertisedHostNames = res.advertisedHostnames.values().stream().flatMap(s -> s.values().stream()).collect(Collectors.toSet());
                     assertThat(allBrokersAdvertisedHostNames.size(), is(3));
-                    assertThat(allBrokersAdvertisedHostNames, hasItems("my-address-0", "my-address-1", "my-address-2"));
+                    assertThat(allBrokersAdvertisedHostNames, hasItems("my-address-0", "my-kafka-brokers-11.test.svc", "my-address-2"));
                     assertThat(res.advertisedPorts.size(), is(3));
                     assertThat(res.advertisedPorts.values().stream().flatMap(s -> s.values().stream()).collect(Collectors.toSet()), hasItems("9094"));
                     // Check creation of services

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
@@ -133,7 +133,8 @@ which is `9095` in the following example.
 You must specify the hostname used by the bootstrap service using xref:type-GenericKafkaListenerConfigurationBootstrap-reference[`GenericKafkaListenerConfigurationBootstrap`] property.
 And you must also specify the hostnames used by the per-broker services
 using xref:type-GenericKafkaListenerConfigurationBroker-reference[`GenericKafkaListenerConfigurationBroker`]
-and xref:type-GenericKafkaListenerConfiguration-reference[`hostTemplate`] properties.
+or xref:type-GenericKafkaListenerConfiguration-reference[`hostTemplate`] properties.
+With the `hostTemplate` property, you don't need to specify the configuration for every broker.
 +
 .Example `ingress` listener configuration
 [source,yaml,subs="+attributes"]

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListener.adoc
@@ -130,9 +130,10 @@ Kafka clients can use these `Ingress` resources to connect to Kafka on port 443.
 The client connects on port 443, the default controller port, but traffic is then routed to the port you configure,
 which is `9095` in the following example.
 +
-You must specify the hostnames used by the bootstrap and per-broker services
-using xref:type-GenericKafkaListenerConfigurationBootstrap-reference[`GenericKafkaListenerConfigurationBootstrap`]
-and xref:type-GenericKafkaListenerConfigurationBroker-reference[`GenericKafkaListenerConfigurationBroker`] properties.
+You must specify the hostname used by the bootstrap service using xref:type-GenericKafkaListenerConfigurationBootstrap-reference[`GenericKafkaListenerConfigurationBootstrap`] property.
+And you must also specify the hostnames used by the per-broker services
+using xref:type-GenericKafkaListenerConfigurationBroker-reference[`GenericKafkaListenerConfigurationBroker`]
+and xref:type-GenericKafkaListenerConfiguration-reference[`hostTemplate`] properties.
 +
 .Example `ingress` listener configuration
 [source,yaml,subs="+attributes"]
@@ -150,15 +151,9 @@ spec:
         authentication:
           type: tls
         configuration:
+          hostTemplate: broker-{nodeId}.myingress.com
           bootstrap:
             host: bootstrap.myingress.com
-          brokers:
-          - broker: 0
-            host: broker-0.myingress.com
-          - broker: 1
-            host: broker-1.myingress.com
-          - broker: 2
-            host: broker-2.myingress.com
   #...
 ----
 +

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
@@ -182,6 +182,37 @@ listeners:
 # ...
 ----
 
+Instead of specifying the `host` field for every broker, you can also use an `hostTemplate` to generate them automatically.
+The `hostTemplate` supports the following variables:
+
+* The `{nodeId}` variable will be replaced with the ID of the Kafka node to which the template is applied.
+* The `{nodePodName}` variable will be replaced with the Kubernetes pod name for the Kafka node where the template is applied.
+
+The `hostTemplate` field is applied only to the per-broker `host` fields.
+The bootstrap `host` field has to be always specified.
+
+.Example `ingress` listener with the `hostTemplate`
+[source,yaml,subs="+attributes"]
+----
+#...
+spec:
+  kafka:
+    #...
+    listeners:
+      #...
+      - name: external2
+        port: 9095
+        type: ingress
+        tls: true
+        authentication:
+          type: tls
+        configuration:
+          hostTemplate: broker-{nodeId}.myingress.com
+          bootstrap:
+            host: bootstrap.myingress.com
+  #...
+----
+
 [id='property-listener-config-nodeport-{context}']
 = Overriding assigned node ports
 

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfiguration.adoc
@@ -182,16 +182,16 @@ listeners:
 # ...
 ----
 
-Instead of specifying the `host` field for every broker, you can also use an `hostTemplate` to generate them automatically.
+Instead of specifying the `host` property for every broker, you can also use an `hostTemplate` to generate them automatically.
 The `hostTemplate` supports the following variables:
 
-* The `{nodeId}` variable will be replaced with the ID of the Kafka node to which the template is applied.
-* The `{nodePodName}` variable will be replaced with the Kubernetes pod name for the Kafka node where the template is applied.
+* The `{nodeId}` variable is replaced with the ID of the Kafka node to which the template is applied.
+* The `{nodePodName}` variable is replaced with the Kubernetes pod name for the Kafka node where the template is applied.
 
-The `hostTemplate` field is applied only to the per-broker `host` fields.
-The bootstrap `host` field has to be always specified.
+The `hostTemplate` property applies only to per-broker values.
+The bootstrap `host` property must always be specified.
 
-.Example `ingress` listener with the `hostTemplate`
+.Example `ingress` listener with `hostTemplate` configuration
 [source,yaml,subs="+attributes"]
 ----
 #...

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker.adoc
@@ -34,3 +34,23 @@ listeners:
         advertisedPort: 12342
 # ...
 ----
+
+Instead of specifying the `advertisedHost` field for every broker, you can also use an `advertisedHostTemplate` to generate them automatically.
+The `advertisedHostTemplate` supports the following variables:
+
+* The `{nodeId}` variable will be replaced with the ID of the Kafka node to which the template is applied.
+* The `{nodePodName}` variable will be replaced with the Kubernetes pod name for the Kafka node where the template is applied.
+
+.Example of an external `route` listener configured with overrides for advertised addresses using the `advertisedHostTemplate` field.
+[source,yaml,subs="attributes+"]
+----
+listeners:
+  #...
+  - name: external1
+    port: 9094
+    type: route
+    tls: true
+    configuration:
+      advertisedHostTemplate: example.hostname.{nodeId}
+# ...
+----

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerConfigurationBroker.adoc
@@ -38,10 +38,10 @@ listeners:
 Instead of specifying the `advertisedHost` field for every broker, you can also use an `advertisedHostTemplate` to generate them automatically.
 The `advertisedHostTemplate` supports the following variables:
 
-* The `{nodeId}` variable will be replaced with the ID of the Kafka node to which the template is applied.
-* The `{nodePodName}` variable will be replaced with the Kubernetes pod name for the Kafka node where the template is applied.
+* The `{nodeId}` variable is replaced with the ID of the Kafka node to which the template is applied.
+* The `{nodePodName}` variable is replaced with the Kubernetes pod name for the Kafka node where the template is applied.
 
-.Example of an external `route` listener configured with overrides for advertised addresses using the `advertisedHostTemplate` field.
+.Example `route` listener with `advertisedHostTemplate` configuration
 [source,yaml,subs="attributes+"]
 ----
 listeners:

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -503,6 +503,12 @@ This property is used to select the preferred address type, which is checked fir
 |publishNotReadyAddresses
 |boolean
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+|hostTemplate
+|string
+|Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|advertisedHostTemplate
+|string
+|Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -505,10 +505,10 @@ This property is used to select the preferred address type, which is checked fir
 |Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
 |hostTemplate
 |string
-|Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
 |advertisedHostTemplate
 |string
-|Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
+++ b/documentation/modules/security/proc-accessing-kafka-using-ingress.adoc
@@ -49,8 +49,7 @@ The name of the listener is `external2`.
 
 . Configure a `Kafka` resource with an external listener set to the `ingress` type.
 +
-Specify an ingress hostname for the bootstrap service and each of the Kafka brokers in the Kafka cluster.
-Add any hostname to the `bootstrap` and `broker-<index>` prefixes that identify the bootstrap and brokers.
+Specify an ingress hostname for the bootstrap service and for the Kafka brokers in the Kafka cluster.
 +
 For example:
 +
@@ -74,22 +73,18 @@ spec:
         authentication:
           type: tls
         configuration:
+          class: nginx # <2>
+          hostTemplate: broker-{nodeId}.myingress.com  # <3>
           bootstrap:
-            host: bootstrap.myingress.com
-          brokers:
-          - broker: 0
-            host: broker-0.myingress.com
-          - broker: 1
-            host: broker-1.myingress.com
-          - broker: 2
-            host: broker-2.myingress.com
-          class: nginx  # <2>
+            host: bootstrap.myingress.com # <4>
     # ...
   zookeeper:
     # ...
 ----
 <1> For `ingress` type listeners, TLS encryption must be enabled (`true`).
-<2> (Optional) Class that specifies the ingress controller to use. You might need to add a class if you have not set up a default and a class name is missing in the ingresses created. 
+<2> (Optional) Class that specifies the ingress controller to use. You might need to add a class if you have not set up a default and a class name is missing in the ingresses created.
+<3> The host template used to generate the hostnames for the per-broker Ingress resources.
+<4> The host used as the hostnames for the bootstrap Ingress resource.
 
 . Create or update the resource.
 +

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -482,10 +482,10 @@ spec:
                                 description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
                               hostTemplate:
                                 type: string
-                                description: "Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                               advertisedHostTemplate:
                                 type: string
-                                description: "Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                                description: "Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -480,6 +480,12 @@ spec:
                               publishNotReadyAddresses:
                                 type: boolean
                                 description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+                              hostTemplate:
+                                type: string
+                                description: "Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              advertisedHostTemplate:
+                                type: string
+                                description: "Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -479,6 +479,12 @@ spec:
                             publishNotReadyAddresses:
                               type: boolean
                               description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+                            hostTemplate:
+                              type: string
+                              description: "Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            advertisedHostTemplate:
+                              type: string
+                              description: "Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -481,10 +481,10 @@ spec:
                               description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
                             hostTemplate:
                               type: string
-                              description: "Configures the template for generating the host names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                             advertisedHostTemplate:
                               type: string
-                              description: "Configures the template for generating the advertisedHost names of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              description: "Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [Strimzi Proposal 84](https://github.com/strimzi/proposals/blob/main/084-templating-host-and-advertisedHost-fields.md) and adds support for templating `host` and `advertisedHost` fields in the listener configuration. The `host` fields apply to route and ingress type listeners, the advertised hosts can be used with any listener. The implementation is as describe int he proposal.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md