### PR TITLE
Replace Vert.x in CruiseControlAPI with native HttpClient API from Java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -29,6 +29,7 @@ import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.ModelUtils;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlConfiguration;
+import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.AbstractRebalanceOptions;
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.AddBrokerOptions;
@@ -67,8 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -801,7 +800,7 @@ public class KafkaRebalanceAssemblyOperator
                             p.fail(e);
                         });
             } else {
-                fromCompletableFuture(apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId))
+                VertxUtil.completableFutureToVertxFuture(apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId))
                         .onSuccess(cruiseControlResponse -> handleUserTaskStatusResponse(reconciliation, cruiseControlResponse, p, sessionId, conditions, kafkaRebalance, configMapOperator, true, host, apiClient, rebalanceOptionsBuilder))
                         .onFailure(e -> {
                             LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance proposal status failed", e.getCause());
@@ -968,7 +967,7 @@ public class KafkaRebalanceAssemblyOperator
         String sessionId = kafkaRebalance.getStatus().getSessionId();
         if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.stop) {
             LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task");
-            fromCompletableFuture(apiClient.stopExecution(reconciliation, host, cruiseControlPort))
+            VertxUtil.completableFutureToVertxFuture(apiClient.stopExecution(reconciliation, host, cruiseControlPort))
                 .onSuccess(r -> p.complete(buildRebalanceStatus(null, KafkaRebalanceState.Stopped, StatusUtils.validate(reconciliation, kafkaRebalance))))
                 .onFailure(e -> {
                     LOGGER.errorCr(reconciliation, "Cruise Control stopping execution failed", e.getCause());
@@ -976,7 +975,7 @@ public class KafkaRebalanceAssemblyOperator
                 });
         } else if (rebalanceAnnotation(kafkaRebalance) == KafkaRebalanceAnnotation.refresh) {
             LOGGER.infoCr(reconciliation, "Stopping current Cruise Control rebalance user task since refresh annotation is applied on the KafkaRebalance resource and requesting a new proposal");
-            fromCompletableFuture(apiClient.stopExecution(reconciliation, host, cruiseControlPort))
+            VertxUtil.completableFutureToVertxFuture(apiClient.stopExecution(reconciliation, host, cruiseControlPort))
                     .onSuccess(r -> {
                         requestRebalance(reconciliation, host, apiClient, kafkaRebalance, true, rebalanceOptionsBuilder)
                                 .onSuccess(p::complete)
@@ -993,7 +992,7 @@ public class KafkaRebalanceAssemblyOperator
             LOGGER.infoCr(reconciliation, "Getting Cruise Control rebalance user task status");
             Set<Condition> conditions = StatusUtils.validate(reconciliation, kafkaRebalance);
             validateAnnotation(reconciliation, conditions, KafkaRebalanceState.Rebalancing, rebalanceAnnotation(kafkaRebalance), kafkaRebalance);
-            fromCompletableFuture(apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId))
+            VertxUtil.completableFutureToVertxFuture(apiClient.getUserTaskStatus(reconciliation, host, cruiseControlPort, sessionId))
                 .onSuccess(cruiseControlResponse -> handleUserTaskStatusResponse(reconciliation, cruiseControlResponse, p, sessionId, conditions, kafkaRebalance, configMapOperator, false, host, apiClient, rebalanceOptionsBuilder))
                 .onFailure(e -> {
                     LOGGER.errorCr(reconciliation, "Cruise Control getting rebalance task status failed", e);
@@ -1203,16 +1202,16 @@ public class KafkaRebalanceAssemblyOperator
         Future<CruiseControlRebalanceResponse> future;
         switch (mode) {
             case ADD_BROKERS:
-                future = fromCompletableFuture(apiClient.addBroker(reconciliation, host, cruiseControlPort, ((AddBrokerOptions.AddBrokerOptionsBuilder) rebalanceOptionsBuilder).build(), null));
+                future = VertxUtil.completableFutureToVertxFuture(apiClient.addBroker(reconciliation, host, cruiseControlPort, ((AddBrokerOptions.AddBrokerOptionsBuilder) rebalanceOptionsBuilder).build(), null));
                 break;
             case REMOVE_BROKERS:
-                future = fromCompletableFuture(apiClient.removeBroker(reconciliation, host, cruiseControlPort, ((RemoveBrokerOptions.RemoveBrokerOptionsBuilder) rebalanceOptionsBuilder).build(), null));
+                future = VertxUtil.completableFutureToVertxFuture(apiClient.removeBroker(reconciliation, host, cruiseControlPort, ((RemoveBrokerOptions.RemoveBrokerOptionsBuilder) rebalanceOptionsBuilder).build(), null));
                 break;
             case REMOVE_DISKS:
-                future = fromCompletableFuture(apiClient.removeDisks(reconciliation, host, cruiseControlPort, ((RemoveDisksOptions.RemoveDisksOptionsBuilder) rebalanceOptionsBuilder).build(), null));
+                future = VertxUtil.completableFutureToVertxFuture(apiClient.removeDisks(reconciliation, host, cruiseControlPort, ((RemoveDisksOptions.RemoveDisksOptionsBuilder) rebalanceOptionsBuilder).build(), null));
                 break;
             default:
-                future = fromCompletableFuture(apiClient.rebalance(reconciliation, host, cruiseControlPort, ((RebalanceOptions.RebalanceOptionsBuilder) rebalanceOptionsBuilder).build(), null));
+                future = VertxUtil.completableFutureToVertxFuture(apiClient.rebalance(reconciliation, host, cruiseControlPort, ((RebalanceOptions.RebalanceOptionsBuilder) rebalanceOptionsBuilder).build(), null));
                 break;
         }
         return future.map(response -> handleRebalanceResponse(reconciliation, kafkaRebalance, dryrun, response));
@@ -1250,24 +1249,6 @@ public class KafkaRebalanceAssemblyOperator
         } else {
             throw new CruiseControlRestException("Rebalance returned unknown response: " + response);
         }
-    }
-
-    private static <T> Future<T> fromCompletableFuture(CompletableFuture<T> completableFuture) {
-        Promise<T> promise = Promise.promise();
-
-        completableFuture.whenComplete((result, exception) -> {
-            if (exception != null) {
-                // Unwrap CompletionException to get the root cause
-                if (exception instanceof CompletionException && exception.getCause() != null) {
-                    promise.fail(exception.getCause());
-                } else {
-                    promise.fail(exception);
-                }
-            } else {
-                promise.complete(result);
-            }
-        });
-        return promise.future();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApi.java
@@ -5,7 +5,8 @@
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.core.Future;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Cruise Control REST API interface definition
@@ -30,21 +31,21 @@ public interface CruiseControlApi {
      * @param verbose Whether the response from state endpoint should include more details.
      * @return A future for the response from the Cruise Control server with details of the Cruise Control server state.
      */
-    Future<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose);
+    CompletableFuture<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose);
 
     /**
-     *  Send a request to the Cruise Control server to perform a cluster rebalance.
+     * Send a request to the Cruise Control server to perform a cluster rebalance.
      *
      * @param reconciliation The reconciliation marker
-     * @param host The address of the Cruise Control server.
-     * @param port The port the Cruise Control Server is listening on.
-     * @param options The rebalance parameters to be passed to the Cruise Control server.
-     * @param userTaskId This is the unique ID of a previous rebalance request. If a previous request had not been
-     *                   completed when the response was returned then this ID can be used to retrieve the results of that
-     *                   request.
+     * @param host           The address of the Cruise Control server.
+     * @param port           The port the Cruise Control Server is listening on.
+     * @param options        The rebalance parameters to be passed to the Cruise Control server.
+     * @param userTaskId     This is the unique ID of a previous rebalance request. If a previous request had not been
+     *                       completed when the response was returned then this ID can be used to retrieve the results of that
+     *                       request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId);
+    CompletableFuture<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when adding new brokers.
@@ -60,7 +61,7 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> addBroker(Reconciliation reconciliation, String host, int port, AddBrokerOptions options, String userTaskId);
+    CompletableFuture<CruiseControlRebalanceResponse> addBroker(Reconciliation reconciliation, String host, int port, AddBrokerOptions options, String userTaskId);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when removing existing brokers.
@@ -75,7 +76,7 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> removeBroker(Reconciliation reconciliation, String host, int port, RemoveBrokerOptions options, String userTaskId);
+    CompletableFuture<CruiseControlRebalanceResponse> removeBroker(Reconciliation reconciliation, String host, int port, RemoveBrokerOptions options, String userTaskId);
 
     /**
      * Send a request to the Cruise Control server to perform a cluster rebalance when moving replicas off a broker's volumes.
@@ -90,7 +91,7 @@ public interface CruiseControlApi {
      *                   request.
      * @return A future for the rebalance response from the Cruise Control server containing details of the optimization.
      */
-    Future<CruiseControlRebalanceResponse> removeDisks(Reconciliation reconciliation, String host, int port, RemoveDisksOptions options, String userTaskId);
+    CompletableFuture<CruiseControlRebalanceResponse> removeDisks(Reconciliation reconciliation, String host, int port, RemoveDisksOptions options, String userTaskId);
 
     /**
      *  Get the state of a specific task (e.g. a rebalance) from the Cruise Control server.
@@ -102,7 +103,7 @@ public interface CruiseControlApi {
      *                   This is used to retrieve the task's current state.
      * @return A future for the state of the specified task.
      */
-    Future<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskID);
+    CompletableFuture<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskID);
 
     /**
      *  Issue a stop command to the Cruise Control server. This will halt any task (e.g. a rebalance) which is currently
@@ -113,6 +114,6 @@ public interface CruiseControlApi {
      * @param port The port the Cruise Control Server is listening on.
      * @return A future for the response from the Cruise Control server indicating if the stop command was issued.
      */
-    Future<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port);
+    CompletableFuture<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port);
 }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -6,32 +6,36 @@ package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
 import io.fabric8.kubernetes.api.model.HTTPHeader;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.strimzi.operator.cluster.operator.resource.HttpClientUtils;
 import io.strimzi.operator.common.CruiseControlUtil;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.TimeoutException;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.auth.PemTrustSet;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
+import io.strimzi.operator.common.model.cruisecontrol.CruiseControlHeaders;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlRebalanceKeys;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlUserTaskStatus;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.PemTrustOptions;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
-import java.util.concurrent.TimeoutException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 import static io.strimzi.operator.common.model.cruisecontrol.CruiseControlHeaders.USER_TASK_ID_HEADER;
 
@@ -44,51 +48,81 @@ public class CruiseControlApiImpl implements CruiseControlApi {
      * Default timeout for the HTTP client (-1 means use the clients default)
      */
     public static final int HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS = -1;
-    private static final boolean HTTP_CLIENT_ACTIVITY_LOGGING = false;
     private static final String STATUS_KEY = "Status";
-
-    private final Vertx vertx;
     private final long idleTimeout;
     private final boolean apiSslEnabled;
     private final HTTPHeader authHttpHeader;
     private final PemTrustOptions pto;
-
+    private final PemTrustSet pemTrustSet;
+    private final HttpClient httpClient;
     /**
      * Constructor
      *
-     * @param vertx             Vert.x instance
      * @param idleTimeout       Idle timeout
      * @param ccSecret          Cruise Control Secret
      * @param ccApiSecret       Cruise Control API Secret
      * @param apiAuthEnabled    Flag indicating if authentication is enabled
      * @param apiSslEnabled     Flag indicating if TLS is enabled
      */
-    public CruiseControlApiImpl(Vertx vertx, int idleTimeout, Secret ccSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
-        this.vertx = vertx;
+    public CruiseControlApiImpl(int idleTimeout, Secret ccSecret, Secret ccApiSecret, Boolean apiAuthEnabled, boolean apiSslEnabled) {
         this.idleTimeout = idleTimeout;
         this.apiSslEnabled = apiSslEnabled;
         this.authHttpHeader = getAuthHttpHeader(apiAuthEnabled, ccApiSecret);
         this.pto = new PemTrustOptions().addCertValue(Buffer.buffer(Util.decodeBase64FieldFromSecret(ccSecret, "cruise-control.crt")));
+        this.pemTrustSet = new PemTrustSet(ccSecret);
+        this.httpClient = buildHttpClient();
     }
 
     @Override
-    public Future<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose) {
-        return getCruiseControlState(reconciliation, host, port, verbose, null);
-    }
+    public CompletableFuture<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose) {
+        String path = new PathBuilder(CruiseControlEndpoints.STATE)
+                .withParameter(CruiseControlParameters.VERBOSE, String.valueOf(verbose))
+                .withParameter(CruiseControlParameters.JSON, "true")
+                .build();
 
-    private HttpClientOptions getHttpClientOptions() {
-        if (apiSslEnabled) {
-            return new HttpClientOptions()
-                .setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING)
-                .setSsl(true)
-                .setVerifyHost(true)
-                .setTrustOptions(
-                    new PemTrustOptions(pto)
-                );
-        } else {
-            return new HttpClientOptions()
-                    .setLogActivity(HTTP_CLIENT_ACTIVITY_LOGGING);
+        HttpRequest.Builder builder;
+        builder = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
+                .GET();
+
+
+        if (authHttpHeader != null) {
+            builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
         }
+
+        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+            builder.timeout(Duration.ofSeconds(idleTimeout));
+        }
+
+        HttpRequest request = builder.build();
+        LOGGER.traceOp("Request: {}", request);
+
+        LOGGER.debugCr(reconciliation, "Sending GET request to {}", path);
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    // send request and handle response
+                    LOGGER.traceCr(reconciliation, "Response: {}, body: {}", response, response.body());
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json.getString(CC_REST_API_ERROR_KEY)));
+                        } else {
+                            return CompletableFuture.completedFuture(new CruiseControlResponse(userTaskID, json));
+                        }
+                    } else {
+                        return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
+                    }
+
+                })
+                .exceptionally(ex -> {
+                    throw httpExceptionHandler(ex, request.method(), idleTimeout);
+                });
     }
 
     private static HTTPHeader generateAuthHttpHeader(String user, String password) {
@@ -106,152 +140,119 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private Future<CruiseControlResponse> getCruiseControlState(Reconciliation reconciliation, String host, int port, boolean verbose, String userTaskId) {
+    private HttpClient buildHttpClient() {
+        try {
+            HttpClient.Builder builder = HttpClient.newBuilder();
+            if (apiSslEnabled) {
+                String trustManagerFactoryAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
+                trustManagerFactory.init(pemTrustSet.jksTrustStore());
 
-        String path = new PathBuilder(CruiseControlEndpoints.STATE)
-                .withParameter(CruiseControlParameters.JSON, "true")
-                .withParameter(CruiseControlParameters.VERBOSE, String.valueOf(verbose))
-                .build();
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
 
-        HttpClientOptions options = getHttpClientOptions();
-
-        return HttpClientUtils.withHttpClient(vertx, options, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending GET request to {}", path);
-            httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                if (request.succeeded()) {
-
-                    if (authHttpHeader != null) {
-                        request.result().putHeader(authHttpHeader.getName(), authHttpHeader.getValue());
-                    }
-
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
-                                String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                                response.result().bodyHandler(buffer -> {
-                                    JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
-                                    if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                        result.fail(new CruiseControlRestException(
-                                                "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                        json.getString(CC_REST_API_ERROR_KEY)));
-                                    } else {
-                                        CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
-                                        result.complete(ccResponse);
-                                    }
-                                });
-
-                            } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Unexpected status code " + response.result().statusCode() + " for request to " + host + ":" + port + path));
-                            }
-                        } else {
-                            httpExceptionHandler(result, response.cause());
-                        }
-                    });
-                } else {
-                    result.fail(request.cause());
-                }
-
-                if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-                    request.result().setTimeout(idleTimeout * 1000);
-                }
-
-                if (userTaskId != null) {
-                    request.result().putHeader(USER_TASK_ID_HEADER, userTaskId);
-                }
-            });
-        });
-    }
-
-    private void internalRebalance(Reconciliation reconciliation, String host, int port, String path, String userTaskId,
-                                   AsyncResult<HttpClientRequest> request, Promise<CruiseControlRebalanceResponse> result) {
-        if (request.succeeded()) {
-            if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-                request.result().idleTimeout(idleTimeout * 1000);
+                builder.sslContext(sslContext);
             }
-
-            if (userTaskId != null) {
-                request.result().putHeader(USER_TASK_ID_HEADER, userTaskId);
-            }
-
-            if (authHttpHeader != null) {
-                request.result().putHeader(authHttpHeader.getName(), authHttpHeader.getValue());
-            }
-
-            request.result().send(response -> {
-                if (response.succeeded()) {
-                    if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
-                        response.result().bodyHandler(buffer -> {
-                            String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, summary = {}", response.result().statusCode(), path, userTaskID, json.getString("summary"));
-                            CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                            result.complete(ccResponse);
-                        });
-                    } else if (response.result().statusCode() == 202) {
-                        response.result().bodyHandler(buffer -> {
-                            String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}, in progress = {}", response.result().statusCode(), path, userTaskID, json.containsKey(CC_REST_API_PROGRESS_KEY));
-                            CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                            if (json.containsKey(CC_REST_API_PROGRESS_KEY)) {
-                                // If the response contains a "progress" key then the rebalance proposal has not yet completed processing
-                                ccResponse.setProposalStillCalculating(true);
-                            } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Error for request: " + host + ":" + port + path +
-                                                ". 202 Status code did not contain progress key. Server returned: " +
-                                                ccResponse.getJson().toString()));
-                            }
-                            result.complete(ccResponse);
-                        });
-                    } else if (response.result().statusCode() == 500) {
-                        response.result().bodyHandler(buffer -> {
-                            String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                            JsonObject json = buffer.toJsonObject();
-                            LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
-                            if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                // If there was a client side error, check whether it was due to not enough data being available ...
-                                if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
-                                    CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
-                                    ccResponse.setNotEnoughDataForProposal(true);
-                                    result.complete(ccResponse);
-                                // ... or one or more brokers doesn't exist on a add/remove brokers rebalance request
-                                } else if (json.getString(CC_REST_API_ERROR_KEY).contains("IllegalArgumentException") &&
-                                            json.getString(CC_REST_API_ERROR_KEY).contains("does not exist.")) {
-                                    result.fail(new IllegalArgumentException("Some/all brokers specified don't exist"));
-                                } else {
-                                    // If there was any other kind of error propagate this to the operator
-                                    result.fail(new CruiseControlRestException(
-                                            "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                    json.getString(CC_REST_API_ERROR_KEY)));
-                                }
-                            } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                json));
-                            }
-                        });
-                    } else {
-                        result.fail(new CruiseControlRestException(
-                                "Unexpected status code " + response.result().statusCode() + " for request to " + host + ":" + port + path));
-                    }
-                } else {
-                    result.fail(response.cause());
-                }
-            });
-        } else {
-            httpExceptionHandler(result, request.cause());
+            return builder.build();
+        } catch (Throwable t) {
+            throw new RuntimeException(String.format("HTTP client build failed: %s", t.getMessage()));
         }
     }
 
