### PR TITLE
Improved `KafkaRebalance` columns for rebalancing status and template

### DIFF
--- a/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
+++ b/api/src/main/java/io/strimzi/api/ResourceAnnotations.java
@@ -45,6 +45,11 @@ public class ResourceAnnotations {
     public static final String ANNO_STRIMZI_IO_REBALANCE_AUTOAPPROVAL = STRIMZI_DOMAIN + "rebalance-auto-approval";
 
     /**
+     * Use this boolean annotation to set the KafkaRebalance as a template to be used for auto-rebalancing operations
+     */
+    public static final String ANNO_STRIMZI_IO_REBALANCE_TEMPLATE = STRIMZI_DOMAIN + "rebalance-template";
+
+    /**
      * Annotation which enabled the use of the connector operator
      */
     public static final String STRIMZI_IO_USE_CONNECTOR_RESOURCES = STRIMZI_DOMAIN + "use-connector-resources";

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalance.java
@@ -51,35 +51,15 @@ import java.util.function.Predicate;
                 jsonPath = ".metadata.labels.strimzi\\.io/cluster",
                 type = "string"),
             @Crd.Spec.AdditionalPrinterColumn(
-                name = "PendingProposal",
-                description = "A proposal has been requested from Cruise Control",
-                jsonPath = ".status.conditions[?(@.type==\"PendingProposal\")].status",
+                name = "Template",
+                description = "If this rebalance resource is a template",
+                jsonPath = ".metadata.annotations.strimzi\\.io/rebalance-template",
                 type = "string"),
             @Crd.Spec.AdditionalPrinterColumn(
-                name = "ProposalReady",
-                description = "A proposal is ready and waiting for approval",
-                jsonPath = ".status.conditions[?(@.type==\"ProposalReady\")].status",
-                type = "string"),
-            @Crd.Spec.AdditionalPrinterColumn(
-                name = "Rebalancing",
-                description = "Cruise Control is doing the rebalance",
-                jsonPath = ".status.conditions[?(@.type==\"Rebalancing\")].status",
-                type = "string"),
-            @Crd.Spec.AdditionalPrinterColumn(
-                name = "Ready",
-                description = "The rebalance is complete",
-                jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",
-                type = "string"),
-            @Crd.Spec.AdditionalPrinterColumn(
-                name = "NotReady",
-                description = "There is an error on the custom resource",
-                jsonPath = ".status.conditions[?(@.type==\"NotReady\")].status",
-                type = "string"),
-            @Crd.Spec.AdditionalPrinterColumn(
-                    name = "Stopped",
-                    description = "Processing the proposal or running rebalancing was stopped",
-                    jsonPath = ".status.conditions[?(@.type==\"Stopped\")].status",
-                    type = "string")
+                name = "Status",
+                description = "Status of the current rebalancing operation",
+                jsonPath = ".status.conditions[*].type",
+                type = "string")
         }
     )
 )

--- a/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceAnnotation.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/rebalance/KafkaRebalanceAnnotation.java
@@ -25,14 +25,6 @@ public enum KafkaRebalanceAnnotation {
      */
     refresh,
     /**
-     * Used to represent a KafkaRebalance custom resource that represents a configuration template.
-     * This is used for auto-rebalancing on scaling to define the configuration template to be used for a specific
-     * rebalancing mode, as add-brokers or remove-brokers.
-     * When this annotation is applied to a KafkaRebalance custom resource, it doesn't trigger any actual auto-rebalance,
-     * instead the resource is just ignored.
-     */
-    template,
-    /**
      * Any other unsupported/unknown annotation value.
      */
     unknown

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_REBALANCE_TEMPLATE;
 import static io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControlApiImpl.HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS;
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_REBALANCE;
 import static io.strimzi.operator.common.Annotations.ANNO_STRIMZI_IO_REBALANCE_AUTOAPPROVAL;
@@ -996,8 +997,8 @@ public class KafkaRebalanceAssemblyOperator
             return Future.succeededFuture();
         }
 
