### PR TITLE
Enable multi version single step downgrade for ZooKeeper based clusters

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ZooKeeperReconciler.java
@@ -49,6 +49,7 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import org.apache.zookeeper.common.StringUtils;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -372,7 +373,12 @@ public class ZooKeeperReconciler {
                 versionChangeType = "upgrade";
             }
 
-            if (versionChange.from().zookeeperVersion().equals(versionChange.to().zookeeperVersion())) {
+            if (StringUtils.isBlank(versionChange.from().zookeeperVersion())) {
+                LOGGER.infoCr(reconciliation, "Kafka {} from {} to {} may require Zookeeper version change",
+                        versionChangeType,
+                        versionChange.from().version(),
+                        versionChange.to().version());
+            } else if (versionChange.from().zookeeperVersion().equals(versionChange.to().zookeeperVersion())) {
                 LOGGER.infoCr(reconciliation, "Kafka {} from {} to {} requires Zookeeper {} from {} to {}",
                         versionChangeType,
                         versionChange.from().version(),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #10801 
Introduces handling for encountering an unknown Kafka version in downgrade of a Zookeeper based cluster in order to enable multi version single step downgrade

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

