### PR TITLE
Handle the failure due to reaching the servlet capacity when getting user tasks

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -817,8 +817,8 @@ public class KafkaRebalanceAssemblyOperator
                                               String host, CruiseControlApi apiClient,
                                               AbstractRebalanceOptions.AbstractRebalanceOptionsBuilder<?, ?> rebalanceOptionsBuilder) {
         if (cruiseControlResponse.isMaxActiveUserTasksReached()) {
-            LOGGER.warnCr(reconciliation, "The maximum number of active user tasks that can run concurrently has reached therefore will retry getting user tasks in the next reconciliation. " +
-                    "If this occurs often, consider increasing the value for max.active.user.tasks configuration.");
+            LOGGER.warnCr(reconciliation, "The maximum number of active user tasks that Cruise Control can run concurrently has been reached, therefore will retry getting user tasks in the next reconciliation. " +
+                    "If this occurs often, consider increasing the value for max.active.user.tasks in the Cruise Control configuration.");
             configMapOperator.getAsync(kafkaRebalance.getMetadata().getNamespace(), kafkaRebalance.getMetadata().getName())
                     .onSuccess(loadmap -> p.complete(new MapAndStatus<>(loadmap, buildRebalanceStatusFromPreviousStatus(kafkaRebalance.getStatus(), conditions))));
             return;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -102,7 +102,7 @@ public interface CruiseControlApi {
      *                   This is used to retrieve the task's current state.
      * @return A future for the state of the specified task.
      */
-    Future<CruiseControlResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskID);
+    Future<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskID);
 
     /**
      *  Issue a stop command to the Cruise Control server. This will halt any task (e.g. a rebalance) which is currently

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -330,7 +330,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     @Override
     @SuppressWarnings("deprecation")
-    public Future<CruiseControlResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskId) {
+    public Future<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskId) {
 
         PathBuilder pathBuilder = new PathBuilder(CruiseControlEndpoints.USER_TASKS)
                         .withParameter(CruiseControlParameters.JSON, "true")
@@ -365,7 +365,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                         // This may happen if:
                                         // 1. Cruise Control restarted so resetting the state because the tasks queue is not persisted
                                         // 2. Task's retention time expired, or the cache has become full
-                                        result.complete(new CruiseControlResponse(userTaskID, statusJson));
+                                        result.complete(new CruiseControlUserTasksResponse(userTaskID, statusJson));
                                     } else {
                                         JsonObject jsonUserTask = userTasks.getJsonObject(0);
                                         String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
@@ -409,7 +409,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                             default:
                                                 throw new IllegalStateException("Unexpected user task status: " + taskStatus);
                                         }
-                                        result.complete(new CruiseControlResponse(userTaskID, statusJson));
+                                        result.complete(new CruiseControlUserTasksResponse(userTaskID, statusJson));
                                     }
                                 });
                             } else if (response.result().statusCode() == 500) {
@@ -423,8 +423,15 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                                     } else {
                                         errorString = json.toString();
                                     }
-                                    result.fail(new CruiseControlRestException(
-                                            "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
+                                    if (errorString.matches(".*" + "There are already \\d+ active user tasks, which has reached the servlet capacity." + ".*")) {
+                                        LOGGER.debugCr(reconciliation, errorString);
+                                        CruiseControlUserTasksResponse ccResponse = new CruiseControlUserTasksResponse(userTaskID, json);
+                                        ccResponse.setMaxActiveUserTasksReached(true);
+                                        result.complete(ccResponse);
+                                    } else {
+                                        result.fail(new CruiseControlRestException(
+                                                "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
+                                    }
                                 });
                             } else {
                                 result.fail(new CruiseControlRestException(

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlUserTasksResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlUserTasksResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Response to user tasks request
+ */
+public class CruiseControlUserTasksResponse extends CruiseControlResponse {
+    private boolean isMaxActiveUserTasksReached;
+
+    /**
+     * Constructor
+     *
+     * @param userTaskId    User task ID
+     * @param json          JSON data
+     */
+    CruiseControlUserTasksResponse(String userTaskId, JsonObject json) {
+        super(userTaskId, json);
+        // The maximum number of active user tasks that can run concurrently has reached
+        // Sourced from the error message that contains "reached the servlet capacity" from the Cruise Control response
+        this.isMaxActiveUserTasksReached = false;
+    }
+
+    /**
+     * @return  True If the maximum number of active user tasks that can run concurrently has reached
+     */
+    public boolean isMaxActiveUserTasksReached() {
+        return isMaxActiveUserTasksReached;
+    }
+
+    protected void setMaxActiveUserTasksReached(boolean maxActiveUserTasksReached) {
+        this.isMaxActiveUserTasksReached = maxActiveUserTasksReached;
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -553,7 +553,7 @@ public class CruiseControlClientTest {
 
         cruiseControlServer.setupCCUserTasksResponseNoGoals(0, pendingCalls1);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
+        Future<CruiseControlUserTasksResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
 
         for (int i = 1; i <= pendingCalls1; i++) {
             statusFuture = statusFuture.compose(response -> {
@@ -611,7 +611,7 @@ public class CruiseControlClientTest {
 
         CruiseControlApi client = cruiseControlClientProvider(vertx);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
+        Future<CruiseControlUserTasksResponse> statusFuture = client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
 
         // One interaction is always expected at the end of the test, hence the +1
         Checkpoint expectedInteractions = context.checkpoint(pendingCalls + 1);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -515,6 +515,25 @@ public class MockCruiseControl {
                                 .withDelay(TimeUnit.SECONDS, 0));
     }
 
+    public void setupCCUserTasksToReturnError(int statusCode, String errorMessage) throws IOException, URISyntaxException {
+        // This simulates asking for the status of a task that has Complete with error and fetch_completed_task=true
+        JsonBody errorJson = new JsonBody("{\"errorMessage\":\"" + errorMessage + "\"}");
+        server
+                .when(
+                        request()
+                                .withMethod("GET")
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.toString(), "true"))
+                                .withQueryStringParameter(Parameter.param(CruiseControlParameters.FETCH_COMPLETE.toString(), "true"))
+                                .withPath(CruiseControlEndpoints.USER_TASKS.toString())
+                                .withHeader(AUTH_HEADER)
+                                .withSecure(true))
+                .respond(
+                        response()
+                                .withBody(errorJson)
+                                .withStatusCode(statusCode)
+                                .withDelay(TimeUnit.SECONDS, 0));
+    }
+
     /**
      * Setup response when user task is not found
      */


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

If failed to get user tasks due to reaching the servlet capacity, it will no longer transition the KafkaRebalance status to NotReady.  Instead, KafkaRebalance status will not be changed and in the next reconciliation, it will retry getting the user tasks again. The operator will also report a warning message.

Resolves #10704  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

