### PR TITLE
Refactor the implementation for getting status of rebalance proposal request

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -743,6 +743,7 @@ public class KafkaRebalanceAssemblyOperator
             validateAnnotation(reconciliation, conditions, KafkaRebalanceState.PendingProposal, rebalanceAnnotation(kafkaRebalance), kafkaRebalance);
             String sessionId = kafkaRebalance.getStatus().getSessionId();
             if (sessionId == null) {
+                // sessionId can be null if the response to the previously issued request for a proposal was NotEnoughDataForProposal.
                 requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
             } else {
                 apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -387,7 +387,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalToProposalReady(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Set up the rebalance endpoint with the number of pending calls before a response is received.
-        cruiseControlServer.setupCCRebalanceResponse(2, endpoint);
+        cruiseControlServer.setupCCRebalanceResponse(1, endpoint);
+        cruiseControlServer.setupCCUserTasksResponseNoGoals(1, 0);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
         crdCreateKafka();
@@ -531,6 +532,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     private void krNewToPendingProposalToStoppedAndRefresh(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Set up the rebalance endpoint with the number of pending calls before a response is received.
         cruiseControlServer.setupCCRebalanceResponse(2, endpoint);
+        cruiseControlServer.setupCCUserTasksResponseNoGoals(0, 0);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
         crdCreateKafka();
@@ -1133,7 +1135,8 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private void krNewToPendingProposalDelete(VertxTestContext context, CruiseControlEndpoints endpoint, KafkaRebalance kr) throws IOException, URISyntaxException {
         // Set up the rebalance endpoint with the number of pending calls before a response is received.
-        cruiseControlServer.setupCCRebalanceResponse(2, endpoint);
+        cruiseControlServer.setupCCRebalanceResponse(1, endpoint);
+        cruiseControlServer.setupCCUserTasksResponseNoGoals(1, 0);
 
         Crds.kafkaRebalanceOperation(client).inNamespace(namespace).resource(kr).create();
         crdCreateKafka();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -264,7 +264,7 @@ public class MockCruiseControl {
                 .respond(
                         response()
                                 .withBody(pendingJson)
-                                .withHeaders(header("User-Task-ID", REBALANCE_NO_GOALS_RESPONSE_UTID))
+                                .withHeaders(header("User-Task-ID", REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID))
                                 .withStatusCode(202)
                                 .withDelay(TimeUnit.SECONDS, responseDelay));
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

- Use `/kafkacruisecontrol/user_tasks` endpoint to check the status of proposal request (rebalance request in dry mode) instead of `/kafkacruisecontrol/rebalance` endpoint with userTaskId. This makes it more consistent with how we check the status of rebalance request. 

- Updated MockCruiseControl.setupCCRebalanceResponse() to set user task id to the one that matches verbose response, so that the subsequent requests to /user_tasks endpoint can return a verbose response with load optimisation. 

Closes #10294 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

