### PR TITLE
[system test] [doc] Add TestDocsLabels class to remove redundancy

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/docs/TestDocsLabels.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/docs/TestDocsLabels.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.docs;
+
+/**
+ * Provides documentation labels used in {@link io.skodjob.annotations.SuiteDoc#labels()} or
+ * {@link io.skodjob.annotations.TestDoc#labels()}.
+ */
+public interface TestDocsLabels {
+
+    String BRIDGE = "bridge";
+    String CONNECT = "connect";
+    String CRUISE_CONTROL = "cruise-control";
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeCorsST.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.resources.crd.KafkaBridgeResource;
@@ -55,7 +56,7 @@ import static org.hamcrest.Matchers.containsString;
         @Step(value = "Deploy required Kafka resources and scraper pod", expected = "Kafka resources and scraper pod are deployed and running")
     },
     labels = {
-        @Label("bridge")
+        @Label(TestDocsLabels.BRIDGE)
     }
 )
 public class HttpBridgeCorsST extends AbstractST {
@@ -79,7 +80,7 @@ public class HttpBridgeCorsST extends AbstractST {
             @Step(value = "Check if the GET request response is '404 Not Found'", expected = "Response for GET request is 404 Not Found")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testCorsOriginAllowed() {
@@ -134,7 +135,7 @@ public class HttpBridgeCorsST extends AbstractST {
             @Step(value = "Verify the response contains '403' and 'CORS Rejected - Invalid origin'", expected = "Response indicates the CORS request is rejected")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testCorsForbidden() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeST.java
@@ -21,6 +21,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -72,7 +73,7 @@ import static org.hamcrest.Matchers.containsString;
         @Step(value = "Initialize Test Storage and deploy Kafka and Kafka Bridge", expected = "Kafka and Kafka Bridge are deployed with necessary configuration")
     },
     labels = {
-        @Label("bridge"),
+        @Label(TestDocsLabels.BRIDGE),
     }
 )
 class HttpBridgeST extends AbstractST {
@@ -95,7 +96,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Verify Kafka Bridge service labels", expected = "Labels for Kafka Bridge service are correctly set and verified")
         },
         labels = {
-            @Label("bridge"),
+            @Label(TestDocsLabels.BRIDGE),
         }
     )
     void testSendSimpleMessage() {
@@ -139,7 +140,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Verify message reception", expected = "All messages are received by Kafka Bridge consumer client")
         },
         labels = {
-            @Label("bridge"),
+            @Label(TestDocsLabels.BRIDGE),
         }
     )
     void testReceiveSimpleMessage() {
@@ -181,7 +182,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Verify Kafka Bridge configurations for producer and consumer", expected = "Producer and consumer configurations match the updated settings")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testCustomAndUpdatedValues() {
@@ -314,7 +315,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Verify the status of KafkaBridge", expected = "KafkaBridge status should indicate it is ready with zero replicas")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testScaleBridgeToZero() {
@@ -351,7 +352,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Check pod naming conventions.", expected = "Pod names should match the naming convention and be consistent.")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testScaleBridgeSubresource() {
@@ -400,7 +401,7 @@ class HttpBridgeST extends AbstractST {
             @Step(value = "Check that observed generation is 2 and the new label is present", expected = "Observed generation is 2 and label 'another=label' is present")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testConfigureDeploymentStrategy() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeScramShaST.java
@@ -20,6 +20,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -57,7 +58,7 @@ import static io.strimzi.systemtest.TestConstants.REGRESSION;
         
     },
     labels = {
-        @Label("bridge")
+        @Label(TestDocsLabels.BRIDGE)
     }
 )
 class HttpBridgeScramShaST extends AbstractST {
@@ -78,7 +79,7 @@ class HttpBridgeScramShaST extends AbstractST {
             @Step(value = "Wait for consumer success", expected = "Consumer finishes receiving messages without errors")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testSendSimpleMessageTlsScramSha() {
@@ -114,7 +115,7 @@ class HttpBridgeScramShaST extends AbstractST {
             @Step(value = "Wait for clients' success validation", expected = "Messages are successfully consumed from the Kafka topic")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testReceiveSimpleMessageTlsScramSha() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/bridge/HttpBridgeTlsST.java
@@ -25,6 +25,7 @@ import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.BridgeClientsBuilder;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
@@ -59,7 +60,7 @@ import static io.strimzi.systemtest.TestConstants.REGRESSION;
         @Step(value = "Deploy HTTP bridge with TLS configuration", expected = "HTTP bridge is deployed with TLS configuration")
     },
     labels = {
-        @Label("bridge")
+        @Label(TestDocsLabels.BRIDGE)
     }
 )
 class HttpBridgeTlsST extends AbstractST {
@@ -79,7 +80,7 @@ class HttpBridgeTlsST extends AbstractST {
             @Step(value = "Verify that the consumer successfully receives messages", expected = "Consumer successfully receives the expected number of messages")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testSendSimpleMessageTls() {
@@ -116,7 +117,7 @@ class HttpBridgeTlsST extends AbstractST {
             @Step(value = "Verify message consumption", expected = "Messages are successfully consumed by the Kafka Bridge consumer.")
         },
         labels = {
-            @Label("bridge")
+            @Label(TestDocsLabels.BRIDGE)
         }
     )
     void testReceiveSimpleMessageTls() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectBuilderST.java
@@ -34,6 +34,7 @@ import io.strimzi.systemtest.annotations.KindNotSupported;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.annotations.OpenShiftOnly;
 import io.strimzi.systemtest.annotations.ParallelTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -85,7 +86,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuiteDoc(
     description = @Desc("Testing Kafka Connect build and plugin management."),
     labels = {
-        @Label(value = "connect"),
+        @Label(value = TestDocsLabels.CONNECT),
     }
 )
 class ConnectBuilderST extends AbstractST {
@@ -168,7 +169,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Verify that EchoSink KafkaConnector is listed in Kafka Connect resource status", expected = "EchoSink KafkaConnector is listed in the status of Kafka Connect resource")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testBuildFailsWithWrongChecksumOfArtifact() {
@@ -254,7 +255,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Check logs for received message", expected = "Logs contain the expected received message")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testBuildWithJarTgzAndZip() {
@@ -317,7 +318,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Verify KafkaConnect build artifacts and status", expected = "KafkaConnect has two plugins, uses the image stream output and is in the 'Ready' state")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testPushIntoImageStream() {
@@ -372,7 +373,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Verify that both connectors and plugins are present in Kafka Connect", expected = "Both connectors and plugins are verified successfully")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testUpdateConnectWithAnotherPlugin() {
@@ -479,7 +480,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Verify plugin file name after update using the plugin's hash", expected = "Plugin file name is different from the previous name and matches the hash")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testBuildOtherPluginTypeWithAndWithoutFileName() {
@@ -552,7 +553,7 @@ class ConnectBuilderST extends AbstractST {
             @Step(value = "Verify that consumer receives messages", expected = "Consumer receives the expected messages")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testBuildPluginUsingMavenCoordinatesArtifacts() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/connect/ConnectST.java
@@ -45,6 +45,7 @@ import io.strimzi.systemtest.Environment;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.MicroShiftNotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClients;
 import io.strimzi.systemtest.kafkaclients.internalClients.KafkaClientsBuilder;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
@@ -117,7 +118,7 @@ import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
         @Step(value = "Deploy scraper Pod for accessing all other Pods", expected = "Scraper Pod is deployed")
     },
     labels = {
-        @Label(value = "connect")
+        @Label(value = TestDocsLabels.CONNECT)
     }
 )
 class ConnectST extends AbstractST {
@@ -137,7 +138,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Kafka Connectors", expected = "Various Kafka Connect resource labels and configurations are verified to ensure correct deployment")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testDeployRollUndeploy() {
@@ -196,7 +197,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Pause and run connector by modifying 'spec.state' property of Connector (with priority over now set 'spec.pause=false'), while also producing messages when connector pauses.", expected = "Connector pauses and resumes as expected, after resuming, produced messages are present in destination file, indicating connector resumed correctly.")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testKafkaConnectAndConnectorStateWithFileSinkPlugin() {
@@ -270,7 +271,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify messages in KafkaConnect file sink", expected = "FileSink contains the expected number of messages")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testKafkaConnectWithPlainAndScramShaAuthentication() {
@@ -361,7 +362,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Execute assertions to verify the Kafka Connector configuration and status", expected = "Assertions confirm the Kafka Connector is successfully deployed, has the correct configuration, and is running.")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testKafkaConnectAndConnectorFileSinkPlugin() {
@@ -424,7 +425,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify JVM options and resource requirements", expected = "JVM options and resource requests/limits are correctly applied to the Kafka Connect pod")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testJvmAndResources() {
@@ -480,7 +481,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify the replica count after scaling down", expected = "Replica count is verified to be the initial count")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testKafkaConnectScaleUpScaleDown() {
@@ -534,7 +535,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify messages in Kafka Connect FileSink", expected = "Messages are verified in Kafka Connect FileSink")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testSecretsWithKafkaConnectWithTlsAndTlsClientAuthentication() {
@@ -627,7 +628,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify messages in Kafka Connect file sink", expected = "Messages found in the specified file path")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testSecretsWithKafkaConnectWithTlsAndScramShaAuthentication() {
@@ -718,7 +719,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify auto-restart count reset", expected = "Auto-restart count is reset to zero after task stability")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testConnectorTaskAutoRestart() {
@@ -823,7 +824,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify updated configuration and environment variables", expected = "Updated configuration and environment variables are as expected")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testCustomAndUpdatedValues() {
@@ -940,7 +941,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify that Kafka Connect writes messages to the specified file sink", expected = "Messages successfully written to the file sink by Kafka Connect")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testMultiNodeKafkaConnectWithConnectorCreation() {
@@ -1008,7 +1009,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify that Kafka Connect can consume messages", expected = "Messages are consumed successfully by Kafka Connect")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testConnectTlsAuthWithWeirdUserName() {
@@ -1101,7 +1102,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify that connector receives messages", expected = "Messages consumed by the connector and written to the specified sink")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testConnectScramShaAuthWithWeirdUserName() {
@@ -1193,7 +1194,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify that KafkaConnect has 0 pods", expected = "No KafkaConnect pods are running and status is ready.")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testScaleConnectWithoutConnectorToZero() {
@@ -1243,7 +1244,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify conditions", expected = "Pod size is 0, Kafka Connect is ready, Kafka Connector is not ready due to zero replicas")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testScaleConnectWithConnectorToZero() {
@@ -1308,7 +1309,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify Kafka Connector subresource scaling", expected = "Kafka Connector task max in spec, status and Connect Pods API are as expected")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testScaleConnectAndConnectorSubresource() {
@@ -1393,7 +1394,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify mounted volumes", expected = "Kafka Connect mounted volumes contain expected values from Secrets and ConfigMaps.")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testMountingSecretAndConfigMapAsVolumesAndEnvVars() {
@@ -1574,7 +1575,7 @@ class ConnectST extends AbstractST {
             @Step(value = "Verify Kafka Connect continues to function after rolling update", expected = "Kafka Connect remains functional and REST API is available")
         },
         labels = {
-            @Label(value = "connect")
+            @Label(value = TestDocsLabels.CONNECT)
         }
     )
     void testKafkaConnectWithScramShaAuthenticationRolledAfterPasswordChanged() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlApiST.java
@@ -12,6 +12,7 @@ import io.skodjob.annotations.TestDoc;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
 import io.strimzi.systemtest.storage.TestStorage;
@@ -42,7 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
         @Step(value = "Deploy the cluster operator", expected = "Cluster operator is deployed")
     },
     labels = {
-        @Label(value = "cruise-control"),
+        @Label(value = TestDocsLabels.CRUISE_CONTROL),
     }
 )
 public class CruiseControlApiST extends AbstractST {
@@ -61,7 +62,7 @@ public class CruiseControlApiST extends AbstractST {
             @Step(value = "Verify the Cruise Control state response", expected = "Response indicates Cruise Control is RUNNING with NO_TASK_IN_PROGRESS")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlBasicAPIRequestsWithSecurityDisabled() {
@@ -107,7 +108,7 @@ public class CruiseControlApiST extends AbstractST {
             @Step(value = "Do request to Cruise Control's API, specifically to `/state` endpoint with `arnost:heslo` user", expected = "Request is successful and response contains information about state of the Cruise Control")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlAPIUsers() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlConfigurationST.java
@@ -18,6 +18,7 @@ import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfiguration
 import io.strimzi.systemtest.AbstractST;
 import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.admin.AdminClient;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -62,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
         @Step(value = "Set up the Cluster Operator", expected = "Cluster Operator is installed and running")
     },
     labels = {
-        @Label(value = "cruise-control")
+        @Label(value = TestDocsLabels.CRUISE_CONTROL)
     }
 )
 public class CruiseControlConfigurationST extends AbstractST {
@@ -83,7 +84,7 @@ public class CruiseControlConfigurationST extends AbstractST {
             @Step(value = "Verify Cruise Control and related configurations", expected = "Cruise Control and its configurations are verified to be present")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testDeployAndUnDeployCruiseControl() throws IOException {
@@ -164,7 +165,7 @@ public class CruiseControlConfigurationST extends AbstractST {
             @Step(value = "Verify new configurations are applied to Cruise Control in Kafka CR", expected = "New configurations are correctly applied")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testConfigurationUpdate() throws IOException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -30,6 +30,7 @@ import io.strimzi.systemtest.TestConstants;
 import io.strimzi.systemtest.annotations.IsolatedTest;
 import io.strimzi.systemtest.annotations.MixedRoleNotSupported;
 import io.strimzi.systemtest.annotations.ParallelNamespaceTest;
+import io.strimzi.systemtest.docs.TestDocsLabels;
 import io.strimzi.systemtest.kafkaclients.internalClients.admin.AdminClient;
 import io.strimzi.systemtest.resources.NodePoolsConverter;
 import io.strimzi.systemtest.resources.ResourceManager;
@@ -86,7 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         @Step(value = "Deploy cluster operator with default installation", expected = "Cluster operator is deployed and running")
     },
     labels = {
-        @Label(value = "cruise-control"),
+        @Label(value = TestDocsLabels.CRUISE_CONTROL),
     }
 )
 public class CruiseControlST extends AbstractST {
@@ -104,7 +105,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Verify Cruise Control topics are present", expected = "Cruise Control topics are found present in the configuration")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testAutoCreationOfCruiseControlTopicsWithResources() {
@@ -196,7 +197,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Execute rebalance process again", expected = "Rebalancing process re-executed successfully")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlWithRebalanceResourceAndRefreshAnnotation() {
@@ -248,7 +249,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Wait until KafkaRebalance returns to ProposalReady state", expected = "KafkaRebalance re-enters ProposalReady state following the update")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlChangesFromRebalancingtoProposalReadyWhenSpecUpdated() {
@@ -288,7 +289,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Check that the Kafka status no longer contains the single-node error message", expected = "Error message resolved")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlWithSingleNodeKafka() {
@@ -344,7 +345,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Wait for KafkaRebalance to reach Ready state", expected = "KafkaRebalance reaches the Ready state")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlTopicExclusion() {
@@ -395,7 +396,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Verify the updated Cruise Control configuration", expected = "Updated replica movement strategies are verified in Cruise Control configuration")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlReplicaMovementStrategy() {
@@ -455,7 +456,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Check the status of the Kafka Rebalance for intra-broker disk balancing", expected = "The 'provisionStatus' in the optimization result is 'UNDECIDED'")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlIntraBrokerBalancing() {
@@ -514,7 +515,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Scale Kafka down to the initial number of brokers", expected = "Kafka brokers are scaled down to the original number of replicas")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testCruiseControlDuringBrokerScaleUpAndDown() {
@@ -613,7 +614,7 @@ public class CruiseControlST extends AbstractST {
             @Step(value = "Perform re-balancing process with auto-approval", expected = "Re-balancing process completes successfully with auto-approval")
         },
         labels = {
-            @Label(value = "cruise-control"),
+            @Label(value = TestDocsLabels.CRUISE_CONTROL),
         }
     )
     void testKafkaRebalanceAutoApprovalMechanism() {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adds a `TestDocsLabels` class to remove redundancy from system test documented classes completely.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass