### PR TITLE
Reverted Python to v3.x working for pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
We started to face the following issue when running the `pre-commit` action:

```shell
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 66[8](https://github.com/strimzi/strimzi-kafka-operator/actions/runs/11349857009/job/31569820324?pr=10720#step:4:10) for the detailed specification.
Error: Process completed with exit code 1.
```

There are several [issues](https://github.com/pre-commit/action/issues?q=is%3Aissue+is%3Aclosed) on the pre-commit repo explaining that it's related to latest upgrades to Debian/Ubuntu managing Python version and conflicting with what pre-commit needs, which is Python v3.
This PR tries to fix the issue by changing the setup-python action moving from current v5 to a [v3.1.4](https://github.com/actions/setup-python/releases/tag/v3.1.4)

