### PR TITLE
Follow up on fixing stuck reconciliation on failed request rebalance

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -733,7 +733,7 @@ public class KafkaRebalanceAssemblyOperator
 
         if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.refresh) {
             LOGGER.infoCr(reconciliation, "Requesting a new proposal since refresh annotation is applied on the KafkaRebalance resource");
-            requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
+            return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder);
         } else if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.stop) {
             LOGGER.infoCr(reconciliation, "Stopping to request proposal or checking the status");
             p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, StatusUtils.validate(reconciliation, kafkaRebalance)));
@@ -744,7 +744,7 @@ public class KafkaRebalanceAssemblyOperator
             String sessionId = kafkaRebalance.getStatus().getSessionId();
             if (sessionId == null) {
                 // sessionId can be null if the response to the previously issued request for a proposal was NotEnoughDataForProposal.
-                requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
+                return requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder);
             } else {
                 apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId)
                         .onSuccess(cruiseControlResponse -> handleUserTaskStatusResponse(reconciliation, cruiseControlResponse, p, sessionId, conditions, kafkaRebalance, configMapOperator, true, host, apiClient, rebalanceOptionsBuilder))
@@ -915,7 +915,12 @@ public class KafkaRebalanceAssemblyOperator
             LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task since refresh annotation is applied on the KafkaRebalance resource and requesting a new proposal");
             apiClient.stopExecution(reconciliation, host, cruiseControlPort)
                     .onSuccess(r -> {
-                        requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder).onSuccess(p::complete);
+                        requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder)
+                                .onSuccess(p::complete)
+                                .onFailure(e -> {
+                                    LOGGER.errorCr(reconciliation, "Requesting a new proposal with refresh annotation failed", e);
+                                    p.fail(e);
+                                });
                     })
                     .onFailure(e -> {
                         LOGGER.errorCr(reconciliation, "Cruise Control stopping execution failed", e.getCause());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -1168,7 +1168,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     /**
      * Tests the transition from 'Rebalancing' to 'NotReady' due to a user task not existing and an error
-     * on re-issuing the optimization proposal request (i.e. brokers don't exist during a "remove-broker")
+     * on re-issuing the optimization proposal request (i.e. brokers don't exist during the "remove-broker" operation)
      *
      * 1. A new KafkaRebalance resource is created; it is in the Rebalancing state
      * 2. The operator requests the status of the corresponding user task through the Cruise Control REST API
@@ -1194,7 +1194,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     }
 
     /**
-     * Tests the transition from 'PendingProposal' to 'NotReady' due to an error (i.e. brokers don't exist during a "remove-broker")
+     * Tests the transition from 'PendingProposal' to 'NotReady' due to an error (i.e. brokers don't exist during the "remove-broker" operation)
      * on re-issuing the optimization proposal request when applying the "strimzi.io/rebalance: refresh" annotation
      *
      * 1. A new KafkaRebalance resource is created; it is in the PendingProposal state
@@ -1209,7 +1209,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     }
 
     /**
-     * Tests the transition from 'PendingProposal' to 'NotReady' due to an error (i.e. brokers don't exist during a "remove-broker")
+     * Tests the transition from 'PendingProposal' to 'NotReady' due to an error (i.e. brokers don't exist during the "remove-broker" operation)
      * on re-issuing the optimization proposal request because the user task session ID is empty and status cannot be checked
      *
      * 1. A new KafkaRebalance resource is created; it is in the PendingProposal state
@@ -1224,7 +1224,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
     }
 
     /**
-     * Tests the transition from 'Rebalancing' to 'NotReady' due to an error (i.e. brokers don't exist during a "remove-broker")
+     * Tests the transition from 'Rebalancing' to 'NotReady' due to an error (i.e. brokers don't exist during the "remove-broker" operation)
      * on re-issuing the optimization proposal request by applying the "strimzi.io/rebalance: refresh" annotation
      *
      * 1. A new KafkaRebalance resource is created; it is in the Rebalancing state


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR is a follow up for #10717.
It fixes a stuck `KafkaRebalance` reconciliation in some other few places also adding corresponding tests using the "remove-brokers" to simulate and error in Cruise Control in PendingProposal (without session id, with refresh) as well as in Rebalancing (with refresh).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging