### PR TITLE
fix: Enhance IPv6 Normalization Regex in IpAndDnsValidation

### DIFF
--- a/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
+++ b/certificate-manager/src/main/java/io/strimzi/certs/IpAndDnsValidation.java
@@ -35,7 +35,7 @@ public class IpAndDnsValidation {
     }
 
     // Pattern used to normalize the segments of the IPv6 address
-    private static final Pattern IPV6_LEADING_ZEROS_TRIMMING = Pattern.compile("(^|:)0+([\\da-f]+)(:|$)");
+    private static final Pattern IPV6_LEADING_ZEROS_TRIMMING = Pattern.compile("(?<=^|:)0+(?=[\\da-f]+)");
 
     /**
      * Returns true if the name is a valid DNS name or a wildcard DNS name. That means that it matches the DNS_NAME
@@ -131,9 +131,7 @@ public class IpAndDnsValidation {
         // Make it lowercase
         normalized = normalized.toLowerCase(Locale.ENGLISH);
 
-        // Remove leading zeros (this intentionally runs twice, because I do not know how to write a better REGEX which would do everything in one go)
-        normalized = IPV6_LEADING_ZEROS_TRIMMING.matcher(normalized).replaceAll("$1$2$3");
-        normalized = IPV6_LEADING_ZEROS_TRIMMING.matcher(normalized).replaceAll("$1$2$3");
+        normalized = IPV6_LEADING_ZEROS_TRIMMING.matcher(normalized).replaceAll("");
 
         // return the normalized IPv6 address
         return normalized;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_


- Refactoring


### Description

This PR improves the IPv6 address normalization logic in IpAndDnsValidation by enhancing the regex used to remove leading zeros in a single pass. This optimization ensures better performance and simplifies the code without introducing new methods or dependencies.

#### Verified the `certificate-manager` tests pass
<img width="953" alt="image" src="https://github.com/user-attachments/assets/691218a2-1dc3-44ee-a1d6-27d3d3a61a9e">

#### Performed some custom test as well

<img width="441" alt="image" src="https://github.com/user-attachments/assets/e81e203c-0598-4027-a9ae-522a563f50d8">


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