+    private CompletableFuture<CruiseControlRebalanceResponse> internalRebalance(Reconciliation reconciliation, String host, int port, String path, String userTaskId) {
+        HttpRequest.Builder builder;
+        builder = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
+                .POST(HttpRequest.BodyPublishers.noBody());
+
+
+        if (authHttpHeader != null) {
+            builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
+        }
+
+        if (userTaskId != null) {
+            builder.header(USER_TASK_ID_HEADER, userTaskId);
+        }
+
+        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+            builder.timeout(Duration.ofSeconds(idleTimeout));
+        }
+
+        HttpRequest request = builder.build();
+        LOGGER.traceOp("Request: {}", request);
+
+        LOGGER.debugCr(reconciliation, "Sending POST request to {} with userTaskID {}", path, userTaskId);
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    // send request and handle response
+                    LOGGER.traceCr(reconciliation, "Response: {}, body: {}", response, response.body());
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json.getString(CC_REST_API_ERROR_KEY)));
+                        } else {
+                            return CompletableFuture.completedFuture(new CruiseControlRebalanceResponse(userTaskID, json));
+                        }
+                    } else if (statusCode == 202) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                        if (json.containsKey(CC_REST_API_PROGRESS_KEY)) {
+                            // If the response contains a "progress" key then the rebalance proposal has not yet completed processing
+                            ccResponse.setProposalStillCalculating(true);
+                        } else {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path +
+                                            ". 202 Status code did not contain progress key. Server returned: " +
+                                            ccResponse.getJson().toString()));
+                        }
+                        return CompletableFuture.completedFuture(ccResponse);
+                    } else if (statusCode == 500) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            // If there was a client side error, check whether it was due to not enough data being available ...
+                            if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
+                                CruiseControlRebalanceResponse ccResponse = new CruiseControlRebalanceResponse(userTaskID, json);
+                                ccResponse.setNotEnoughDataForProposal(true);
+                                return CompletableFuture.completedFuture(ccResponse);
+                                // ... or one or more brokers doesn't exist on a add/remove brokers rebalance request
+                            } else if (json.getString(CC_REST_API_ERROR_KEY).contains("IllegalArgumentException") &&
+                                    json.getString(CC_REST_API_ERROR_KEY).contains("does not exist.")) {
+                                return CompletableFuture.failedFuture(new IllegalArgumentException("Some/all brokers specified don't exist"));
+                            } else {
+                                // If there was any other kind of error propagate this to the operator
+                                return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                        "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                                json.getString(CC_REST_API_ERROR_KEY)));
+                            }
+                        } else {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json));
+                        }
+                    } else {
+                        return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
+                    }
+                })
+                .exceptionally(ex -> {
+                    throw httpExceptionHandler(ex, request.method(), idleTimeout);
+                });
+    }
+
     @Override
