### PR TITLE
Add support for Secret or ConfigMap based environment variables in `ContainerTemplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   If needed, `ContinueReconciliationOnManualRollingUpdateFailure` can be disabled in the feature gates configuration in the Cluster Operator.
 * Add support for managing connector offsets via KafkaConnector and KafkaMirrorMaker2 custom resources.
 * Add support for templating `host` and `advertisedHost` fields in listener configuration
+* Allow configuration of environment variables based on Config Map or Secret for every container in the container template sections
 
 ### Changes, deprecations and removals
 
@@ -14,8 +15,8 @@
   Kubernetes 1.23 and 1.24 are not supported anymore.
 * When finalizers are enabled (default), the Topic Operator will no longer restore finalizers on unmanaged `KafkaTopic` resources if they are removed, aligning the behavior with paused topics, where finalizers are also not restored.
   This change matches user expectations.
-* The External Configuration Volumes (`.spec.externalConfiguration.volumes`) in `KafkaConnect` and `KafkaMirrorMaker2` resources are deprecated and will be removed in the future.
-  Please use the additional volumes and volume mounts in Pod and container templates instead to mount additional Secrets or ConfigMaps.
+* The External Configuration (`.spec.externalConfiguration`) in `KafkaConnect` and `KafkaMirrorMaker2` resources is deprecated and will be removed in the future.
+  Please use the environment variables, additional volumes and volume mounts in Pod and container templates instead.
 
 ## 0.43.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -7,7 +7,9 @@ package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.template.ContainerEnvVarSource;
 import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.OneOf;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -23,12 +25,14 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({"name", "value"})
+@JsonPropertyOrder({"name", "value", "valueFrom"})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("value")), @OneOf.Alternative(@OneOf.Alternative.Property("valueFrom"))})
 @EqualsAndHashCode
 @ToString
 public class ContainerEnvVar implements UnknownPropertyPreserving {
     private String name;
     private String value;
+    private ContainerEnvVarSource valueFrom;
     private Map<String, Object> additionalProperties;
 
     @Description("The environment variable key.")
@@ -47,6 +51,15 @@ public class ContainerEnvVar implements UnknownPropertyPreserving {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    @Description("Reference to Secret or ConfigMap field to which will be the environment variable set.")
+    public ContainerEnvVarSource getValueFrom() {
+        return valueFrom;
+    }
+
+    public void setValueFrom(ContainerEnvVarSource valueFrom) {
+        this.valueFrom = valueFrom;
     }
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/ContainerEnvVar.java
@@ -2,7 +2,6 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 package io.strimzi.api.kafka.model.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -53,7 +52,7 @@ public class ContainerEnvVar implements UnknownPropertyPreserving {
         this.value = value;
     }
 
-    @Description("Reference to Secret or ConfigMap field to which will be the environment variable set.")
+    @Description("Reference to secret or config map property to which will be the environment variable is set.")
     public ContainerEnvVarSource getValueFrom() {
         return valueFrom;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerEnvVarSource.java
@@ -37,7 +37,7 @@ public class ContainerEnvVarSource implements UnknownPropertyPreserving {
     private ConfigMapKeySelector configMapKeyRef;
     private Map<String, Object> additionalProperties;
 
-    @Description("Reference to a key in a Secret.")
+    @Description("Reference to a key in a secret.")
     @KubeLink(group = "core", version = "v1", kind = "secretkeyselector")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public SecretKeySelector getSecretKeyRef() {
@@ -48,7 +48,7 @@ public class ContainerEnvVarSource implements UnknownPropertyPreserving {
         this.secretKeyRef = secretKeyRef;
     }
 
-    @Description("Reference to a key in a ConfigMap.")
+    @Description("Reference to a key in a config map.")
     @KubeLink(group = "core", version = "v1", kind = "configmapkeyselector")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public ConfigMapKeySelector getConfigMapKeyRef() {

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerEnvVarSource.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/ContainerEnvVarSource.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
+import io.fabric8.kubernetes.api.model.SecretKeySelector;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.KubeLink;
+import io.strimzi.crdgenerator.annotations.OneOf;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation for environment variables which will be passed to a container
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonPropertyOrder({"secretKeyRef", "configMapKeyRef"})
+@OneOf({@OneOf.Alternative(@OneOf.Alternative.Property("secretKeyRef")), @OneOf.Alternative(@OneOf.Alternative.Property("configMapKeyRef"))})
+@EqualsAndHashCode
+@ToString
+public class ContainerEnvVarSource implements UnknownPropertyPreserving {
+    private SecretKeySelector secretKeyRef;
+    private ConfigMapKeySelector configMapKeyRef;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Reference to a key in a Secret.")
+    @KubeLink(group = "core", version = "v1", kind = "secretkeyselector")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public SecretKeySelector getSecretKeyRef() {
+        return secretKeyRef;
+    }
+
+    public void setSecretKeyRef(SecretKeySelector secretKeyRef) {
+        this.secretKeyRef = secretKeyRef;
+    }
+
+    @Description("Reference to a key in a ConfigMap.")
+    @KubeLink(group = "core", version = "v1", kind = "configmapkeyselector")
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    public ConfigMapKeySelector getConfigMapKeyRef() {
+        return configMapKeyRef;
+    }
+
+    public void setConfigMapKeyRef(ConfigMapKeySelector configMapKeyRef) {
+        this.configMapKeyRef = configMapKeyRef;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.HasConfigurableLogging;
 import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
@@ -39,6 +40,7 @@ import lombok.ToString;
     "template", "externalConfiguration" })
 @EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
 @ToString(callSuper = true)
+@SuppressWarnings("deprecation") // External Configuration is deprecated
 public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfigurableMetrics, HasConfigurableLogging, HasJmxOptions, HasLivenessProbe, HasReadinessProbe {
     private Logging logging;
     private int replicas = 3;
@@ -188,6 +190,9 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
 
     @Description("Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Deprecated
+    @DeprecatedProperty(description = "The external configuration is deprecated and will be removed in the future. " +
+            "Please use the template section instead to configure additional environment variables or volumes.")
     public ExternalConfiguration getExternalConfiguration() {
         return externalConfiguration;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -43,7 +43,7 @@ public class ExternalConfiguration implements UnknownPropertyPreserving {
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     @Deprecated
     @DeprecatedProperty(description = "The external configuration environment variables are deprecated and will be removed in the future. " +
-            "Please use the environment variables in container template instead.")
+            "Please use the environment variables in a container template instead.")
     public List<ExternalConfigurationEnv> getEnv() {
         return env;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfiguration.java
@@ -7,6 +7,7 @@ package io.strimzi.api.kafka.model.connect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.strimzi.api.annotations.DeprecatedProperty;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
@@ -29,6 +30,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "env", "volumes" })
+@Deprecated
+@DeprecatedType(replacedWithType = KafkaConnectTemplate.class)
 @EqualsAndHashCode
 @ToString
 public class ExternalConfiguration implements UnknownPropertyPreserving {
@@ -38,6 +41,9 @@ public class ExternalConfiguration implements UnknownPropertyPreserving {
 
     @Description("Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    @Deprecated
+    @DeprecatedProperty(description = "The external configuration environment variables are deprecated and will be removed in the future. " +
+            "Please use the environment variables in container template instead.")
     public List<ExternalConfigurationEnv> getEnv() {
         return env;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/ExternalConfigurationEnv.java
@@ -7,7 +7,9 @@ package io.strimzi.api.kafka.model.connect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedType;
 import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.ContainerEnvVar;
 import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.sundr.builder.annotations.Buildable;
@@ -26,6 +28,8 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({"name", "valueFrom"})
+@Deprecated
+@DeprecatedType(replacedWithType = ContainerEnvVar.class)
 @EqualsAndHashCode
 @ToString
 public class ExternalConfigurationEnv implements UnknownPropertyPreserving {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -132,6 +132,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
     protected String loggingAndMetricsConfigMapName;
 
     protected String bootstrapServers;
+    @SuppressWarnings("deprecation") // External Configuration environment variables are deprecated
     protected List<ExternalConfigurationEnv> externalEnvs = Collections.emptyList();
 
     @SuppressWarnings("deprecation") // External Configuration volumes are deprecated
@@ -653,6 +654,7 @@ public class KafkaConnectCluster extends AbstractModel implements SupportsMetric
         }
     }
 
+    @SuppressWarnings("deprecation") // External Configuration environment variables are deprecated
     private List<EnvVar> getExternalConfigurationEnvVars()   {
         List<EnvVar> varList = new ArrayList<>();
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Cluster.java
@@ -122,6 +122,7 @@ public class KafkaMirrorMaker2Cluster extends KafkaConnectCluster {
         return fromSpec(reconciliation, buildKafkaConnectSpec(spec, connectCluster), versions, result);
     }
 
+    @SuppressWarnings("deprecation") // External Configuration is deprecated
     private static KafkaConnectSpec buildKafkaConnectSpec(KafkaMirrorMaker2Spec spec, KafkaMirrorMaker2ClusterSpec connectCluster) {
 
         ClientTls connectTls = null;

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1374,7 +1374,7 @@ Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |The environment variable value.
 |valueFrom
 |xref:type-ContainerEnvVarSource-{context}[`ContainerEnvVarSource`]
-|Reference to Secret or ConfigMap field to which will be the environment variable set.
+|Reference to secret or config map property to which will be the environment variable is set.
 |====
 
 [id='type-ContainerEnvVarSource-{context}']
@@ -1388,10 +1388,10 @@ Used in: xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`]
 |Property |Property type |Description
 |secretKeyRef
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#secretkeyselector-v1-core[SecretKeySelector]
-|Reference to a key in a Secret.
+|Reference to a key in a secret.
 |configMapKeyRef
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#configmapkeyselector-v1-core[ConfigMapKeySelector]
-|Reference to a key in a ConfigMap.
+|Reference to a key in a config map.
 |====
 
 [id='type-TieredStorageCustom-{context}']
