### PR TITLE
Add allocateLoadBalancerNodePorts configuration to listeners configuration

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -58,7 +58,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private String hostTemplate;
     private String advertisedHostTemplate;
     private Map<String, Object> additionalProperties;
-    private Boolean allocateLoadBalancerNodePorts = true;
+    private Boolean allocateLoadBalancerNodePorts;
 
     @Description("Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. " +
             "The certificate can optionally contain the whole chain. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -58,7 +58,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private String hostTemplate;
     private String advertisedHostTemplate;
     private Map<String, Object> additionalProperties;
-    private Boolean allocateLoadBalancerNodePorts;
+    private Boolean allocateLoadBalancerNodePorts = true;
 
     @Description("Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. " +
             "The certificate can optionally contain the whole chain. " +

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -31,7 +31,7 @@ import java.util.Map;
 @JsonPropertyOrder({"brokerCertChainAndKey", "class", "preferredAddressType", "externalTrafficPolicy",
     "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService",
     "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType",
-    "publishNotReadyAddresses", "hostTemplate", "advertisedHostTemplate"})
+    "publishNotReadyAddresses", "hostTemplate", "advertisedHostTemplate", "allocateLoadBalancerNodePorts"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,
@@ -58,6 +58,7 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     private String hostTemplate;
     private String advertisedHostTemplate;
     private Map<String, Object> additionalProperties;
+    private Boolean allocateLoadBalancerNodePorts;
 
     @Description("Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. " +
             "The certificate can optionally contain the whole chain. " +
@@ -280,6 +281,19 @@ public class GenericKafkaListenerConfiguration implements UnknownPropertyPreserv
     public void setAdvertisedHostTemplate(String advertisedHostTemplate) {
         this.advertisedHostTemplate = advertisedHostTemplate;
     }
+
+    @Description("Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.\n" +
+            "This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type\n" +
+            "For `loadbalancer` listeners only.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getAllocateLoadBalancerNodePorts() {
+        return allocateLoadBalancerNodePorts;
+    }
+
+    public void setAllocateLoadBalancerNodePorts(Boolean allocateLoadBalancerNodePorts) {
+        this.allocateLoadBalancerNodePorts = allocateLoadBalancerNodePorts;
+    }
+
 
     @Override
     public Map<String, Object> getAdditionalProperties() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -775,8 +775,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     service.getSpec().setLoadBalancerClass(loadBalancerClass);
                 }
 
-                boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
-                service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
+                service.getSpec().setAllocateLoadBalancerNodePorts(
+                        ListenersUtils.allocateLoadBalancerNodePorts(listener));
             }
 
             if (KafkaListenerType.NODEPORT == listener.getType()) {
@@ -863,6 +863,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                             if (loadBalancerClass != null) {
                                 service.getSpec().setLoadBalancerClass(loadBalancerClass);
                             }
+
+                            service.getSpec().setAllocateLoadBalancerNodePorts(
+                                    ListenersUtils.allocateLoadBalancerNodePorts(listener));
                         }
 
                         if (KafkaListenerType.NODEPORT == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -774,6 +774,13 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 if (loadBalancerClass != null) {
                     service.getSpec().setLoadBalancerClass(loadBalancerClass);
                 }
+
+                Boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
+                if (allocateLoadBalancerNodePorts != null) {
+                    LOGGER.infoCr(reconciliation, "VENKATESH updating allocateLoadBalancerNodePorts={}",
+                            allocateLoadBalancerNodePorts);
+                    service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
+                }
             }
 
             if (KafkaListenerType.NODEPORT == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -775,12 +775,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     service.getSpec().setLoadBalancerClass(loadBalancerClass);
                 }
 
-                Boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
-                if (allocateLoadBalancerNodePorts != null) {
-                    LOGGER.infoCr(reconciliation, "VENKATESH updating allocateLoadBalancerNodePorts={}",
-                            allocateLoadBalancerNodePorts);
-                    service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
-                }
+                boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
+                service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
             }
 
             if (KafkaListenerType.NODEPORT == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -775,8 +775,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     service.getSpec().setLoadBalancerClass(loadBalancerClass);
                 }
 
-                service.getSpec().setAllocateLoadBalancerNodePorts(
-                        ListenersUtils.allocateLoadBalancerNodePorts(listener));
+                Boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
+                if (allocateLoadBalancerNodePorts != null) {
+                    service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
+                }
             }
 
             if (KafkaListenerType.NODEPORT == listener.getType()) {
@@ -864,8 +866,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                                 service.getSpec().setLoadBalancerClass(loadBalancerClass);
                             }
 
-                            service.getSpec().setAllocateLoadBalancerNodePorts(
-                                    ListenersUtils.allocateLoadBalancerNodePorts(listener));
+                            Boolean allocateLoadBalancerNodePorts = ListenersUtils.allocateLoadBalancerNodePorts(listener);
+                            if (allocateLoadBalancerNodePorts != null) {
+                                service.getSpec().setAllocateLoadBalancerNodePorts(allocateLoadBalancerNodePorts);
+                            }
                         }
 
                         if (KafkaListenerType.NODEPORT == listener.getType()) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -787,11 +787,11 @@ public class ListenersUtils {
      * @param listener Listener for which to allocate NodePorts
      * @return         Whether to allocate NodePorts for Service
      */
-    public static Boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
+    public static boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
         if (listener.getConfiguration() != null) {
             return listener.getConfiguration().getAllocateLoadBalancerNodePorts();
         } else {
-            return null;
+            return false;
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
@@ -787,11 +788,11 @@ public class ListenersUtils {
      * @param listener Listener for which to allocate NodePorts
      * @return         Whether to allocate NodePorts for Service
      */
+    @SuppressFBWarnings(value = {"NP_BOOLEAN_RETURN_NULL"}, justification = "Null is being checked by the caller, so " +
+                                                                            "the Service defaults can takeover properly")
     public static Boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
-        if (listener.getConfiguration() != null) {
-            return listener.getConfiguration().getAllocateLoadBalancerNodePorts();
-        } else {
-            return true;
-        }
+        return listener.getConfiguration() != null ?
+                listener.getConfiguration().getAllocateLoadBalancerNodePorts() :
+                null;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -780,4 +780,18 @@ public class ListenersUtils {
                     .findAny()
                     .orElse(null) : null;
     }
+
+    /**
+     * Returns whether to allocate NodePorts for LoadBalancer Service type
+     *
+     * @param listener Listener for which to allocate NodePorts
+     * @return         Whether to allocate NodePorts for Service
+     */
+    public static Boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
+        if (listener.getConfiguration() != null) {
+            return listener.getConfiguration().getAllocateLoadBalancerNodePorts();
+        } else {
+            return null;
+        }
+    }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -787,7 +787,7 @@ public class ListenersUtils {
      * @param listener Listener for which to allocate NodePorts
      * @return         Whether to allocate NodePorts for Service
      */
-    public static boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
+    public static Boolean allocateLoadBalancerNodePorts(GenericKafkaListener listener) {
         if (listener.getConfiguration() != null) {
             return listener.getConfiguration().getAllocateLoadBalancerNodePorts();
         } else {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -791,7 +791,7 @@ public class ListenersUtils {
         if (listener.getConfiguration() != null) {
             return listener.getConfiguration().getAllocateLoadBalancerNodePorts();
         } else {
-            return false;
+            return true;
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersValidator.java
@@ -80,6 +80,7 @@ public class ListenersValidator {
                 validateControllerClass(errors, listener);
                 validateExternalTrafficPolicy(errors, listener);
                 validateLoadBalancerSourceRanges(errors, listener);
+                validateAllocateLoadBalancerNodePorts(errors, listener);
                 validateFinalizers(errors, listener);
                 validatePreferredAddressType(errors, listener);
                 validatePublishNotReadyAddresses(errors, listener);
@@ -307,6 +308,20 @@ public class ListenersValidator {
                 && listener.getConfiguration().getLoadBalancerSourceRanges() != null
                 && !listener.getConfiguration().getLoadBalancerSourceRanges().isEmpty())    {
             errors.add("listener " + listener.getName() + " cannot configure loadBalancerSourceRanges because it is not LoadBalancer based listener");
+        }
+    }
+
+    /**
+     * Validates that allocateLoadBalancerNodePorts is used only with Loadbalancer type listener
+     *
+     * @param errors    List where any found errors will be added
+     * @param listener  Listener which needs to be validated
+     */
+    private static void validateAllocateLoadBalancerNodePorts(Set<String> errors, GenericKafkaListener listener) {
+        if (!KafkaListenerType.LOADBALANCER.equals(listener.getType())
+                && listener.getConfiguration().getAllocateLoadBalancerNodePorts() != null) {
+            errors.add("listener " + listener.getName() + " cannot configure allocateLoadBalancerNodePorts because it" +
+                    " is not LoadBalancer based listener");
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterListenersTest.java
@@ -1012,7 +1012,7 @@ public class KafkaClusterListenersTest {
         assertThat(bootstrapServices.get(0).getSpec().getLoadBalancerIP(), is(nullValue()));
         assertThat(bootstrapServices.get(0).getSpec().getExternalTrafficPolicy(), is("Cluster"));
         assertThat(bootstrapServices.get(0).getSpec().getLoadBalancerSourceRanges(), is(List.of()));
-        assertThat(bootstrapServices.get(0).getSpec().getAllocateLoadBalancerNodePorts(), is(true));
+        assertThat(bootstrapServices.get(0).getSpec().getAllocateLoadBalancerNodePorts(), is(nullValue()));
         TestUtils.checkOwnerReference(bootstrapServices.get(0), KAFKA);
 
         // Check per pod services
@@ -1041,7 +1041,7 @@ public class KafkaClusterListenersTest {
             assertThat(service.getSpec().getLoadBalancerIP(), is(nullValue()));
             assertThat(service.getSpec().getExternalTrafficPolicy(), is("Cluster"));
             assertThat(service.getSpec().getLoadBalancerSourceRanges(), is(List.of()));
-            assertThat(service.getSpec().getAllocateLoadBalancerNodePorts(), is(true));
+            assertThat(service.getSpec().getAllocateLoadBalancerNodePorts(), is(nullValue()));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -123,7 +123,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -153,14 +152,6 @@ public class KafkaClusterTest {
                                     .withPort(9093)
                                     .withType(KafkaListenerType.INTERNAL)
                                     .withTls(true)
-                                    .build(),
-                            new GenericKafkaListenerBuilder()
-                                    .withName("lb")
-                                    .withPort(9094)
-                                    .withType(KafkaListenerType.LOADBALANCER)
-                                    .withNewConfiguration()
-                                        .withAllocateLoadBalancerNodePorts(false)
-                                    .endConfiguration()
                                     .build())
                 .endKafka()
             .endSpec()
@@ -205,18 +196,18 @@ public class KafkaClusterTest {
             .endSpec()
             .build();
     private final static Map<Integer, Map<String, String>> ADVERTISED_HOSTNAMES = Map.of(
-            3, Map.of("PLAIN_9092", "mixed-3", "TLS_9093", "mixed-3", "LB_9094", "mixed-3"),
-            4, Map.of("PLAIN_9092", "mixed-4", "TLS_9093", "mixed-4", "LB_9094", "mixed-4"),
-            5, Map.of("PLAIN_9092", "broker-5", "TLS_9093", "broker-5", "LB_9094", "broker-5"),
-            6, Map.of("PLAIN_9092", "broker-6", "TLS_9093", "broker-6", "LB_9094", "broker-6"),
-            7, Map.of("PLAIN_9092", "broker-7", "TLS_9093", "broker-7", "LB_9094", "broker-7")
+            3, Map.of("PLAIN_9092", "mixed-3", "TLS_9093", "mixed-3"),
+            4, Map.of("PLAIN_9092", "mixed-4", "TLS_9093", "mixed-4"),
+            5, Map.of("PLAIN_9092", "broker-5", "TLS_9093", "broker-5"),
+            6, Map.of("PLAIN_9092", "broker-6", "TLS_9093", "broker-6"),
+            7, Map.of("PLAIN_9092", "broker-7", "TLS_9093", "broker-7")
     );
     private final static Map<Integer, Map<String, String>> ADVERTISED_PORTS = Map.of(
-            3, Map.of("PLAIN_9092", "9092", "TLS_9093", "10003", "LB_9094", "9094"),
-            4, Map.of("PLAIN_9092", "9092", "TLS_9093", "10004", "LB_9094", "9094"),
-            5, Map.of("PLAIN_9092", "9092", "TLS_9093", "10005", "LB_9094", "9094"),
-            6, Map.of("PLAIN_9092", "9092", "TLS_9093", "10006", "LB_9094", "9094"),
-            7, Map.of("PLAIN_9092", "9092", "TLS_9093", "10007", "LB_9094", "9094")
+            3, Map.of("PLAIN_9092", "9092", "TLS_9093", "10003"),
+            4, Map.of("PLAIN_9092", "9092", "TLS_9093", "10004"),
+            5, Map.of("PLAIN_9092", "9092", "TLS_9093", "10005"),
+            6, Map.of("PLAIN_9092", "9092", "TLS_9093", "10006"),
+            7, Map.of("PLAIN_9092", "9092", "TLS_9093", "10007")
     );
 
     private static final List<KafkaPool> POOLS = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, KAFKA, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
@@ -841,7 +832,6 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getSpec().getIpFamilyPolicy(), is(nullValue()));
         assertThat(clusterIp.getSpec().getIpFamilies(), is(nullValue()));
         assertThat(clusterIp.getSpec().getPublishNotReadyAddresses(), is(nullValue()));
-        assertThat(clusterIp.getSpec().getAllocateLoadBalancerNodePorts(), is(nullValue()));
         
         assertThat(clusterIp.getMetadata().getAnnotations(), hasKey("strimzi.io/discovery"));        
         JsonArray annotation = new JsonArray(clusterIp.getMetadata().getAnnotations().get("strimzi.io/discovery"));
@@ -860,27 +850,6 @@ public class KafkaClusterTest {
         assertThat(clusterIp.getMetadata().getLabels().get(Labels.STRIMZI_DISCOVERY_LABEL), is("true"));
 
         TestUtils.checkOwnerReference(clusterIp, KAFKA);
-    }
-
-    @ParallelTest
-    public void testGenerateExternalBootstrapServices() {
-        List<Service> services = KC.generateExternalBootstrapServices();
-
-        assertThat(services, hasSize(1));
-        Service service = services.get(0);
-
-        assertThat(service.getSpec().getAllocateLoadBalancerNodePorts(), is(false));
-    }
-
-    @ParallelTest
-    public void testGeneratePerPodServices() {
-        List<Service> services = KC.generatePerPodServices();
-
-        assertThat(services, hasSize(5));
-        assertThat(services.stream()
-                        .filter(s -> !s.getSpec().getAllocateLoadBalancerNodePorts())
-                        .collect(Collectors.toList()),
-                hasSize(5));
     }
 
     @ParallelTest
@@ -1156,16 +1125,16 @@ public class KafkaClusterTest {
         config = KC.generatePerBrokerConfiguration(4, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
         assertThat(config, CoreMatchers.containsString("node.id=4"));
         assertThat(config, CoreMatchers.containsString("log.dirs=/var/lib/kafka/data-0/kafka-log4"));
-        assertThat(config, CoreMatchers.containsString("\nlisteners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092,TLS-9093://0.0.0.0:9093,LB-9094://0.0.0.0:9094\n"));
-        assertThat(config, CoreMatchers.containsString("advertised.listeners=REPLICATION-9091://foo-mixed-4.foo-kafka-brokers.test.svc:9091,PLAIN-9092://mixed-4:9092,TLS-9093://mixed-4:10004,LB-9094://mixed-4:9094\n"));
+        assertThat(config, CoreMatchers.containsString("\nlisteners=CONTROLPLANE-9090://0.0.0.0:9090,REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092,TLS-9093://0.0.0.0:9093\n"));
+        assertThat(config, CoreMatchers.containsString("advertised.listeners=REPLICATION-9091://foo-mixed-4.foo-kafka-brokers.test.svc:9091,PLAIN-9092://mixed-4:9092,TLS-9093://mixed-4:10004\n"));
         assertThat(config, CoreMatchers.containsString("process.roles=broker,controller\n"));
         assertThat(config, CoreMatchers.containsString("controller.quorum.voters=0@foo-controllers-0.foo-kafka-brokers.test.svc.cluster.local:9090,1@foo-controllers-1.foo-kafka-brokers.test.svc.cluster.local:9090,2@foo-controllers-2.foo-kafka-brokers.test.svc.cluster.local:9090,3@foo-mixed-3.foo-kafka-brokers.test.svc.cluster.local:9090,4@foo-mixed-4.foo-kafka-brokers.test.svc.cluster.local:9090\n"));
 
         config = KC.generatePerBrokerConfiguration(6, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
         assertThat(config, CoreMatchers.containsString("node.id=6"));
         assertThat(config, CoreMatchers.containsString("log.dirs=/var/lib/kafka/data-0/kafka-log6"));
-        assertThat(config, CoreMatchers.containsString("\nlisteners=REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092,TLS-9093://0.0.0.0:9093,LB-9094://0.0.0.0:9094\n"));
-        assertThat(config, CoreMatchers.containsString("advertised.listeners=REPLICATION-9091://foo-brokers-6.foo-kafka-brokers.test.svc:9091,PLAIN-9092://broker-6:9092,TLS-9093://broker-6:10006,LB-9094://broker-6:9094\n"));
+        assertThat(config, CoreMatchers.containsString("\nlisteners=REPLICATION-9091://0.0.0.0:9091,PLAIN-9092://0.0.0.0:9092,TLS-9093://0.0.0.0:9093\n"));
+        assertThat(config, CoreMatchers.containsString("advertised.listeners=REPLICATION-9091://foo-brokers-6.foo-kafka-brokers.test.svc:9091,PLAIN-9092://broker-6:9092,TLS-9093://broker-6:10006\n"));
         assertThat(config, CoreMatchers.containsString("process.roles=broker\n"));
         assertThat(config, CoreMatchers.containsString("controller.quorum.voters=0@foo-controllers-0.foo-kafka-brokers.test.svc.cluster.local:9090,1@foo-controllers-1.foo-kafka-brokers.test.svc.cluster.local:9090,2@foo-controllers-2.foo-kafka-brokers.test.svc.cluster.local:9090,3@foo-mixed-3.foo-kafka-brokers.test.svc.cluster.local:9090,4@foo-mixed-4.foo-kafka-brokers.test.svc.cluster.local:9090\n"));
     }
@@ -1195,7 +1164,7 @@ public class KafkaClusterTest {
                 assertThat(cm.getData().get(LoggingModel.LOG4J1_CONFIG_MAP_KEY), is(notNullValue()));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CONFIGURATION_FILENAME), is(notNullValue()));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CONFIGURATION_FILENAME), CoreMatchers.containsString("process.roles=broker\n"));
-                assertThat(cm.getData().get(KafkaCluster.BROKER_LISTENERS_FILENAME), is("PLAIN_9092 TLS_9093 LB_9094"));
+                assertThat(cm.getData().get(KafkaCluster.BROKER_LISTENERS_FILENAME), is("PLAIN_9092 TLS_9093"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_METADATA_STATE_FILENAME), is("4"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CLUSTER_ID_FILENAME), is("dummy-cluster-id"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_METADATA_VERSION_FILENAME), is(KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE.metadataVersion()));
@@ -1204,7 +1173,7 @@ public class KafkaClusterTest {
                 assertThat(cm.getData().get(LoggingModel.LOG4J1_CONFIG_MAP_KEY), is(notNullValue()));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CONFIGURATION_FILENAME), is(notNullValue()));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CONFIGURATION_FILENAME), CoreMatchers.containsString("process.roles=broker,controller\n"));
-                assertThat(cm.getData().get(KafkaCluster.BROKER_LISTENERS_FILENAME), is("PLAIN_9092 TLS_9093 LB_9094"));
+                assertThat(cm.getData().get(KafkaCluster.BROKER_LISTENERS_FILENAME), is("PLAIN_9092 TLS_9093"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_METADATA_STATE_FILENAME), is("4"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_CLUSTER_ID_FILENAME), is("dummy-cluster-id"));
                 assertThat(cm.getData().get(KafkaCluster.BROKER_METADATA_VERSION_FILENAME), is(KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE.metadataVersion()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -782,7 +782,7 @@ public class ListenersUtilsTest {
 
         assertThat(ListenersUtils.allocateLoadBalancerNodePorts(lbListenerWithNodePorts), is(true));
         assertThat(ListenersUtils.allocateLoadBalancerNodePorts(lbListenerWithoutNodePorts), is(false));
-        assertThat(ListenersUtils.allocateLoadBalancerNodePorts(lbListenerWithoutConfiguration), is(true));
+        assertThat(ListenersUtils.allocateLoadBalancerNodePorts(lbListenerWithoutConfiguration), is(nullValue()));
         assertThat(ListenersUtils.allocateLoadBalancerNodePorts(newLoadBalancer2), is(nullValue()));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -207,6 +207,7 @@ public class ListenersUtilsTest {
                 .withLoadBalancerSourceRanges(asList("10.0.0.0/8", "130.211.204.1/32"))
                 .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                 .withPublishNotReadyAddresses(false)
+                .withAllocateLoadBalancerNodePorts(false)
                 .withNewBootstrap()
                     .withAlternativeNames(asList("my-lb-1", "my-lb-2"))
                     .withLoadBalancerIP("130.211.204.1")
@@ -760,5 +761,20 @@ public class ListenersUtilsTest {
 
         assertThat(ListenersUtils.advertisedPortFromOverrideOrParameter(listener, 0, 12345), is("12345"));
         assertThat(ListenersUtils.advertisedPortFromOverrideOrParameter(listener, 0, 12345), is("12345"));
+    }
+
+    @ParallelTest
+    public void testAllocateLoadBalancerNodePorts() {
+        assertThat(internalListeners.stream()
+                        .filter(l -> ListenersUtils.allocateLoadBalancerNodePorts(l) == null ||
+                                     ListenersUtils.allocateLoadBalancerNodePorts(l))
+                        .collect(Collectors.toList()),
+                hasSize(4));
+        assertThat(allListeners.stream()
+                        .filter(l -> ListenersUtils.allocateLoadBalancerNodePorts(l) == null ||
+                                ListenersUtils.allocateLoadBalancerNodePorts(l))
+                        .collect(Collectors.toList()),
+                hasSize(13));
+        assertThat(ListenersUtils.allocateLoadBalancerNodePorts(newLoadBalancer2), is(false));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersValidatorTest.java
@@ -314,6 +314,7 @@ public class ListenersValidatorTest {
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
+                    .withAllocateLoadBalancerNodePorts(false)
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
                     .withHostTemplate("my-host-{nodeId}")
@@ -397,6 +398,7 @@ public class ListenersValidatorTest {
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withAllocateLoadBalancerNodePorts(false)
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -438,7 +440,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener"
+                "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -480,6 +483,7 @@ public class ListenersValidatorTest {
                     .withIpFamilyPolicy(IpFamilyPolicy.REQUIRE_DUAL_STACK)
                     .withIpFamilies(IpFamily.IPV4, IpFamily.IPV6)
                     .withPreferredNodePortAddressType(NodeAddressType.INTERNAL_DNS)
+                    .withAllocateLoadBalancerNodePorts(false)
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
@@ -528,7 +532,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
+                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, THREE_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -586,6 +591,7 @@ public class ListenersValidatorTest {
                     .withLoadBalancerSourceRanges(List.of("10.0.0.0/8", "130.211.204.1/32"))
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
+                    .withAllocateLoadBalancerNodePorts(false)
                     .withHostTemplate("my-host-{nodeId}")
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
@@ -627,7 +633,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure bootstrap.loadBalancerIP because it is not LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure brokers[].loadBalancerIP because it is not LoadBalancer based listener",
-                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener"
+                "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));
@@ -849,6 +856,7 @@ public class ListenersValidatorTest {
                     .withFinalizers(List.of("service.kubernetes.io/load-balancer-cleanup"))
                     .withPublishNotReadyAddresses(true)
                     .withHostTemplate("my-host-{nodeId}")
+                    .withAllocateLoadBalancerNodePorts(false)
                     .withAdvertisedHostTemplate("my-advertised-host-{nodeId}")
                     .withNewBootstrap()
                         .withAlternativeNames(List.of("my-name-1", "my-name-2"))
@@ -892,7 +900,8 @@ public class ListenersValidatorTest {
                 "listener " + name + " cannot configure brokers[].nodePort because it is not NodePort based listener",
                 "listener " + name + " cannot configure class because it is not an Ingress or LoadBalancer based listener",
                 "listener " + name + " cannot configure bootstrap.host because it is not Route or Ingress based listener",
-                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener"
+                "listener " + name + " cannot configure brokers[].host because it is not Route or Ingress based listener",
+                "listener " + name + " cannot configure allocateLoadBalancerNodePorts because it is not LoadBalancer based listener"
         );
 
         assertThat(ListenersValidator.validateAndGetErrorMessages(Reconciliation.DUMMY_RECONCILIATION, TWO_NODES, listeners), containsInAnyOrder(expectedErrors.toArray()));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -509,6 +509,11 @@ This property is used to select the preferred address type, which is checked fir
 |advertisedHostTemplate
 |string
 |Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`.
+|allocateLoadBalancerNodePorts
+|boolean
+|Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
+This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
+For `loadbalancer` listeners only.
 |====
 
 [id='type-CertAndKeySecretSource-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -486,6 +486,12 @@ spec:
                               advertisedHostTemplate:
                                 type: string
                                 description: "Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                              allocateLoadBalancerNodePorts:
+                                type: boolean
+                                description: |-
+                                  Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
+                                  This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
+                                  For `loadbalancer` listeners only.
                             description: Additional listener configuration.
                           networkPolicyPeers:
                             type: array

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -485,6 +485,12 @@ spec:
                             advertisedHostTemplate:
                               type: string
                               description: "Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            allocateLoadBalancerNodePorts:
+                              type: boolean
+                              description: |-
+                                Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
+                                This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
+                                For `loadbalancer` listeners only.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array


### PR DESCRIPTION
### Type of change

Enhancement / new feature

### Description

Enabling users to configure `spec.allocateLoadBalancerNodePorts` in an external `LoadBalancer` type `Service` by providing an option in `GenericKafkaListenerConfiguration`.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

