### PR TITLE
Update zookeeper to 3.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <vertx-junit5.version>4.5.10</vertx-junit5.version>
         <kafka.version>3.8.1</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
-        <zookeeper.version>3.8.4</zookeeper.version>
+        <zookeeper.version>3.9.3</zookeeper.version>
         <snappy.version>1.1.10.5</snappy.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the zookeeper to 3.9.3 to address some critical CVE
- CVE-2024-8184
- CVE-2024-47554
- CVE-2023-33202
- CVE-2023-33201
- CVE-2020-26939
- CVE-2020-15522

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

