### PR TITLE
Added script code to enable debug on Cruise Control

### DIFF
--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -40,6 +40,26 @@ if [ "$CRUISE_CONTROL_METRICS_ENABLED" = "true" ]; then
   export KAFKA_OPTS
 fi
 
+# Set Debug options if enabled
+if [ "x$KAFKA_DEBUG" != "x" ]; then
+
+    # Use default ports
+    DEFAULT_JAVA_DEBUG_PORT="5005"
+
+    if [ -z "$JAVA_DEBUG_PORT" ]; then
+        JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+    fi
+
+    # Use the defaults if JAVA_DEBUG_OPTS was not set
+    DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${DEBUG_SUSPEND_FLAG:-n},address=$JAVA_DEBUG_PORT"
+    if [ -z "$JAVA_DEBUG_OPTS" ]; then
+        JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+    fi
+
+    echo "Enabling Java debug options: $JAVA_DEBUG_OPTS"
+    KAFKA_OPTS="$JAVA_DEBUG_OPTS $KAFKA_OPTS"
+fi
+
 # Configure heap based on the available resources if needed
 . ./dynamic_resources.sh
 


### PR DESCRIPTION
In the DEBUGGING guide we explain how to enable remote debugging on Kafka brokers which should apply the same on Cruise Control but it currently doesn't work.
The `cruise_control_run.sh` script is missing the part for setting the Java debug port, the suspend flag and so on.
For the Kafka broker script this is already covered within the `kafka_server_start.sh` (coming from Kafka itself and we use out of box) but it's missing in the script running Cruise Control.

This PR fixes this issue by using exactly the same code even because this is what is also used upstream in Cruise Control within the `kafka-cruise-control-start.sh` [here](https://github.com/linkedin/cruise-control/blob/main/kafka-cruise-control-start.sh#L103).