### PR TITLE
docs(jbod): using cc to reassign partitions on jbod disks

### DIFF
--- a/documentation/deploying/deploying.adoc
+++ b/documentation/deploying/deploying.adoc
@@ -50,6 +50,8 @@ include::assemblies/configuring/assembly-scaling-kafka-clusters.adoc[leveloffset
 include::assemblies/cruise-control/assembly-cruise-control-concepts.adoc[leveloffset=+1]
 //Using Cruise Control for changing topic replication factor
 include::modules/cruise-control/proc-cruise-control-topic-replication.adoc[leveloffset=+1]
+//Using Cruise Control to move data on jbod disks
+include::modules/cruise-control/proc-cruise-control-moving-data.adoc[leveloffset=+1]
 //Using the reassign tool to change topic replicas
 include::assemblies/configuring/assembly-reassign-tool.adoc[leveloffset=+1]
 //Introduce metrics and monitoring to your deployment

--- a/documentation/modules/cruise-control/con-cruise-control-overview.adoc
+++ b/documentation/modules/cruise-control/con-cruise-control-overview.adoc
@@ -12,12 +12,12 @@ Load Monitor:: Load Monitor collects the metrics and analyzes cluster workload d
 Analyzer:: Analyzer generates optimization proposals based on collected data and configured goals.
 Anomaly Detector:: Anomaly Detector identifies and reports irregularities in cluster behavior.
 Executor:: Executor applies approved optimization proposals to the cluster.
-
-Cruise Control also provides a REST API for client interactions, which Strimzi uses to support these features:
-
+REST API:: Cruise Control provides a REST API for client interactions, which Strimzi uses to support these features:
++
 * Generating optimization proposals from optimization goals
 * Rebalancing a Kafka cluster based on an optimization proposal
 * Changing topic replication factor
+* Reassigning partitions between JBOD disks
 
 NOTE: Other Cruise Control features are not currently supported, including self healing, notifications, and write-your-own goals.
 
@@ -235,7 +235,7 @@ The performance of the cluster during the rebalance is affected by the number an
 [id='con-optimization-proposals-modes-{context}']
 === Rebalancing modes
 
-Proposals for rebalances can be generated in three modes, which are specified using the `spec.mode` property of the `KafkaRebalance` custom resource.
+Proposals for rebalances can be generated in four modes, which are specified using the `spec.mode` property of the `KafkaRebalance` custom resource.
 
 `full` mode:: The `full` mode runs a full rebalance by moving replicas across all the brokers in the cluster.
 This is the default mode if the `spec.mode` property is not defined in the `KafkaRebalance` custom resource.
@@ -250,6 +250,9 @@ You specify the new brokers as a list using the `spec.brokers` property of the `
 The `remove-brokers` mode moves replicas off the brokers that are going to be removed.
 When these brokers are not hosting replicas anymore, you can safely run the scaling down operation.
 You specify the brokers you're removing as a list in the `spec.brokers` property in the `KafkaRebalance` custom resource.
+
+`remove-disks` mode:: The `remove-disks` mode is used specifically to reassign partitions between JBOD disks used for storage on the same broker.
+You specify a list of broker IDs with corresponding volume IDs for partition reassignment. 
 
 NOTE: Brokers are shut down even if they host replicas when xref:con-skipping-scale-down-checks-{context}[checks are skipped on scale-down operations].
 

--- a/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
+++ b/documentation/modules/cruise-control/proc-approving-optimization-proposal.adoc
@@ -28,18 +28,16 @@ Cruise Control will then apply the optimization proposal to the Kafka cluster, r
 Perform these steps for the optimization proposal that you want to approve.
 
 . Unless the optimization proposal is newly generated, check that it is based on current information about the state of the Kafka cluster.
-To do so, refresh the optimization proposal to make sure it uses the latest cluster metrics:
-
-.. Annotate the `KafkaRebalance` resource in Kubernetes with `strimzi.io/rebalance=refresh`:
+To do so, annotate the `KafkaRebalance` resource to refresh the optimization proposal and make sure it uses the latest cluster metrics:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
 kubectl annotate kafkarebalance <kafka_rebalance_resource_name> strimzi.io/rebalance="refresh"
 ----
 
 . Wait for the status of the optimization proposal to change to `ProposalReady`:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
 kubectl get kafkarebalance -o wide -w -n <namespace>
 ----
@@ -51,22 +49,20 @@ kubectl get kafkarebalance -o wide -w -n <namespace>
 +
 When the status changes to `ProposalReady`, the optimization proposal is ready to approve.
 
-. Approve the optimization proposal that you want Cruise Control to apply.
+. Annotate the `KafkaRebalance` resource to approve the optimization proposal:
 +
-Annotate the `KafkaRebalance` resource in Kubernetes with `strimzi.io/rebalance=approve`:
-+
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl annotate kafkarebalance _<kafka_rebalance_resource_name>_ strimzi.io/rebalance="approve"
+kubectl annotate kafkarebalance <kafka_rebalance_resource_name> strimzi.io/rebalance="approve"
 ----
 
 . The Cluster Operator detects the annotated resource and instructs Cruise Control to rebalance the Kafka cluster.
 
 . Wait for the status of the optimization proposal to change to `Ready`:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl get kafkarebalance -o wide -w -n _<namespace>_
+kubectl get kafkarebalance -o wide -w -n <namespace>
 ----
 +
 --

--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -2,7 +2,7 @@
 = Using Cruise Control to reassign partitions on JBOD disks
 
 [role="_abstract"]
-If you are using JBOD storage and have Cruise Control installed with Strimzi, you can reassign partitions and move data between the JBOD disks used for storage on the same broker.
+If you are using JBOD storage and have Cruise Control installed with Strimzi, you can reassign partitions between the JBOD disks used for storage on the same broker.
 This capability also allows you to remove JBOD disks without data loss.
 
 To reassign partitions, configure a `KafkaRebalance` resource in `remove-disks` mode and specify a list of broker IDs with corresponding volume IDs for partition reassignment. 
@@ -333,8 +333,3 @@ In this example, the log directories for volumes 1 and 2 no longer have partitio
       ]
     }
 ----
-
-
-
-
-

--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -1,0 +1,339 @@
+[id='proc-cruise-control-moving-data-{context}']
+= Using Cruise Control to reassign partitions on JBOD disks
+
+[role="_abstract"]
+If you are using JBOD storage and have Cruise Control installed with Strimzi, you can move reassign partitions and move data between the JBOD disks used for storage on the same broker.
+This capability also allows you to remove JBOD disks without data loss.
+
+To reassign partitions, configure a `KafkaRebalance` resource in `remove-disks` mode and specify a list of broker IDs with corresponding volume IDs for partition reassignment. 
+Cruise Control generates an optimization proposal based on the configuration and reassigns the partitions when approved manually or automatically. 
+
+Use the Kafka `kafka-log-dirs.sh` tool to check information about Kafka topic partitions and their location on brokers before and after moving them.
+Use an interactive pod to avoid running the tool within the broker container and causing any disruptions.
+
+.Prerequisites
+
+* xref:deploying-cluster-operator-str[The Cluster Operator must be deployed.]
+* xref:proc-configuring-deploying-cruise-control-str[Cruise Control is deployed with Kafka.]
+* Kafka operates in KRaft mode and brokers use JBOD storage.
+* More than one JBOD disk must be configured on the broker. 
+For more information on configuring Kafka storage, see xref:assembly-storage-str[].
+
+In this procedure, we use a Kafka cluster named `my-cluster`, which is deployed to the `my-project` namespace with node pools and Cruise Control enabled.
+
+.Example Kafka cluster configuration
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: my-project
+  annotations:
+    strimzi.io/node-pools: enabled
+spec:
+  kafka:
+    # ...
+  cruiseControl: {}
+    # ...
+----
+
+A node pool named `pool-a` is configured with three broker replicas that use three JBOD storage volumes.
+In the procedure, we show how partitions are reassigned from volume 1 and 2 to volume 0. 
+
+.Example node pool configuration with JBOD storage
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaNodePoolApiVersion}
+kind: KafkaNodePool
+metadata:
+  name: pool-a
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 2000Gi
+        deleteClaim: false
+      - id: 1
+        type: persistent-claim
+        size: 2000Gi
+        deleteClaim: false
+      - id: 2
+        type: persistent-claim
+        size: 2000Gi
+        deleteClaim: false
+  # ...
+----
+
+.Procedure
+
+. Run a new interactive pod container using the Kafka image to connect to a running Kafka broker.
++
+[source,shell,subs="+quotes,attributes"]
+----
+kubectl run --restart=Never --image={DockerKafkaImageCurrent} helper-pod -- /bin/sh -c "sleep 3600"
+----
++
+In this procedure, we use a pod named `helper-pod`.
+
+. Check the partition replica data on broker 0 by opening a terminal inside the interactive pod and running the Kafka `kafka-log-dirs.sh` tool:
++
+[source,shell]
+----
+kubectl exec -n myproject -ti my-cluster-pool-a-0 bin/kafka-log-dirs.sh --describe --bootstrap-server my-cluster-kafka-bootstrap:9092 --broker-list 0,1,2 --topic-list my-topic
+----
++
+`my-cluster-pool-a-0` is the pod name for broker 0.
+The tool returns topic information for each log directory.
+The JBOD volumes used for log directories are mounted at `/var/lib/kafka/data-<volume_id>/kafka-log<pod_id>`.
++
+.Example output data for each log directory
+[source,shell]
+----
+{
+  "brokers": [
+    {
+      "broker": 0, # <1>
+      "logDirs": [
+        {
+          "partitions": [ # <2>
+            {
+              "partition": "my-topic-5",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-2",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            }
+          ],
+          "error": null, # <3>
+          "logDir": "/var/lib/kafka/data-2/kafka-log0" # <4>
+        },
+        {
+          "partitions": [
+            {
+              "partition": "my-topic-0",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-3",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            }
+          ],
+          "error": null,
+          "logDir": "/var/lib/kafka/data-0/kafka-log0"
+        },
+        {
+          "partitions": [
+            {
+              "partition": "my-topic-4",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-1",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            }
+          ],
+          "error": null,
+          "logDir": "/var/lib/kafka/data-1/kafka-log0"
+        }
+      ]
+    }
+----
+<1> The broker ID.
+<2> Partition details: name, size, offset lag. The (`isFuture`) property indicates that the partition is moving between log directories when showing as `true`. 
+<3> If `error` is not `null`, there is an issue with the disk hosting the log directory.
+<4> The path and name of the log directory.
+
+. Create a `KafkaRebalance` resource in `remove-disks` mode, listing the brokers and volume IDs to reassign partitions from.
+Without specific configuration, the default rebalance goals are used. 
++
+.Example Cruise Control configuration
+[source,shell]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  mode: remove-disks
+  moveReplicasOffVolumes:
+    - brokerId: 0 # <1> 
+      volumeIds: [1, 2] # <2>
+----
+<1> The broker from which to reassign partitions.
+<2> The volume IDs to reassign partitions from.
++
+In this example, `my-rebalance` reassigns partitions from volumes with IDs 1 and 2 on broker 0.
+
+. (Optional) To approve the optimization proposal automatically, set the `strimzi.io/rebalance-auto-approval` annotation to `true`:
++
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+  labels:
+    strimzi.io/cluster: my-cluster
+  annotations:
+    strimzi.io/rebalance-auto-approval: "true"  
+spec:
+  mode: remove-disks
+  moveReplicasOffVolumes:
+    - brokerId: 0
+      volumeIds: [1, 2]
+----
+
+. Apply the `KafkaRebalance` configuration.
+
+. If manually approving, wait for the status of the proposal to move to `ProposalReady` before approving the changes.
+
+.. Check the summary of the changes in the `KafkaRebalance` status:
++
+[source,shell]
+----
+kubectl get kafkarebalance my-rebalance -n my-project -o yaml
+----
++
+.Example summary of changes
+[source,shell]
+----
+apiVersion: {KafkaRebalanceApiVersion}
+kind: KafkaRebalance
+metadata:
+  name: my-rebalance
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  mode: remove-disks
+  moveReplicasOffVolumes:
+    - brokerId: 0 
+      volumeIds: [1, 2]
+status:
+  - lastTransitionTime: "2024-11-13T06:55:42.217794891Z"
+    status: "True"
+    type: ProposalReady
+  observedGeneration: 1
+  optimizationResult:
+    afterBeforeLoadConfigMap: my-rebalance
+    dataToMoveMB: 0
+    excludedBrokersForLeadership: []
+    excludedBrokersForReplicaMove: []
+    excludedTopics: []
+    intraBrokerDataToMoveMB: 0
+    monitoredPartitionsPercentage: 100
+    numIntraBrokerReplicaMovements: 26
+    numLeaderMovements: 0
+    numReplicaMovements: 0
+    onDemandBalancednessScoreAfter: 100
+    onDemandBalancednessScoreBefore: 0
+    provisionRecommendation: ""
+    provisionStatus: UNDECIDED
+    recentWindows: 1
+  sessionId: 24537b9c-a315-4715-8e86-01481e914771        
+----
++
+NOTE: The summary only shows the changes after optimization, not the load before optimization.
+
+.. Annotate the `KafkaRebalance` resource to approve the changes:
++
+[source,shell,subs="+quotes"]
+----
+kubectl annotate kafkarebalance my-rebalance strimzi.io/rebalance="approve"
+----
+
+. Wait for the status of the proposal to change to `Ready`.
+
+. Use the Kafka `kafka-log-dirs.sh` tool again to verify data movement.
++
+In this example, the log directories for volumes 1 and 2 no longer have partitions assigned to them and volume 0 holds partitions for six topics, indicating that the partitions have been successfully reassigned.
++
+.Example output data following reassignment of partitions
+[source,shell]
+----
+{
+  "brokers": [
+    {
+      "broker": 0,
+      "logDirs": [
+        {
+          "partitions": [],
+          "error": null,
+          "logDir": "/var/lib/kafka/data-2/kafka-log0"
+        },
+        {
+          "partitions": [
+            {
+              "partition": "my-topic-4",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-5",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-0",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-1",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-2",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            },
+            {
+              "partition": "my-topic-3",
+              "size": 0,
+              "offsetLag": 0,
+              "isFuture": false
+            }
+          ],
+          "error": null,
+          "logDir": "/var/lib/kafka/data-0/kafka-log0"
+        },
+        {
+          "partitions": [],
+          "error": null,
+          "logDir": "/var/lib/kafka/data-1/kafka-log0"
+        }
+      ]
+    }
+----
+
+
+
+
+

--- a/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
+++ b/documentation/modules/cruise-control/proc-cruise-control-moving-data.adoc
@@ -2,7 +2,7 @@
 = Using Cruise Control to reassign partitions on JBOD disks
 
 [role="_abstract"]
-If you are using JBOD storage and have Cruise Control installed with Strimzi, you can move reassign partitions and move data between the JBOD disks used for storage on the same broker.
+If you are using JBOD storage and have Cruise Control installed with Strimzi, you can reassign partitions and move data between the JBOD disks used for storage on the same broker.
 This capability also allows you to remove JBOD disks without data loss.
 
 To reassign partitions, configure a `KafkaRebalance` resource in `remove-disks` mode and specify a list of broker IDs with corresponding volume IDs for partition reassignment. 
@@ -83,7 +83,7 @@ kubectl run --restart=Never --image={DockerKafkaImageCurrent} helper-pod -- /bin
 +
 In this procedure, we use a pod named `helper-pod`.
 
-. Check the partition replica data on broker 0 by opening a terminal inside the interactive pod and running the Kafka `kafka-log-dirs.sh` tool:
+. (Optional) Check the partition replica data on broker 0 by opening a terminal inside the interactive pod and running the Kafka `kafka-log-dirs.sh` tool:
 +
 [source,shell]
 ----
@@ -92,6 +92,7 @@ kubectl exec -n myproject -ti my-cluster-pool-a-0 bin/kafka-log-dirs.sh --descri
 +
 `my-cluster-pool-a-0` is the pod name for broker 0.
 The tool returns topic information for each log directory.
+In this example, we are restricting the information to `my-topic` to show the steps against a single topic.  
 The JBOD volumes used for log directories are mounted at `/var/lib/kafka/data-<volume_id>/kafka-log<pod_id>`.
 +
 .Example output data for each log directory
@@ -267,7 +268,7 @@ kubectl annotate kafkarebalance my-rebalance strimzi.io/rebalance="approve"
 
 . Use the Kafka `kafka-log-dirs.sh` tool again to verify data movement.
 +
-In this example, the log directories for volumes 1 and 2 no longer have partitions assigned to them and volume 0 holds partitions for six topics, indicating that the partitions have been successfully reassigned.
+In this example, the log directories for volumes 1 and 2 no longer have partitions assigned to them and volume 0 holds 6 partitions for `my-topic`, indicating that the partitions have been successfully reassigned.
 +
 .Example output data following reassignment of partitions
 [source,shell]

--- a/documentation/modules/cruise-control/proc-fixing-problems-with-kafkarebalance.adoc
+++ b/documentation/modules/cruise-control/proc-fixing-problems-with-kafkarebalance.adoc
@@ -31,25 +31,23 @@ During a “refresh”, a new optimization proposal is requested from the Cruise
 
 . Get information about the error from the `KafkaRebalance` status:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl describe kafkarebalance _rebalance-cr-name_
+kubectl describe kafkarebalance <kafka_rebalance_resource_name>
 ----
 
-. Attempt to resolve the issue in the `KafkaRebalance` resource.
-
-. Annotate the `KafkaRebalance` resource in Kubernetes:
+. Attempt to resolve the issue by annotating the `KafkaRebalance` resource to refresh the proposal:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl annotate kafkarebalance _rebalance-cr-name_ strimzi.io/rebalance="refresh"
+kubectl annotate kafkarebalance <kafka_rebalance_resource_name> strimzi.io/rebalance="refresh"
 ----
 
 . Check the status of the `KafkaRebalance` resource:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl describe kafkarebalance _rebalance-cr-name_
+kubectl describe kafkarebalance <kafka_rebalance_resource_name>
 ----
 
 . Wait until the status changes to `PendingProposal`, or directly to `ProposalReady`.

--- a/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
+++ b/documentation/modules/cruise-control/proc-generating-optimization-proposals.adoc
@@ -10,7 +10,7 @@ When you create or update a `KafkaRebalance` resource, Cruise Control generates 
 Analyze the information in the optimization proposal and decide whether to approve it.
 You can use the results of the optimization proposal to rebalance your Kafka cluster.
 
-You can run the optimization proposal in one of the following modes:
+This procedure covers using the following modes for generating optimization proposals related to rebalances:
 
 * `full` (default)
 * `add-brokers`

--- a/documentation/modules/cruise-control/proc-stopping-cluster-rebalance.adoc
+++ b/documentation/modules/cruise-control/proc-stopping-cluster-rebalance.adoc
@@ -21,18 +21,18 @@ NOTE: The performance of the Kafka cluster in the intermediate (stopped) state m
 
 .Procedure
 
-. Annotate the `KafkaRebalance` resource in Kubernetes:
+. Annotate the `KafkaRebalance` resource to stop the rebalance:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl annotate kafkarebalance _rebalance-cr-name_ strimzi.io/rebalance="stop"
+kubectl annotate kafkarebalance <kafka_rebalance_resource_name> strimzi.io/rebalance="stop"
 ----
 
 . Check the status of the `KafkaRebalance` resource:
 +
-[source,shell,subs="+quotes"]
+[source,shell]
 ----
-kubectl describe kafkarebalance _rebalance-cr-name_
+kubectl describe kafkarebalance <kafka_rebalance_resource_name>
 ----
 
 . Wait until the status changes to `Stopped`.


### PR DESCRIPTION
**Documentation**

Adds a new procedure to demonstrate how to reassign partitions and move data between the JBOD disks used for storage on the same broker.

Plus a few updates to the Cruise Control to refresh formatting and make consistent with new content.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

