### PR TITLE
Fix typos in Kafka Connect custom volume examples

### DIFF
--- a/documentation/modules/configuring/proc-loading-config-from-file.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-file.adoc
@@ -64,7 +64,7 @@ spec:
         - name: connector-config-volume # <3>
           secret:
             secretName: mysecret # <4>
-    kafkaContainer:
+    connectContainer:
       volumeMounts:
         - name: connector-config-volume # <5>
           mountPath: /mnt/mysecret # <6>

--- a/documentation/modules/configuring/proc-loading-config-from-files.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-files.adoc
@@ -74,7 +74,7 @@ spec:
         - name: cluster-ca-volume
           secret:
             secretName: my-cluster-cluster-ca-cert
-    kafkaContainer:
+    connectContainer:
       volumeMounts:
         - name: my-user-volume # <5>
           mountPath: /mnt/my-user # <6>


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR fixes the wrong container names in the documentation about using custom volumes with Kafka Connect where I used `kafkaContainer` instead of `connectContainer`.

### Checklist

- [x] Update documentation