### PR TITLE
Only roll pods once for ClientsCa cert renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add support for Kafka 3.8.1
 * Ability to move data between JBOD disks using Cruise Control.
+* Only roll pods once for ClientsCa cert renewal.
+  This change also means the restart reason ClientCaCertKeyReplaced is removed and either CaCertRenewed or CaCertHasOldGeneration will be used.
 
 ## 0.44.0
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/RestartReason.java
@@ -29,11 +29,6 @@ public enum RestartReason {
     CA_CERT_RENEWED("CA certificate renewed"),
 
     /**
-     * Clients CA private key was replaced
-     */
-    CLIENT_CA_CERT_KEY_REPLACED("Trust new clients CA certificate signed by new key"),
-
-    /**
      * Cluster CA private key was replaced
      */
     CLUSTER_CA_CERT_KEY_REPLACED("Trust new cluster CA certificate signed by new key"),

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -2104,11 +2104,11 @@ public class CaReconcilerTest {
         }
 
         @Override
-        Future<Void> rollDeploymentIfExists(String deploymentName, String reason) {
+        Future<Void> rollDeploymentIfExists(String deploymentName, RestartReason reason) {
             return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                     .compose(dep -> {
                         if (dep != null) {
-                            this.deploymentRestartReasons.put(deploymentName, reason);
+                            this.deploymentRestartReasons.put(deploymentName, reason.getDefaultNote());
                         }
                         return Future.succeededFuture();
                     });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -1788,11 +1788,8 @@ public class CaReconcilerTest {
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
-                    });
+                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
                     assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
                     async.flag();
                 })));
@@ -1971,11 +1968,8 @@ public class CaReconcilerTest {
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
-                    });
+                    // We rely on KafkaReconciler to roll pods for ClientsCa renewal
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
                     assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
                     async.flag();
                 })));