-    public Future<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId) {
+    public CompletableFuture<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId) {
 
         if (options == null && userTaskId == null) {
-            return Future.failedFuture(
+            return CompletableFuture.failedFuture(
                     new IllegalArgumentException("Either rebalance options or user task ID should be supplied, both were null"));
         }
 
@@ -260,18 +261,13 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .withRebalanceParameters(options)
                 .build();
 
-        HttpClientOptions httpOptions = getHttpClientOptions();
-
-        return HttpClientUtils.withHttpClient(vertx, httpOptions, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending POST request to {} with userTaskID {}", path, userTaskId);
-            httpClient.request(HttpMethod.POST, port, host, path, request -> internalRebalance(reconciliation, host, port, path, userTaskId, request, result));
-        });
+        return internalRebalance(reconciliation, host, port, path, userTaskId);
     }
 
     @Override
-    public Future<CruiseControlRebalanceResponse> addBroker(Reconciliation reconciliation, String host, int port, AddBrokerOptions options, String userTaskId) {
+    public CompletableFuture<CruiseControlRebalanceResponse> addBroker(Reconciliation reconciliation, String host, int port, AddBrokerOptions options, String userTaskId) {
         if (options == null && userTaskId == null) {
-            return Future.failedFuture(
+            return CompletableFuture.failedFuture(
                     new IllegalArgumentException("Either add broker options or user task ID should be supplied, both were null"));
         }
 
@@ -280,18 +276,13 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .withAddBrokerParameters(options)
                 .build();
 
-        HttpClientOptions httpOptions = getHttpClientOptions();
-
-        return HttpClientUtils.withHttpClient(vertx, httpOptions, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending POST request to {} with userTaskID {}", path, userTaskId);
-            httpClient.request(HttpMethod.POST, port, host, path, request -> internalRebalance(reconciliation, host, port, path, userTaskId, request, result));
-        });
+        return internalRebalance(reconciliation, host, port, path, userTaskId);
     }
 
     @Override
-    public Future<CruiseControlRebalanceResponse> removeBroker(Reconciliation reconciliation, String host, int port, RemoveBrokerOptions options, String userTaskId) {
+    public CompletableFuture<CruiseControlRebalanceResponse> removeBroker(Reconciliation reconciliation, String host, int port, RemoveBrokerOptions options, String userTaskId) {
         if (options == null && userTaskId == null) {
-            return Future.failedFuture(
+            return CompletableFuture.failedFuture(
                     new IllegalArgumentException("Either remove broker options or user task ID should be supplied, both were null"));
         }
 
@@ -300,18 +291,13 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .withRemoveBrokerParameters(options)
                 .build();
 
-        HttpClientOptions httpOptions = getHttpClientOptions();
-
-        return HttpClientUtils.withHttpClient(vertx, httpOptions, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending POST request to {} with userTaskID {}", path, userTaskId);
-            httpClient.request(HttpMethod.POST, port, host, path, request -> internalRebalance(reconciliation, host, port, path, userTaskId, request, result));
-        });
+        return internalRebalance(reconciliation, host, port, path, userTaskId);
     }
 
     @Override
-    public Future<CruiseControlRebalanceResponse> removeDisks(Reconciliation reconciliation, String host, int port, RemoveDisksOptions options, String userTaskId) {
+    public CompletableFuture<CruiseControlRebalanceResponse> removeDisks(Reconciliation reconciliation, String host, int port, RemoveDisksOptions options, String userTaskId) {
         if (options == null && userTaskId == null) {
-            return Future.failedFuture(
+            return CompletableFuture.failedFuture(
                     new IllegalArgumentException("Either remove disks options or user task ID should be supplied, both were null"));
         }
 
@@ -320,17 +306,12 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .withRemoveBrokerDisksParameters(options)
                 .build();
 
-        HttpClientOptions httpOptions = getHttpClientOptions();
-
-        return HttpClientUtils.withHttpClient(vertx, httpOptions, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending POST request to {} with userTaskID {}", path, userTaskId);
-            httpClient.request(HttpMethod.POST, port, host, path, request -> internalRebalance(reconciliation, host, port, path, userTaskId, request, result));
-        });
+        return internalRebalance(reconciliation, host, port, path, userTaskId);
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public Future<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskId) {
+    public CompletableFuture<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskId) {
 
         PathBuilder pathBuilder = new PathBuilder(CruiseControlEndpoints.USER_TASKS)
                         .withParameter(CruiseControlParameters.JSON, "true")
@@ -342,181 +323,174 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
         String path = pathBuilder.build();
 
-        HttpClientOptions options = getHttpClientOptions();
+        HttpRequest.Builder builder;
+        builder = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
+                .GET();
 
-        return HttpClientUtils.withHttpClient(vertx, options, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending GET request to {} with userTaskID {}", path, userTaskId);
-            httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                if (request.succeeded()) {
+        if (authHttpHeader != null) {
+            builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
+        }
 
-                    if (authHttpHeader != null) {
-                        request.result().putHeader(authHttpHeader.getName(), authHttpHeader.getValue());
-                    }
+        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+            builder.timeout(Duration.ofSeconds(idleTimeout));
+        }
 
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
-                                String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                                response.result().bodyHandler(buffer -> {
-                                    JsonObject json = buffer.toJsonObject();
-                                    JsonArray userTasks = json.getJsonArray("userTasks");
-                                    JsonObject statusJson = new JsonObject();
-                                    if (userTasks.isEmpty()) {
-                                        // This may happen if:
-                                        // 1. Cruise Control restarted so resetting the state because the tasks queue is not persisted
-                                        // 2. Task's retention time expired, or the cache has become full
-                                        result.complete(new CruiseControlUserTasksResponse(userTaskID, statusJson));
-                                    } else {
-                                        JsonObject jsonUserTask = userTasks.getJsonObject(0);
-                                        String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
-                                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, status = {}", response.result().statusCode(), path, userTaskID, taskStatusStr);
-                                        // This should not be an error with a 200 status but we play it safe
-                                        if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
-                                            result.fail(new CruiseControlRestException(
-                                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
-                                                            json.getString(CC_REST_API_ERROR_KEY)));
-                                        }
-                                        statusJson.put(STATUS_KEY, taskStatusStr);
-                                        CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
-                                        switch (taskStatus) {
-                                            case ACTIVE:
-                                                // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
-                                                break;
-                                            case IN_EXECUTION:
-                                                // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
-                                                // We handle these in the same way as COMPLETED tasks so we drop down to that case.
-                                            case COMPLETED:
-                                                // Completed tasks will have the original rebalance proposal summary in their original response
-                                                JsonObject originalResponse = (JsonObject) Json.decodeValue(jsonUserTask.getString(
-                                                        CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
-                                                statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(),
-                                                        originalResponse.getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()));
-                                                // Extract the load before/after information for the brokers
-                                                JsonObject jsonObject = originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey());
-                                                if (jsonObject != null) {
-                                                    statusJson.put(
-                                                            CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey(),
-                                                            originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey()));
-                                                }
-                                                statusJson.put(
-                                                        CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey(),
-                                                        originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey()));
-                                                break;
-                                            case COMPLETED_WITH_ERROR:
-                                                // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
-                                                statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(), jsonUserTask.getString(CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
-                                                break;
-                                            default:
-                                                throw new IllegalStateException("Unexpected user task status: " + taskStatus);
-                                        }
-                                        result.complete(new CruiseControlUserTasksResponse(userTaskID, statusJson));
-                                    }
-                                });
-                            } else if (response.result().statusCode() == 500) {
-                                response.result().bodyHandler(buffer -> {
-                                    String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                                    JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
-                                    String errorString;
-                                    if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                        errorString = json.getString(CC_REST_API_ERROR_KEY);
-                                    } else {
-                                        errorString = json.toString();
-                                    }
-                                    if (errorString.matches(".*" + "There are already \\d+ active user tasks, which has reached the servlet capacity." + ".*")) {
-                                        LOGGER.debugCr(reconciliation, errorString);
-                                        CruiseControlUserTasksResponse ccResponse = new CruiseControlUserTasksResponse(userTaskID, json);
-                                        ccResponse.setMaxActiveUserTasksReached(true);
-                                        result.complete(ccResponse);
-                                    } else {
-                                        result.fail(new CruiseControlRestException(
-                                                "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
-                                    }
-                                });
-                            } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Unexpected status code " + response.result().statusCode() + " for GET request to " +
-                                                host + ":" + port + path));
-                            }
+        HttpRequest request = builder.build();
+        LOGGER.traceOp("Request: {}", request);
+
+        LOGGER.debugCr(reconciliation, "Sending GET request to {}", path);
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    // send request and handle response
+                    LOGGER.traceCr(reconciliation, "Response: {}, body: {}", response, response.body());
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        JsonArray userTasks = json.getJsonArray("userTasks");
+                        JsonObject statusJson = new JsonObject();
+                        if (userTasks.isEmpty()) {
+                            // This may happen if:
+                            // 1. Cruise Control restarted so resetting the state because the tasks queue is not persisted
+                            // 2. Task's retention time expired, or the cache has become full
+                            return CompletableFuture.completedFuture(new CruiseControlUserTasksResponse(userTaskID, statusJson));
                         } else {
-                            result.fail(response.cause());
+                            JsonObject jsonUserTask = userTasks.getJsonObject(0);
+                            String taskStatusStr = jsonUserTask.getString(STATUS_KEY);
+                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}, status = {}", response.statusCode(), path, userTaskID, taskStatusStr);
+                            // This should not be an error with a 200 status but we play it safe
+                            if (jsonUserTask.containsKey(CC_REST_API_ERROR_KEY)) {
+                                return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                        "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                                json.getString(CC_REST_API_ERROR_KEY)));
+                            }
+                            statusJson.put(STATUS_KEY, taskStatusStr);
+                            CruiseControlUserTaskStatus taskStatus = CruiseControlUserTaskStatus.lookup(taskStatusStr);
+                            switch (taskStatus) {
+                                case ACTIVE:
+                                    // If the status is ACTIVE there will not be a "summary" so we skip pulling the summary key
+                                    break;
+                                case IN_EXECUTION:
+                                    // Tasks in execution will be rebalance tasks, so their original response will contain the summary of the rebalance they are executing
+                                    // We handle these in the same way as COMPLETED tasks so we drop down to that case.
+                                case COMPLETED:
+                                    // Completed tasks will have the original rebalance proposal summary in their original response
+                                    JsonObject originalResponse = (JsonObject) Json.decodeValue(jsonUserTask.getString(
+                                            CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
+                                    statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(),
+                                            originalResponse.getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()));
+                                    // Extract the load before/after information for the brokers
+                                    JsonObject loadBeforeOptJsonObject = originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey());
+                                    if (loadBeforeOptJsonObject != null) {
+                                        statusJson.put(
+                                                CruiseControlRebalanceKeys.LOAD_BEFORE_OPTIMIZATION.getKey(),
+                                                loadBeforeOptJsonObject);
+                                    }
+                                    statusJson.put(
+                                            CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey(),
+                                            originalResponse.getJsonObject(CruiseControlRebalanceKeys.LOAD_AFTER_OPTIMIZATION.getKey()));
+                                    break;
+                                case COMPLETED_WITH_ERROR:
+                                    // Completed with error tasks will have "CompletedWithError" as their original response, which is not Json.
+                                    statusJson.put(CruiseControlRebalanceKeys.SUMMARY.getKey(), jsonUserTask.getString(CruiseControlRebalanceKeys.ORIGINAL_RESPONSE.getKey()));
+                                    break;
+                                default:
+                                    throw new IllegalStateException("Unexpected user task status: " + taskStatus);
+                            }
+                            return CompletableFuture.completedFuture(new CruiseControlUserTasksResponse(userTaskID, statusJson));
                         }
