### PR TITLE
Do not log Kafka Agent configuration at Kafka node startup

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -108,16 +108,17 @@ else
   rm -f $KAFKA_READY $ZK_CONNECTED 2> /dev/null
 fi
 
-KEY_STORE=/tmp/kafka/cluster.keystore.p12
-TRUST_STORE=/tmp/kafka/cluster.truststore.p12
-
+# Generate the Kafka Agent configuration file
+echo ""
+echo "Preparing Kafka Agent configuration"
 rm -f /tmp/kafka-agent.properties
-tee /tmp/kafka-agent.properties <<EOF
-sslKeyStorePath=${KEY_STORE}
+cat <<EOF > /tmp/kafka-agent.properties
+sslKeyStorePath=/tmp/kafka/cluster.keystore.p12
 sslKeyStorePass=${CERTS_STORE_PASSWORD}
-sslTrustStorePath=${TRUST_STORE}
+sslTrustStorePath=/tmp/kafka/cluster.truststore.p12
 sslTrustStorePass=${CERTS_STORE_PASSWORD}
 EOF
+echo ""
 
 KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/kafka-agent*.jar)=$KAFKA_READY:$ZK_CONNECTED:/tmp/kafka-agent.properties"
 export KAFKA_OPTS


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#10480 tried to remove the keystore/truststore passwords used by the Kafka Agent from the command to not make them discoverable through the `/proc` tree. But while doing that, it started printing them into the log:

```
sslKeyStorePath=/tmp/kafka/cluster.keystore.p12
sslKeyStorePass=MVjwFQdM26EhQdqD3quZ_ur5qCEqnoL5
sslTrustStorePath=/tmp/kafka/cluster.truststore.p12
sslTrustStorePass=MVjwFQdM26EhQdqD3quZ_ur5qCEqnoL5
```

This PR fixes that and stops printing them into the log. These are on-the-fly generated passwords that apply to files existing in the container only and are anyway stored in a file in the same container. So I do not think this is a major issue. But it is not desired.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally