### PR TITLE
[ST] Add CollectorElement to the NamespaceManager for situations when we are creating Namespaces manually

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/NamespaceManager.java
@@ -135,13 +135,18 @@ public class NamespaceManager {
     }
 
     /**
-     * Overloads {@link #createNamespaceAndPrepare(String, CollectorElement)} - with {@code CollectorElement} set to {@code null},
-     * so the Namespace will not be added into the {@link #MAP_WITH_SUITE_NAMESPACES}.
+     * Overloads {@link #createNamespaceAndPrepare(String, CollectorElement)}, but it creates a new {@link CollectorElement} for
+     * test class and test method automatically. The {@link CollectorElement} is needed for {@link io.strimzi.systemtest.logs.TestLogCollector} to
+     * correctly collect logs from all the Namespaces -> even those that are created manually in the test cases.
      *
      * @param namespaceName name of Namespace that should be created
      */
     public void createNamespaceAndPrepare(String namespaceName) {
-        createNamespaceAndPrepare(namespaceName, null);
+        final String testSuiteName = ResourceManager.getTestContext().getRequiredTestClass().getName();
+        final String testCaseName = ResourceManager.getTestContext().getTestMethod().orElse(null) == null ?
+            "" : ResourceManager.getTestContext().getRequiredTestMethod().getName();
+
+        createNamespaceAndPrepare(namespaceName, new CollectorElement(testSuiteName, testCaseName));
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In some situations and test-cases - for example in upgrade/downgrade tests - we are not collecting logs from the `co-namespace` and other. That is quite a big issue, as it makes the debugging of the failures really difficult - as we are missing the logs from CO.
The issue is that when we are creating the Namespaces "manually" -> meaning using the `NamespaceManager.createNamespaceAndPrepare` -> the Namespace is not added to the Map from which we are getting the list of Namespaces passed to the LogCollector.

This PR fixes this issue by adding the CollectorElement also for these Namespaces created "manually".

### Checklist

- [ ] Make sure all tests pass


