### PR TITLE
Bump upload artifact action to 4.4.3 to do deprecation of current 3.x

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
I have got the following email ...

Artifact actions v3 will be deprecated by December 5, 2024. You are receiving this email because you have GitHub Actions workflows using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=d2da2b8a2e2546f6bbbefc4362a25248&elq=598963e5b9ca4aab8c415143e743a641&elqaid=4245&elqat=1&elqak=8AF5A79567D1D842C6394C4E2A26BD2485A90C8710ED4EC3675B7A8888A74B2EE87F) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=a0c373a95cb941a69247c326aef08dfe&elq=598963e5b9ca4aab8c415143e743a641&elqaid=4245&elqat=1&elqak=8AF5A416F3461CA0C91DF8AF94CEC73EC20A0C8710ED4EC3675B7A8888A74B2EE87F). After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.

To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

November 14, 12pm - 1pm EST
November 21, 9am - 5pm EST
What you need to do
Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://app.github.media/e/er?s=88570519&lid=6646&elqTrackId=d75d31293f0e47148c8f2a339957fcaf&elq=598963e5b9ca4aab8c415143e743a641&elqaid=4245&elqat=1&elqak=8AF52EF15428B1DCF971E377BBEBF230341A0C8710ED4EC3675B7A8888A74B2EE87F) from previous versions that may require updates to your workflows. Please see [the documentation](https://app.github.media/e/er?s=88570519&lid=6645&elqTrackId=53ce96ddadbb4fe1951a5a31db6a10b3&elq=598963e5b9ca4aab8c415143e743a641&elqaid=4245&elqat=1&elqak=8AF5B7CF2FDD10084FA269DD666DEC9DD40F0C8710ED4EC3675B7A8888A74B2EE87F) in the project repositories for guidance on how to migrate your workflows.

So this PR updates the action to latest 4.4.3
