### PR TITLE
Delete stale Cruise Control API users

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentials.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentials.java
@@ -223,7 +223,13 @@ public class HashLoginServiceApiCredentials {
         if (secret != null) {
             if (secret.getData().containsKey(AUTH_FILE_KEY)) {
                 String credentialsAsString = Util.decodeFromBase64(secret.getData().get(AUTH_FILE_KEY));
-                entries.putAll(parseEntriesFromString(credentialsAsString));
+                for (Map.Entry<String, UserEntry> entry : parseEntriesFromString(credentialsAsString).entrySet()) {
+                    String key = entry.getKey();
+                    UserEntry value = entry.getValue();
+                    if (key.equals(REBALANCE_OPERATOR_USERNAME) || key.equals(HEALTHCHECK_USERNAME)) {
+                        entries.put(key, value);
+                    }
+                }
             }
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/cruisecontrol/HashLoginServiceApiCredentialsTest.java
@@ -268,10 +268,12 @@ public class HashLoginServiceApiCredentialsTest {
     public void testGenerateCoManagedApiCredentials() {
         PasswordGenerator mockPasswordGenerator = new PasswordGenerator(10, "a", "a");
 
-        // Test that credentials from previous secret are reused
+        // Given an existing cruiseControlApi secret test that CO credentials are reused and user-managed credentials are deleted
         Map<String, String> map1 = Map.of("cruise-control.authFile",
                 encodeToBase64("rebalance-operator: password,ADMIN\n" +
-                                     "healthcheck: password,USER"));
+                        "healthcheck: password,USER\n" +
+                        "userOne: passwordOne, USER\n" +
+                        "userTwo: passwordOne, VIEWER"));
         Map<String, HashLoginServiceApiCredentials.UserEntry> entries = new HashMap<>();
         HashLoginServiceApiCredentials.generateCoManagedApiCredentials(entries, mockPasswordGenerator, createSecret(map1));
         assertThat(entries.get("rebalance-operator").username(), is("rebalance-operator"));
@@ -281,6 +283,10 @@ public class HashLoginServiceApiCredentialsTest {
         assertThat(entries.get("healthcheck").username(), is("healthcheck"));
         assertThat(entries.get("healthcheck").password(), is("password"));
         assertThat(entries.get("healthcheck").role(), is(HashLoginServiceApiCredentials.Role.USER));
+
+        assertThat(entries.size(),  is(2));
+        assertThat(entries.get("userOne"),  is(nullValue()));
+        assertThat(entries.get("userTwo"),  is(nullValue()));
 
         // Test malformed secret credentials with blank password for user throws error
         final Map<String, String> map2 = Map.of("cruise-control.authFile",

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec.adoc
@@ -193,7 +193,7 @@ spec:
   cruiseControl:
     # ...
     apiUsers:
-      type: hashloginservice
+      type: hashLoginService
       valueFrom:
         secretKeyRef:
           name: cruise-control-api-users-secret


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Addresses #10649

There is a bug in the Cruise Control integration code that prevents stale API users from past user-managed API secrets from being deleted. The bug makes it impossible to update the passwords and roles of usernames that had been used by past user-managed secrets without manually deleting the Cruise Control API secret.

This PR ensures that the API users added to the Cruise Control API secret from past user-managed API secrets are removed at reconciliation. It also fixes a typo in the documentation for enabling CC API users

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

