### PR TITLE
Add warning about removal of Strimzi `EnvVarConfigProvider` and `IdentityRepicationPolicy` to `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * **Strimzi 0.45 is the last minor Strimzi version with support for ZooKeeper-based Apache Kafka clusters and MirrorMaker 1 deployments.**
   **Please make sure to migrate to KRaft and MirrorMaker 2 before upgrading to Strimzi 0.46 or newer.**
+* **Strimzi 0.45 is the last Strimzi version to include the [Strimzi EnvVar Configuration Provider](https://github.com/strimzi/kafka-env-var-config-provider) (deprecated in Strimzi 0.38.0) and [Strimzi MirrorMaker 2 Extensions](https://github.com/strimzi/mirror-maker-2-extensions) (deprecated in Strimzi 0.28.0).**
+  Please use the Apache Kafka [EnvVarConfigProvider](https://github.com/strimzi/kafka-env-var-config-provider?tab=readme-ov-file#deprecation-notice) and [Identity Replication Policy](https://github.com/strimzi/mirror-maker-2-extensions?tab=readme-ov-file#identity-replication-policy) instead. 
 
 ## 0.44.0
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As we plan to stop including the deprecated Strimzi plugins in Strimzi from 0.46.0 (to bundle this change with the ZooKeeper removal etc.), this PR adds one last warning to the CHANGELOG / release notes of the 0.45.0 release.

### Checklist

- [x] Update CHANGELOG.md