### PR TITLE
Add stop_ongoing_execution flag to rebalance requests for full run

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -867,7 +867,7 @@ public class KafkaRebalanceAssemblyOperator
                                                                       AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
         if (Annotations.booleanAnnotation(kafkaRebalance, ANNO_STRIMZI_IO_REBALANCE_AUTOAPPROVAL, false)) {
             LOGGER.infoCr(reconciliation, "Auto-approval set on the KafkaRebalance resource");
-            return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder);
+            return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, true);
         } else {
             KafkaRebalanceAnnotation rebalanceAnnotation = rebalanceAnnotation(kafkaRebalance);
             switch (rebalanceAnnotation) {
@@ -876,7 +876,7 @@ public class KafkaRebalanceAssemblyOperator
                     return configMapOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName()).compose(loadmap -> Future.succeededFuture(new MapAndStatus<>(loadmap, buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), StatusUtils.validate(reconciliation, kafkaRebalance)))));
                 case approve:
                     LOGGER.debugCr(reconciliation, "Annotation {}={}", ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.approve);
-                    return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder);
+                    return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, true);
                 case refresh:
                     LOGGER.debugCr(reconciliation, "Annotation {}={}", ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh);
                     return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder);
@@ -1130,20 +1130,31 @@ public class KafkaRebalanceAssemblyOperator
     }
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation,
+                                                                                   String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
+                                                                                   boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                                   boolean stopOngoingExecution) {
+        return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null, stopOngoingExecution);
+    }
+
+    private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation,
                                                           String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
                                                           boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
-        return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null);
+        return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null, false);
     }
 
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation, String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
                                                                                    boolean dryrun,
-                                                                                   AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder, String userTaskID) {
+                                                                                   AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
+                                                                                   String userTaskID, boolean stopOngoingExecution) {
 
-        LOGGER.infoCr(reconciliation, "Requesting Cruise Control rebalance [dryrun={}]", dryrun);
+        LOGGER.infoCr(reconciliation, "Requesting Cruise Control rebalance [dryrun={}] [stop_ongoing_execution={}]", dryrun, stopOngoingExecution);
         rebalanceOptionsBuilder.withVerboseResponse();
         if (!dryrun) {
             rebalanceOptionsBuilder.withFullRun();
+        }
+        if (stopOngoingExecution) {
+            rebalanceOptionsBuilder.withStopOngoingExecution();
         }
         // backward compatibility, no mode specified means "full"
         KafkaRebalanceMode mode = Optional.ofNullable(kafkaRebalance.getSpec())

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -867,7 +867,7 @@ public class KafkaRebalanceAssemblyOperator
                                                                       AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
         if (Annotations.booleanAnnotation(kafkaRebalance, ANNO_STRIMZI_IO_REBALANCE_AUTOAPPROVAL, false)) {
             LOGGER.infoCr(reconciliation, "Auto-approval set on the KafkaRebalance resource");
-            return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, true);
+            return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, null, true);
         } else {
             KafkaRebalanceAnnotation rebalanceAnnotation = rebalanceAnnotation(kafkaRebalance);
             switch (rebalanceAnnotation) {
@@ -876,7 +876,7 @@ public class KafkaRebalanceAssemblyOperator
                     return configMapOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName()).compose(loadmap -> Future.succeededFuture(new MapAndStatus<>(loadmap, buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), StatusUtils.validate(reconciliation, kafkaRebalance)))));
                 case approve:
                     LOGGER.debugCr(reconciliation, "Annotation {}={}", ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.approve);
-                    return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, true);
+                    return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, false, rebalanceOptionsBuilder, null, true);
                 case refresh:
                     LOGGER.debugCr(reconciliation, "Annotation {}={}", ANNO_STRIMZI_IO_REBALANCE, KafkaRebalanceAnnotation.refresh);
                     return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder);
@@ -1131,17 +1131,9 @@ public class KafkaRebalanceAssemblyOperator
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation,
                                                                                    String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                                                   boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder,
-                                                                                   boolean stopOngoingExecution) {
-        return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null, stopOngoingExecution);
-    }
-
-    private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation,
-                                                          String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
-                                                          boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
+                                                                                   boolean dryrun, AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
         return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, dryrun, rebalanceOptionsBuilder, null, false);
     }
