### PR TITLE
Add/Update warnings for Zoo and MM1 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   Remove support for Kafka 3.7.0 and 3.7.1
 * Ability to move data between JBOD disks using Cruise Control.
 
+### Major changes, deprecations and removals
+
+* **Strimzi 0.45 is the last minor Strimzi version with support for ZooKeeper-based Apache Kafka clusters and Mirror Maker 1 deployments.**
+  **Please make sure to migrate to KRaft and Mirror Maker 2 before upgrading to Strimzi 0.46 or newer.**
+
 ## 0.44.0
 
 * Add the "Unmanaged" KafkaTopic status update.

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -255,6 +255,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 return Future.failedFuture(e);
             }
         } else {
+            // Add warning about upcoming ZooKeeper removal
+            LOGGER.warnCr(reconcileState.reconciliation, "Support for ZooKeeper-based Apache Kafka clusters will be removed in the next Strimzi release (0.46.0). Please migrate to KRaft.");
+            StatusUtils.addConditionsToStatus(reconcileState.kafkaStatus, Set.of(StatusUtils.buildWarningCondition("ZooKeeperRemoval", "Support for ZooKeeper-based Apache Kafka clusters will be removed in the next Strimzi release (0.46.0). Please migrate to KRaft.")));
+
             // Validates the properties required for a ZooKeeper based Kafka cluster
             try {
                 KRaftUtils.validateKafkaCrForZooKeeper(reconcileState.kafkaAssembly.getSpec(), nodePoolsEnabled);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperator.java
@@ -127,8 +127,8 @@ public class KafkaMirrorMakerAssemblyOperator extends AbstractAssemblyOperator<K
                         StatusUtils.setStatusConditionAndObservedGeneration(assemblyResource, kafkaMirrorMakerStatus, reconciliationResult.cause());
 
                         // Add warning about Mirror Maker 1 being deprecated and removed soon
-                        LOGGER.warnCr(reconciliation, "Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2.");
-                        StatusUtils.addConditionsToStatus(kafkaMirrorMakerStatus, Set.of(StatusUtils.buildWarningCondition("MirrorMaker1Deprecation", "Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2.")));
+                        LOGGER.warnCr(reconciliation, "Mirror Maker 1 is deprecated and will be removed in the next Strimzi release (0.46.0). Please migrate to Mirror Maker 2.");
+                        StatusUtils.addConditionsToStatus(kafkaMirrorMakerStatus, Set.of(StatusUtils.buildWarningCondition("MirrorMaker1Deprecation", "Mirror Maker 1 is deprecated and will be removed in the next Strimzi release (0.46.0). Please migrate to Mirror Maker 2.")));
 
                         kafkaMirrorMakerStatus.setReplicas(mirror.getReplicas());
                         kafkaMirrorMakerStatus.setLabelSelector(mirror.getSelectorLabels().toSelectorString());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorZooBasedTest.java
@@ -22,6 +22,7 @@ import io.fabric8.openshift.api.model.RouteStatus;
 import io.fabric8.openshift.api.model.RouteStatusBuilder;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.strimzi.api.kafka.model.common.Condition;
 import io.strimzi.api.kafka.model.common.InlineLogging;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxAuthenticationPasswordBuilder;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
@@ -129,6 +130,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -758,6 +760,10 @@ public class KafkaAssemblyOperatorZooBasedTest {
 
                 assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
 
+                Condition zooRemovalWarning = status.getConditions().stream().filter(c -> "ZooKeeperRemoval".equals(c.getReason())).findFirst().orElse(null);
+                assertThat(zooRemovalWarning, is(notNullValue()));
+                assertThat(zooRemovalWarning.getMessage(), is("Support for ZooKeeper-based Apache Kafka clusters will be removed in the next Strimzi release (0.46.0). Please migrate to KRaft."));
+
                 async.flag();
             })));
     }
@@ -1273,6 +1279,10 @@ public class KafkaAssemblyOperatorZooBasedTest {
 
                 assertThat(status.getOperatorLastSuccessfulVersion(), is(KafkaAssemblyOperator.OPERATOR_VERSION));
                 assertThat(status.getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
+
+                Condition zooRemovalWarning = status.getConditions().stream().filter(c -> "ZooKeeperRemoval".equals(c.getReason())).findFirst().orElse(null);
+                assertThat(zooRemovalWarning, is(notNullValue()));
+                assertThat(zooRemovalWarning.getMessage(), is("Support for ZooKeeper-based Apache Kafka clusters will be removed in the next Strimzi release (0.46.0). Please migrate to KRaft."));
 
                 async.flag();
             })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMakerAssemblyOperatorTest.java
@@ -178,7 +178,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
                 assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
                 assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
-                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
+                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in the next Strimzi release (0.46.0). Please migrate to Mirror Maker 2."));
 
                 async.flag();
             })));
@@ -656,7 +656,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                 assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
                 assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
                 assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
-                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
+                assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in the next Strimzi release (0.46.0). Please migrate to Mirror Maker 2."));
 
                 async.flag();
             })));
@@ -716,7 +716,7 @@ public class KafkaMirrorMakerAssemblyOperatorTest {
                     assertThat(mm.getStatus().getConditions().get(1).getType(), is("Warning"));
                     assertThat(mm.getStatus().getConditions().get(1).getReason(), is("MirrorMaker1Deprecation"));
                     assertThat(mm.getStatus().getConditions().get(1).getStatus(), is("True"));
-                    assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in Apache Kafka 4.0.0. Please migrate to Mirror Maker 2."));
+                    assertThat(mm.getStatus().getConditions().get(1).getMessage(), is("Mirror Maker 1 is deprecated and will be removed in the next Strimzi release (0.46.0). Please migrate to Mirror Maker 2."));
 
                     async.flag();
                 })));


### PR DESCRIPTION
### Type of change

- Task

### Description

We are now pretty certain the ZooKeeper and MM1 will be gone in Strimzi 0.46.0 as decided in [SP|77](https://github.com/strimzi/proposals/blob/main/077-support-for-kafka-4.0.md). This PR:
* Adds the removal warning for Zoo-based Kafka clusters
* Updates the warning for MM1 clusters

It also adds the warning to the CHANGELOG.md.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md