### PR TITLE
Improve the `CA not found` error message

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_tls_prepare_certificates.sh
@@ -15,14 +15,14 @@ for CRT in /opt/kafka/cluster-ca-certs/*.crt; do
 done
 echo "Preparing truststore for replication listener is complete"
 
-echo "Looking for the right CA"
+echo "Looking for the CA matching the server certificate"
 CA=$(find_ca /opt/kafka/cluster-ca-certs "/opt/kafka/broker-certs/$HOSTNAME.crt")
 
 if [ ! -f "$CA" ]; then
-    echo "No CA found. Thus exiting."
+    echo "No CA matching the server certificate found. This process will exit with failure."
     exit 1
 fi
-echo "Found the right CA: $CA"
+echo "CA matching the server certificate found: $CA"
 
 echo "Preparing keystore for replication and clienttls listener"
 STORE=/tmp/kafka/cluster.keystore.p12

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_tls_prepare_certificates.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_tls_prepare_certificates.sh
@@ -15,14 +15,15 @@ for CRT in /opt/kafka/cluster-ca-certs/*.crt; do
 done
 echo "Preparing truststore is complete"
 
-echo "Looking for the right CA"
+echo "Looking for the CA matching the server certificate"
 CA=$(find_ca "/opt/kafka/cluster-ca-certs" "/opt/kafka/zookeeper-node-certs/$HOSTNAME.crt")
 
 if [ ! -f "$CA" ]; then
-    echo "No CA found. Thus exiting."
+    echo "No CA matching the server certificate found. This process will exit with failure."
     exit 1
 fi
-echo "Found the right CA: $CA"
+
+echo "CA matching the server certificate found: $CA"
 
 echo "Preparing keystore for client and quorum listeners"
 STORE=/tmp/zookeeper/cluster.keystore.p12


### PR DESCRIPTION
### Type of change

- Task

### Description

When the ZooKeeper or Kafka container starts up, it is trying to find the right CA matching its server certificate to configure the ZooKeeper / Kafka node. When it fails to do so, for example, because the user provided a wrong custom certificates etc., it will print an error `CA not found` and exit.

This PR tries to clarify a bit the error message, as we typically have some CAs, but none of them is matching the server certificate. So it tries to be a bit more clear and say that `No CA matching the server certificate found`.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally