### PR TITLE
Update `setup-kind.sh` to correctly set docker login and remove unused variables from the script

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -9,16 +9,7 @@ KIND_VERSION=${KIND_VERSION:-"v0.23.0"}
 KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"kindest/node:v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
 
-DEFAULT_CLUSTER_MEMORY=$(free -m | grep "Mem" | awk '{print $2}')
-DEFAULT_CLUSTER_CPU=$(awk '$1~/cpu[0-9]/{usage=($2+$4)*100/($2+$4+$5); print $1": "usage"%"}' /proc/stat | wc -l)
-
-CLUSTER_MEMORY=${CLUSTER_MEMORY:-$DEFAULT_CLUSTER_MEMORY}
-CLUSTER_CPU=${CLUSTER_CPU:-$DEFAULT_CLUSTER_CPU}
-
 KIND_CLUSTER_NAME="kind-cluster"
-
-echo "[INFO] CLUSTER_MEMORY: ${CLUSTER_MEMORY}"
-echo "[INFO] CLUSTER_CPU: ${CLUSTER_CPU}"
 
 # note that IPv6 is only supported on kind (i.e., minikube does not support it). Also we assume that when you set this flag
 # to true then you meet requirements (i.) net.ipv6.conf.all.disable_ipv6 = 0 (ii. you have installed CNI supporting IPv6)

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -77,18 +77,17 @@ function add_docker_hub_credentials_to_kubernetes {
     # Add Docker hub credentials to Minikube
     if [ "$COPY_DOCKER_LOGIN" = "true" ]
     then
-      set +ex
-
       for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-        # the -oname format is kind/name (so node/name) we just want name
-        node_name=${node#node/}
-        # copy the config to where kubelet will look
-        docker cp "$HOME/.docker/config.json" "${node_name}:/var/lib/kubelet/config.json"
-        # restart kubelet to pick up the config
-        docker exec "${node_name}" systemctl restart kubelet.service
+        if [[ "$node" != *"external-load-balancer"* ]];
+        then
+          # the -oname format is kind/name (so node/name) we just want name
+          node_name=${node#node/}
+          # copy the config to where kubelet will look
+          docker cp "$HOME/.docker/config.json" "${node_name}:/var/lib/kubelet/config.json"
+          # restart kubelet to pick up the config
+          docker exec "${node_name}" systemctl restart kubelet.service
+        fi
       done
-
-      set -ex
     fi
 }
 

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -79,7 +79,7 @@ function add_docker_hub_credentials_to_kubernetes {
     then
       set +ex
 
-      docker exec $1 bash -c "echo '$(cat $HOME/.docker/config.json)'| sudo tee -a /var/lib/kubelet/config.json > /dev/null && sudo systemctl restart kubelet"
+      docker exec $1 bash -c "echo '$(cat $HOME/.docker/config.json)'| tee -a /var/lib/kubelet/config.json > /dev/null && systemctl restart kubelet"
 
       set -ex
     fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Similarly to `setup-kubernetes.sh`, where we are setting the Minikube cluster, in `setup-kind.sh` we have possibility to "copy docker login" -> meaning that it will basically copy the login to registries from the local machine. This works perfectly for the Minikube cluster, but doesn't work on the Kind cluster -> because we need to update this "pull secret" for every node of the Kind cluster. More about this is mentioned in the documentation - https://kind.sigs.k8s.io/docs/user/private-registries/#use-an-access-token

Other than fixing this behavior, I'm removing the unused variables, which were copy-pasted from the `setup-kubernetes.sh`, but not really used in the script right now. In case of need, we can add it back in the future (from the documentation, we can limit the docker with the CPU and memory requests, but it's not possible for the whole Kind cluster).

### Checklist

- [x] Make sure all tests pass
