### PR TITLE
Fix rebalance RF change race issue

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -796,7 +796,7 @@ public class BatchingTopicController {
         var apparentlyDifferentRf = currentStates.filter(pair -> {
             var reconcilableTopic = pair.getKey();
             var currentState = pair.getValue();
-            return reconcilableTopic.kt().getSpec().getReplicas() != null
+            return currentState.uniqueReplicationFactor() > 0 && reconcilableTopic.kt().getSpec().getReplicas() != null
                 && currentState.uniqueReplicationFactor() != reconcilableTopic.kt().getSpec().getReplicas();
         }).toList();
         return TopicOperatorUtil.partitionedByError(kafkaHandler.filterByReassignmentTargetReplicas(apparentlyDifferentRf).stream());


### PR DESCRIPTION
### Type of change

Bugfix

### Description

When a rebalance is running, the Topic Operator reacts by seeing a RF change, where there is none, and raising the task already executing error. This is caused by the `admin.describeTopics` returning no result for some time while the rebalance is in progress. The Topic Operator translates this to a RF value of `Integer.MIN_VALUE`, which is different from any topic's RF. This change fixes the issue by adding a RF greater than zero check.

Closes #10630.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging