### PR TITLE
Removed logback exclusions from CC

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -31,18 +31,6 @@
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
-            <!-- The exclusion is needed because of https://github.com/linkedin/cruise-control/issues/2174.
-                 It can be removed once it is fixed and released in new Cruise Control version. -->
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The thirdparty-libs pom related to CC is still excluding logback but the referred issue https://github.com/linkedin/cruise-control/issues/2174 was closed and merged. Its solution is already available in the currently used 2.5.141 versio.
This PR removes the logback exclusion from our CC pom because it's not needed anymore.