### PR TITLE
Update Kubernetes Config Provider to 1.2.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/ignorelist
@@ -1,2 +1,2 @@
 jmx_prometheus_javaagent-1.0.1.jar
-snakeyaml-2.0.jar
+snakeyaml-2.2.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
@@ -39,10 +39,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
@@ -22,7 +22,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
@@ -38,6 +38,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/ignorelist
@@ -1,2 +1,2 @@
 jmx_prometheus_javaagent-1.0.1.jar
-snakeyaml-2.0.jar
+snakeyaml-2.2.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
@@ -39,10 +39,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
@@ -22,7 +22,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
@@ -38,6 +38,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
         </repository>
     </repositories>
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/ignorelist
@@ -1,2 +1,2 @@
 jmx_prometheus_javaagent-1.0.1.jar
-snakeyaml-2.0.jar
+snakeyaml-2.2.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -39,10 +39,6 @@
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
         </repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
-        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -22,7 +22,7 @@
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
-        <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
@@ -38,6 +38,10 @@
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
+        </repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1229/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Kubernetes Config Provider bundled in our images to 1.2.0.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally