### PR TITLE
[ST] Remove line for setting null for LMFV in StrimziDowngradeST

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziDowngradeST.java
@@ -43,8 +43,6 @@ public class StrimziDowngradeST extends AbstractUpgradeST {
     void testDowngradeOfKafkaKafkaConnectAndKafkaConnector(String from, String to, String fgBefore, String fgAfter, BundleVersionModificationData downgradeData) throws IOException {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
         UpgradeKafkaVersion downgradeKafkaVersion = UpgradeKafkaVersion.getKafkaWithVersionFromUrl(downgradeData.getFromKafkaVersionsUrl(), downgradeData.getDeployKafkaVersion());
-        // setting log message version to null, similarly to the examples, which are not configuring LMFV
-        downgradeKafkaVersion.setLogMessageVersion(null);
 
         assumeTrue(StUtils.isAllowOnCurrentEnvironment(downgradeData.getEnvFlakyVariable()));
         assumeTrue(StUtils.isAllowedOnCurrentK8sVersion(downgradeData.getEnvMaxK8sVersion()));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR removes line that sets `null`as a version for LMFV. In the examples, we are not setting it and we are _leaving_
this on the operator. And initially when I wrote the test, I thought that we are using the examples during the test (during initial deployment of Kafka). However, because we are downgrading from the `HEAD`, we are applying our own Kafka builder, which anyway sets the LMFV.
After this PR is merged, it should fix the version mismatch during the downgrade tests.

### Checklist

- [x] Make sure all tests pass
