### PR TITLE
Annotate StrimziPodSets before rolling during CA renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * after a scaling up, the operator triggers an auto-rebalancing for moving some of the existing partitions to the newly added brokers.
   * before scaling down, and if the brokers to remove are hosting partitions, the operator triggers an auto-rebalancing to these partitions off the brokers to make them free to be removed.
 * Strimzi Access Operator 0.1.0 added to the installation files and examples
+* Patch the StrimziPodSets before rolling the pods during CA certificate renewal.
 
 ### Changes, deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   * after a scaling up, the operator triggers an auto-rebalancing for moving some of the existing partitions to the newly added brokers.
   * before scaling down, and if the brokers to remove are hosting partitions, the operator triggers an auto-rebalancing to these partitions off the brokers to make them free to be removed.
 * Strimzi Access Operator 0.1.0 added to the installation files and examples
-* Patch the StrimziPodSets before rolling the pods during CA certificate renewal.
+* Allow rolling update for new cluster CA trust (during Cluster CA key replacement) to continue where it left off before interruption without rolling all pods again.
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -187,20 +187,20 @@ public class WorkloadUtils {
      * Patch a Strimzi PodSet to merge the provided annotations with the annotations on the Pod resources defined
      * in the PodSet
      *
-     * @param strimziPodSet Strimzi PodSet to patch
-     * @param annotations   Annotations to merge with the existing annotations
+     * @param strimziPodSet             Strimzi PodSet to patch
+     * @param annotationsToBeUpdated    Annotations to merge with the existing annotations
      *
      * @return Patched PodSet
      */
-    public static StrimziPodSet patchAnnotations(StrimziPodSet strimziPodSet, Map<String, String> annotations) {
+    public static StrimziPodSet patchAnnotations(StrimziPodSet strimziPodSet, Map<String, String> annotationsToBeUpdated) {
         List<Map<String, Object>> newPods = PodSetUtils.podSetToPods(strimziPodSet)
                 .stream()
                 .map(pod -> {
                     Map<String, String> updatedAnnotations = pod.getMetadata().getAnnotations();
-                    updatedAnnotations.putAll(annotations);
+                    updatedAnnotations.putAll(annotationsToBeUpdated);
                     return pod.edit()
                             .editMetadata()
-                            .withAnnotations(updatedAnnotations)
+                                .withAnnotations(updatedAnnotations)
                             .endMetadata()
                             .build();
                 })

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -184,6 +184,36 @@ public class WorkloadUtils {
     }
 
     /**
+     * Patch a Strimzi PodSet to merge the provided annotations with the annotations on the Pod resources defined
+     * in the PodSet
+     *
+     * @param strimziPodSet Strimzi PodSet to patch
+     * @param annotations   Annotations to merge with the existing annotations
+     *
+     * @return Patched PodSet
+     */
+    public static StrimziPodSet patchAnnotations(StrimziPodSet strimziPodSet, Map<String, String> annotations) {
+        List<Map<String, Object>> newPods = PodSetUtils.podSetToPods(strimziPodSet)
+                .stream()
+                .map(pod -> {
+                    Map<String, String> updatedAnnotations = pod.getMetadata().getAnnotations();
+                    updatedAnnotations.putAll(annotations);
+                    return pod.edit()
+                            .editMetadata()
+                            .withAnnotations(updatedAnnotations)
+                            .endMetadata()
+                            .build();
+                })
+                .map(PodSetUtils::podToMap)
+                .toList();
+        return new StrimziPodSetBuilder(strimziPodSet)
+                .editSpec()
+                    .withPods(newPods)
+                .endSpec()
+                .build();
+    }
+
+    /**
      * Creates a stateful Pod for use with StrimziPodSets. Stateful in this context means that it has a stable name and
      * typically uses storage.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -556,7 +556,7 @@ public class CaReconciler {
                                 .flatMap(podSet -> ReconcilerUtils.nodesFromPodSet(podSet).stream())
                                 .collect(Collectors.toSet()));
                     } else {
-                        return Future.succeededFuture(new LinkedHashSet<>());
+                        return Future.succeededFuture(Set.of());
                     }
                 });
         

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -56,7 +56,6 @@ import io.vertx.core.Vertx;
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -36,6 +36,7 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
+import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
@@ -361,6 +362,44 @@ public class WorkloadUtilsTest {
         assertThat(podNames, hasItems("my-cluster-nodes-10", "my-cluster-nodes-11", "my-cluster-nodes-12"));
         assertThat(sps.getSpec().getPods().size(), is(3));
         assertThat(sps.getSpec().getPods().stream().map(pod -> PodSetUtils.mapToPod(pod).getMetadata().getName()).toList(), hasItems("my-cluster-nodes-10", "my-cluster-nodes-11", "my-cluster-nodes-12"));
+    }
+
+    @Test
+    public void testPatchPodAnnotations() {
+        Map<String, String> annotations = Map.of("anno-1", "value-1", "anno-2", "value-2", "anno-3", "value-3");
+        List<Pod> pods = new ArrayList<>();
+        pods.add(new PodBuilder()
+                .withNewMetadata()
+                    .withName("pod-0")
+                    .withNamespace(NAMESPACE)
+                    .withAnnotations(annotations)
+                .endMetadata()
+                .build()
+        );
+        pods.add(new PodBuilder()
+                .withNewMetadata()
+                    .withName("pod-1")
+                    .withNamespace(NAMESPACE)
+                    .withAnnotations(annotations)
+                .endMetadata()
+                .build()
+        );
+
+        StrimziPodSet sps = new StrimziPodSetBuilder()
+                .withNewMetadata()
+                    .withName("my-sps")
+                    .withNamespace(NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                    .withPods(PodSetUtils.podsToMaps(pods))
+                .endSpec()
+                .build();
+
+        List<Pod> resultPods = PodSetUtils.podSetToPods(WorkloadUtils.patchAnnotations(sps, Map.of("anno-2", "value-2a", "anno-4", "value-4")));
+        assertThat(resultPods.size(), is(2));
+        Map<String, String> expectedAnnotations = Map.of("anno-1", "value-1", "anno-2", "value-2a", "anno-3", "value-3", "anno-4", "value-4");
+        assertThat(resultPods.get(0).getMetadata().getAnnotations(), is(expectedAnnotations));
+        assertThat(resultPods.get(1).getMetadata().getAnnotations(), is(expectedAnnotations));
     }
 
     //////////////////////////////////////////////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -12,13 +12,13 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
+import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.RestartReason;
 import io.strimzi.operator.cluster.model.RestartReasons;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -47,10 +47,8 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -265,16 +263,13 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Set<NodeRef>> getKafkaReplicas() {
-            Set<NodeRef> nodes = new HashSet<>();
-            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-0")));
-            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-1")));
-            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-2")));
-            return Future.succeededFuture(nodes);
+        Future<List<StrimziPodSet>> updateKafkaPodCertAnnotations() {
+            //Response is ignored by rollKafka method in the mock
+            return Future.succeededFuture(List.of());
         }
 
         @Override
-        Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
+        Future<Void> rollKafka(List<StrimziPodSet> podSets, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
             this.kPodRollReasons = podRollReasons;
             return Future.succeededFuture();
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -12,13 +12,13 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.api.kafka.model.podset.StrimziPodSet;
 import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
+import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.RestartReason;
 import io.strimzi.operator.cluster.model.RestartReasons;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -263,13 +264,13 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<List<StrimziPodSet>> updateKafkaPodCertAnnotations() {
+        Future<Set<NodeRef>> patchCaGenerationAndReturnNodes() {
             //Response is ignored by rollKafka method in the mock
-            return Future.succeededFuture(List.of());
+            return Future.succeededFuture(Set.of());
         }
 
         @Override
-        Future<Void> rollKafka(List<StrimziPodSet> podSets, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
+        Future<Void> rollKafka(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
             this.kPodRollReasons = podRollReasons;
             return Future.succeededFuture();
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Update the CaReconciler to annotate the StrimziPodSets with the new CA cert generations before it rolls the Kafka nodes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

