### PR TITLE
Simplify Ca and CaReconciler logic

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -93,6 +93,11 @@ public class ClusterCa extends Ca {
         return "cluster-ca";
     }
 
+    @Override
+    protected String caName() {
+        return "Cluster CA";
+    }
+
     /**
      * Prepares the Cruise Control certificate. It either reuses the existing certificate, renews it or generates new
      * certificate if needed.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -263,7 +263,7 @@ public class CaReconciler {
                             ModelUtils.getRenewalDays(clusterCaConfig),
                             clusterCaConfig == null || clusterCaConfig.isGenerateCertificateAuthority(), clusterCaConfig != null ? clusterCaConfig.getCertificateExpirationPolicy() : null);
                     clusterCa.createRenewOrReplace(
-                            reconciliation.namespace(), reconciliation.name(), caLabels,
+                            reconciliation.namespace(), caLabels,
                             clusterCaCertLabels, clusterCaCertAnnotations,
                             clusterCaConfig != null && !clusterCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
                             clusterCaSecrets,
@@ -277,7 +277,7 @@ public class CaReconciler {
                             ModelUtils.getRenewalDays(clientsCaConfig),
                             clientsCaConfig == null || clientsCaConfig.isGenerateCertificateAuthority(),
                             clientsCaConfig != null ? clientsCaConfig.getCertificateExpirationPolicy() : null);
-                    clientsCa.createRenewOrReplace(reconciliation.namespace(), reconciliation.name(),
+                    clientsCa.createRenewOrReplace(reconciliation.namespace(),
                             caLabels, Map.of(), Map.of(),
                             clientsCaConfig != null && !clientsCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
                             clientsCaSecrets,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -45,7 +45,6 @@ import io.strimzi.operator.common.auth.PemTrustSet;
 import io.strimzi.operator.common.auth.TlsPemIdentity;
 import io.strimzi.operator.common.model.Ca;
 import io.strimzi.operator.common.model.ClientsCa;
-import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.PasswordGenerator;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
@@ -258,9 +257,6 @@ public class CaReconciler {
                         }
                     }
 
-                    // When we are not supposed to generate the CA, but it does not exist, we should just throw an error
-                    checkCustomCaSecret(clusterCaConfig, clusterCaCertSecret, clusterCaKeySecret, "Cluster CA");
-
                     clusterCa = new ClusterCa(reconciliation, certManager, passwordGenerator, reconciliation.name(), clusterCaCertSecret,
                             clusterCaKeySecret,
                             ModelUtils.getCertificateValidity(clusterCaConfig),
@@ -272,9 +268,6 @@ public class CaReconciler {
                             clusterCaConfig != null && !clusterCaConfig.isGenerateSecretOwnerReference() ? null : ownerRef,
                             clusterCaSecrets,
                             Util.isMaintenanceTimeWindowsSatisfied(reconciliation, maintenanceWindows, clock.instant()));
-
-                    // When we are not supposed to generate the CA, but it does not exist, we should just throw an error
-                    checkCustomCaSecret(clientsCaConfig, clientsCaCertSecret, clientsCaKeySecret, "Clients CA");
 
                     clientsCa = new ClientsCa(reconciliation, certManager,
                             passwordGenerator, clientsCaCertName,
@@ -319,22 +312,6 @@ public class CaReconciler {
 
                     return caUpdatePromise.future();
                 });
-    }
-
-    /**
-     * Utility method for checking the Secret existence when custom CA is used. The custom CA is configured but the
-     * secrets do not exist, it will throw InvalidConfigurationException.
-     *
-     * @param ca            The CA Configuration from the Custom Resource
-     * @param certSecret    Secret with the certificate public key
-     * @param keySecret     Secret with the certificate private key
-     * @param caDescription The name of the CA for which this check is executed ("Cluster CA" or "Clients CA" - used
-     *                      in the exception message)
-     */
-    private void checkCustomCaSecret(CertificateAuthority ca, Secret certSecret, Secret keySecret, String caDescription)   {
-        if (ca != null && !ca.isGenerateCertificateAuthority() && (certSecret == null || keySecret == null))   {
-            throw new InvalidResourceException(caDescription + " should not be generated, but the secrets were not found.");
-        }
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaTest.java
@@ -41,7 +41,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
 
         // force key replacement so certificate renewal ...
@@ -56,7 +56,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(4));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(true));
 
@@ -66,7 +66,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), clusterCa.caKeySecret());
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(false));
     }
@@ -79,7 +79,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         // check certificate expiration out of the renewal period, certificate is not expiring
         instantExpected = "2023-02-15T09:00:00Z";
@@ -102,7 +102,7 @@ public class ClusterCaTest {
 
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, null, null);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(3));
 
         // force key replacement so certificate renewal ...
@@ -117,7 +117,7 @@ public class ClusterCaTest {
 
         clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(clock), new PasswordGenerator(10, "a", "a"), cluster, clusterCa.caCertSecret(), caKeySecretWithReplaceAnno);
         clusterCa.setClock(clock);
