### PR TITLE
Fix and unify redaction rule in report.sh

### DIFF
--- a/tools/report.sh
+++ b/tools/report.sh
@@ -21,7 +21,7 @@ SECRETS_OPT="hidden"
 # sed non-printable text delimiter
 SD=$(echo -en "\001") && readonly SD
 # sed sensitive information filter expression
-SE="s${SD}^\(\s*.*\password\s*:\s*\).*${SD}\1\<hidden>'${SD}; s${SD}^\(\s*.*\.key\s*:\s*\).*${SD}\1\<hidden>${SD}" && readonly SE
+SE="s${SD}^\(\s*\(.*\.\)\{0,1\}password\(\..*\)\{0,1\}\s*:\s*\).*${SD}\1\'<hidden>'${SD}; s${SD}^\(\s*\(.*\.\)\{0,1\}key\(\..*\)\{0,1\}\s*:\s*\).*${SD}\1\'<hidden>'${SD}" && readonly SE
 
 error() {
   echo "$@" 1>&2 && exit 1


### PR DESCRIPTION
The pattern and the replacement was different for "password" and "key". This unifies the 2 branches, and makes the pattern more generic - anything with dot separated "password" and "key" words will be covered.

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

