### PR TITLE
 allow TLSv1.3 in ZK for FIPS client connection in `testCertificates`

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.common.CertificateAuthorityBuilder;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.kafka.Kafka;
+import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlResources;
 import io.strimzi.api.kafka.model.kafka.exporter.KafkaExporterResources;
@@ -124,21 +125,33 @@ class SecurityST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaEphemeral(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)
-                .editOrNewSpec()
-                    .editOrNewZookeeper()
-                        // enable TLSv1.3 in ZK to allow connection to FIPS enabled server.
-                        .addToConfig("ssl.protocol", "TLSv1.3")
-                        .addToConfig("ssl.quorum.protocol", "TLSv1.3")
-                        .addToConfig("ssl.enabledProtocols", "TLSv1.3,TLSv1.2")
-                        .addToConfig("ssl.quorum.enabledProtocols", "TLSv1.3,TLSv1.2")
-                        .addToConfig("ssl.ciphersuites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256")
-                        .addToConfig("ssl.quorum.ciphersuites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256")
-                    .endZookeeper()
-                .endSpec()
-                .build()
-        );
 
+        KafkaBuilder kafkaBuilder = KafkaTemplates.kafkaEphemeral(testStorage.getNamespaceName(), testStorage.getClusterName(), 3);
+
+        if (!Environment.isKRaftModeEnabled()) {
+            // in order to make the connection work on FIPS-enabled cluster, we need to enable TLSv1.3 on the ZooKeeper side
+            // Note, this cipherSuites comes from ZK master branch, where some cipher suites are missing in v3.8.4 branch:
+            // https://github.com/apache/zookeeper/blob/837f86cc713a5e4ce56e1f75eeb335093ca18821/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java#L142
+            String tlsV13CipherSuites = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA," +
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA," +
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256";
+
+            kafkaBuilder = kafkaBuilder
+                    .editSpec()
+                        .editOrNewZookeeper()
+                            .addToConfig("ssl.protocol", "TLSv1.3")
+                            .addToConfig("ssl.quorum.protocol", "TLSv1.3")
+                            .addToConfig("ssl.enabledProtocols", "TLSv1.3,TLSv1.2")
+                            .addToConfig("ssl.quorum.enabledProtocols", "TLSv1.3,TLSv1.2")
+                            .addToConfig("ssl.ciphersuites", tlsV13CipherSuites)
+                            .addToConfig("ssl.quorum.ciphersuites", tlsV13CipherSuites)
+                        .endZookeeper()
+                    .endSpec();
+        }
+
+        resourceManager.createResourceWithWait(kafkaBuilder.build());
 
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -124,7 +124,21 @@ class SecurityST extends AbstractST {
                 KafkaNodePoolTemplates.controllerPoolPersistentStorage(testStorage.getNamespaceName(), testStorage.getControllerPoolName(), testStorage.getClusterName(), 3).build()
             )
         );
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaEphemeral(testStorage.getNamespaceName(), testStorage.getClusterName(), 3).build());
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaEphemeral(testStorage.getNamespaceName(), testStorage.getClusterName(), 3)
+                .editOrNewSpec()
+                    .editOrNewZookeeper()
+                        // enable TLSv1.3 in ZK to allow connection to FIPS enabled server.
+                        .addToConfig("ssl.protocol", "TLSv1.3")
+                        .addToConfig("ssl.quorum.protocol", "TLSv1.3")
+                        .addToConfig("ssl.enabledProtocols", "TLSv1.3,TLSv1.2")
+                        .addToConfig("ssl.quorum.enabledProtocols", "TLSv1.3,TLSv1.2")
+                        .addToConfig("ssl.ciphersuites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256")
+                        .addToConfig("ssl.quorum.ciphersuites", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256")
+                    .endZookeeper()
+                .endSpec()
+                .build()
+        );
+
 
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

In RHEL 9, there is a [new policy forced](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.2_release_notes/new-features#new-features-security) in FIPS mode:
`The Extended Master Secret TLS Extension is now enforced on FIPS-enabled systems`

The result is that:
`Legacy clients that do not support EMS or TLS 1.3 now cannot connect to FIPS servers running on RHEL 9.`

This is the case we saw in the test.

So, to allow the client connect to FIPS server, we need to enable TLSv1.3 in zookeeper. 

In v3.8.x, it only enables TLSv1.2 by default. We need to enable it manually. To enable TLSv1.3 in ZK, we need to set some [configurations](https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_authOptions). You can see the default value of `ssl.protocol` and `ssl.quorum.protocol` is `TLSv1.2`. We need to update them.

For the `ssl.ciphersuites`, we need to add `TLSv13Ciphers` manually, too. Compared [v3.8.4](https://github.com/apache/zookeeper/blob/release-3.8.4/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java#L103) with [master](https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/common/X509Util.java#L142) branch, we can see the `TLSv13Ciphers` is missed in v3.8.4 branch. I added them into the config, too.

With this change, the `SecurityST#testCertificates` can pass in FIPS enabled cluster.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [V] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

