### PR TITLE
Prepare upgrade files in packit pipelines in test phase where all envs are set properly

### DIFF
--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -2,13 +2,13 @@
 
 set -x
 
-RELEASE=$(cat release.version)
+RELEASE_VERSION=$(cat release.version)
 
 # The commands 1) and 2) are used for change tag in installation files for CO. For each branch only of them match and apply changes
 # 1) The following command is applied only for branches, where release.version contains *SNAPSHOT* (main + others)
 sed -i "s#:latest#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 # 2) The following command is applied only for release branches, where release.version contains a final version like 0.29.0
-sed -i "s#:${RELEASE}#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#:${RELEASE_VERSION}#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 
 # Change registry and org
 sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -93,11 +93,6 @@ prepare:
     script: |
       ./.azure/scripts/setup-helm.sh
 
-  - name: Setup upgrade
-    how: shell
-    script: |
-      ./.azure/scripts/setup_upgrade.sh
-
   - name: Install shellcheck
     how: shell
     script: |

--- a/systemtest/tmt/tests/strimzi/test.sh
+++ b/systemtest/tmt/tests/strimzi/test.sh
@@ -27,6 +27,9 @@ echo "Using container org '$DOCKER_ORG'"
 echo "Using container tag '$DOCKER_TAG'"
 echo "Using CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN=$CONNECT_IMAGE_WITH_FILE_SINK_PLUGIN"
 
+# Prepare upgrade files
+./.azure/scripts/setup_upgrade.sh
+
 mvn compile -pl config-model-generator -DskipTests -Dmaven.javadoc.skip=true --no-transfer-progress
 mvn verify -pl systemtest -P ${TEST_PROFILE} \
     $([[ "${TEST_GROUPS}" != "" ]] && echo "-Dgroups=${TEST_GROUPS}" || echo "") \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

For 0.44.0 we ran packit pipelines, but there were failures in upgrade tests. In turned out the problem was in calling `setup_upgrade.sh` on wrong place. This PR moves the script execution to test phase where all env variables are properly set so all files used within upgrade tests are prepared properly.

I tested it within my fork - https://github.com/Frawless/strimzi-kafka-operator/runs/32710100554

### Checklist

- [x] Make sure all tests pass

