### PR TITLE
Fix reliability issue with test case

### DIFF
--- a/mockkube/src/test/java/io/strimzi/test/mockkube3/MockKube3ControllersMockTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/mockkube3/MockKube3ControllersMockTest.java
@@ -134,7 +134,7 @@ public class MockKube3ControllersMockTest {
 
         client.apps().deployments().inNamespace(namespace).resource(dep).create();
         
-        TestUtils.waitFor("Wait for deployment to have status", 100L, 10_000L, 
+        TestUtils.waitFor("Wait for deployment to have non-empty status", 100L, 10_000L, 
                 () -> client.apps().deployments().inNamespace(namespace).withName(deploymentName).get() != null
                         && client.apps().deployments().inNamespace(namespace).withName(deploymentName).get().getStatus() != null
                         && client.apps().deployments().inNamespace(namespace).withName(deploymentName).get().getStatus().getObservedGeneration() != null);

--- a/mockkube/src/test/java/io/strimzi/test/mockkube3/MockKube3ControllersMockTest.java
+++ b/mockkube/src/test/java/io/strimzi/test/mockkube3/MockKube3ControllersMockTest.java
@@ -133,8 +133,11 @@ public class MockKube3ControllersMockTest {
                 .build();
 
         client.apps().deployments().inNamespace(namespace).resource(dep).create();
-
-        TestUtils.waitFor("Wait for deployment to have status", 100L, 10_000L, () -> client.apps().deployments().inNamespace(namespace).withName(deploymentName).get() != null && client.apps().deployments().inNamespace(namespace).withName(deploymentName).get().getStatus() != null);
+        
+        TestUtils.waitFor("Wait for deployment to have status", 100L, 10_000L, 
+                () -> client.apps().deployments().inNamespace(namespace).withName(deploymentName).get() != null
+                        && client.apps().deployments().inNamespace(namespace).withName(deploymentName).get().getStatus() != null
+                        && client.apps().deployments().inNamespace(namespace).withName(deploymentName).get().getStatus().getObservedGeneration() != null);
 
         Deployment createdDeployment = client.apps().deployments().inNamespace(namespace).withName(deploymentName).get();
         assertThat(createdDeployment, is(notNullValue()));


### PR DESCRIPTION
### Type of change

- Bugfix (bug in test case)

### Description

Addresses reliability issue with MockKube3ControllersMockTest.testDeploymentController test case by changing the wait condition to wait until after the MockDeploymentController has processed the deployment creation
Closes #10616 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

