### PR TITLE
MirrorMaker2: Check if bootstrap servers are the same for different cluster aliases

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -18,6 +18,7 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ConnectorSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
+import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Spec;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -26,12 +27,14 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -116,7 +119,7 @@ public class KafkaMirrorMaker2Connectors {
                         errorMessages.add("Target cluster alias " + mirror.getTargetCluster() + " is used in a mirror definition, but cluster with this alias does not exist in cluster definitions");
                     }
 
-                    if (!mirror.getTargetCluster().equals(connectCluster)) {
+                    if (!mirror.getTargetCluster().equals(connectCluster) && !hasMatchingBootstrapServers(kafkaMirrorMaker2, mirror, connectCluster)) {
                         errorMessages.add("Connect cluster alias (currently set to " + connectCluster + ") has to be the same as the target cluster alias " + mirror.getTargetCluster());
                     }
                 }
@@ -323,5 +326,24 @@ public class KafkaMirrorMaker2Connectors {
         } else {
             return "PLAINTEXT";
         }
+    }
+
+    private static boolean hasMatchingBootstrapServers(KafkaMirrorMaker2 kafkaMirrorMaker2, KafkaMirrorMaker2MirrorSpec mirror, String connectCluster) {
+        Map<String, String> configs = new HashMap<>();
+
+        Optional.ofNullable(kafkaMirrorMaker2)
+                .map(KafkaMirrorMaker2::getSpec)
+                .map(KafkaMirrorMaker2Spec::getClusters)
+                .orElse(Collections.emptyList())
+                .forEach(clusterLists -> {
+                    if (connectCluster != null && connectCluster.equals(clusterLists.getAlias())) {
+                        configs.put("connectClusterBootstrapServer", clusterLists.getBootstrapServers());
+                    }
+                    if (mirror.getTargetCluster() != null && mirror.getTargetCluster().equals(clusterLists.getAlias())) {
+                        configs.put("targetClusterBootstrapServers", clusterLists.getBootstrapServers());
+                    }
+                });
+
+        return configs.get("connectClusterBootstrapServer").equals(configs.get("targetClusterBootstrapServers"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -150,6 +150,20 @@ public class KafkaMirrorMaker2ConnectorsTest {
                 "[Connect cluster alias (currently set to target) has to be the same as the target cluster alias third]"));
     }
 
+
+    @Test
+    public void testClusterNotSameButBootstrapUrlSame() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                .editCluster(1)
+                .withBootstrapServers("source:9092")
+                .endCluster()
+                .withConnectCluster("source")
+                .endSpec()
+                .build();
+        assertDoesNotThrow(() -> KafkaMirrorMaker2Connectors.validateConnectors(kmm2));
+    }
+
     @Test
     public void testConnectors() {
         KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, KMM2);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Refactoring

### Description

After the changes we made in the PR #9923, the current condition prevents users from independently managing the connections between Kafka Connect and Kafka, as well as between the MM2 connectors and Kafka. 
Specifically, we’re using two distinct KafkaUsers, each assigned with minimal set of ACLs that are required.

Our proposed solution is to modify the condition to permit scenarios where the connectCluster bootstrapServer and the mirror.targetCluster bootstrapServer are identical.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

