### PR TITLE
docs(metrics): adds missing callout to metrics file list

### DIFF
--- a/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
+++ b/documentation/assemblies/metrics/assembly-metrics-config-files.adoc
@@ -56,7 +56,8 @@ metrics
 <10> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for Kafka Connect.
 <11> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for Cruise Control.
 <12> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for Kafka and ZooKeeper.
-<13> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for OAuth 2.0.
+<13> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for MirrorMaker 2.
+<14> Metrics configuration that defines Prometheus JMX Exporter relabeling rules for OAuth 2.0.
 
 //Example Prometheus metrics files
 include::../../modules/metrics/ref-prometheus-metrics-config.adoc[leveloffset=+1]


### PR DESCRIPTION
Documentation

Adds callout description that was missing for the list of example metrics files 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