-        clusterCa.createRenewOrReplace(namespace, cluster, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(namespace, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         assertThat(clusterCa.caCertSecret().getData().size(), is(4));
         assertThat(clusterCa.caCertSecret().getData().containsKey("ca-2023-03-23T09-00-00Z.crt"), is(true));
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -258,9 +258,9 @@ public class KafkaClusterTest {
 
     private Secret generateBrokerSecret(Set<String> externalBootstrapAddress, Map<Integer, Set<String>> externalAddresses) {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, Map.of(), Map.of(), Map.of(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(NAMESPACE, Map.of(), Map.of(), Map.of(), null, List.of(), true);
         ClientsCa clientsCa = new ClientsCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), null, null, null, null, 365, 30, true, CertificateExpirationPolicy.RENEW_CERTIFICATE);
-        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER, Map.of(), Map.of(), Map.of(), null, List.of(), true);
+        clientsCa.createRenewOrReplace(NAMESPACE, Map.of(), Map.of(), Map.of(), null, List.of(), true);
 
         return KC.generateCertificatesSecret(clusterCa, clientsCa, null, externalBootstrapAddress, externalAddresses, true);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
@@ -228,9 +228,9 @@ public class KafkaClusterZooBasedTest {
 
     private Secret generateBrokerSecret(Set<String> externalBootstrapAddress, Map<Integer, Set<String>> externalAddresses) {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(NAMESPACE, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
         ClientsCa clientsCa = new ClientsCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), null, null, null, null, 365, 30, true, CertificateExpirationPolicy.RENEW_CERTIFICATE);
-        clientsCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clientsCa.createRenewOrReplace(NAMESPACE, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         return KC.generateCertificatesSecret(clusterCa, clientsCa, null, externalBootstrapAddress, externalAddresses, true);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -149,7 +149,7 @@ public class ZookeeperClusterTest {
 
     private Secret generateCertificatesSecret() {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
-        clusterCa.createRenewOrReplace(NAMESPACE, CLUSTER, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        clusterCa.createRenewOrReplace(NAMESPACE, emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         return ZC.generateCertificatesSecret(clusterCa, null, true);
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -327,7 +327,7 @@ public class CaReconcilerTest {
         reconcileCa(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(InvalidResourceException.class));
-                assertThat(e.getMessage(), is("cluster-ca should not be generated, but the secrets were not found."));
+                assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
                 async.flag();
             })));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -327,7 +327,7 @@ public class CaReconcilerTest {
         reconcileCa(vertx, certificateAuthority, certificateAuthority)
             .onComplete(context.failing(e -> context.verify(() -> {
                 assertThat(e, instanceOf(InvalidResourceException.class));
-                assertThat(e.getMessage(), is("Cluster CA should not be generated, but the secrets were not found."));
+                assertThat(e.getMessage(), is("cluster-ca should not be generated, but the secrets were not found."));
                 async.flag();
             })));
     }

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/ClientsCa.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/ClientsCa.java
@@ -46,4 +46,9 @@ public class ClientsCa extends Ca {
     public String toString() {
         return "clients-ca";
     }
+
+    @Override
+    protected String caName() {
+        return "Clients CA";
+    }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/CaTest.java
@@ -48,6 +48,11 @@ class CaTest {
         protected String caCertGenerationAnnotation() {
             return "mock";
         }
+
+        @Override
+        protected String caName() {
+            return "Mock CA";
+        }
     }
 
     private Ca ca;
@@ -64,7 +69,7 @@ class CaTest {
     @Test
     @DisplayName("Should return certificate expiration date as epoch when certificate is present")
     void shouldReturnCertificateExpirationDateEpoch() {
-        ca.createRenewOrReplace("mock", "mock", emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
+        ca.createRenewOrReplace("mock", emptyMap(), emptyMap(), emptyMap(), null, List.of(), true);
 
         Instant inOneYear = Clock.offset(now, oneYear).instant();
         long expectedEpoch = inOneYear.truncatedTo(ChronoUnit.SECONDS).toEpochMilli();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Simplify Ca and CaReconciler logic:
1. Remove code in CaReconciler that is never being executed.
2. Move Secret existence checking from CaReconciler to Ca.

Here are fuller explanations of why I did the refactors.

1
Today `logRenewalState()` in `Ca.java` is only called from inside [`shouldCreateOrRenew()`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java#L688), and `shouldCreateOrRenew()` is only called from [`createRenewOrReplace()`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java#L533) and only when `generateCa` is `true`. Therefore any code in `logRenewalState()` that is only executed when `generateCa` is false is never executed. To further simplify the code I removed `logRenewalState()` completely and moved the code that is executed inside `shouldCreateOrRenew()`.

2
Today `createRenewOrReplace()` in `Ca.java` is only called (excluding test classes) from [`CaReconciler.java`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java#L269), once for the ClusterCA and once for the ClientsCA. Prior to that call we call [`checkCustomCaSecret()`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java#L262) to verify the Secret exists. Then inside `Ca.java` we have additional logic to handle the case where the Secrets are null. I moved the verification logic into `Ca.java` to simplify the code.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