@@ -2780,7 +2780,7 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 |Property |Property type |Description
 |env
 |xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`] array
-|**The `env` property has been deprecated.** The external configuration environment variables are deprecated and will be removed in the future. Please use the environment variables in container template instead. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
+|**The `env` property has been deprecated.** The external configuration environment variables are deprecated and will be removed in the future. Please use the environment variables in a container template instead. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
 |volumes
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
 |**The `volumes` property has been deprecated.** The external configuration volumes are deprecated and will be removed in the future. Please use the additional volumes and volume mounts in pod and container templates instead to mount additional secrets or config maps. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1372,6 +1372,26 @@ Used in: xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |value
 |string
 |The environment variable value.
+|valueFrom
+|xref:type-ContainerEnvVarSource-{context}[`ContainerEnvVarSource`]
+|Reference to Secret or ConfigMap field to which will be the environment variable set.
+|====
+
+[id='type-ContainerEnvVarSource-{context}']
+= `ContainerEnvVarSource` schema reference
+
+Used in: xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|secretKeyRef
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#secretkeyselector-v1-core[SecretKeySelector]
+|Reference to a key in a Secret.
+|configMapKeyRef
+|https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#configmapkeyselector-v1-core[ConfigMapKeySelector]
+|Reference to a key in a ConfigMap.
 |====
 
 [id='type-TieredStorageCustom-{context}']
@@ -2384,7 +2404,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|**The `externalConfiguration` property has been deprecated.** The external configuration is deprecated and will be removed in the future. Please use the template section instead to configure additional environment variables or volumes. Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |build
 |xref:type-Build-{context}[`Build`]
 |Configures how the Connect container image should be built. Optional.
@@ -2742,6 +2762,9 @@ Used in: xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`]
 [id='type-ExternalConfiguration-{context}']
 = `ExternalConfiguration` schema reference
 
+*The type `ExternalConfiguration` has been deprecated.*
+Please use xref:type-KafkaConnectTemplate-{context}[`KafkaConnectTemplate`] instead.
+
 Used in: xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`]
 
 xref:type-ExternalConfiguration-schema-{context}[Full list of `ExternalConfiguration` schema properties]
@@ -2757,7 +2780,7 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 |Property |Property type |Description
 |env
 |xref:type-ExternalConfigurationEnv-{context}[`ExternalConfigurationEnv`] array
-|Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
+|**The `env` property has been deprecated.** The external configuration environment variables are deprecated and will be removed in the future. Please use the environment variables in container template instead. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as environment variables.
 |volumes
 |xref:type-ExternalConfigurationVolumeSource-{context}[`ExternalConfigurationVolumeSource`] array
 |**The `volumes` property has been deprecated.** The external configuration volumes are deprecated and will be removed in the future. Please use the additional volumes and volume mounts in pod and container templates instead to mount additional secrets or config maps. Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
@@ -2765,6 +2788,9 @@ include::../api/io.strimzi.api.kafka.model.connect.ExternalConfiguration.adoc[le
 
 [id='type-ExternalConfigurationEnv-{context}']
 = `ExternalConfigurationEnv` schema reference
+
+*The type `ExternalConfigurationEnv` has been deprecated.*
+Please use xref:type-ContainerEnvVar-{context}[`ContainerEnvVar`] instead.
 
 Used in: xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
 
@@ -4189,7 +4215,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.
 |externalConfiguration
 |xref:type-ExternalConfiguration-{context}[`ExternalConfiguration`]
-|Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
+|**The `externalConfiguration` property has been deprecated.** The external configuration is deprecated and will be removed in the future. Please use the template section instead to configure additional environment variables or volumes. Pass data from Secrets or ConfigMaps to the Kafka Connect pods and use them to configure connectors.
 |====
 
 [id='type-KafkaMirrorMaker2ClusterSpec-{context}']

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -179,5 +179,5 @@ By default, Kafka Connect connects to Kafka brokers using a plain text connectio
 <16> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
 <17> SPECIALIZED OPTION: Rack awareness configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
 <18> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<19> Environment variables are set for distributed tracing or to pass credentials to connectors.
+<19> Environment variables are set for distributed tracing and to pass credentials to connectors.
 <20> Distributed tracing is enabled by using OpenTelemetry.

--- a/documentation/modules/configuring/con-config-kafka-connect.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connect.adoc
@@ -93,26 +93,13 @@ spec:
           - type: jar
             url: <url_to_download_connector_2_artifact>
             sha512sum: <SHA-512_checksum_of_connector_2_artifact>
-  # External configuration (optional)
-  externalConfiguration: # <12>
-    env:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds
-            key: awsAccessKey
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds
-            key: awsSecretAccessKey
   # Logging configuration (optional)
-  logging: # <13>
+  logging: # <12>
     type: inline
     loggers:
       log4j.rootLogger: INFO
   # Readiness probe (optional)
-  readinessProbe: # <14>
+  readinessProbe: # <13>
     initialDelaySeconds: 15
     timeoutSeconds: 5
   # Liveness probe (optional)
@@ -120,23 +107,23 @@ spec:
     initialDelaySeconds: 15
     timeoutSeconds: 5
   # Metrics configuration (optional)
-  metricsConfig: # <15>
+  metricsConfig: # <14>
     type: jmxPrometheusExporter
     valueFrom:
       configMapKeyRef:
         name: my-config-map
         key: my-key
   # JVM options (optional)
-  jvmOptions: # <16>
+  jvmOptions: # <15>
     "-Xmx": "1g"
     "-Xms": "1g"
   # Custom image (optional)
-  image: my-org/my-image:latest # <17>
+  image: my-org/my-image:latest # <16>
   # Rack awareness (optional)
   rack:
-    topologyKey: topology.kubernetes.io/zone # <18>
-  # Pod template (optional)
-  template: # <19>
+    topologyKey: topology.kubernetes.io/zone # <17>
+  # Pod and container template (optional)
+  template: # <18>
     pod:
       affinity:
         podAntiAffinity:
@@ -149,15 +136,25 @@ spec:
                       - postgresql
                       - mongodb
               topologyKey: "kubernetes.io/hostname"
-    connectContainer: # <20>
+    connectContainer: # <19>
       env:
         - name: OTEL_SERVICE_NAME
           value: my-otel-service
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://otlp-host:4317"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-creds
+              key: awsAccessKey
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-creds
+              key: awsSecretAccessKey
   # Tracing configuration (optional)
   tracing:
-    type: opentelemetry # <21>
+    type: opentelemetry # <20>
 ----
 <1> Use `KafkaConnect`.
 <2> Enables the use of `KafkaConnector` resources to start, stop, and manage connector instances.
@@ -175,14 +172,12 @@ By default, Kafka Connect connects to Kafka brokers using a plain text connectio
 <9> Build configuration properties for building a container image with connector plugins automatically.
 <10> (Required) Configuration of the container registry where new images are pushed.
 <11> (Required) List of connector plugins and their artifacts to add to the new container image. Each plugin must be configured with at least one `artifact`.
-<12> External configuration for connectors using environment variables, as shown here, or volumes.
-You can also use configuration provider plugins to load configuration values from external sources.
-<13> Specified Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` or `log4j2.properties` key in the ConfigMap. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
-<14> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
-<15> Prometheus metrics, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
-<16> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka Connect.
-<17> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
-<18> SPECIALIZED OPTION: Rack awareness configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
-<19> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
-<20> Environment variables are set for distributed tracing.
-<21> Distributed tracing is enabled by using OpenTelemetry.
+<12> Specified Kafka Connect loggers and log levels added directly (`inline`) or indirectly (`external`) through a ConfigMap. A custom Log4j configuration must be placed under the `log4j.properties` or `log4j2.properties` key in the ConfigMap. For the Kafka Connect `log4j.rootLogger` logger, you can set the log level to INFO, ERROR, WARN, TRACE, DEBUG, FATAL or OFF.
+<13> Healthchecks to know when to restart a container (liveness) and when a container can accept traffic (readiness).
+<14> Prometheus metrics, which are enabled by referencing a ConfigMap containing configuration for the Prometheus JMX exporter in this example. You can enable metrics without further configuration using a reference to a ConfigMap containing an empty file under `metricsConfig.valueFrom.configMapKeyRef.key`.
+<15> JVM configuration options to optimize performance for the Virtual Machine (VM) running Kafka Connect.
+<16> ADVANCED OPTION: Container image configuration, which is recommended only in special situations.
+<17> SPECIALIZED OPTION: Rack awareness configuration for the deployment. This is a specialized option intended for a deployment within the same location, not across regions. Use this option if you want connectors to consume from the closest replica rather than the leader replica. In certain cases, consuming from the closest replica can improve network utilization or reduce costs . The `topologyKey` must match a node label containing the rack ID. The example used in this configuration specifies a zone using the standard `{K8sZoneLabel}` label. To consume from the closest replica, enable the `RackAwareReplicaSelector`  in the Kafka broker configuration.
+<18> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
+<19> Environment variables are set for distributed tracing or to pass credentials to connectors.
+<20> Distributed tracing is enabled by using OpenTelemetry.

--- a/documentation/modules/configuring/con-config-kafka-connector.adoc
+++ b/documentation/modules/configuring/con-config-kafka-connector.adoc
@@ -41,5 +41,5 @@ For instance, a source connector with `tasksMax: 2` might split the import of so
 
 include::../../shared/snip-example-source-connector-config.adoc[]
 
-To include external connector configurations, such as user access credentials stored in a secret, use the `externalConfiguration` property of the `KafkaConnect` resource. 
+To include external connector configurations, such as user access credentials stored in a secret, use the `template` property of the `KafkaConnect` resource.
 You can also load values using xref:assembly-loading-config-with-providers-str[configuration providers]. 

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -213,19 +213,6 @@ spec:
   # Tracing configuration (optional)
   tracing:
     type: opentelemetry # <43>
-  # External configuration (optional)
-  externalConfiguration: # <44>
-    env:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds
-            key: awsAccessKey
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds
-            key: awsSecretAccessKey
 ----
 <1> The number of replica nodes for the workers that run tasks.
 <2> Kafka cluster alias for Kafka Connect, which must specify the *target* Kafka cluster. The Kafka cluster is used by Kafka Connect for its internal topics.
@@ -271,5 +258,3 @@ Standard Apache Kafka configuration may be provided, restricted to those propert
 <41> Template customization. Here a pod is scheduled with anti-affinity, so the pod is not scheduled on nodes with the same hostname.
 <42> Environment variables are set for distributed tracing.
 <43> Distributed tracing is enabled by using OpenTelemetry.
