### PR TITLE
[system test] Move TestUtils methods used only in STs to systemtest m…

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
@@ -25,7 +25,6 @@ import io.strimzi.systemtest.resources.crd.KafkaMirrorMaker2Resource;
 import io.strimzi.systemtest.resources.crd.KafkaResource;
 import io.strimzi.systemtest.resources.crd.StrimziPodSetResource;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
-import io.strimzi.test.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -365,14 +364,14 @@ public class VerificationUtils {
             //Verifying docker image for zookeeper pods
             for (int i = 0; i < controllerPods; i++) {
                 String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, KafkaResources.zookeeperPodName(clusterName, i), "zookeeper");
-                assertThat("ZooKeeper Pod: " + i + " uses wrong image", imgFromPod, containsString(TestUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_IMAGE_MAP)).get(kafkaVersion)));
+                assertThat("ZooKeeper Pod: " + i + " uses wrong image", imgFromPod, containsString(StUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_IMAGE_MAP)).get(kafkaVersion)));
             }
         }
 
         //Verifying docker image for kafka pods
         brokerPods.forEach(brokerPod -> {
             String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, brokerPod, "kafka");
-            assertThat("Kafka Pod: " + brokerPod + " uses wrong image", imgFromPod, containsString(TestUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_IMAGE_MAP)).get(kafkaVersion)));
+            assertThat("Kafka Pod: " + brokerPod + " uses wrong image", imgFromPod, containsString(StUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_IMAGE_MAP)).get(kafkaVersion)));
 
             if (rackAwareEnabled) {
                 String initContainerImage = PodUtils.getInitContainerImageName(brokerPod);
@@ -415,7 +414,7 @@ public class VerificationUtils {
             connectVersion = Environment.ST_KAFKA_VERSION;
         }
 
-        assertThat(TestUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_CONNECT_IMAGE_MAP)).get(connectVersion), is(connectImageName));
+        assertThat(StUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_CONNECT_IMAGE_MAP)).get(connectVersion), is(connectImageName));
         LOGGER.info("Docker image name of KafkaConnect verified");
     }
 
@@ -440,7 +439,7 @@ public class VerificationUtils {
             mirrormaker2Version = Environment.ST_KAFKA_VERSION;
         }
 
-        assertThat(TestUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_MIRROR_MAKER_2_IMAGE_MAP)).get(mirrormaker2Version), is(mirrormaker2ImageName));
+        assertThat(StUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_MIRROR_MAKER_2_IMAGE_MAP)).get(mirrormaker2Version), is(mirrormaker2ImageName));
         LOGGER.info("Docker image name of MM2 verified");
     }
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaUtils.java
@@ -60,7 +60,7 @@ import static io.strimzi.api.kafka.model.kafka.KafkaResources.kafkaComponentName
 import static io.strimzi.api.kafka.model.kafka.KafkaResources.zookeeperComponentName;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.NotReady;
 import static io.strimzi.systemtest.enums.CustomResourceStatus.Ready;