-                    });
-
-                    if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-                        request.result().setTimeout(idleTimeout * 1000);
+                    } else if (statusCode == 500) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        String errorString;
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            errorString = json.getString(CC_REST_API_ERROR_KEY);
+                        } else {
+                            errorString = json.toString();
+                        }
+                        
+                        if (errorString.matches(".*" + "There are already \\d+ active user tasks, which has reached the servlet capacity." + ".*")) {
+                            LOGGER.debugCr(reconciliation, errorString);
+                            CruiseControlUserTasksResponse ccResponse = new CruiseControlUserTasksResponse(userTaskID, json);
+                            ccResponse.setMaxActiveUserTasksReached(true);
+                            return CompletableFuture.completedFuture(ccResponse);
+                        } else {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " + errorString));
+                        }
+                    } else {
+                        return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                "Unexpected status code " + response.statusCode() + " for GET request to " +
+                                        host + ":" + port + path));
                     }
+                })
+                .exceptionally(ex -> {
+                    throw httpExceptionHandler(ex, request.method(), idleTimeout);
+                });
 
-                } else {
-                    httpExceptionHandler(result, request.cause());
-                }
-            });
-        });
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public Future<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port) {
+    public CompletableFuture<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port) {
 
         String path = new PathBuilder(CruiseControlEndpoints.STOP)
                         .withParameter(CruiseControlParameters.JSON, "true").build();
+        HttpRequest.Builder builder;
+        builder = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
+                .POST(HttpRequest.BodyPublishers.noBody());
 
-        HttpClientOptions options = getHttpClientOptions();
 
-        return HttpClientUtils.withHttpClient(vertx, options, (httpClient, result) -> {
-            LOGGER.debugCr(reconciliation, "Sending POST request to {}", path);
-            httpClient.request(HttpMethod.POST, port, host, path, request -> {
-                if (request.succeeded()) {
+        if (authHttpHeader != null) {
+            builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
+        }
 
-                    if (authHttpHeader != null) {
-                        request.result().putHeader(authHttpHeader.getName(), authHttpHeader.getValue());
+        if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
+            builder.timeout(Duration.ofSeconds(idleTimeout));
+        }
+
+        HttpRequest request = builder.build();
+        LOGGER.traceOp("Request: {}", request);
+
+        LOGGER.debugCr(reconciliation, "Sending POST request to {}", path);
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    // send request and handle response
+                    LOGGER.traceCr(reconciliation, "Response: {}, body: {}", response, response.body());
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        String userTaskID = response.headers().firstValue(CruiseControlHeaders.USER_TASK_ID_HEADER).orElse("");
+                        JsonObject json = new JsonObject(response.body());
+                        LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.statusCode(), path, userTaskID);
+                        if (json.containsKey(CC_REST_API_ERROR_KEY)) {
+                            return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                    "Error for request: " + host + ":" + port + path + ". Server returned: " +
+                                            json.getString(CC_REST_API_ERROR_KEY)));
+                        } else {
+                            return CompletableFuture.completedFuture(new CruiseControlResponse(userTaskID, json));
+                        }
+                    } else {
+                        return CompletableFuture.failedFuture(new CruiseControlRestException(
+                                "Unexpected status code " + response.statusCode() + " for request to " + host + ":" + port + path));
                     }
 
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
-                                String userTaskID = response.result().getHeader(USER_TASK_ID_HEADER);
-                                response.result().bodyHandler(buffer -> {
-                                    JsonObject json = buffer.toJsonObject();
-                                    LOGGER.debugCr(reconciliation, "Got {} response to POST request to {} : userTaskID = {}", response.result().statusCode(), path, userTaskID);
-                                    if (json.containsKey(CC_REST_API_ERROR_KEY)) {
-                                        result.fail(json.getString(CC_REST_API_ERROR_KEY));
-                                    } else {
-                                        CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
-                                        result.complete(ccResponse);
-                                    }
-                                });
-                            } else {
-                                result.fail(new CruiseControlRestException(
-                                        "Unexpected status code " + response.result().statusCode() + " for GET request to " +
-                                                host + ":" + port + path));
-                            }
-                        } else {
-                            result.fail(response.cause());
-                        }
-                    });
-                } else {
-                    httpExceptionHandler(result, request.cause());
-                }
-                if (idleTimeout != HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS) {
-                    request.result().setTimeout(idleTimeout * 1000);
-                }
-            });
-        });
+                })
+                .exceptionally(ex -> {
+                    throw httpExceptionHandler(ex, request.method(), idleTimeout);
+                });
+
     }
 
-    private void httpExceptionHandler(Promise<? extends CruiseControlResponse> result, Throwable t) {
-        if (t instanceof TimeoutException) {
-            // Vert.x throws a NoStackTraceTimeoutException (inherits from TimeoutException) when the request times out
-            // so we catch and raise a TimeoutException instead
-            result.fail(new TimeoutException(t.getMessage()));
-        } else if (t instanceof NoRouteToHostException || t instanceof ConnectException) {
-            // Netty throws a AnnotatedNoRouteToHostException (inherits from NoRouteToHostException) when it cannot resolve the host
-            // Vert.x throws a AnnotatedConnectException (inherits from ConnectException) when the request times out
-            // so we catch and raise a CruiseControlRetriableConnectionException instead
-            result.fail(new CruiseControlRetriableConnectionException(t));
+    private RuntimeException httpExceptionHandler(Throwable ex, String requestMethod, long timeout) {
+        if (ex.getCause() instanceof HttpTimeoutException) {
+            return new TimeoutException("The timeout period of " + timeout * 1000 + "ms has been exceeded while executing " + requestMethod);
+        } else if (ex.getCause() instanceof NoRouteToHostException || ex.getCause() instanceof ConnectException) {
+            return new CruiseControlRetriableConnectionException(ex.getCause());
         } else {
-            result.fail(t);
+            return (RuntimeException) ex.getCause();
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -18,11 +18,9 @@ import io.strimzi.operator.common.model.cruisecontrol.CruiseControlHeaders;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlParameters;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlRebalanceKeys;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlUserTaskStatus;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.PemTrustOptions;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -52,7 +50,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     private final long idleTimeout;
     private final boolean apiSslEnabled;
     private final HTTPHeader authHttpHeader;
-    private final PemTrustOptions pto;
     private final PemTrustSet pemTrustSet;
     private final HttpClient httpClient;
     /**
@@ -68,7 +65,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
         this.idleTimeout = idleTimeout;
         this.apiSslEnabled = apiSslEnabled;
         this.authHttpHeader = getAuthHttpHeader(apiAuthEnabled, ccApiSecret);
-        this.pto = new PemTrustOptions().addCertValue(Buffer.buffer(Util.decodeBase64FieldFromSecret(ccSecret, "cruise-control.crt")));
         this.pemTrustSet = new PemTrustSet(ccSecret);
         this.httpClient = buildHttpClient();
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlApiImpl.java
@@ -76,11 +76,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .withParameter(CruiseControlParameters.JSON, "true")
                 .build();
 
-        HttpRequest.Builder builder;
-        builder = HttpRequest.newBuilder()
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
                 .GET();
-
 
         if (authHttpHeader != null) {
             builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
@@ -156,11 +154,9 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     }
 
     private CompletableFuture<CruiseControlRebalanceResponse> internalRebalance(Reconciliation reconciliation, String host, int port, String path, String userTaskId) {
-        HttpRequest.Builder builder;
-        builder = HttpRequest.newBuilder()
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
                 .POST(HttpRequest.BodyPublishers.noBody());
-
 
         if (authHttpHeader != null) {
             builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
@@ -246,7 +242,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
     @Override
     public CompletableFuture<CruiseControlRebalanceResponse> rebalance(Reconciliation reconciliation, String host, int port, RebalanceOptions options, String userTaskId) {
-
         if (options == null && userTaskId == null) {
             return CompletableFuture.failedFuture(
                     new IllegalArgumentException("Either rebalance options or user task ID should be supplied, both were null"));
@@ -308,7 +303,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
     @Override
     @SuppressWarnings("deprecation")
     public CompletableFuture<CruiseControlUserTasksResponse> getUserTaskStatus(Reconciliation reconciliation, String host, int port, String userTaskId) {
-
         PathBuilder pathBuilder = new PathBuilder(CruiseControlEndpoints.USER_TASKS)
                         .withParameter(CruiseControlParameters.JSON, "true")
                         .withParameter(CruiseControlParameters.FETCH_COMPLETE, "true");
@@ -319,8 +313,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
 
         String path = pathBuilder.build();
 
-        HttpRequest.Builder builder;
-        builder = HttpRequest.newBuilder()
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
                 .GET();
 
@@ -425,20 +418,17 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .exceptionally(ex -> {
                     throw httpExceptionHandler(ex, request.method(), idleTimeout);
                 });
-
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public CompletableFuture<CruiseControlResponse> stopExecution(Reconciliation reconciliation, String host, int port) {
-
         String path = new PathBuilder(CruiseControlEndpoints.STOP)
                         .withParameter(CruiseControlParameters.JSON, "true").build();
-        HttpRequest.Builder builder;
-        builder = HttpRequest.newBuilder()
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(String.format("%s://%s:%d%s", apiSslEnabled ? "https" : "http", host, port, path)))
                 .POST(HttpRequest.BodyPublishers.noBody());
-
 
         if (authHttpHeader != null) {
             builder.header(authHttpHeader.getName(), authHttpHeader.getValue());
@@ -477,7 +467,6 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .exceptionally(ex -> {
                     throw httpExceptionHandler(ex, request.method(), idleTimeout);
                 });
-
     }
 
     private RuntimeException httpExceptionHandler(Throwable ex, String requestMethod, long timeout) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -38,6 +38,7 @@ import io.strimzi.operator.cluster.operator.resource.cruisecontrol.CruiseControl
 import io.strimzi.operator.cluster.operator.resource.cruisecontrol.MockCruiseControl;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.TimeoutException;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlEndpoints;
@@ -48,7 +49,6 @@ import io.strimzi.test.TestUtils;
 import io.strimzi.test.mockkube3.MockKube3;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
-import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -206,7 +206,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
             @Override
             public CruiseControlApi cruiseControlClientProvider(Secret ccSecret, Secret ccApiSecret, boolean apiAuthEnabled, boolean apiSslEnabled) {
-                return new CruiseControlApiImpl(vertx, 1, ccSecret, ccApiSecret, true, true);
+                return new CruiseControlApiImpl(1, ccSecret, ccApiSecret, true, true);
             }
         };
     }
@@ -1835,7 +1835,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
             .onComplete(context.succeeding(v -> {
                 // the resource moved from New to NotReady (mocked Cruise Control didn't reply on time)
                 assertState(context, client, namespace, RESOURCE_NAME,
-                        KafkaRebalanceState.NotReady, NoStackTraceTimeoutException.class,
+                        KafkaRebalanceState.NotReady, TimeoutException.class,
                         "The timeout period of 1000ms has been exceeded while executing POST");
                 checkpoint.flag();
             }));
@@ -1870,7 +1870,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 // the resource moved from 'New' to 'NotReady' (mocked Cruise Control not reachable)
                 assertState(context, client, namespace, RESOURCE_NAME,
                         KafkaRebalanceState.NotReady, CruiseControlRetriableConnectionException.class,
-                        "Connection refused");
+                        "java.net.ConnectException");
                 checkpoint.flag();
             }));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceStateMachineTest.java
@@ -185,7 +185,7 @@ public class KafkaRebalanceStateMachineTest {
                                                          KafkaRebalanceState nextState,
                                                          KafkaRebalance kcRebalance) {
 
-        CruiseControlApi client = new CruiseControlApiImpl(vertx, HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
+        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
         ConfigMapOperator mockCmOps = supplier.configMapOperations;
         KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx, supplier, ResourceUtils.dummyClusterOperatorConfig(), cruiseControlPort) {
@@ -1304,7 +1304,7 @@ public class KafkaRebalanceStateMachineTest {
         KafkaRebalance kcRebalance = createKafkaRebalance(KafkaRebalanceState.Rebalancing, MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID, null, REMOVE_BROKER_KAFKA_REBALANCE_SPEC, null, false);
         cruiseControlServer.setupCCUserTasksToReturnError(500, "Some error");
 
-        CruiseControlApi client = new CruiseControlApiImpl(vertx, HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
+        CruiseControlApi client = new CruiseControlApiImpl(HTTP_DEFAULT_IDLE_TIMEOUT_SECONDS, MockCruiseControl.CC_SECRET, MockCruiseControl.CC_API_SECRET, true, true);
         KafkaRebalanceAssemblyOperator kcrao = new KafkaRebalanceAssemblyOperator(vertx,  ResourceUtils.supplierWithMocks(true), ResourceUtils.dummyClusterOperatorConfig(), cruiseControlPort) {
             @Override
             public String cruiseControlHost(String clusterName, String clusterNamespace) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -565,6 +565,6 @@ public class CruiseControlClientTest {
                     response.getJson().getString("Status"),
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()));
             return CompletableFuture.completedFuture(response);
-        });
+        }).join();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/MockCruiseControl.java
@@ -128,7 +128,7 @@ public class MockCruiseControl {
      * Setup state responses in mock server.
      */
     public void setupCCStateResponse() {
-        // Non-verbose response
+        // Verbose/Non-verbose response
         JsonBody jsonProposalNotReady = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-State-proposal-not-ready.json"));
 
         server
@@ -145,7 +145,6 @@ public class MockCruiseControl {
                                 .withBody(jsonProposalNotReady)
                                 .withHeaders(header("User-Task-ID", STATE_PROPOSAL_NOT_READY_RESPONSE))
                                 .withDelay(TimeUnit.SECONDS, 0));
-
 
         // Non-verbose response
         JsonBody json = new JsonBody(ReadWriteUtils.readFileFromResources(getClass(), "/" + CC_JSON_ROOT + "CC-State.json"));


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Refactoring

### Description

Replace use of Vertx HTTP and Future from CruiseControl API implementation with Java CompletableFuture and HTTP API.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

