### PR TITLE
Revert "Annotate StrimziPodSets before rolling during CA renewal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
   * after a scaling up, the operator triggers an auto-rebalancing for moving some of the existing partitions to the newly added brokers.
   * before scaling down, and if the brokers to remove are hosting partitions, the operator triggers an auto-rebalancing to these partitions off the brokers to make them free to be removed.
 * Strimzi Access Operator 0.1.0 added to the installation files and examples
-* Allow rolling update for new cluster CA trust (during Cluster CA key replacement) to continue where it left off before interruption without rolling all pods again.
 
 ### Changes, deprecations and removals
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/WorkloadUtils.java
@@ -184,36 +184,6 @@ public class WorkloadUtils {
     }
 
     /**
-     * Patch a Strimzi PodSet to merge the provided annotations with the annotations on the Pod resources defined
-     * in the PodSet
-     *
-     * @param strimziPodSet             Strimzi PodSet to patch
-     * @param annotationsToBeUpdated    Annotations to merge with the existing annotations
-     *
-     * @return Patched PodSet
-     */
-    public static StrimziPodSet patchAnnotations(StrimziPodSet strimziPodSet, Map<String, String> annotationsToBeUpdated) {
-        List<Map<String, Object>> newPods = PodSetUtils.podSetToPods(strimziPodSet)
-                .stream()
-                .map(pod -> {
-                    Map<String, String> updatedAnnotations = pod.getMetadata().getAnnotations();
-                    updatedAnnotations.putAll(annotationsToBeUpdated);
-                    return pod.edit()
-                            .editMetadata()
-                                .withAnnotations(updatedAnnotations)
-                            .endMetadata()
-                            .build();
-                })
-                .map(PodSetUtils::podToMap)
-                .toList();
-        return new StrimziPodSetBuilder(strimziPodSet)
-                .editSpec()
-                    .withPods(newPods)
-                .endSpec()
-                .build();
-    }
-
-    /**
      * Creates a stateful Pod for use with StrimziPodSets. Stateful in this context means that it has a stable name and
      * typically uses storage.
      *

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/WorkloadUtilsTest.java
@@ -36,7 +36,6 @@ import io.strimzi.api.kafka.model.common.template.ResourceTemplateBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.api.kafka.model.podset.StrimziPodSet;
-import io.strimzi.api.kafka.model.podset.StrimziPodSetBuilder;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import org.junit.jupiter.api.Test;
@@ -362,44 +361,6 @@ public class WorkloadUtilsTest {
         assertThat(podNames, hasItems("my-cluster-nodes-10", "my-cluster-nodes-11", "my-cluster-nodes-12"));
         assertThat(sps.getSpec().getPods().size(), is(3));
         assertThat(sps.getSpec().getPods().stream().map(pod -> PodSetUtils.mapToPod(pod).getMetadata().getName()).toList(), hasItems("my-cluster-nodes-10", "my-cluster-nodes-11", "my-cluster-nodes-12"));
-    }
-
-    @Test
-    public void testPatchPodAnnotations() {
-        Map<String, String> annotations = Map.of("anno-1", "value-1", "anno-2", "value-2", "anno-3", "value-3");
-        List<Pod> pods = new ArrayList<>();
-        pods.add(new PodBuilder()
-                .withNewMetadata()
-                    .withName("pod-0")
-                    .withNamespace(NAMESPACE)
-                    .withAnnotations(annotations)
-                .endMetadata()
-                .build()
-        );
-        pods.add(new PodBuilder()
-                .withNewMetadata()
-                    .withName("pod-1")
-                    .withNamespace(NAMESPACE)
-                    .withAnnotations(annotations)
-                .endMetadata()
-                .build()
-        );
-
-        StrimziPodSet sps = new StrimziPodSetBuilder()
-                .withNewMetadata()
-                    .withName("my-sps")
-                    .withNamespace(NAMESPACE)
-                .endMetadata()
-                .withNewSpec()
-                    .withPods(PodSetUtils.podsToMaps(pods))
-                .endSpec()
-                .build();
-
-        List<Pod> resultPods = PodSetUtils.podSetToPods(WorkloadUtils.patchAnnotations(sps, Map.of("anno-2", "value-2a", "anno-4", "value-4")));
-        assertThat(resultPods.size(), is(2));
-        Map<String, String> expectedAnnotations = Map.of("anno-1", "value-1", "anno-2", "value-2a", "anno-3", "value-3", "anno-4", "value-4");
-        assertThat(resultPods.get(0).getMetadata().getAnnotations(), is(expectedAnnotations));
-        assertThat(resultPods.get(1).getMetadata().getAnnotations(), is(expectedAnnotations));
     }
 
     //////////////////////////////////////////////////

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -47,6 +47,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -264,13 +265,16 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Set<NodeRef>> patchCaGenerationAndReturnNodes() {
-            //Response is ignored by rollKafka method in the mock
-            return Future.succeededFuture(Set.of());
+        Future<Set<NodeRef>> getKafkaReplicas() {
+            Set<NodeRef> nodes = new HashSet<>();
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-0")));
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-1")));
+            nodes.add(ReconcilerUtils.nodeFromPod(podWithName("my-kafka-kafka-2")));
+            return Future.succeededFuture(nodes);
         }
 
         @Override
-        Future<Void> rollKafka(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
+        Future<Void> rollKafkaBrokers(Set<NodeRef> nodes, RestartReasons podRollReasons, TlsPemIdentity coTlsPemIdentity) {
             this.kPodRollReasons = podRollReasons;
             return Future.succeededFuture();
         }


### PR DESCRIPTION
This PR reverts the changes from strimzi/strimzi-kafka-operator#10711. We tried to fix this in #10749, but that is still work in progress. So, in order to unblock the 0.44 release, we [decided](https://cloud-native.slack.com/archives/C018247K8T0/p1729499010653679) to revert the original code (although it does not seem to be breaking anything).

CC @katheris 