### PR TITLE
Integrate Strimzi Access Operator into the release bundle

### DIFF
--- a/packaging/examples/README.md
+++ b/packaging/examples/README.md
@@ -19,3 +19,5 @@ This folder contains different examples of Strimzi custom resources and demonstr
     * JMX Trans deployment
 * [Security](./security)
     * Deployments of Kafka, Kafka Connect and HTTP Bridge using TLS encryption, authentication and authorization
+* [Kafka Access examples](./kafka-access)
+    * Examples of the `KafkaAccess` resources for the Strimzi Access Operator

--- a/packaging/install/Makefile
+++ b/packaging/install/Makefile
@@ -39,6 +39,7 @@ release:
 	$(CP) -r ./topic-operator $(RELEASE_PATH)/
 	$(CP) -r ./strimzi-admin $(RELEASE_PATH)/
 	$(CP) -r ./drain-cleaner $(RELEASE_PATH)/
+	$(CP) -r ./access-operator $(RELEASE_PATH)/
 
 java_build: crd_install
 java_install: java_build


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR adds the missing integration of the Strimzi Access Operator installation files to the release bundles which I originally forgot about. It also updates the examples README to list the new folder with the Access Operator examples.