### PR TITLE
[ST] fix usages of logPodImages in UpgradeSTs

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/AbstractUpgradeST.java
@@ -244,6 +244,13 @@ public class AbstractUpgradeST extends AbstractST {
         logPodImages(clusterOperatorNamespaceName, coSelector);
     }
 
+    /**
+     * Logs images of Pods' containers in the specified {@param namespaceName}. Each image is logged per each label selector.
+     *
+     * @param namespaceName the name of the Kubernetes namespace where the pods are located
+     * @param labelSelectors optional array of {@link LabelSelector} objects used to filter pods based on labels.
+     *                       If no selectors are provided, no Pods are selected.
+     */
     protected void logPodImages(String namespaceName, LabelSelector... labelSelectors) {
         Arrays.stream(labelSelectors)
             .parallel()

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/kraft/KRaftStrimziUpgradeST.java
@@ -127,12 +127,12 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
 
         waitForKafkaClusterRollingUpdate(testStorage.getNamespaceName());
 
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
 
         // Upgrade kafka
         changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData, true);
 
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
 
         checkAllComponentsImages(testStorage.getNamespaceName(), acrossUpgradeData);
 
@@ -162,7 +162,7 @@ public class KRaftStrimziUpgradeST extends AbstractKRaftUpgradeST {
         eoPods = DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
 
         LOGGER.info("Rolling to new images has finished!");
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
 
         // Upgrade kafka
         changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData);

--- a/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/upgrade/regular/StrimziUpgradeST.java
@@ -91,13 +91,13 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         // Upgrade CO
         changeClusterOperator(CO_NAMESPACE, testStorage.getNamespaceName(),  acrossUpgradeData);
 
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
 
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), controllerSelector, 3, zooSnapshot);
         RollingUpdateUtils.waitTillComponentHasRolledAndPodsReady(testStorage.getNamespaceName(), brokerSelector, 3, kafkaSnapshot);
         DeploymentUtils.waitTillDepHasRolled(testStorage.getNamespaceName(), KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoSnapshot);
 
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
         checkAllComponentsImages(testStorage.getNamespaceName(), acrossUpgradeData);
 
         // Verify that Pods are stable
@@ -124,10 +124,10 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
 
         // Upgrade CO
         changeClusterOperator(CO_NAMESPACE, TEST_SUITE_NAMESPACE, acrossUpgradeData);
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
         //  Upgrade kafka
         changeKafkaVersion(TEST_SUITE_NAMESPACE, acrossUpgradeData);
-        logPodImages(TEST_SUITE_NAMESPACE);
+        logPodImages(TEST_SUITE_NAMESPACE, coSelector);
         checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TEST_SUITE_NAMESPACE, clusterName);
@@ -152,10 +152,10 @@ public class StrimziUpgradeST extends AbstractUpgradeST {
         eoPods = DeploymentUtils.waitTillDepHasRolled(TEST_SUITE_NAMESPACE, KafkaResources.entityOperatorDeploymentName(clusterName), 1, eoPods);
 
         LOGGER.info("Rolling to new images has finished!");
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
         //  Upgrade kafka
         changeKafkaVersion(testStorage.getNamespaceName(), acrossUpgradeData);
-        logPodImages(CO_NAMESPACE);
+        logPodImages(CO_NAMESPACE, coSelector);
         checkAllComponentsImages(TEST_SUITE_NAMESPACE, acrossUpgradeData);
         // Verify that Pods are stable
         PodUtils.verifyThatRunningPodsAreStable(TEST_SUITE_NAMESPACE, clusterName);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The way we used `logPodImages` in UpgradeST caused in some cases that nothing was actually logged due to absence of proper selectors. This PR adds docs to the function and corrects all usages.  