-<44> External configuration for a Kubernetes Secret mounted to Kafka MirrorMaker as an environment variable.
-You can also use configuration provider plugins to load configuration values from external sources.

--- a/documentation/modules/configuring/con-configuration-points-configmaps.adoc
+++ b/documentation/modules/configuring/con-configuration-points-configmaps.adoc
@@ -39,7 +39,7 @@ logging:
 
 To use a ConfigMap for metrics configuration, you add a reference to the `metricsConfig` configuration of the component in the same way.
 
-`ExternalConfiguration` properties make data from a ConfigMap (or Secret) mounted to a pod available as environment variables or volumes.
+`template` properties make data from a ConfigMap (or Secret) mounted to a pod available as environment variables or volumes.
 You can use external configuration data for the connectors used by Kafka Connect.
 The data might be related to an external data source, providing the values needed for the connector to communicate with that data source.
 
@@ -54,13 +54,14 @@ metadata:
   name: my-connect
 spec:
   # ...
-  externalConfiguration:
-    env:
-      - name: MY_ENVIRONMENT_VARIABLE
-        valueFrom:
-          configMapKeyRef:
-            name: my-config-map
-            key: my-key
+  template:
+    connectContainer:
+      env:
+        - name: MY_ENVIRONMENT_VARIABLE
+          valueFrom:
+            configMapKeyRef:
+              name: my-config-map
+              key: my-key
 ----
 
 If you are using ConfigMaps that are managed externally, use configuration providers to load the data in the ConfigMaps.  
