### PR TITLE
Decide if option is custom or not in a single place

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConfiguration.java
@@ -2,7 +2,6 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 package io.strimzi.operator.cluster.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -288,7 +287,7 @@ public class KafkaConfiguration extends AbstractConfiguration {
         Map<String, ConfigModel> configModel = readConfigModel(kafkaVersion);
         Set<String> result = new HashSet<>();
         for (Map.Entry<String, String> e :this.asOrderedProperties().asMap().entrySet()) {
-            if (!configModel.containsKey(e.getKey())) {
+            if (isCustomConfigurationOption(e.getKey(), configModel)) {
                 result.add(e.getKey() + "=" + e.getValue());
             }
         }
@@ -317,6 +316,21 @@ public class KafkaConfiguration extends AbstractConfiguration {
      * @return  True if the configuration is empty. False otherwise.
      */
     public boolean isEmpty() {
-        return this.asOrderedProperties().asMap().size() == 0;
+        return this.asOrderedProperties().asMap().isEmpty();
+    }
+
+    /**
+     * Checks if the Kafka configuration option is part of the Kafka configuration or is a custom option not recognized
+     * by Kafka broker configuration APIs. Custom options can be for example options used by plugins etc. But right now,
+     * also the options prefixed with the listener prefix as considered custom by this method as well (which is correct
+     * for the time being as we anyway do a rolling update when they change).
+     *
+     * @param optionName    Name of the option to check
+     * @param configModel   Configuration model for given Kafka version
+     *
+     * @return  True if entry is custom (not default). False otherwise.
+     */
+    public static boolean isCustomConfigurationOption(String optionName, Map<String, ConfigModel> configModel) {
+        return !configModel.containsKey(optionName);
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -202,7 +202,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
 
     private void updateOrAdd(String propertyName, Map<String, ConfigModel> configModel, Map<String, String> desiredMap, Collection<AlterConfigOp> updatedCE, boolean nodeIsController) {
         if (!isIgnorableProperty(propertyName, nodeIsController)) {
-            if (isCustomEntry(propertyName, configModel)) {
+            if (KafkaConfiguration.isCustomConfigurationOption(propertyName, configModel)) {
                 LOGGER.traceCr(reconciliation, "custom property {} has been updated/added {}", propertyName, desiredMap.get(propertyName));
             } else {
                 LOGGER.traceCr(reconciliation, "property {} has been updated/added {}", propertyName, desiredMap.get(propertyName));
@@ -214,7 +214,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
     }
 
     private void removeProperty(Map<String, ConfigModel> configModel, Collection<AlterConfigOp> updatedCE, String pathValueWithoutSlash, ConfigEntry entry, boolean nodeIsController) {
-        if (isCustomEntry(entry.name(), configModel)) {
+        if (KafkaConfiguration.isCustomConfigurationOption(entry.name(), configModel)) {
             // we are deleting custom option
             LOGGER.traceCr(reconciliation, "removing custom property {}", entry.name());
         } else if (entry.isDefault()) {
@@ -242,15 +242,4 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
     public boolean isEmpty() {
         return brokerConfigDiff.isEmpty();
     }
-
-    /**
-     * For some reason not all default entries have set ConfigEntry.ConfigSource.DEFAULT_CONFIG so we need to compare
-     * @param entryName tested ConfigEntry
-     * @param configModel configModel
-     * @return true if entry is custom (not default)
-     */
-    private static boolean isCustomEntry(String entryName, Map<String, ConfigModel> configModel) {
-        return !configModel.containsKey(entryName);
-    }
-
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We have currently two places to decide if a Kafka configuration option is custom or not. One in `KafkaBrokerConfigurationDiff` and another one in `KafkaConfiguration`. And they are both used for the same purpose - to determine if the option is custom and requires a rolling of the Kafka broker or whether it is not custom and can be possibly updated dynamically through Kafka API.

So having this done in two places is dangerous because the option should be always either one or the other. And by having it done in two places means that we face a risk that one day someone updates only one part. This PR creates a public method in the`KafkaConfiguration` class that is used in both places and help to mitigate the risk. (+ it fixes one or two minor IDE warnings in the same class)

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally