### PR TITLE
Only update cluster-ca-key-generation from CaReconciler

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
@@ -29,11 +29,6 @@ public enum RestartReason {
     CA_CERT_RENEWED("CA certificate renewed"),
 
     /**
-     * Clients CA private key was replaced
-     */
-    CLIENT_CA_CERT_KEY_REPLACED("Trust new clients CA certificate signed by new key"),
-
-    /**
      * Cluster CA private key was replaced
      */
     CLUSTER_CA_CERT_KEY_REPLACED("Trust new cluster CA certificate signed by new key"),

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -582,10 +582,14 @@ public class CaReconciler {
                 if (clusterCaKeyGeneration == podClusterCaKeyGeneration) {
                     LOGGER.debugCr(reconciliation, "Not rolling Pod {} since the CA cert key generation is correct.", pod.getMetadata().getName());
                     return RestartReasons.empty();
+                } else {
+                    LOGGER.debugCr(reconciliation, "Rolling Pod {} due to {}", pod.getMetadata().getName(), podRollReasons.getReasons());
+                    return podRollReasons;
                 }
+            } else {
+                LOGGER.debugCr(reconciliation, "Rolling Pod {} due to {}", pod.getMetadata().getName(), podRollReasons.getReasons());
+                return podRollReasons;
             }
-            LOGGER.debugCr(reconciliation, "Rolling Pod {} due to {}", pod.getMetadata().getName(), podRollReasons.getReasons());
-            return podRollReasons;
         });
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -97,6 +97,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
@@ -1493,115 +1494,6 @@ public class CaReconcilerTest {
     }
 
     @Test
-    public void testRollingReasonsWithClusterCAKeyNotTrusted(Vertx vertx, VertxTestContext context) {
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .withNewEntityOperator()
-                    .endEntityOperator()
-                    .withNewCruiseControl()
-                    .endCruiseControl()
-                    .withNewKafkaExporter()
-                    .endKafkaExporter()
-                .endSpec()
-                .build();
-
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        SecretOperator secretOps = supplier.secretOperations;
-        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture())).thenAnswer(i -> {
-            Secret s = clusterCaCert.getValue();
-            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-            return Future.succeededFuture(ReconcileResult.created(s));
-        });
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture())).thenAnswer(i -> {
-            Secret s = clusterCaKey.getValue();
-            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-            return Future.succeededFuture(ReconcileResult.created(s));
-        });
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clusterOperatorCertsSecretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");
-
-        StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
-        when(spsOps.getAsync(eq(NAMESPACE), eq(KafkaResources.zookeeperComponentName(NAME)))).thenReturn(Future.succeededFuture());
-
-        List<Pod> pods = new ArrayList<>();
-        // adding a terminating Cruise Control pod to test that it's skipped during the key generation check
-        Pod ccPod = podWithNameAndAnnotations("my-cluster-cruise-control", false, false, generationAnnotations);
-        ccPod.getMetadata().setDeletionTimestamp("2023-06-08T16:23:18Z");
-        pods.add(ccPod);
-
-        // adding Kafka pods with old CA cert and key generation
-        List<Pod> controllerPods = new ArrayList<>();
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-3", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-4", false, true, generationAnnotations));
-        controllerPods.add(podWithNameAndAnnotations("my-cluster-controllers-5", false, true, generationAnnotations));
-        pods.addAll(controllerPods);
-
-        List<Pod> brokerPods = new ArrayList<>();
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-0", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-1", true, false, generationAnnotations));
-        brokerPods.add(podWithNameAndAnnotations("my-cluster-brokers-2", true, false, generationAnnotations));
-        pods.addAll(brokerPods);
-
-        StrimziPodSet controllerPodSet = new StrimziPodSetBuilder()
-                .withNewMetadata()
-                    .withName(NAME + "-controller")
-                .endMetadata()
-                .withNewSpec()
-                    .withPods(PodSetUtils.podsToMaps(controllerPods))
-                .endSpec()
-                .build();
-
-        StrimziPodSet brokerPodSet = new StrimziPodSetBuilder()
-                .withNewMetadata()
-                    .withName(NAME + "-broker")
-                .endMetadata()
-                .withNewSpec()
-                    .withPods(PodSetUtils.podsToMaps(brokerPods))
-                .endSpec()
-                .build();
-
-        PodOperator mockPodOps = supplier.podOperations;
-        when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
-
-        when(spsOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of(controllerPodSet, brokerPodSet)));
-        when(spsOps.batchReconcile(any(), eq(NAMESPACE), any(), any(Labels.class))).thenReturn(Future.succeededFuture());
-
-        Map<String, Deployment> deps = new HashMap<>();
-        deps.put("my-cluster-entity-operator", deploymentWithName("my-cluster-entity-operator"));
-        deps.put("my-cluster-cruise-control", deploymentWithName("my-cluster-cruise-control"));
-        deps.put("my-cluster-kafka-exporter", deploymentWithName("my-cluster-kafka-exporter"));
-        DeploymentOperator depsOperator = supplier.deploymentOperations;
-        when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1))));
-
-        Checkpoint async = context.checkpoint();
-
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(reconciliation, kafka, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat(mockCaReconciler.isClusterCaNeedFullTrust, is(true));
-                    assertThat(mockCaReconciler.kPodRollReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                    assertThat(mockCaReconciler.deploymentRollReason.size() == 3, is(true));
-                    for (String reason: mockCaReconciler.deploymentRollReason) {
-                        assertThat(reason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true));
-                    }
-                    async.flag();
-                })));
-    }
-
-    @Test
     public void testCertAnnotationsPatchedWithCAKeysNotTrusted(Vertx vertx, VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -1725,12 +1617,12 @@ public class CaReconcilerTest {
     public void testCertAnnotationsNotPatchedWithCACertsUpdated(Vertx vertx, VertxTestContext context) {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
-                .withNewEntityOperator()
-                .endEntityOperator()
-                .withNewCruiseControl()
-                .endCruiseControl()
-                .withNewKafkaExporter()
-                .endKafkaExporter()
+                    .withNewEntityOperator()
+                    .endEntityOperator()
+                    .withNewCruiseControl()
+                    .endCruiseControl()
+                    .withNewKafkaExporter()
+                    .endKafkaExporter()
                 .endSpec()
                 .build();
 
@@ -1778,19 +1670,19 @@ public class CaReconcilerTest {
 
         StrimziPodSet controllerPodSet = new StrimziPodSetBuilder()
                 .withNewMetadata()
-                .withName(NAME + "-controller")
+                    .withName(NAME + "-controller")
                 .endMetadata()
                 .withNewSpec()
-                .withPods(PodSetUtils.podsToMaps(controllerPods))
+                    .withPods(PodSetUtils.podsToMaps(controllerPods))
                 .endSpec()
                 .build();
 
         StrimziPodSet brokerPodSet = new StrimziPodSetBuilder()
                 .withNewMetadata()
-                .withName(NAME + "-broker")
+                    .withName(NAME + "-broker")
                 .endMetadata()
                 .withNewSpec()
-                .withPods(PodSetUtils.podsToMaps(brokerPods))
+                    .withPods(PodSetUtils.podsToMaps(brokerPods))
                 .endSpec()
                 .build();
 
@@ -1817,41 +1709,21 @@ public class CaReconcilerTest {
 
     @Test
     public void testShouldRollPod() {
-        RestartReasons restartReasons = RestartReasons.empty();
-        restartReasons.add(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED);
-        restartReasons.add(RestartReason.CLIENT_CA_CERT_KEY_REPLACED);
-
-        Function<Pod, RestartReasons> shouldRollFn = CaReconciler.shouldRollPodForChangedCaKey(Reconciliation.DUMMY_RECONCILIATION, restartReasons, 1);
-        Pod podNeedingClusterCaUpdate = podWithNameAndAnnotations("my-cluster-broker-0", true, false,
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "1"));
-        Pod podNeedingClientsCaUpdate = podWithNameAndAnnotations("my-cluster-broker-0", true, false,
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1", Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
+        Function<Pod, RestartReasons> shouldRollFn = CaReconciler.shouldRollPodForChangedCaKey(Reconciliation.DUMMY_RECONCILIATION, 1);
         Pod podNeedingUpdate = podWithNameAndAnnotations("my-cluster-broker-0", true, false,
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0"));
         Pod podNeedingNoUpdate = podWithNameAndAnnotations("my-cluster-broker-0", true, false,
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1", Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "1"));
-
-        RestartReasons clusterCaReasons = shouldRollFn.apply(podNeedingClusterCaUpdate);
-        assertThat(clusterCaReasons.getReasons(), hasSize(2));
-        assertThat(clusterCaReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-        assertThat(clusterCaReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
-
-        RestartReasons clientsCaReasons = shouldRollFn.apply(podNeedingClientsCaUpdate);
-        assertThat(clientsCaReasons.getReasons(), hasSize(1));
-        assertThat(clientsCaReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
+                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
 
         RestartReasons updateReasons = shouldRollFn.apply(podNeedingUpdate);
-        assertThat(updateReasons.getReasons(), hasSize(2));
+        assertThat(updateReasons.getReasons(), hasSize(1));
         assertThat(updateReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-        assertThat(updateReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
 
         RestartReasons noUpdateReasons = shouldRollFn.apply(podNeedingNoUpdate);
-        assertThat(noUpdateReasons.getReasons(), hasSize(1));
-        assertThat(noUpdateReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
+        assertThat(shouldRollFn.apply(podNeedingNoUpdate).getReasons(), empty());
     }
 
     static class MockCaReconciler extends CaReconciler {
-        RestartReasons kPodRollReasons;
         List<String> deploymentRollReason = new ArrayList<>();
 
         public MockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
@@ -1859,8 +1731,7 @@ public class CaReconcilerTest {
         }
 
         @Override
-        Future<Void> rollKafka(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
-            this.kPodRollReasons = podRollReasons;
+        Future<Void> rollKafka(Set<NodeRef> nodes, TlsPemIdentity coTlsPemIdentity) {
             return Future.succeededFuture();
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -1691,7 +1691,8 @@ public class CaReconcilerTest {
                         .toList();
                 for (Pod pod : returnedPods) {
                     Map<String, String> podAnnotations = pod.getMetadata().getAnnotations();
-                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "1"));
+                    // Expect that the CA key generation was updated. CA cert generations are updated by component reconcilers
+                    assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
                     assertThat(podAnnotations, hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "1"));
                 }
             });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -264,7 +264,7 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Set<NodeRef>> patchCaGenerationAndReturnNodes() {
+        Future<Set<NodeRef>> patchCaKeyGenerationAndReturnNodes() {
             //Response is ignored by rollKafka method in the mock
             return Future.succeededFuture(Set.of());
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -7,26 +7,18 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
-import io.strimzi.certs.CertManager;
 import io.strimzi.certs.OpenSslCertManager;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.ResourceUtils;
 import io.strimzi.operator.cluster.model.AbstractModel;
-import io.strimzi.operator.cluster.model.NodeRef;
-import io.strimzi.operator.cluster.model.RestartReason;
-import io.strimzi.operator.cluster.model.RestartReasons;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
-import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.SecretOperator;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
@@ -45,11 +37,8 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -164,152 +153,12 @@ public class CaReconcilerZooBasedTest {
                 })));
     }
 
-    @Test
-    public void testRollingReasonsWithClusterCAKeyNotTrusted(Vertx vertx, VertxTestContext context) {
-        Reconciliation reconciliation = new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, NAMESPACE, NAME);
-        ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
-
-        SecretOperator secretOps = supplier.secretOperations;
-        ArgumentCaptor<Secret> clusterCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clusterCaKey = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaCert = ArgumentCaptor.forClass(Secret.class);
-        ArgumentCaptor<Secret> clientsCaKey = ArgumentCaptor.forClass(Secret.class);
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaCertSecretName(NAME)), clusterCaCert.capture())).thenAnswer(i -> {
-            Secret s = clusterCaCert.getValue();
-            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_CERT_GENERATION, "1"));
-            return Future.succeededFuture(ReconcileResult.created(s));
-        });
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(AbstractModel.clusterCaKeySecretName(NAME)), clusterCaKey.capture())).thenAnswer(i -> {
-            Secret s = clusterCaKey.getValue();
-            s.getMetadata().setAnnotations(Map.of(Ca.ANNO_STRIMZI_IO_CA_KEY_GENERATION, "1"));
-            return Future.succeededFuture(ReconcileResult.created(s));
-        });
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaCertificateSecretName(NAME)), clientsCaCert.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clientsCaKeySecretName(NAME)), clientsCaKey.capture())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.clusterOperatorCertsSecretName(NAME)), any())).thenAnswer(i -> Future.succeededFuture(ReconcileResult.created(i.getArgument(0))));
-        when(secretOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(List.of()));
-
-        Map<String, String> generationAnnotations =
-                Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0", Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0");
-
-        PodOperator mockPodOps = supplier.podOperations;
-        when(mockPodOps.listAsync(any(), any(Labels.class))).thenAnswer(i -> {
-            List<Pod> pods = new ArrayList<>();
-            // adding a terminating Cruise Control pod to test that it's skipped during the key generation check
-            Pod ccPod = podWithNameAndAnnotations("my-kafka-cruise-control", generationAnnotations);
-            ccPod.getMetadata().setDeletionTimestamp("2023-06-08T16:23:18Z");
-            pods.add(ccPod);
-            // adding ZooKeeper and Kafka pods with old CA cert and key generation
-            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-0", generationAnnotations));
-            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-1", generationAnnotations));
-            pods.add(podWithNameAndAnnotations("my-kafka-zookeeper-2", generationAnnotations));
-            pods.add(podWithNameAndAnnotations("my-kafka-kafka-0", generationAnnotations));
-            pods.add(podWithNameAndAnnotations("my-kafka-kafka-1", generationAnnotations));
-            pods.add(podWithNameAndAnnotations("my-kafka-kafka-2", generationAnnotations));
-            return Future.succeededFuture(pods);
-        });
-
-        Map<String, Deployment> deps = new HashMap<>();
-        deps.put("my-kafka-entity-operator", deploymentWithName("my-kafka-entity-operator"));
-        deps.put("my-kafka-cruise-control", deploymentWithName("my-kafka-cruise-control"));
-        deps.put("my-kafka-kafka-exporter", deploymentWithName("my-kafka-kafka-exporter"));
-        DeploymentOperator depsOperator = supplier.deploymentOperations;
-        when(depsOperator.getAsync(any(), any())).thenAnswer(i -> Future.succeededFuture(deps.get(i.getArgument(1))));
-
-        Checkpoint async = context.checkpoint();
-
-        MockCaReconciler mockCaReconciler = new MockCaReconciler(reconciliation, KAFKA, new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), KafkaVersionTestUtils.getKafkaVersionLookup()).with(ClusterOperatorConfig.OPERATION_TIMEOUT_MS.key(), "1").build(),
-                supplier, vertx, CERT_MANAGER, PASSWORD_GENERATOR);
-        mockCaReconciler
-                .reconcile(Clock.systemUTC())
-                .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat(mockCaReconciler.isClusterCaNeedFullTrust, is(true));
-                    assertThat(mockCaReconciler.zkPodRestartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                    assertThat(mockCaReconciler.kPodRollReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
-                    assertThat(mockCaReconciler.deploymentRollReason.size() == 3, is(true));
-                    for (String reason: mockCaReconciler.deploymentRollReason) {
-                        assertThat(reason.equals(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()), is(true));
-                    }
-                    async.flag();
-                })));
-    }
-
-    static class MockCaReconciler extends CaReconciler {
-
-        RestartReasons zkPodRestartReasons;
-        RestartReasons kPodRollReasons;
-        List<String> deploymentRollReason = new ArrayList<>();
-
-        public MockCaReconciler(Reconciliation reconciliation, Kafka kafkaCr, ClusterOperatorConfig config, ResourceOperatorSupplier supplier, Vertx vertx, CertManager certManager, PasswordGenerator passwordGenerator) {
-            super(reconciliation, kafkaCr, config, supplier, vertx, certManager, passwordGenerator);
-        }
-
-        @Override
-        Future<Void> verifyClusterCaFullyTrustedAndUsed() {
-            // assuming the CA key is not trusted
-            this.isClusterCaNeedFullTrust = true;
-            this.isClusterCaFullyUsed = false;
-            return Future.succeededFuture();
-        }
-
-        @Override
-        Future<Integer> getZooKeeperReplicas() {
-            return Future.succeededFuture(3);
-        }
-
-        @Override
-        Future<Void> maybeRollZookeeper(int replicas, RestartReasons podRestartReasons, TlsPemIdentity coTlsPemIdentity) {
-            this.zkPodRestartReasons = podRestartReasons;
-            return Future.succeededFuture();
-        }
-
-        @Override
-        Future<Set<NodeRef>> patchCaKeyGenerationAndReturnNodes() {
-            //Response is ignored by rollKafka method in the mock
-            return Future.succeededFuture(Set.of());
-        }
-
-        @Override
-        Future<Void> rollKafka(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
-            this.kPodRollReasons = podRollReasons;
-            return Future.succeededFuture();
-        }
-
-        @Override
-        Future<Void> rollDeploymentIfExists(String deploymentName, String reason) {
-            return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
-                    .compose(dep -> {
-                        if (dep != null) {
-                            this.deploymentRollReason.add(reason);
-                        }
-                        return Future.succeededFuture();
-                    });
-        }
-
-        @Override
-        Future<Void> maybeRemoveOldClusterCaCertificates() {
-            return Future.succeededFuture();
-        }
-    }
-
-    public static Pod podWithName(String name) {
-        return podWithNameAndAnnotations(name, Collections.emptyMap());
-    }
-
     public static Pod podWithNameAndAnnotations(String name, Map<String, String> annotations) {
         return new PodBuilder()
                 .withNewMetadata()
                     .withName(name)
                     .withAnnotations(annotations)
                     .withLabels(Map.of(Labels.STRIMZI_CLUSTER_LABEL, NAME))
-                .endMetadata()
-                .build();
-    }
-
-    public static Deployment deploymentWithName(String name) {
-        return new DeploymentBuilder()
-                .withNewMetadata()
-                    .withName(name)
                 .endMetadata()
                 .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
@@ -112,9 +112,9 @@ class KubernetesRestartEventPublisherTest {
             }
         };
 
-        Set<String> expectedReasons = Set.of("ClientCaCertKeyReplaced", "ClusterCaCertKeyReplaced");
+        Set<String> expectedReasons = Set.of("FileSystemResizeNeeded", "ClusterCaCertKeyReplaced");
 
-        RestartReasons reasons = new RestartReasons().add(RestartReason.CLIENT_CA_CERT_KEY_REPLACED)
+        RestartReasons reasons = new RestartReasons().add(RestartReason.FILE_SYSTEM_RESIZE_NEEDED)
                                                      .add(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED);
 
         capturingPublisher.publishRestartEvents(mockPod, reasons);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -107,7 +107,6 @@ import static io.strimzi.operator.cluster.model.AbstractModel.clusterCaKeySecret
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_HAS_OLD_GENERATION;
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_REMOVED;
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_RENEWED;
-import static io.strimzi.operator.cluster.model.RestartReason.CLIENT_CA_CERT_KEY_REPLACED;
 import static io.strimzi.operator.cluster.model.RestartReason.CLUSTER_CA_CERT_KEY_REPLACED;
 import static io.strimzi.operator.cluster.model.RestartReason.CONFIG_CHANGE_REQUIRES_RESTART;
 import static io.strimzi.operator.cluster.model.RestartReason.FILE_SYSTEM_RESIZE_NEEDED;
