### PR TITLE
[ST] Remove assumption for skipping run on OLM and Helm from few tests

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaNodePoolST.java
@@ -45,7 +45,6 @@ import java.util.Random;
 import static io.strimzi.operator.common.Util.hashStub;
 import static io.strimzi.systemtest.TestTags.REGRESSION;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
@@ -457,7 +456,6 @@ public class KafkaNodePoolST extends AbstractST {
 
     @BeforeAll
     void setup() {
-        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
         assumeTrue(Environment.isKafkaNodePoolsEnabled());
 
         this.clusterOperator = this.clusterOperator.defaultInstallation()

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/KafkaRollerST.java
@@ -70,7 +70,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(REGRESSION)
@@ -396,7 +395,7 @@ public class KafkaRollerST extends AbstractST {
      * particularly the controller nodes, while leaving others like broker nodes unaffected.
      *
      * @steps
-     *  1. - Assume that KRaft mode is enabled and the installation method is bundle only.
+     *  1. - Assume that KRaft mode is enabled.
      *  2. - Create and deploy a Kafka node pool with broker role (brokerPool) and another with controller role (controllerPool), each with 3 replicas.
      *  3. - Take snapshots of the broker and controller pods for later comparison.
      *  4. - Update a specific Kafka configuration that affects only controller nodes and verify the rolling update behavior.
@@ -416,7 +415,6 @@ public class KafkaRollerST extends AbstractST {
     @ParallelNamespaceTest
     void testKafkaRollingUpdatesOfSingleRoleNodePools() {
         assumeTrue(Environment.isKRaftModeEnabled());
-        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
 
@@ -493,7 +491,7 @@ public class KafkaRollerST extends AbstractST {
      * of nodes serving mixed roles, while ensuring compatibility with KRaft mode and excluding OLM or Helm installations.
      *
      * @steps
-     *  1. - Ensure that the environment is running in KRaft mode and is neither an OLM nor Helm installation (only Bundle/YAML!).
+     *  1. - Ensure that the environment is running in KRaft mode.
      *  2. - Create and deploy a Kafka node pool with mixed roles (controller and broker), consisting of 6 replicas.
      *  3. - Take a snapshot of the mixed-role pods for comparison before and after the configuration change.
      *  4. - Update a specific Kafka configuration targeting controller roles.
@@ -508,7 +506,6 @@ public class KafkaRollerST extends AbstractST {
     @ParallelNamespaceTest
     void testKafkaRollingUpdatesOfMixedNodes() {
         assumeTrue(Environment.isKRaftModeEnabled());
-        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         final int mixedPoolReplicas = 6;

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/RollingUpdateST.java
@@ -74,7 +74,6 @@ import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag(REGRESSION)
@@ -253,7 +252,6 @@ class RollingUpdateST extends AbstractST {
     @Tag(ROLLING_UPDATE)
     void testRecoveryDuringKRaftRollingUpdate() {
         assumeTrue(Environment.isKRaftModeEnabled());
-        assumeFalse(Environment.isOlmInstall() || Environment.isHelmInstall());
 
         // kafka with 1 knp broker and 1 knp controller
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR removes assumption for skipping test run when installing operator using OLM or Helm from few tests. It was previously needed because of re-configuration of CO and setting the FG to different one, but since KafkaNodePools and KRaft FGs are moved to GA, we don't need to skip these tests.

### Checklist

- [x] Make sure all tests pass

