### PR TITLE
[DOC] Fix the image name in the TO customization Dockerfile

### DIFF
--- a/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
+++ b/documentation/modules/deploying/proc-deploy-topic-operator-standalone.adoc
@@ -190,9 +190,9 @@ env:
 <3> Specifies the SASL properties to be set in JSON format. Only properties starting with `sasl.` are allowed.
 +
 .Example Dockerfile with external jars
-[source,shell,subs=+quotes]
+[source,shell,subs="+quotes,attributes"]
 ----
-FROM strimzi/operator:latest
+FROM {DockerTopicOperator}
 
 USER root
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The Standalone TO deployment guide in our docs contains a Docerfile example for adding custom authentication libraries. but it is using the `strimzi/operator:latest` image that points to DockerHub and that makes it not work. This PR fixes it to match the correct TO image.

### Checklist

- [x] Update documentation