### PR TITLE
docs(quota plugins): note on quotas for internal users

### DIFF
--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -50,13 +50,13 @@ Limits can be overridden by xref:con-configuring-client-quotas-str[user-specific
 When using the default Kafka quotas plugin, quotas are applied to all users. 
 This includes internal users such as the Topic Operator and Cruise Control, which may impact their operations.
 
+Unlike the Strimzi Quotas plugin, where internal users can be excluded using the `excludedPrincipals` option, the Kafka quotas plugin does not provide an exclusion mechanism.
+To avoid unduly limiting internal users when using the Strimzi Quotas plugin, consider tuning the quotas effectively.
+
 For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
 Monitoring of relevant controller and broker metrics can help track the rate of operations on topics.
 Cruise Control and its metrics reporter also require sufficient produce and fetch rates to conduct rebalances, depending on the scale and configuration of the Kafka cluster.
 To prevent issues for Cruise Control, you might start with a rate of at least 1 KB/s for its producers and consumers in small clusters, such as three brokers with moderate traffic, and adjust as needed for larger or more active clusters.
-
-Unlike the Strimzi Quotas plugin, where internal users can be excluded using the `excludedPrincipals` option, the Kafka quotas plugin does not have an exclusion mechanism.
-If you want to avoid unduly limiting internal users, consider tuning the quotas effectively or using the Strimzi Quotas plugin where exclusion is possible.
 
 .Prerequisites
 

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -47,9 +47,11 @@ Limits can be overridden by xref:con-configuring-client-quotas-str[user-specific
 * The number of concurrent partition creation and deletion operations (mutations) allowed per second can be set on a per-broker basis.
 
 .Impact on internal users
-When using the default Kafka quotas plugin, quotas are applied to all users, including internal users such as the Topic Operator or Cruise Control. 
-This means that internal users can hit the set quotas, potentially affecting their operations. 
+When using the default Kafka quotas plugin, quotas are applied to all users. 
+This includes internal users such as the Topic Operator and Cruise Control, which may impact their operations.
+
 For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
+To avoid the implications of throttling, monitoring of relevant controller and broker metrics can help track operations on topics.
 Cruise Control and its metrics reporter also require sufficient produce and fetch rates to conduct rebalances, depending on the scale and configuration of the Kafka cluster.
 To prevent issues for Cruise Control, you might start with a rate of at least 1 KB/s for its producers and consumers in small clusters, such as three brokers with moderate traffic, and adjust as needed for larger or more active clusters.
 

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -44,12 +44,13 @@ Limits can be overridden by xref:con-configuring-client-quotas-str[user-specific
 * CPU utilization limits for each client can be set as a percentage of the network threads and I/O threads on a per-broker basis.
 * The number of concurrent partition creation and deletion operations (mutations) allowed per second can be set on a per-broker basis.
 
-When using the default Kafka quotas plugin, quotas are applied to all users. 
+When using the default Kafka quotas plugin, the default quotas (if set) are applied to all users. 
 This includes internal users such as the Topic Operator and Cruise Control, which may impact their operations.
 To avoid unduly limiting internal users, consider tuning the quotas effectively.
 
-For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
-Monitoring of relevant controller and broker metrics can help track the rate of operations on topics.
+For example, a quota automatically applied to the Topic Operator by the Kafka quotas plugin could constrain the controller mutation rate, potentially throttling topic creation or deletion operations. 
+Therefore, it is important to understand the minimal quotas required by the Topic Operator to function correctly and explicitly set appropriate quotas to avoid such issues. 
+Monitoring relevant controller and broker metrics can help track and optimize the rate of operations on topics.
 Cruise Control and its metrics reporter also require sufficient produce and fetch rates to conduct rebalances, depending on the scale and configuration of the Kafka cluster.
 To prevent issues for Cruise Control, you might start with a rate of at least 1 KB/s for its producers and consumers in small clusters, such as three brokers with moderate traffic, and adjust as needed for larger or more active clusters.
 

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -51,7 +51,7 @@ When using the default Kafka quotas plugin, quotas are applied to all users.
 This includes internal users such as the Topic Operator and Cruise Control, which may impact their operations.
 
 For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
-To avoid the implications of throttling, monitoring of relevant controller and broker metrics can help track operations on topics.
+Monitoring of relevant controller and broker metrics can help track the rate of operations on topics.
 Cruise Control and its metrics reporter also require sufficient produce and fetch rates to conduct rebalances, depending on the scale and configuration of the Kafka cluster.
 To prevent issues for Cruise Control, you might start with a rate of at least 1 KB/s for its producers and consumers in small clusters, such as three brokers with moderate traffic, and adjust as needed for larger or more active clusters.
 

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -10,8 +10,6 @@
 This procedure describes how to set throughput and storage limits on brokers in your Kafka cluster.
 Enable a quota plugin and configure limits using `quotas` properties in the `Kafka` resource.
 
-.Quota plugins
-
 There are two types of quota plugins available:
 
 * The `strimzi` type enables the _Strimzi Quotas_ plugin.
@@ -46,12 +44,9 @@ Limits can be overridden by xref:con-configuring-client-quotas-str[user-specific
 * CPU utilization limits for each client can be set as a percentage of the network threads and I/O threads on a per-broker basis.
 * The number of concurrent partition creation and deletion operations (mutations) allowed per second can be set on a per-broker basis.
 
-.Impact on internal users
 When using the default Kafka quotas plugin, quotas are applied to all users. 
 This includes internal users such as the Topic Operator and Cruise Control, which may impact their operations.
-
-Unlike the Strimzi Quotas plugin, where internal users can be excluded using the `excludedPrincipals` option, the Kafka quotas plugin does not provide an exclusion mechanism.
-To avoid unduly limiting internal users when using the Strimzi Quotas plugin, consider tuning the quotas effectively.
+To avoid unduly limiting internal users, consider tuning the quotas effectively.
 
 For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
 Monitoring of relevant controller and broker metrics can help track the rate of operations on topics.

--- a/documentation/modules/managing/proc-setting-broker-limits.adoc
+++ b/documentation/modules/managing/proc-setting-broker-limits.adoc
@@ -46,6 +46,16 @@ Limits can be overridden by xref:con-configuring-client-quotas-str[user-specific
 * CPU utilization limits for each client can be set as a percentage of the network threads and I/O threads on a per-broker basis.
 * The number of concurrent partition creation and deletion operations (mutations) allowed per second can be set on a per-broker basis.
 
+.Impact on internal users
+When using the default Kafka quotas plugin, quotas are applied to all users, including internal users such as the Topic Operator or Cruise Control. 
+This means that internal users can hit the set quotas, potentially affecting their operations. 
+For example, configuring a controller mutation rate quota may result in the Topic Operator being throttled during topic creation or deletion operations.
+Cruise Control and its metrics reporter also require sufficient produce and fetch rates to conduct rebalances, depending on the scale and configuration of the Kafka cluster.
+To prevent issues for Cruise Control, you might start with a rate of at least 1 KB/s for its producers and consumers in small clusters, such as three brokers with moderate traffic, and adjust as needed for larger or more active clusters.
+
+Unlike the Strimzi Quotas plugin, where internal users can be excluded using the `excludedPrincipals` option, the Kafka quotas plugin does not have an exclusion mechanism.
+If you want to avoid unduly limiting internal users, consider tuning the quotas effectively or using the Strimzi Quotas plugin where exclusion is possible.
+
 .Prerequisites
 
 * The Cluster Operator that manages the Kafka cluster is running.
@@ -103,9 +113,6 @@ spec:
 <2> Sets the controller mutation rate to 50 operations per second.
 
 . Apply the changes to the `Kafka` configuration.
-
-NOTE: `minAvailableBytesPerVolume` and `minAvailableRatioPerVolume` are mutually exclusive.
-This means that only one of these parameters should be configured.
 
 NOTE: Additional options can be configured in the `spec.kafka.config` section.
 The full list of supported options can be found in the https://github.com/strimzi/kafka-quotas-plugin?tab=readme-ov-file#properties-and-their-defaults[plugin documentation].


### PR DESCRIPTION
**Documentation**

Adds a description of the impact on internal users when applying quotas through the Kafka quotas plugin.
Describes how Topic Operator and Cruise Control operations can be affected and how to avoid any impact.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