@@ -78,5 +79,5 @@ Make sure that any custom ConfigMaps you create do not have the same name as the
 * xref:ref-list-of-kafka-cluster-resources-str[List of Kafka cluster resources] (including ConfigMaps)
 * xref:external-logging_str[Logging configuration]
 * link:{BookURLConfiguring}#con-common-configuration-prometheus-reference[`metricsConfig`^]
-* link:{BookURLConfiguring}#type-ExternalConfiguration-reference[`ExternalConfiguration` schema reference^]
+* link:{BookURLConfiguring}#type-ContainerTemplate-reference[`ContainerTemplate` schema reference^]
 * xref:assembly-loading-config-with-providers-{context}[Loading configuration values from external sources]

--- a/documentation/modules/configuring/con-configuration-points-configmaps.adoc
+++ b/documentation/modules/configuring/con-configuration-points-configmaps.adoc
@@ -39,7 +39,7 @@ logging:
 
 To use a ConfigMap for metrics configuration, you add a reference to the `metricsConfig` configuration of the component in the same way.
 
-`template` properties make data from a ConfigMap (or Secret) mounted to a pod available as environment variables or volumes.
+`template` properties allow data from a `ConfigMap` or `Secret` to be mounted in a pod as environment variables or volumes.
 You can use external configuration data for the connectors used by Kafka Connect.
 The data might be related to an external data source, providing the values needed for the connector to communicate with that data source.
 

--- a/documentation/modules/configuring/con-external-config.adoc
+++ b/documentation/modules/configuring/con-external-config.adoc
@@ -49,7 +49,7 @@ You can supply connector configuration for Kafka Connect or MirrorMaker 2 in thi
 
 * Mount config maps or secrets into the Kafka Connect pod as environment variables or volumes
 * Enable `EnvVarConfigProvider`, `FileConfigProvider`, or `DirectoryConfigProvider` in the Kafka Connect or MirrorMaker 2 configuration
-* Pass connector configuration using the `externalConfiguration` property in the `spec` of the `KafkaConnect` or `KafkaMirrorMaker2` resource
+* Pass connector configuration using the `template` property in the `spec` of the `KafkaConnect` or `KafkaMirrorMaker2` resource
 
 Using providers help prevent the passing of restricted information through the Kafka Connect REST interface.
 You can use this approach in the following scenarios:
@@ -63,4 +63,4 @@ NOTE: A restart is required when using a new `Secret` or `ConfigMap` for a conne
 [role="_additional-resources"]
 .Additional resources
 
-link:{BookURLConfiguring}#type-ExternalConfiguration-reference[`ExternalConfiguration` schema reference^]
+link:{BookURLConfiguring}#type-KafkaConnectTemplate-reference[`KafkaConnectTemplate` schema reference^]

--- a/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-env-vars.adoc
@@ -40,7 +40,7 @@ data:
 +
 --
 * Enable the `EnvVarConfigProvider`
-* Specify the environment variables using the `externalConfiguration` property.
+* Specify the environment variables using the `template` property.
 --
 +
 .Example Kafka Connect configuration to use external environment variables
@@ -59,18 +59,19 @@ spec:
     config.providers: env # <1>
     config.providers.env.class: org.apache.kafka.common.config.provider.EnvVarConfigProvider # <2>
   # ...
-  externalConfiguration:
-    env:
-      - name: AWS_ACCESS_KEY_ID # <3>
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds # <4>
-            key: awsAccessKey # <5>
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: aws-creds
-            key: awsSecretAccessKey          
+  template:
+    connectContainer:
+      env:
+        - name: AWS_ACCESS_KEY_ID # <3>
+          valueFrom:
+            secretKeyRef:
+              name: aws-creds # <4>
+              key: awsAccessKey # <5>
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-creds
+              key: awsSecretAccessKey
   # ...
 ----
 <1> The alias for the configuration provider is used to define other configuration parameters.

--- a/documentation/modules/configuring/proc-loading-config-from-files.adoc
+++ b/documentation/modules/configuring/proc-loading-config-from-files.adoc
@@ -80,14 +80,6 @@ spec:
           mountPath: /mnt/my-user # <6>
         - name: cluster-ca-volume
           mountPath: /mnt/cluster-ca
