### PR TITLE
[ST] add new util method to check crd presence and use it in UpgradeSTs

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/crds/CrdUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kubeUtils/crds/CrdUtils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.kubeUtils.crds;
+
+import static io.strimzi.test.k8s.KubeClusterResource.cmdKubeClient;
+
+public class CrdUtils {
+
+    /**
+     * Checks if a given Custom Resource Definition (CRD) is present in the Kubernetes cluster.
+     * This method constructs the fully qualified name of the CRD using its resource plural name
+     * and API group.
+     *
+     * @param resourcePluralName  The plural name of the custom resource (e.g., "kafkatopics").
+     * @param resourceApiGroupName The API group name of the custom resource (e.g., "kafka.strimzi.io").
+     * @return {@code true} if the CRD is present in the cluster, {@code false} otherwise.
+     */
+    public static boolean isCrdPresent(final String resourcePluralName, final String resourceApiGroupName) {
+        final String fullyQualifiedCrdName = resourcePluralName + "." + resourceApiGroupName;
+        return cmdKubeClient().exec(false, "get", "crd", fullyQualifiedCrdName).returnCode() == 0;
+    }
+}


### PR DESCRIPTION


### Type of change


- refactor


### Description

in case test is assumed to false (and we install CRDs only later in test) some of tests may fail on clean up (for example `kafkaTopics` in upgrade donwgrade system tests) 

solution was added new method with 2 parameters, plural resource name and group (rather than just one class that extends Abstract CustomResource class) as these do not necessarily provide all desired information.  