-
 
     private Future<MapAndStatus<ConfigMap, KafkaRebalanceStatus>> requestRebalance(Reconciliation reconciliation, String host, CruiseControlApi apiClient, KafkaRebalance kafkaRebalance,
                                                                                    boolean dryrun,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AbstractRebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/AbstractRebalanceOptions.java
@@ -21,6 +21,8 @@ public abstract class AbstractRebalanceOptions {
     private final boolean skipHardGoalCheck;
     /** Sets whether the response should be JSON formatted or formatted for readability on the command line */
     private final boolean json;
+    /** Sets whether to stop the ongoing execution (if any) and start executing the given request. */
+    private final boolean stopOngoingExecution;
     /** A regular expression to specify topics that should not be considered for replica movement */
     private final String excludedTopics;
     /** The upper bound of ongoing replica movements going into/out of each broker */
@@ -68,6 +70,13 @@ public abstract class AbstractRebalanceOptions {
     }
 
     /**
+     * @return  True if stopping the ongoing execution (if any) and starting executing the given request. False otherwise.
+     */
+    public boolean isStopOngoingExecution() {
+        return stopOngoingExecution;
+    }
+
+    /**
      * @return  Excludes topics
      */
     public String getExcludedTopics() {
@@ -108,6 +117,7 @@ public abstract class AbstractRebalanceOptions {
         this.verbose = builder.verbose;
         this.skipHardGoalCheck = builder.skipHardGoalCheck;
         this.json = builder.json;
+        this.stopOngoingExecution = builder.stopOngoingExecution;
         this.excludedTopics = builder.excludedTopics;
         this.concurrentPartitionMovementsPerBroker = builder.concurrentPartitionMovementsPerBroker;
         this.concurrentLeaderMovements = builder.concurrentLeaderMovements;
@@ -127,6 +137,7 @@ public abstract class AbstractRebalanceOptions {
         private boolean verbose;
         private boolean skipHardGoalCheck;
         private boolean json;
+        private boolean stopOngoingExecution;
         private String excludedTopics;
         private int concurrentPartitionMovementsPerBroker;
         private int concurrentLeaderMovements;
@@ -138,6 +149,7 @@ public abstract class AbstractRebalanceOptions {
             goals = null;
             verbose = false;
             skipHardGoalCheck = false;
+            stopOngoingExecution = false;
             json = true;
             excludedTopics = null;
             concurrentPartitionMovementsPerBroker = 0;
@@ -180,6 +192,16 @@ public abstract class AbstractRebalanceOptions {
          */
         public B withSkipHardGoalCheck() {
             this.skipHardGoalCheck = true;
+            return self();
+        }
+
+        /**
+         * Stop the ongoing execution (if any) and start executing the given request
+         *
+         * @return  Instance of this builder
+         */
+        public B withStopOngoingExecution() {
+            this.stopOngoingExecution = true;
             return self();
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilder.java
@@ -101,7 +101,8 @@ public class PathBuilder {
         if (options != null) {
             PathBuilder builder = withParameter(CruiseControlParameters.DRY_RUN, String.valueOf(options.isDryRun()))
                     .withParameter(CruiseControlParameters.VERBOSE, String.valueOf(options.isVerbose()))
-                    .withParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, String.valueOf(options.isSkipHardGoalCheck()));
+                    .withParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, String.valueOf(options.isSkipHardGoalCheck()))
+                    .withParameter(CruiseControlParameters.STOP_ONGOING_EXECUTION, String.valueOf(options.isStopOngoingExecution()));
 
             if (options.getExcludedTopics() != null) {
                 builder.withParameter(CruiseControlParameters.EXCLUDED_TOPICS, options.getExcludedTopics());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -1167,6 +1167,27 @@ public class KafkaRebalanceStateMachineTest {
     }
 
     /**
+     * Tests the transition from 'Rebalancing' to 'ProposalReady' when refresh
+     *
+     * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Rebalancing state
+     * 2. The operator calls the /stop_proposal_execution to stop the ongoing rebalance execution
+     * 3. The operator sends a request for a new proposal
+     * 4. The operator computes the next state on the proposal via the Cruise Control REST API
+     * 5. The rebalance proposal is ready on the first call
+     * 6. The KafkaRebalance resource moves to the 'ProposalReady' state
+     */
+    @Test
+    public void testRebalancingToRefreshProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
+        KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, "", "refresh", REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
+        cruiseControlServer.setupCCStopResponse();
+        cruiseControlServer.setupCCRebalanceResponse(0, CruiseControlEndpoints.REMOVE_BROKER);
+        checkTransition(vertx, context,
+                KafkaRebalanceState.Rebalancing, KafkaRebalanceState.ProposalReady,
+                kcRebalance)
+                .onComplete(result -> checkOptimizationResults(result, context, false));
+    }
+
+    /**
      * Tests the transition from 'Stopped' to 'ProposalReady' when refresh
      *
      * 1. A new KafkaRebalance resource is created and annotated with strimzi.io/rebalance=refresh; it is in the Stopped state

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/PathBuilderTest.java
@@ -34,6 +34,7 @@ public class PathBuilderTest {
                         CruiseControlParameters.DRY_RUN + "=false&" +
                         CruiseControlParameters.VERBOSE + "=true&" +
                         CruiseControlParameters.SKIP_HARD_GOAL_CHECK + "=false&" +
+                        CruiseControlParameters.STOP_ONGOING_EXECUTION + "=false&" +
                         CruiseControlParameters.EXCLUDED_TOPICS + "=test-.*&" +
                         CruiseControlParameters.GOALS + "=");
 
@@ -72,6 +73,7 @@ public class PathBuilderTest {
                 .withParameter(CruiseControlParameters.DRY_RUN, "false")
                 .withParameter(CruiseControlParameters.VERBOSE, "true")
                 .withParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, "false")
+                .withParameter(CruiseControlParameters.STOP_ONGOING_EXECUTION, "false")
                 .withParameter(CruiseControlParameters.EXCLUDED_TOPICS, "test-.*")
                 .withParameter(CruiseControlParameters.GOALS, GOALS)
                 .withParameter(CruiseControlParameters.REBALANCE_DISK, "false")

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlParameters.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/cruisecontrol/CruiseControlParameters.java
@@ -95,7 +95,12 @@ public enum CruiseControlParameters {
     /**
      * Skip rack awareness check
      */
-    SKIP_RACK_AWARENESS_CHECK("skip_rack_awareness_check");
+    SKIP_RACK_AWARENESS_CHECK("skip_rack_awareness_check"),
+
+    /**
+     * Stop the ongoing execution (if any) and start executing the given request
+     */
+    STOP_ONGOING_EXECUTION("stop_ongoing_execution");
 
     private final String key;
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This adds an option to set stop_ongoing_execution flag. 
The new flag is set when sending rebalancing requests for full run to avoid "Cannot start a new execution while there is an ongoing execution" error. This error can happen even if the operator calls CC's endpoint `/stop_proposal_execution` before sending a new rebalance request. The reason for this is documented [here](https://github.com/linkedin/cruise-control/wiki/rest-apis) as:
```
Note that Cruise Control does not wait for the ongoing batch to finish when it stops execution, i.e. the in-progress batch may still be running after Cruise Control stops the execution.
```

Here is the possible flow that causes this issue:
1. Currently KafkaRebalance CR for removing brokers is in Rebalancing state
2. User updates the CR with a refresh annotation and with a new set of brokers to remove
3. The operator sends a request to `/stop_proposal_execution` endpoint to stop the current rebalance operation
4. The request completes successfully, however there are still in-progress batch for the current balance operation in CC.
5. The operator sends a request for a new proposal for the updated set of brokers to remove. 
6. The new proposal is ready, therefore the KafkaRebalance is in ProposalReady state
7. The operator sends a request to execute the removal of the updated set of brokers
8. This request fails because there are still in-progress batch of the previous rebalance operation.
9. KafkaRebalance is in NotReady state due to this failure. 

The fix is to update step 7, to send the request with "stop_ongoing_execution" flag set to true, so that CC first stops the still in-progress batch of the previous rebalance operation before processing the new rebalance request. The flow would become:

  7. The operator sends a request to execute the removal of the updated set of brokers with "stop_ongoing_execution" flag set to true
  8. CC waits for the still in-progress batch of the previous rebalance operation to stop
  9. CC processes the request to execute the removal of the updated set of brokers
  10. The KafkaRebalance is in Ready.

There were no test cases for the existing flow where operator calls `/stop_proposal_execution` when KafkaRebalance is in Rebalancing state and then refresh annotation is applied. These missing tests cases are added , however they do not test the new flow because we cannot mock the internal state of CC to have still in-progress batch. 

Closes #10571

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