-  externalConfiguration:
-    volumes: # <3>
-      - name: cluster-ca # <4>
-        secret:
-          secretName: my-cluster-cluster-ca-cert # <5>
-      - name: my-user
-        secret:
-          secretName: my-user # <6>
 ----
 <1> The alias for the configuration provider is used to define other configuration parameters.
 <2> `DirectoryConfigProvider` provides values from files in a directory. The parameter uses the alias from `config.providers`, taking the form `config.providers.${alias}.class`.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1815,7 +1815,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -1825,7 +1825,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -1835,7 +1835,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -1958,7 +1958,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -1968,7 +1968,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -1978,7 +1978,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -3241,7 +3241,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -3251,7 +3251,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -3261,7 +3261,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -4483,7 +4483,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -4493,7 +4493,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -4503,7 +4503,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -4626,7 +4626,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -4636,7 +4636,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -4646,7 +4646,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -4769,7 +4769,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -4779,7 +4779,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -4789,7 +4789,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -5937,7 +5937,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -5947,7 +5947,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -5957,7 +5957,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -6080,7 +6080,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -6090,7 +6090,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -6100,7 +6100,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -7047,7 +7047,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -7057,7 +7057,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -7067,7 +7067,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}
@@ -7943,7 +7943,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a Secret.
+                                        description: Reference to a key in a secret.
                                       configMapKeyRef:
                                         type: object
                                         properties:
@@ -7953,7 +7953,7 @@ spec:
                                             type: string
                                           optional:
                                             type: boolean
-                                        description: Reference to a key in a ConfigMap.
+                                        description: Reference to a key in a config map.
                                     oneOf:
                                       - properties:
                                           secretKeyRef: {}
@@ -7963,7 +7963,7 @@ spec:
                                           configMapKeyRef: {}
                                         required:
                                           - configMapKeyRef
-                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                    description: Reference to secret or config map property to which will be the environment variable is set.
                                 oneOf:
                                   - properties:
                                       value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -1803,6 +1803,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -1904,6 +1946,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -3145,6 +3229,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -4345,6 +4471,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -4446,6 +4614,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -4547,6 +4757,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -5673,6 +5925,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -5774,6 +6068,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -6699,6 +7035,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object
@@ -7553,6 +7931,48 @@ spec:
                                   value:
                                     type: string
                                     description: The environment variable value.
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      secretKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a Secret.
+                                      configMapKeyRef:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        description: Reference to a key in a ConfigMap.
+                                    oneOf:
+                                      - properties:
+                                          secretKeyRef: {}
+                                        required:
+                                          - secretKeyRef
+                                      - properties:
+                                          configMapKeyRef: {}
+                                        required:
+                                          - configMapKeyRef
+                                    description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                oneOf:
+                                  - properties:
+                                      value: {}
+                                    required:
+                                      - value
+                                  - properties:
+                                      valueFrom: {}
+                                    required:
+                                      - valueFrom
                               description: Environment variables which should be applied to the container.
                             securityContext:
                               type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1191,6 +1191,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
@@ -1292,6 +1334,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
@@ -2034,6 +2118,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -1203,7 +1203,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1213,7 +1213,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1223,7 +1223,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}
@@ -1346,7 +1346,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1356,7 +1356,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1366,7 +1366,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}
@@ -2130,7 +2130,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -2140,7 +2140,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -2150,7 +2150,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1312,6 +1312,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
@@ -1324,7 +1324,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1334,7 +1334,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1344,7 +1344,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1169,6 +1169,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
@@ -1306,6 +1348,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -1181,7 +1181,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1191,7 +1191,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1201,7 +1201,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}
@@ -1360,7 +1360,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1370,7 +1370,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1380,7 +1380,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1408,6 +1408,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
@@ -1509,6 +1551,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object
@@ -2251,6 +2335,48 @@ spec:
                               value:
                                 type: string
                                 description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a Secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a ConfigMap.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
                           description: Environment variables which should be applied to the container.
                         securityContext:
                           type: object

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -1420,7 +1420,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1430,7 +1430,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1440,7 +1440,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}
@@ -1563,7 +1563,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -1573,7 +1573,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1583,7 +1583,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}
@@ -2347,7 +2347,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a Secret.
+                                    description: Reference to a key in a secret.
                                   configMapKeyRef:
                                     type: object
                                     properties:
@@ -2357,7 +2357,7 @@ spec:
                                         type: string
                                       optional:
                                         type: boolean
-                                    description: Reference to a key in a ConfigMap.
+                                    description: Reference to a key in a config map.
                                 oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -2367,7 +2367,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                       - configMapKeyRef