-import static io.strimzi.test.TestUtils.indent;
+import static io.strimzi.systemtest.utils.StUtils.indent;
 import static io.strimzi.test.TestUtils.waitFor;
 import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
 import static io.strimzi.test.k8s.KubeClusterResource.kubeClient;

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -310,9 +310,9 @@ public class AbstractUpgradeST extends AbstractST {
 
         Arrays.stream(Objects.requireNonNull(root.listFiles())).sorted().forEach(f -> {
             if (watchedNsRoleBindingFilePrefixes.stream().anyMatch((rbFilePrefix) -> f.getName().startsWith(rbFilePrefix))) {
-                cmdKubeClient(componentsNamespaceName).replaceContent(TestUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
+                cmdKubeClient(componentsNamespaceName).replaceContent(StUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
             } else if (f.getName().matches(".*RoleBinding.*")) {
-                cmdKubeClient(clusterOperatorNamespaceName).replaceContent(TestUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
+                cmdKubeClient(clusterOperatorNamespaceName).replaceContent(StUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
             } else if (f.getName().matches(".*Deployment.*")) {
                 cmdKubeClient(clusterOperatorNamespaceName).replaceContent(StUtils.changeDeploymentConfiguration(componentsNamespaceName, f, strimziFeatureGatesValue));
             } else {
@@ -345,9 +345,9 @@ public class AbstractUpgradeST extends AbstractST {
             Arrays.stream(Objects.requireNonNull(root.listFiles())).sorted().forEach(f -> {
                 try {
                     if (watchedNsRoleBindingFilePrefixes.stream().anyMatch((rbFilePrefix) -> f.getName().startsWith(rbFilePrefix))) {
-                        cmdKubeClient(componentsNamespaceName).deleteContent(TestUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
+                        cmdKubeClient(componentsNamespaceName).deleteContent(StUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
                     } else if (f.getName().matches(".*RoleBinding.*")) {
-                        cmdKubeClient(clusterOperatorNamespaceName).deleteContent(TestUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
+                        cmdKubeClient(clusterOperatorNamespaceName).deleteContent(StUtils.changeRoleBindingSubject(f, clusterOperatorNamespaceName));
                     } else {
                         cmdKubeClient(clusterOperatorNamespaceName).delete(f);
                     }

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -145,26 +145,6 @@ public final class TestUtils {
     }
 
     /**
-     * Indents the input string with for empty spaces at the beginning of each line.
-     *
-     * TODO: This is used only in system tests and should be moved there.
-     *
-     * @param input     Input string that should be indented
-     *
-     * @return  Indented string
-     */
-    public static String indent(String input) {
-        StringBuilder sb = new StringBuilder();
-        String[] lines = input.split("[\n\r]");
-
-        for (String line : lines) {
-            sb.append("    ").append(line).append(System.lineSeparator());
-        }
-
-        return sb.toString();
-    }
-
-    /**
      * Creates a modifiable set wit the desired elements. Use {@code Set.of()} if immutable set is sufficient.
      *
      * @param elements  The elements that will be added to the Set
@@ -219,58 +199,6 @@ public final class TestUtils {
         assertThat(or.getUid(), is(owner.getMetadata().getUid()));
         assertThat(or.getBlockOwnerDeletion(), is(false));
         assertThat(or.getController(), is(false));
-    }
-
-    /**
-     * Changes the {@code subject} of the RoleBinding in the given YAML resource to be the
-     * {@code strimzi-cluster-operator} {@code ServiceAccount} in the given namespace.
-     *
-     * TODO: This is used only in system tests and should be moved there.
-     *
-     * @param roleBindingFile   The RoleBinding YAML file to load and change
-     * @param namespace         Namespace of the service account which should be the subject of this RoleBinding
-     *
-     * @return Modified RoleBinding resource YAML
-     */
-    public static String changeRoleBindingSubject(File roleBindingFile, String namespace) {
-        YAMLMapper mapper = new YAMLMapper();
-        try {
-            JsonNode node = mapper.readTree(roleBindingFile);
-            ArrayNode subjects = (ArrayNode) node.get("subjects");
-            ObjectNode subject = (ObjectNode) subjects.get(0);
-            subject.put("kind", "ServiceAccount")
-                    .put("name", "strimzi-cluster-operator")
-                    .put("namespace", namespace);
-            return mapper.writeValueAsString(node);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Parse the image map String into a Map.
-     *
-     * TODO: This is used only in system tests and should be moved there.
-     *
-     * @param imageMapString    String with the image map (contains key-value pairs separated by new lines in a single string)
-     *
-     * @return  Map with the parsed images
-     */
-    public static Map<String, String> parseImageMap(String imageMapString) {
-        if (imageMapString != null) {
-            StringTokenizer tok = new StringTokenizer(imageMapString, ", \t\n\r");
-            HashMap<String, String> map = new HashMap<>();
-            while (tok.hasMoreTokens()) {
-                String versionImage = tok.nextToken();
-                int endIndex = versionImage.indexOf('=');
-                String version = versionImage.substring(0, endIndex);
-                String image = versionImage.substring(endIndex + 1);
-                map.put(version.trim(), image.trim());
-            }
-            return Collections.unmodifiableMap(map);
-        } else {
-            return Collections.emptyMap();
-        }
     }
 
     /**

--- a/test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/test/src/main/java/io/strimzi/test/TestUtils.java
@@ -4,10 +4,6 @@
  */
 package io.strimzi.test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
@@ -16,19 +12,16 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.ServerSocket;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
…odule

### Type of change

- Enhancement / new feature
- Refactoring

### Description

TLDR; This PR solves [1]. 

A few methods were currently located in the `test` module, but such methods were only in the `systemtest` module. Therefore we have decided to move it to the `systemtest` module.

[1] - https://github.com/strimzi/strimzi-kafka-operator/issues/10557

### Checklist

- [x] Make sure all tests pass
