### PR TITLE
Test possible Kafka 3.9.0 migration workaround on Kafka 3.8.0

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -355,7 +355,7 @@ public class KafkaBrokerConfigurationBuilder {
         }
 
         // Control plane listener is on all ZooKeeper based brokers, needed during migration as well, when broker still using ZooKeeper but KRaft controllers are ready
-        if (node.broker() && kafkaMetadataConfigState.isZooKeeperToMigration()) {
+        if (node.broker() && kafkaMetadataConfigState.isZooKeeper()) {
             writer.println("control.plane.listener.name=" + CONTROL_PLANE_LISTENER_NAME);
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -2781,11 +2781,16 @@ public class KafkaBrokerConfigurationBuilderTest {
                     .withListeners("my-cluster", KAFKA_3_8_0, "my-namespace", singletonList(listener), listenerId -> "my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc", listenerId -> "9092")
                     .build();
 
-            if (state.isZooKeeperToMigration()) {
+            if (state.isZooKeeper()) {
                 // control plane is set as listener and advertised up to migration ...
                 assertThat(configuration, containsString("listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092"));
                 assertThat(configuration, containsString("advertised.listeners=CONTROLPLANE-9090://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9092"));
                 assertThat(configuration, containsString("control.plane.listener.name=CONTROLPLANE-9090"));
+            } else if (state.isZooKeeperToMigration()) {
+                // control plane is set as listener and advertised up to migration ...
+                assertThat(configuration, containsString("listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092"));
+                assertThat(configuration, containsString("advertised.listeners=CONTROLPLANE-9090://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9092"));
+                assertThat(configuration, not(containsString("control.plane.listener.name=CONTROLPLANE-9090")));
             } else {
                 // ... it's removed when in post-migration because brokers are full KRaft-mode
                 assertThat(configuration, containsString("listeners=REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterMigrationTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterMigrationTest.java
@@ -132,13 +132,22 @@ public class KafkaClusterMigrationTest {
 
             assertThat(configuration, containsString("node.id=0"));
             // from ZK up to MIGRATION ...
-            if (state.isZooKeeperToMigration()) {
+            if (state.isZooKeeper()) {
                 // ... has ZooKeeper connection configured
                 assertThat(configuration, containsString("zookeeper.connect"));
                 // ... broker.id still set
                 assertThat(configuration, containsString("broker.id=0"));
                 // ... control plane is set as listener and advertised
                 assertThat(configuration, containsString("control.plane.listener.name=CONTROLPLANE-9090"));
+                assertThat(configuration, containsString("listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092"));
+                assertThat(configuration, containsString("advertised.listeners=CONTROLPLANE-9090://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9092"));
+            } else if (state.isZooKeeperToMigration()) {
+                // ... has ZooKeeper connection configured
+                assertThat(configuration, containsString("zookeeper.connect"));
+                // ... broker.id still set
+                assertThat(configuration, containsString("broker.id=0"));
+                // ... control plane is set as listener and advertised
+                assertThat(configuration, not(containsString("control.plane.listener.name=CONTROLPLANE-9090")));
                 assertThat(configuration, containsString("listeners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092"));
                 assertThat(configuration, containsString("advertised.listeners=CONTROLPLANE-9090://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9090,REPLICATION-9091://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9091,PLAIN-9092://my-cluster-brokers-0.my-cluster-kafka-brokers.my-namespace.svc:9092"));
             } else {


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR tests the possible KRaft migration workaround for Kafka 3.9.0 with older Kafka versions (3.8.0).

### Checklist

- [x] Make sure all tests pass