-                                description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                description: Reference to secret or config map property to which will be the environment variable is set.
                             oneOf:
                               - properties:
                                   value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -935,7 +935,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -945,7 +945,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -955,7 +955,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -1078,7 +1078,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1088,7 +1088,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1098,7 +1098,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -923,6 +923,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -1024,6 +1066,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1814,7 +1814,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -1824,7 +1824,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1834,7 +1834,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -1957,7 +1957,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -1967,7 +1967,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -1977,7 +1977,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -3240,7 +3240,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -3250,7 +3250,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -3260,7 +3260,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -4482,7 +4482,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -4492,7 +4492,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -4502,7 +4502,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -4625,7 +4625,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -4635,7 +4635,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -4645,7 +4645,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -4768,7 +4768,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -4778,7 +4778,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -4788,7 +4788,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -5936,7 +5936,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -5946,7 +5946,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -5956,7 +5956,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -6079,7 +6079,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -6089,7 +6089,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -6099,7 +6099,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -7046,7 +7046,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -7056,7 +7056,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -7066,7 +7066,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}
@@ -7942,7 +7942,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a Secret.
+                                      description: Reference to a key in a secret.
                                     configMapKeyRef:
                                       type: object
                                       properties:
@@ -7952,7 +7952,7 @@ spec:
                                           type: string
                                         optional:
                                           type: boolean
-                                      description: Reference to a key in a ConfigMap.
+                                      description: Reference to a key in a config map.
                                   oneOf:
                                   - properties:
                                       secretKeyRef: {}
@@ -7962,7 +7962,7 @@ spec:
                                       configMapKeyRef: {}
                                     required:
                                     - configMapKeyRef
-                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                                  description: Reference to secret or config map property to which will be the environment variable is set.
                               oneOf:
                               - properties:
                                   value: {}

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -1802,6 +1802,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -1903,6 +1945,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -3144,6 +3228,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -4344,6 +4470,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -4445,6 +4613,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -4546,6 +4756,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -5672,6 +5924,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -5773,6 +6067,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -6698,6 +7034,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
@@ -7552,6 +7930,48 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a Secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a ConfigMap.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1202,7 +1202,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1212,7 +1212,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1222,7 +1222,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -1345,7 +1345,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1355,7 +1355,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1365,7 +1365,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -2129,7 +2129,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -2139,7 +2139,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -2149,7 +2149,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -1190,6 +1190,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -1291,6 +1333,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -2033,6 +2117,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1311,6 +1311,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object

--- a/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1323,7 +1323,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1333,7 +1333,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1343,7 +1343,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1168,6 +1168,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -1305,6 +1347,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -1180,7 +1180,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1190,7 +1190,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1200,7 +1200,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -1359,7 +1359,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1369,7 +1369,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1379,7 +1379,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1419,7 +1419,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1429,7 +1429,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1439,7 +1439,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -1562,7 +1562,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1572,7 +1572,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1582,7 +1582,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -2346,7 +2346,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -2356,7 +2356,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -2366,7 +2366,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1407,6 +1407,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -1508,6 +1550,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -2250,6 +2334,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -935,7 +935,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -945,7 +945,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -955,7 +955,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}
@@ -1078,7 +1078,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a Secret.
+                                  description: Reference to a key in a secret.
                                 configMapKeyRef:
                                   type: object
                                   properties:
@@ -1088,7 +1088,7 @@ spec:
                                       type: string
                                     optional:
                                       type: boolean
-                                  description: Reference to a key in a ConfigMap.
+                                  description: Reference to a key in a config map.
                               oneOf:
                               - properties:
                                   secretKeyRef: {}
@@ -1098,7 +1098,7 @@ spec:
                                   configMapKeyRef: {}
                                 required:
                                 - configMapKeyRef
-                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                              description: Reference to secret or config map property to which will be the environment variable is set.
                           oneOf:
                           - properties:
                               value: {}

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -923,6 +923,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
@@ -1024,6 +1066,48 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a Secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a ConfigMap.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to Secret or ConfigMap field to which will be the environment variable set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR implements the [Strimzi Proposal #85](https://github.com/strimzi/proposals/blob/main/085-configure-env-vars-based-on-secrets-or-configmaps.md) and adds the possibily to configure Secret or ConfigMap based environment variables in any container through the container template section.

It also deprecates the rest of the `externalConfiguration` section in Connect and MM2 that allowed the same, but only in the Connect and MM2 resources.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md