### PR TITLE
Update Fabric8 Kubernetes client to 6.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>6.13.3</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>6.13.3</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>6.13.3</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>6.13.4</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>6.13.4</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>6.13.4</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates Fabric8 Kubernetes client to a new version 6.13.4.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally