### PR TITLE
[ST] KRaft mixed roles - fix NodePoolsConverter for mixed roles and add AZPs

### DIFF
--- a/.azure/mixed-roles-regression.yaml
+++ b/.azure/mixed-roles-regression.yaml
@@ -1,0 +1,28 @@
+# Triggers
+# This pipeline will be triggered manually for a release or by github comment
+trigger: none
+pr:
+  autoCancel: false
+  branches:
+    include:
+      - '*'
+
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+    # If releaseVersion == latest then images will be built as part of the pipeline
+    default: "latest"
+  - name: kafkaVersion
+    displayName: Kafka Version
+    type: string
+    # If kafkaVersion == latest, the latest supported version of Kafka is used
+    default: "latest"
+
+# Regression tests are split into 6 jobs because of timeout set to 360 minutes for each job
+jobs:
+  - template: 'templates/jobs/system-tests/mixed_roles_regression_jobs.yaml'
+    # This is needed to propagate releaseVersion parameter down to system_test_general.yaml
+    parameters:
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'

--- a/.azure/templates/jobs/system-tests/mixed_roles_regression_jobs.yaml
+++ b/.azure/templates/jobs/system-tests/mixed_roles_regression_jobs.yaml
@@ -1,0 +1,77 @@
+jobs:
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_kafka'
+      display_name: 'mixed-roles-regression-bundle I. - kafka + oauth'
+      profile: 'azp_kafka_oauth'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_security'
+      display_name: 'mixed-roles-regression-bundle II. - security'
+      profile: 'azp_security'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_dynconfig_listeners_tracing_watcher'
+      display_name: 'mixed-roles-regression-bundle III. - dynconfig + tracing + watcher'
+      profile: 'azp_dynconfig_listeners_tracing_watcher'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_operators'
+      display_name: 'mixed-roles-regression-bundle IV. - operators'
+      profile: 'azp_operators'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_rollingupdate_bridge'
+      display_name: 'mixed-roles-regression-bundle V. - rollingupdate'
+      profile: 'azp_rolling_update_bridge'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_connect_mirrormaker'
+      display_name: 'mixed-roles-regression-bundle VI. - connect + mirrormaker'
+      profile: 'azp_connect_mirrormaker'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'
+
+  - template: '../../steps/system_test_general.yaml'
+    parameters:
+      name: 'mixed_roles_regression_all_remaining'
+      display_name: 'mixed-roles-regression-bundle VII. - remaining system tests'
+      profile: 'azp_remaining'
+      cluster_operator_install_type: 'bundle'
+      timeout: 360
+      releaseVersion: '${{ parameters.releaseVersion }}'
+      kafkaVersion: '${{ parameters.kafkaVersion }}'
+      strimzi_node_pools_role_mode: 'mixed'

--- a/.azure/templates/steps/system_test_general.yaml
+++ b/.azure/templates/steps/system_test_general.yaml
@@ -14,6 +14,7 @@ parameters:
   releaseVersion: "latest"
   strimzi_use_kraft_in_tests: "true"
   strimzi_use_node_pools_in_tests: "true"
+  strimzi_node_pools_role_mode: "separate"
 
 jobs:
 - job: '${{ parameters.name }}_system_tests'
@@ -152,6 +153,7 @@ jobs:
         STRIMZI_FEATURE_GATES: '${{ parameters.strimzi_feature_gates }}'
         STRIMZI_USE_KRAFT_IN_TESTS: '${{ parameters.strimzi_use_kraft_in_tests }}'
         STRIMZI_USE_NODE_POOLS_IN_TESTS: '${{ parameters.strimzi_use_node_pools_in_tests }}'
+        STRIMZI_NODE_POOLS_ROLE_MODE: '${{ parameters.strimzi_node_pools_role_mode }}'
         BUILD_ID: $(Agent.JobName)
         RESOURCE_ALLOCATION_STRATEGY: "NOT_SHARED"
         TEST_LOG_DIR: $(test_log_dir)

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/NodePoolsConverter.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/NodePoolsConverter.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
  *  This handler is needed in STs to switch between modes without a problem - and also to make the whole process less confusing.
  */
 public class NodePoolsConverter {
+    public static final double MIXED_ROLES_MULTIPLIER = 1.5;
 
     /**
      * Method that converts each of the NodePool passed to it, based on the mode.
@@ -65,7 +66,7 @@ public class NodePoolsConverter {
                 // replace the broker role prefix in the NodePool's name with the mixed role prefix
                 nodePool.getMetadata().setName(nodePool.getMetadata().getName().replace(TestConstants.BROKER_ROLE_PREFIX, TestConstants.MIXED_ROLE_PREFIX));
                 // adjust the replicas of the NodePool ->
-                nodePool.getSpec().setReplicas((int) Math.ceil(nodePool.getSpec().getReplicas() * 1.5));
+                nodePool.getSpec().setReplicas((int) Math.ceil(nodePool.getSpec().getReplicas() * MIXED_ROLES_MULTIPLIER));
             });
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

In the previous PR that implemented `NodePoolsConverter` I also implemented the mechanism for switching the NodePools to the "mixed" roles NodePools + I added the possibility to specify the mode by env variable. However, this doesn't work -> we cannot do `removeIf` operation on immutable List. This is now fixed (in this PR).
I also changed few things:

- the name - prefix - is changed from the `b-` to `m-`, indicating that we have mixed roles NodePool
- instead of keeping just the replicas from the original broker's NodePool, the replicas are multiplied by 1.5, so we have more replicas than in the broker's NodePool -> we could possibly add the replicas from the controller's NodePool, but I guess it would be more complicated in terms of storing the value and then adding it to the right NodePool

Also, I'm adding AZPs for mixed roles regression.

### Checklist

- [ ] Make sure all tests pass