@@ -396,15 +395,6 @@ public class KubernetesRestartEventsMockTest {
                 new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_RENEWED, context));
-    }
-
-    @Test
-    void testEventEmittedWhenClientCaCertKeyReplaced(Vertx vertx, VertxTestContext context) {
-        // Annotate Clients CA key secret with force-renew annotation
-        patchSecretWithForceReplaceAnnotation(KafkaResources.clientsCaKeySecretName(CLUSTER_NAME));
-
-        CaReconciler reconciler = new CaReconciler(reconciliation, kafka, clusterOperatorConfig, supplier, vertx, mockCertManager, passwordGenerator);
-        reconciler.reconcile(Clock.systemUTC()).onComplete(verifyEventPublished(CLIENT_CA_CERT_KEY_REPLACED, context));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

When rolling pods to trust new CA cert signed by new CA key only update the cluster-ca-key-generation
annotation. Do not update cluster-ca-cert-generation or clients-ca-cert-generation.

In PR #10711 I added logic to update the cluster-ca-cert-gen , clients-ca-cert-gen and cluster-ca-key-gen annotations before rolling the pods. However, the pods are being rolled to trust a new CA cert that is signed by a new CA key. They are still presenting certificates that were issued by the old CA cert.

This means that if the reconcile fails after rolling the Kafka pods as part of the CaReconciler rolling update, but before it runs the KafkaReconciler logic, when it comes back in it would incorrectly think that the new CA cert was used everywhere and remove the old one from the ca-cert Secret.

We should only update the cluster-ca-key-gen annotation before doing the rolling update

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

