### PR TITLE
Fixed `autoRebalance` status not reset when auto-rebalancing or Cruise Control is not enabled

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -21,9 +21,6 @@ import io.strimzi.api.kafka.model.kafka.KafkaSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.KafkaStatusBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
-import io.strimzi.api.kafka.model.kafka.cruisecontrol.KafkaAutoRebalanceState;
-import io.strimzi.api.kafka.model.kafka.cruisecontrol.KafkaAutoRebalanceStatus;
-import io.strimzi.api.kafka.model.kafka.cruisecontrol.KafkaAutoRebalanceStatusBuilder;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePool;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolList;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
@@ -285,7 +282,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.reconcileEntityOperator(clock))
                 .compose(state -> state.reconcileCruiseControl(clock))
                 .compose(state -> state.reconcileKafkaExporter(clock))
-                .compose(state -> state.maybeAutoRebalancing() ? state.reconcileKafkaAutoRebalancing() : Future.succeededFuture(state))
+                .compose(state -> state.reconcileKafkaAutoRebalancing())
 
                 // Finish the reconciliation
                 .map((Void) null)
@@ -833,14 +830,24 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
         }
 
         /**
-         * Run the reconciliation pipeline for Kafka auto-rebalancing
+         * Based on the autorebalance being enabled or not within Cruise Control configuration:
+         * - run the reconciliation pipeline for Kafka auto-rebalancing ...
+         * - ... create the auto-rebalance status on Idle if the cluster is still in the creation phase (no auto-rebalancing to run yet) or ...
+         * - ... reset to null the auto-rebalance status because the auto-rebalance was disabled
          *
          * @return  Future with Reconciliation State
          */
         Future<ReconciliationState> reconcileKafkaAutoRebalancing() {
-            return kafkaAutoRebalancingReconciler()
-                    .reconcile(kafkaStatus)
-                    .map(this);
+            if (kafkaAssembly.getSpec().getCruiseControl() == null || kafkaAssembly.getSpec().getCruiseControl().getAutoRebalance() == null) {
+                LOGGER.debugCr(reconciliation, "Cruise Control or inner autorebalance field not defined in the Kafka custom resource, no auto-rebalancing to reconcile");
+                // enforce no auto-rebalance status, if we are disabling Cruise Control and/or auto-rebalance from its configuration
+                kafkaStatus.setAutoRebalance(null);
+                return Future.succeededFuture(this);
+            } else {
+                return kafkaAutoRebalancingReconciler()
+                        .reconcile(kafkaStatus)
+                        .map(this);
+            }
         }
 
         /**
@@ -855,40 +862,6 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
             return entityOperatorReconciler()
                     .reconcile(pfa.isOpenshift(), imagePullPolicy, imagePullSecrets, clock)
                     .map(this);
-        }
-
-        /**
-         * Based on the autorebalance being enabled or not within Cruise Control configuration:
-         * - return true because the auto-rebalancing reconciliation has to run or ...
-         * - ... create the auto-rebalance status on Idle if the cluster is still in the creation phase (no auto-rebalancing to run yet) or ...
-         * - ... reset to null the auto-rebalance status because the auto-rebalance was disabled
-         *
-         * @return true if the autorebalance reconciliation has to run, false otherwise
-         */
-        boolean maybeAutoRebalancing() {
-            if (kafkaAssembly.getSpec().getCruiseControl() == null || kafkaAssembly.getSpec().getCruiseControl().getAutoRebalance() == null) {
-                LOGGER.debugCr(reconciliation, "Cruise Control or inner autorebalance field not defined in the Kafka custom resource, no auto-rebalancing to reconcile");
-                // enforce no auto-rebalance status, if we are disabling Cruise Control and/or auto-rebalance from its configuration
-                kafkaStatus.setAutoRebalance(null);
-                return false;
-            } else {
-                // there is an auto-rebalance status already, so we need to run an auto-rebalance reconciliation
-                if (kafkaAssembly.getStatus() != null && kafkaAssembly.getStatus().getAutoRebalance() != null) {
-                    return true;
-                } else {
-                    // when the auto-rebalance status doesn't exist, the Kafka cluster is being created
-                    // so auto-rebalance can be set in an Idle state if it is enabled or
-                    // enforce no auto-rebalance status, if we are disabling auto-rebalance from Cruise Control configuration
-                    KafkaAutoRebalanceStatus kafkaAutoRebalanceStatus = (kafkaAssembly.getSpec().getCruiseControl().getAutoRebalance() != null) ?
-                            new KafkaAutoRebalanceStatusBuilder()
-                                    .withState(KafkaAutoRebalanceState.Idle)
-                                    .withLastTransitionTime(StatusUtils.iso8601Now())
-                                    .build() : null;
-                    kafkaStatus.setAutoRebalance(kafkaAutoRebalanceStatus);
-                    // in both the above cases we don't have to run an auto-rebalance reconciliation
-                    return false;
-                }
-            }
         }
 
         /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -838,15 +838,15 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @return  Future with Reconciliation State
          */
         Future<ReconciliationState> reconcileKafkaAutoRebalancing() {
-            if (kafkaAssembly.getSpec().getCruiseControl() == null || kafkaAssembly.getSpec().getCruiseControl().getAutoRebalance() == null) {
+            if (isAutoRebalancingEnabled()) {
+                return kafkaAutoRebalancingReconciler()
+                        .reconcile(kafkaStatus)
+                        .map(this);
+            } else {
                 LOGGER.debugCr(reconciliation, "Cruise Control or inner autorebalance field not defined in the Kafka custom resource, no auto-rebalancing to reconcile");
                 // enforce no auto-rebalance status, if we are disabling Cruise Control and/or auto-rebalance from its configuration
                 kafkaStatus.setAutoRebalance(null);
                 return Future.succeededFuture(this);
-            } else {
-                return kafkaAutoRebalancingReconciler()
-                        .reconcile(kafkaStatus)
-                        .map(this);
             }
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceUtilsTest.java
@@ -92,7 +92,7 @@ public class KafkaRebalanceUtilsTest {
     public void testAutoRebalanceNoStatusNoAddedNodes() {
         KafkaStatus kafkaStatus = new KafkaStatusBuilder().build();
         KafkaRebalanceUtils.updateKafkaAutoRebalanceStatus(kafkaStatus, null, Set.of());
-        assertThat(kafkaStatus.getAutoRebalance(), is(nullValue()));
+        assertThat(kafkaStatus.getAutoRebalance(), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the cluster starts without Cruise Control enabled or without auto-rebalance configured, the corresponding status is set anyway (which on cluster creation is anyway wrong, because it's not a scaling up operation).
When Cruise Control or auto-rebalance configuration is removed, the status is not reset as well.
For example, you create a Kafka cluster with:

```yaml
cruiseControl: {}
```
  
on creation, the status contains the following:

```yaml
status:
  autoRebalance:
    modes:
    - brokers:
      - 3
      - 4
      - 5
      mode: add-brokers
```

It hasn't to be there, because `cruiseControl.autoRebalance` is not enabled at all and it's even cluster creation not scaling up.
No auto-rebalance runs but the status is anyway wrong.
Another example, you create a Kafka cluster with `cruiseControl.autoRebalance` configured so the status is:

```yaml
status:
  autoRebalance:
    lastTransitionTime: "2024-09-28T14:14:45.485639784Z"
    state: Idle
```

and then you remove the `autoRebalance` part of it or even the entire `cruiseControl` section.
The `status.autoRebalance` should disappear because keeping the info about the "Idle" state doesn't make any sense anymore (auto-rebalance is not configured).

This PR fixes the above issue(s), also improving the way the `KafkaAssemblyOperator` can make the decision about running or not the auto-rebalacing reconciliation at all. This way some state initialization is also pulled out from the reconcile of the `KafkaAutoRebalancingReconciler`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally