### PR TITLE
Remove superflous method from ReadWriteUtils

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -127,7 +127,7 @@ public class MockCruiseControl {
      */
     public void setupCCStateResponse() {
         // Non-verbose response
-        JsonBody jsonProposalNotReady = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State-proposal-not-ready.json"));
+        JsonBody jsonProposalNotReady = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-State-proposal-not-ready.json"));
 
         server
                 .when(
@@ -146,7 +146,7 @@ public class MockCruiseControl {
 
 
         // Non-verbose response
-        JsonBody json = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State.json"));
+        JsonBody json = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-State.json"));
 
         server
                 .when(
@@ -164,7 +164,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
 
         // Verbose response
-        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-State-verbose.json"));
+        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-State-verbose.json"));
 
         server
                 .when(
@@ -188,7 +188,7 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceNotEnoughDataError(CruiseControlEndpoints endpoint) {
         // Rebalance response with no goal that returns an error
-        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-NotEnoughValidWindows-error.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-NotEnoughValidWindows-error.json"));
 
         server
                 .when(
@@ -214,7 +214,7 @@ public class MockCruiseControl {
      */
     public void setupCCBrokerDoesNotExist(CruiseControlEndpoints endpoint) {
         // Add/remove broker response with no goal that returns an error
-        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Broker-not-exist.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Broker-not-exist.json"));
 
         server
                 .when(
@@ -248,7 +248,7 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceResponse(int pendingCalls, int responseDelay, CruiseControlEndpoints endpoint) {
         // Rebalance in progress response with no goals set - non-verbose
-        JsonBody pendingJson = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-in-progress.json"));
+        JsonBody pendingJson = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-no-goals-in-progress.json"));
         server
                 .when(
                         request()
@@ -269,7 +269,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, responseDelay));
 
         // Rebalance response with no goals set - non-verbose
-        JsonBody json = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals.json"));
+        JsonBody json = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-no-goals.json"));
 
         server
                 .when(
@@ -290,7 +290,7 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, responseDelay));
 
         // Rebalance response with no goals set - verbose
-        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
+        JsonBody jsonVerbose = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
 
         server
                 .when(
@@ -316,7 +316,8 @@ public class MockCruiseControl {
      */
     public void setupCCRebalanceBadGoalsError(CruiseControlEndpoints endpoint) {
         // Response if the user has set custom goals which do not include all configured hard.goals
-        JsonBody jsonError = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-bad-goals-error.json"));
+        JsonBody jsonError = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-bad-goals-error.json"));
+
 
         server
                 .when(
@@ -339,7 +340,7 @@ public class MockCruiseControl {
 
         // Response if the user has set custom goals which do not include all configured hard.goals
         // Note: This uses the no-goals example response but the difference between custom goals and default goals is not tested here
-        JsonBody jsonSummary = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
+        JsonBody jsonSummary = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Rebalance-no-goals-verbose.json"));
 
         server
                 .when(
@@ -372,9 +373,9 @@ public class MockCruiseControl {
      */
     public void setupCCUserTasksResponseNoGoals(int activeCalls, int inExecutionCalls) throws IOException, URISyntaxException {
         // User tasks response for the rebalance request with no goals set (non-verbose)
-        JsonBody jsonActive = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-Active.json"));
-        JsonBody jsonInExecution = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-inExecution.json"));
-        JsonBody jsonCompleted = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-completed.json"));
+        JsonBody jsonActive = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-Active.json"));
+        JsonBody jsonInExecution = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-inExecution.json"));
+        JsonBody jsonCompleted = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-completed.json"));
 
         // The first activeCalls times respond that with a status of "Active"
         server
@@ -431,9 +432,9 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
 
         // User tasks response for the rebalance request with no goals set (verbose)
-        JsonBody jsonActiveVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-Active.json"));
-        JsonBody jsonInExecutionVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-inExecution.json"));
-        JsonBody jsonCompletedVerbose = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-completed.json"));
+        JsonBody jsonActiveVerbose = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-Active.json"));
+        JsonBody jsonInExecutionVerbose = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-inExecution.json"));
+        JsonBody jsonCompletedVerbose = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-rebalance-no-goals-verbose-completed.json"));
 
         // The first activeCalls times respond that with a status of "Active"
         server
@@ -496,7 +497,7 @@ public class MockCruiseControl {
      */
     public void setupCCUserTasksCompletedWithError() throws IOException, URISyntaxException {
         // This simulates asking for the status of a task that has Complete with error and fetch_completed_task=true
-        JsonBody compWithErrorJson = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-status-completed-with-error.json"));
+        JsonBody compWithErrorJson = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-status-completed-with-error.json"));
 
         server
                 .when(
@@ -520,7 +521,7 @@ public class MockCruiseControl {
      */
     public void setupUserTasktoEmpty() {
         // This simulates asking for the status with empty user task
-        JsonBody jsonEmptyUserTask = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-User-task-status-empty.json"));
+        JsonBody jsonEmptyUserTask = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-User-task-status-empty.json"));
 
         server
                 .when(
@@ -543,7 +544,7 @@ public class MockCruiseControl {
      * Setup response of task being stopped.
      */
     public void setupCCStopResponse() {
-        JsonBody jsonStop = new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile(CC_JSON_ROOT + "CC-Stop.json"));
+        JsonBody jsonStop = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-Stop.json"));
 
         server
                 .when(

--- a/test/src/main/java/io/strimzi/test/ReadWriteUtils.java
+++ b/test/src/main/java/io/strimzi/test/ReadWriteUtils.java
@@ -21,20 +21,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
-
-import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Class with various utility methods for reading and writing files and objects
@@ -288,31 +281,5 @@ public final class ReadWriteUtils {
         }
         file.deleteOnExit();
         return file;
-    }
-
-    /**
-     * Get JSON content as string from resource file.
-     *
-     * TODO: Does the special handling here really matter? Can't we just use redFileFromResources?
-     *
-     * @param resourcePath Resource path.
-     *
-     * @return JSON content as string.
-     */
-    public static String readSingleLineJsonStringFromResourceFile(String resourcePath) {
-        try {
-            URI resourceURI = Objects.requireNonNull(TestUtils.class.getClassLoader().getResource(resourcePath)).toURI();
-            try (Stream<String> lines = Files.lines(Paths.get(resourceURI), UTF_8)) {
-                Optional<String> content = lines.reduce((x, y) -> x + y);
-
-                if (content.isEmpty()) {
-                    throw new IOException(format("File %s from resources was empty", resourcePath));
-                }
-
-                return content.get();
-            }
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
-        }
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/MockCruiseControl.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/MockCruiseControl.java
@@ -87,7 +87,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -108,7 +108,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -126,7 +126,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
 
@@ -146,7 +146,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/topic-config-success.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
@@ -168,7 +168,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/topic-config-failure.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/topic-config-failure.json")))
                     .withHeader(Header.header("User-Task-ID", "8911ca89-351f-888-8d0f-9aade00e098h"))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
@@ -225,7 +225,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // encryption and authentication enabled
@@ -243,7 +243,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // encryption only
@@ -258,7 +258,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
 
         // authentication only
@@ -275,7 +275,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.OK_200.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-success.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/user-tasks-success.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
 
@@ -294,7 +294,7 @@ public class MockCruiseControl {
             .respond(
                 HttpResponse.response()
                     .withStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500.code())
-                    .withBody(new JsonBody(ReadWriteUtils.readSingleLineJsonStringFromResourceFile("cruisecontrol/user-tasks-failure.json")))
+                    .withBody(new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/cruisecontrol/user-tasks-failure.json")))
                     .withDelay(TimeUnit.SECONDS, 0));
     }
 


### PR DESCRIPTION
### Type of change

Refactoring

### Description

Removing method `ReadWriteUtils.readSingleLineJsonStringFromResourceFile(...)` as `ReadWriteUtils.readFileFromResources(...)` can be used instead.

Closes #10556 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

