### PR TITLE
Clean up methods in Connect and MM2 Assembly Operators

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -214,6 +214,21 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     }
 
     /**
+     * Creates the ClusterRoleBinding required for the init container used for client rack-awareness.
+     * The init-container needs to be able to read the labels from the node it is running on to be able
+     * to determine the `client.rack` option.
+     *
+     * @param reconciliation The reconciliation
+     * @param crbName ClusterRoleBinding name
+     * @param crb ClusterRoleBinding
+     *
+     * @return Future for tracking the asynchronous result of the ClusterRoleBinding reconciliation
+     */
+    protected Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(Reconciliation reconciliation, String crbName, ClusterRoleBinding crb) {
+        return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, crbName, crb), crb);
+    }
+
+    /**
      * Reconciles the NetworkPolicy for the Connect cluster.
      *
      * @param reconciliation       The reconciliation
@@ -905,21 +920,6 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
     private Future<ConnectorStatusAndConditions> updateConnectorTopics(Reconciliation reconciliation, String host, KafkaConnectApi apiClient, String connectorName, ConnectorStatusAndConditions status) {
         return apiClient.getConnectorTopics(reconciliation, host, port, connectorName)
             .compose(updateConnectorStatusAndConditions(status));
-    }
-
-    /**
-     * Creates the ClusterRoleBinding required for the init container used for client rack-awareness.
-     * The init-container needs to be able to read the labels from the node it is running on to be able
-     * to determine the `client.rack` option.
-     *
-     * @param reconciliation The reconciliation
-     * @param crbName ClusterRoleBinding name
-     * @param crb ClusterRoleBinding
-     *
-     * @return Future for tracking the asynchronous result of the ClusterRoleBinding reconciliation
-     */
-    protected Future<ReconcileResult<ClusterRoleBinding>> connectInitClusterRoleBinding(Reconciliation reconciliation, String crbName, ClusterRoleBinding crb) {
-        return ReconcilerUtils.withIgnoreRbacError(reconciliation, clusterRoleBindingOperations.reconcile(reconciliation, crbName, crb), crb);
     }
 
     // Abstract methods for working with connector restarts. These methods are implemented in the KafkaConnectAssemblyOperator and KafkaMirrorMaker2AssemblyOperator


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Clean up methods in Connect and MM2 Assembly Operators:

- Move methods to align them across the KafkaConnectAssemblyOperator, KafkaMirrorMaker2AssemblyOperator and AbstractConnectOperator
- Use `port` field directly instead of hard coded `KafkaConnectCluster.REST_API_PORT`
- Refactor connector reconcile methods in KafkaConnectAssemblyOperator to make it easier to follow

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