-        KafkaRebalanceAnnotation rebalanceAnnotation = rebalanceAnnotation(kafkaRebalance);
-        if (rebalanceAnnotation == KafkaRebalanceAnnotation.template) {
+        boolean isTemplate = Annotations.booleanAnnotation(kafkaRebalance, ANNO_STRIMZI_IO_REBALANCE_TEMPLATE, false);
+        if (isTemplate) {
             LOGGER.traceCr(reconciliation, "KafkaRebalance {} is a template configuration. Skipping it.", kafkaRebalance.getMetadata().getName());
             return Future.succeededFuture();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAutoRebalancingMockTest.java
@@ -65,6 +65,7 @@ import java.util.function.Function;
 
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_NEXT_NODE_IDS;
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_REBALANCE;
+import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_REBALANCE_TEMPLATE;
 import static io.strimzi.api.ResourceAnnotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -1203,7 +1204,7 @@ public class KafkaAutoRebalancingMockTest {
         return new KafkaRebalanceBuilder()
                 .withNewMetadata()
                     .withName(name)
-                    .withAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE, "template"))
+                    .withAnnotations(Map.of(ANNO_STRIMZI_IO_REBALANCE_TEMPLATE, "true"))
                 .endMetadata()
                 .withNewSpec()
                     .withGoals(goals)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1670,7 +1670,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     public void testRebalanceTemplate(VertxTestContext context) {
         KafkaRebalance kr = new KafkaRebalanceBuilder(createKafkaRebalance(namespace, null, RESOURCE_NAME, EMPTY_KAFKA_REBALANCE_SPEC, false))
                 .editMetadata()
-                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.template.toString())
+                    .addToAnnotations(Annotations.ANNO_STRIMZI_IO_REBALANCE_TEMPLATE, "true")
                 .endMetadata()
                 .build();
 

--- a/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
+++ b/packaging/examples/cruise-control/kafka-cruise-control-auto-rebalancing.yaml
@@ -45,7 +45,7 @@ kind: KafkaRebalance
 metadata:
   name: my-add-brokers-rebalancing-template
   annotations:
-    strimzi.io/rebalance: template
+    strimzi.io/rebalance-template: "true"
 # no goals specified, using the default goals from the Cruise Control configuration
 spec: {}
 ---
@@ -54,6 +54,6 @@ kind: KafkaRebalance
 metadata:
   name: my-remove-brokers-rebalancing-template
   annotations:
-    strimzi.io/rebalance: template
+    strimzi.io/rebalance-template: "true"
 # no goals specified, using the default goals from the Cruise Control configuration
 spec: {}

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
@@ -31,29 +31,13 @@ spec:
           description: The name of the Kafka cluster this resource rebalances
           jsonPath: .metadata.labels.strimzi\.io/cluster
           type: string
-        - name: PendingProposal
-          description: A proposal has been requested from Cruise Control
-          jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+        - name: Template
+          description: If this rebalance resource is a template
+          jsonPath: .metadata.annotations.strimzi\.io/rebalance-template
           type: string
-        - name: ProposalReady
-          description: A proposal is ready and waiting for approval
-          jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
-          type: string
-        - name: Rebalancing
-          description: Cruise Control is doing the rebalance
-          jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
-          type: string
-        - name: Ready
-          description: The rebalance is complete
-          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-          type: string
-        - name: NotReady
-          description: There is an error on the custom resource
-          jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
-          type: string
-        - name: Stopped
-          description: Processing the proposal or running rebalancing was stopped
-          jsonPath: ".status.conditions[?(@.type==\"Stopped\")].status"
+        - name: Status
+          description: Status of the current rebalancing operation
+          jsonPath: ".status.conditions[*].type"
           type: string
       schema:
         openAPIV3Schema:

--- a/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
+++ b/packaging/install/cluster-operator/049-Crd-kafkarebalance.yaml
@@ -30,29 +30,13 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       jsonPath: .metadata.labels.strimzi\.io/cluster
       type: string
-    - name: PendingProposal
-      description: A proposal has been requested from Cruise Control
-      jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+    - name: Template
+      description: If this rebalance resource is a template
+      jsonPath: .metadata.annotations.strimzi\.io/rebalance-template
       type: string
-    - name: ProposalReady
-      description: A proposal is ready and waiting for approval
-      jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
-      type: string
-    - name: Rebalancing
-      description: Cruise Control is doing the rebalance
-      jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
-      type: string
-    - name: Ready
-      description: The rebalance is complete
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    - name: NotReady
-      description: There is an error on the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
-      type: string
-    - name: Stopped
-      description: Processing the proposal or running rebalancing was stopped
-      jsonPath: ".status.conditions[?(@.type==\"Stopped\")].status"
+    - name: Status
+      description: Status of the current rebalancing operation
+      jsonPath: ".status.conditions[*].type"
       type: string
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR fixes #10654.
It's about changing the annotation to set a `KafkaRebalance` custom resource as a template, from the current `strimzi.io/rebalance: template` to `strimzi.io/rebalance-template: true`.
This way it allows to have a dedicated "Template" column to show it on the command line.
The PR also changes the way how a rebalancing status is showed in the command line columns, not anymore with a column per status but just one column having the status as value.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging