### PR TITLE
Improve min.insync.replicas parsing in warnTooLargeMinIsr

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -684,11 +684,11 @@ public class BatchingTopicController {
         Reconciliation reconciliation, KafkaTopic kafkaTopic, int currentNumPartitions
     ) {
         var requested = kafkaTopic.getSpec() == null || kafkaTopic.getSpec().getPartitions() == null
-            ? KafkaHandler.BROKER_DEFAULT : kafkaTopic.getSpec().getPartitions();
+            ? KafkaHandler.DEFAULT_PARTITIONS_REPLICAS : kafkaTopic.getSpec().getPartitions();
         if (requested > currentNumPartitions) {
             LOGGER.debugCr(reconciliation, "Partition increase from {} to {}", currentNumPartitions, requested);
             return Either.ofRight(NewPartitions.increaseTo(requested));
-        } else if (requested != KafkaHandler.BROKER_DEFAULT && requested < currentNumPartitions) {
+        } else if (requested != KafkaHandler.DEFAULT_PARTITIONS_REPLICAS && requested < currentNumPartitions) {
             LOGGER.debugCr(reconciliation, "Partition decrease from {} to {}", currentNumPartitions, requested);
             return Either.ofLeft(new TopicOperatorException.NotSupported("Decreasing partitions not supported"));
         } else {
@@ -823,7 +823,7 @@ public class BatchingTopicController {
                 var topicMinIsr = topicConfig.get(KafkaHandler.MIN_INSYNC_REPLICAS);
                 var configuredMinIsr = topicMinIsr != null 
                     ? Integer.parseInt(TopicOperatorUtil.configValueAsString(KafkaHandler.MIN_INSYNC_REPLICAS, topicMinIsr))
-                    : clusterMinIsr.map(Integer::parseInt).orElse(1);
+                    : clusterMinIsr.map(Integer::parseInt).orElse(KafkaHandler.DEFAULT_MIN_ISR);
                 var targetRf = reconcilableTopic.kt().getSpec().getReplicas();
                 if (targetRf < configuredMinIsr) {
                     LOGGER.warnCr(reconcilableTopic.reconciliation(),

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -820,13 +820,15 @@ public class BatchingTopicController {
         for (ReconcilableTopic reconcilableTopic : reconcilableTopics) {
             var topicConfig = reconcilableTopic.kt().getSpec().getConfig();
             if (topicConfig != null) {
-                Integer topicMinIsr = (Integer) topicConfig.get(KafkaHandler.MIN_INSYNC_REPLICAS);
-                var minIsr = topicMinIsr != null ? topicMinIsr : clusterMinIsr.map(Integer::parseInt).orElse(1);
+                var topicMinIsr = topicConfig.get(KafkaHandler.MIN_INSYNC_REPLICAS);
+                var configuredMinIsr = topicMinIsr != null 
+                    ? Integer.parseInt(TopicOperatorUtil.configValueAsString(KafkaHandler.MIN_INSYNC_REPLICAS, topicMinIsr))
+                    : clusterMinIsr.map(Integer::parseInt).orElse(1);
                 var targetRf = reconcilableTopic.kt().getSpec().getReplicas();
-                if (targetRf < minIsr) {
+                if (targetRf < configuredMinIsr) {
                     LOGGER.warnCr(reconcilableTopic.reconciliation(),
                         "The target replication factor ({}) is below the configured {} ({})",
-                        targetRf, KafkaHandler.MIN_INSYNC_REPLICAS, minIsr);
+                        targetRf, KafkaHandler.MIN_INSYNC_REPLICAS, configuredMinIsr);
                 }
             }
         }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -684,11 +684,11 @@ public class BatchingTopicController {
         Reconciliation reconciliation, KafkaTopic kafkaTopic, int currentNumPartitions
     ) {
         var requested = kafkaTopic.getSpec() == null || kafkaTopic.getSpec().getPartitions() == null
-            ? KafkaHandler.DEFAULT_PARTITIONS_REPLICAS : kafkaTopic.getSpec().getPartitions();
+            ? KafkaHandler.DEFAULT_PARTITIONS : kafkaTopic.getSpec().getPartitions();
         if (requested > currentNumPartitions) {
             LOGGER.debugCr(reconciliation, "Partition increase from {} to {}", currentNumPartitions, requested);
             return Either.ofRight(NewPartitions.increaseTo(requested));
-        } else if (requested != KafkaHandler.DEFAULT_PARTITIONS_REPLICAS && requested < currentNumPartitions) {
+        } else if (requested != KafkaHandler.DEFAULT_PARTITIONS && requested < currentNumPartitions) {
             LOGGER.debugCr(reconciliation, "Partition decrease from {} to {}", currentNumPartitions, requested);
             return Either.ofLeft(new TopicOperatorException.NotSupported("Decreasing partitions not supported"));
         } else {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaHandler.java
@@ -56,8 +56,8 @@ public class KafkaHandler {
     /** Kafka configuration for min insync replicas. */
     public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
 
-    /** Default value for partitions and replicas. */
-    public static final int DEFAULT_PARTITIONS_REPLICAS = -1;
+    /** Default value for partitions. */
+    public static final int DEFAULT_PARTITIONS = -1;
     /** Default value for min.insync.replicas. */
     public static final int DEFAULT_MIN_ISR = 1;
     

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaHandler.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/KafkaHandler.java
@@ -50,13 +50,16 @@ import java.util.stream.Stream;
  */
 public class KafkaHandler {
     static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaHandler.class);
-
-    /** Default value for partitions and replicas. */
-    public static final int BROKER_DEFAULT = -1;
+    
     /** Kafka configuration for auto create topic. */
     public static final String AUTO_CREATE_TOPICS_ENABLE = "auto.create.topics.enable";
     /** Kafka configuration for min insync replicas. */
     public static final String MIN_INSYNC_REPLICAS = "min.insync.replicas";
+
+    /** Default value for partitions and replicas. */
+    public static final int DEFAULT_PARTITIONS_REPLICAS = -1;
+    /** Default value for min.insync.replicas. */
+    public static final int DEFAULT_MIN_ISR = 1;
     
     private final TopicOperatorConfig config;
     private final TopicOperatorMetricsHolder metricsHolder;

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
@@ -267,8 +267,6 @@ class BatchingTopicControllerIT implements TestSeparator {
         assertOnUpdateThrowsInterruptedException(adminSpy, withDeletionTimestamp);
     }
 
-    // TODO kube client interrupted exceptions
-
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     public void replicasChangeShouldBeReconciled(boolean cruiseControlEnabled) {
@@ -310,6 +308,8 @@ class BatchingTopicControllerIT implements TestSeparator {
                 .addToLabels("key", "VALUE")
             .endMetadata()
             .withNewSpec()
+                // we also support string values
+                .withConfig(Map.of("min.insync.replicas", "1"))
                 .withPartitions(25)
                 .withReplicas(++replicationFactor)
             .endSpec()

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -994,7 +994,7 @@ class TopicControllerIT implements TestSeparator {
                         return theKt;
                     },
                     expectedCreateConfigs -> {
-                        Map<String, String> expectedUpdatedConfigs = new HashMap<>(expectedCreateConfigs);
+                        var expectedUpdatedConfigs = new HashMap<>(expectedCreateConfigs);
                         expectedUpdatedConfigs.remove(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG);
                         return expectedUpdatedConfigs;
                     });
@@ -1550,7 +1550,7 @@ class TopicControllerIT implements TestSeparator {
             @Override
             public boolean test(KafkaTopic theKt) {
                 return theKt.getStatus() != null
-                    && (theKt.getStatus().getObservedGeneration() >= postUpdateGeneration 
+                    && (theKt.getStatus().getObservedGeneration() == postUpdateGeneration 
                         || !TopicOperatorUtil.isManaged(theKt) || TopicOperatorUtil.isPaused(theKt))
                     && predicate.test(theKt);
             }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When reconciling a replicas change, we check the target number of replicas against the configured minISR. In that case, a ClassCastException is raised if the user sets min.insync.replicas: "1" (quoted value). This patch aligns this configuration parsing to the rest of the code, where this is tolerated.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