@@ -2040,12 +2034,7 @@ public class CaReconcilerTest {
         mockCaReconciler
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
-                    // When user is managing CA a cert renewal implies a key replacement
-                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, aMapWithSize(6));
-                    mockCaReconciler.kafkaRestartReasons.forEach((podName, restartReasons) -> {
-                        assertThat("Restart reasons for pod " + podName, restartReasons.getReasons(), hasSize(1));
-                        assertThat("Restart reasons for pod " + podName, restartReasons.contains(RestartReason.CLIENT_CA_CERT_KEY_REPLACED), is(true));
-                    });
+                    assertThat("Kafka restart reasons", mockCaReconciler.kafkaRestartReasons, anEmptyMap());
                     assertThat("Deployment restart reasons", mockCaReconciler.deploymentRestartReasons, anEmptyMap());
                     async.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -225,7 +225,7 @@ public class CaReconcilerZooBasedTest {
                 .reconcile(Clock.systemUTC())
                 .onComplete(context.succeeding(c -> context.verify(() -> {
                     assertThat(mockCaReconciler.isClusterCaNeedFullTrust, is(true));
-                    assertThat(mockCaReconciler.zkPodRestartReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
+                    assertThat(mockCaReconciler.zkPodRestartReason, is(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED.getDefaultNote()));
                     assertThat(mockCaReconciler.kPodRollReasons.contains(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED), is(true));
                     assertThat(mockCaReconciler.deploymentRollReason.size() == 3, is(true));
                     for (String reason: mockCaReconciler.deploymentRollReason) {
@@ -237,7 +237,7 @@ public class CaReconcilerZooBasedTest {
 
     static class MockCaReconciler extends CaReconciler {
 
-        RestartReasons zkPodRestartReasons;
+        String zkPodRestartReason;
         RestartReasons kPodRollReasons;
         List<String> deploymentRollReason = new ArrayList<>();
 
@@ -259,8 +259,8 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Void> maybeRollZookeeper(int replicas, RestartReasons podRestartReasons, TlsPemIdentity coTlsPemIdentity) {
-            this.zkPodRestartReasons = podRestartReasons;
+        Future<Void> rollZookeeper(int replicas, String restartReason, TlsPemIdentity coTlsPemIdentity) {
+            this.zkPodRestartReason = restartReason;
             return Future.succeededFuture();
         }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerZooBasedTest.java
@@ -259,8 +259,8 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Void> rollZookeeper(int replicas, String restartReason, TlsPemIdentity coTlsPemIdentity) {
-            this.zkPodRestartReason = restartReason;
+        Future<Void> rollZookeeper(int replicas, RestartReason restartReason, TlsPemIdentity coTlsPemIdentity) {
+            this.zkPodRestartReason = restartReason.getDefaultNote();
             return Future.succeededFuture();
         }
 
@@ -280,11 +280,11 @@ public class CaReconcilerZooBasedTest {
         }
 
         @Override
-        Future<Void> rollDeploymentIfExists(String deploymentName, String reason) {
+        Future<Void> rollDeploymentIfExists(String deploymentName, RestartReason reason) {
             return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                     .compose(dep -> {
                         if (dep != null) {
-                            this.deploymentRollReason.add(reason);
+                            this.deploymentRollReason.add(reason.getDefaultNote());
                         }
                         return Future.succeededFuture();
                     });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventPublisherTest.java
@@ -112,9 +112,9 @@ class KubernetesRestartEventPublisherTest {
             }
         };
 
-        Set<String> expectedReasons = Set.of("ClientCaCertKeyReplaced", "ClusterCaCertKeyReplaced");
+        Set<String> expectedReasons = Set.of("FileSystemResizeNeeded", "ClusterCaCertKeyReplaced");
 
-        RestartReasons reasons = new RestartReasons().add(RestartReason.CLIENT_CA_CERT_KEY_REPLACED)
+        RestartReasons reasons = new RestartReasons().add(RestartReason.FILE_SYSTEM_RESIZE_NEEDED)
                                                      .add(RestartReason.CLUSTER_CA_CERT_KEY_REPLACED);
 
         capturingPublisher.publishRestartEvents(mockPod, reasons);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -105,7 +105,6 @@ import static io.strimzi.operator.cluster.model.AbstractModel.clusterCaKeySecret
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_HAS_OLD_GENERATION;
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_REMOVED;
 import static io.strimzi.operator.cluster.model.RestartReason.CA_CERT_RENEWED;
-import static io.strimzi.operator.cluster.model.RestartReason.CLIENT_CA_CERT_KEY_REPLACED;
 import static io.strimzi.operator.cluster.model.RestartReason.CLUSTER_CA_CERT_KEY_REPLACED;
 import static io.strimzi.operator.cluster.model.RestartReason.CONFIG_CHANGE_REQUIRES_RESTART;
 import static io.strimzi.operator.cluster.model.RestartReason.FILE_SYSTEM_RESIZE_NEEDED;
@@ -394,24 +393,6 @@ public class KubernetesRestartEventsMockTest {
                 new KafkaMetadataStateManager(reconciliation, kafka));
 
         reconciler.reconcile(new KafkaStatus(), Clock.systemUTC()).onComplete(verifyEventPublished(CA_CERT_RENEWED, context));
-    }
-
-    @Test
-    void testEventEmittedWhenClientCaCertKeyReplaced(Vertx vertx, VertxTestContext context) {
-        // Turn off cert authority generation to cause reconciliation to roll pods
-        Kafka kafkaWithoutClientCaGen = new KafkaBuilder(kafka)
-                .editSpec()
-                    .editOrNewClientsCa()
-                        .withGenerateCertificateAuthority(false)
-                    .endClientsCa()
-                .endSpec()
-                .build();
-
-        // Bump ca cert generation to make it look newer than pod knows of
-        patchClusterSecretWithAnnotation(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "100000");
-
-        CaReconciler reconciler = new CaReconciler(reconciliation, kafkaWithoutClientCaGen, clusterOperatorConfig, supplier, vertx, mockCertManager, passwordGenerator);
-        reconciler.reconcile(Clock.systemUTC()).onComplete(verifyEventPublished(CLIENT_CA_CERT_KEY_REPLACED, context));
     }
 
     @Test

--- a/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
+++ b/documentation/modules/deploying/ref-operator-restart-events-reasons.adoc
@@ -25,9 +25,6 @@ a|Event
 |CaCertRenewed
 |CA certificates have been renewed, and the pod is restarted to run with the updated certificates.
 
-|ClientCaCertKeyReplaced
-|The key used to sign clients CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
-
 |ClusterCaCertKeyReplaced
 |The key used to sign the cluster's CA certificates has been replaced, and the pod is being restarted as part of the CA renewal process.
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -391,7 +391,7 @@ class SecurityST extends AbstractST {
     @Tag("ClientsCaKeys")
     void testAutoReplaceClientsCaKeysTriggeredByAnno() {
         autoReplaceSomeKeysTriggeredByAnno(
-                2,
+                1,
                 false,
                 true,
                 false,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Update CaReconciler to only roll pods when cluster CA key is replaced, not when clients CA key is replaced.

Currently we do two rolling updates for the key replacement, once in CaReconciler, and once in component reconcilers, e.g. KafkaReconciler. This is not required for clients CA since is is only used for trust.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

