### PR TITLE
Fix `KafkaRebalanceAssemblyOperator` to not ignore exception coming from Cruise Control

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -221,7 +221,8 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                 // ... or one or more brokers doesn't exist on a add/remove brokers rebalance request
                                 } else if (json.getString(CC_REST_API_ERROR_KEY).contains("IllegalArgumentException") &&
                                             json.getString(CC_REST_API_ERROR_KEY).contains("does not exist.")) {
-                                    result.fail(new IllegalArgumentException("Some/all brokers specified don't exist"));
+                                    CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                                    result.complete(ccResponse);
                                 } else {
                                     // If there was any other kind of error propagate this to the operator
                                     result.fail(new CruiseControlRestException(


### PR DESCRIPTION
### Type of change

This PR fixes #10631. Now the KafkaRebalanceAssemblyOperator doesn't ignore the Illegal argument excepts which comes from Cruise Control and move the KafkaRebalance to `NotReady` in case any IllegalArgumentExceptions occurs

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

