### PR TITLE
Add component label to `KafkaNodePool` CRD in Helm Chart

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: strimzi
     strimzi.io/crd-install: "true"
+    component: kafkanodepools.kafka.strimzi.io-crd
 spec:
   group: kafka.strimzi.io
   names:
@@ -13,1241 +14,1241 @@ spec:
     singular: kafkanodepool
     plural: kafkanodepools
     shortNames:
-    - knp
+      - knp
     categories:
-    - strimzi
+      - strimzi
   scope: Namespaced
   conversion:
     strategy: None
   versions:
-  - name: v1beta2
-    served: true
-    storage: true
-    subresources:
-      status: {}
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-        labelSelectorPath: .status.labelSelector
-    additionalPrinterColumns:
-    - name: Desired replicas
-      description: The desired number of replicas
-      jsonPath: .spec.replicas
-      type: integer
-    - name: Roles
-      description: Roles of the nodes in the pool
-      jsonPath: .status.roles
-      type: string
-    - name: NodeIds
-      description: Node IDs used by Kafka nodes in this pool
-      jsonPath: .status.nodeIds
-      type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          apiVersion:
-            type: string
-            description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-          kind:
-            type: string
-            description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-          metadata:
-            type: object
-          spec:
-            type: object
-            properties:
-              replicas:
-                type: integer
-                minimum: 0
-                description: The number of pods in the pool.
-              storage:
-                type: object
-                properties:
-                  class:
-                    type: string
-                    description: The storage class to use for dynamic volume allocation.
-                  deleteClaim:
-                    type: boolean
-                    description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
-                  id:
-                    type: integer
-                    minimum: 0
-                    description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
-                  kraftMetadata:
-                    type: string
-                    enum:
-                    - shared
-                    description: "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set."
-                  overrides:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        class:
-                          type: string
-                          description: The storage class to use for dynamic volume allocation for this broker.
-                        broker:
-                          type: integer
-                          description: Id of the kafka broker (broker identifier).
-                    description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
-                  selector:
-                    additionalProperties:
+    - name: v1beta2
+      served: true
+      storage: true
+      subresources:
+        status: {}
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .status.labelSelector
+      additionalPrinterColumns:
+        - name: Desired replicas
+          description: The desired number of replicas
+          jsonPath: .spec.replicas
+          type: integer
+        - name: Roles
+          description: Roles of the nodes in the pool
+          jsonPath: .status.roles
+          type: string
+        - name: NodeIds
+          description: Node IDs used by Kafka nodes in this pool
+          jsonPath: .status.nodeIds
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+            kind:
+              type: string
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 0
+                  description: The number of pods in the pool.
+                storage:
+                  type: object
+                  properties:
+                    class:
                       type: string
-                    type: object
-                    description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
-                  size:
-                    type: string
-                    description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
-                  sizeLimit:
-                    type: string
-                    pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                    description: "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi)."
-                  type:
+                      description: The storage class to use for dynamic volume allocation.
+                    deleteClaim:
+                      type: boolean
+                      description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
+                    id:
+                      type: integer
+                      minimum: 0
+                      description: Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.
+                    kraftMetadata:
+                      type: string
+                      enum:
+                        - shared
+                      description: "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set."
+                    overrides:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                            description: The storage class to use for dynamic volume allocation for this broker.
+                          broker:
+                            type: integer
+                            description: Id of the kafka broker (broker identifier).
+                      description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                    selector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                      description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
+                    size:
+                      type: string
+                      description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
+                    sizeLimit:
+                      type: string
+                      pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                      description: "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi)."
+                    type:
+                      type: string
+                      enum:
+                        - ephemeral
+                        - persistent-claim
+                        - jbod
+                      description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
+                    volumes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                            description: The storage class to use for dynamic volume allocation.
+                          deleteClaim:
+                            type: boolean
+                            description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
+                          id:
+                            type: integer
+                            minimum: 0
+                            description: Storage identification number. Mandatory for storage volumes defined with a `jbod` storage type configuration.
+                          kraftMetadata:
+                            type: string
+                            enum:
+                              - shared
+                            description: "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set."
+                          overrides:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                class:
+                                  type: string
+                                  description: The storage class to use for dynamic volume allocation for this broker.
+                                broker:
+                                  type: integer
+                                  description: Id of the kafka broker (broker identifier).
+                            description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                            description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
+                          size:
+                            type: string
+                            description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
+                          sizeLimit:
+                            type: string
+                            pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                            description: "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi)."
+                          type:
+                            type: string
+                            enum:
+                              - ephemeral
+                              - persistent-claim
+                            description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
+                        required:
+                          - type
+                      description: List of volumes as Storage objects representing the JBOD disks array.
+                  required:
+                    - type
+                  description: Storage configuration (disk). Cannot be updated.
+                roles:
+                  type: array
+                  items:
                     type: string
                     enum:
-                    - ephemeral
-                    - persistent-claim
-                    - jbod
-                    description: "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'."
-                  volumes:
-                    type: array
-                    items:
+                      - controller
+                      - broker
+                  description: "The roles that the nodes in this pool will have when KRaft mode is enabled. Supported values are 'broker' and 'controller'. This field is required. When KRaft mode is disabled, the only allowed value if `broker`."
+                resources:
+                  type: object
+                  properties:
+                    claims:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  description: CPU and memory resources to reserve.
+                jvmOptions:
+                  type: object
+                  properties:
+                    "-XX":
+                      additionalProperties:
+                        type: string
+                      type: object
+                      description: A map of -XX options to the JVM.
+                    "-Xmx":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xmx option to to the JVM.
+                    "-Xms":
+                      type: string
+                      pattern: "^[0-9]+[mMgG]?$"
+                      description: -Xms option to to the JVM.
+                    gcLoggingEnabled:
+                      type: boolean
+                      description: Specifies whether the Garbage Collection logging is enabled. The default is false.
+                    javaSystemProperties:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                            description: The system property name.
+                          value:
+                            type: string
+                            description: The system property value.
+                      description: A map of additional system properties which will be passed using the `-D` option to the JVM.
+                  description: JVM Options for pods.
+                template:
+                  type: object
+                  properties:
+                    podSet:
                       type: object
                       properties:
-                        class:
-                          type: string
-                          description: The storage class to use for dynamic volume allocation.
-                        deleteClaim:
-                          type: boolean
-                          description: Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
-                        id:
-                          type: integer
-                          minimum: 0
-                          description: Storage identification number. Mandatory for storage volumes defined with a `jbod` storage type configuration.
-                        kraftMetadata:
-                          type: string
-                          enum:
-                          - shared
-                          description: "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set."
-                        overrides:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka `StrimziPodSet` resource.
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                        imagePullSecrets:
                           type: array
                           items:
                             type: object
                             properties:
-                              class:
+                              name:
                                 type: string
-                                description: The storage class to use for dynamic volume allocation for this broker.
-                              broker:
-                                type: integer
-                                description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
-                        selector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                          description: Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.
-                        size:
-                          type: string
-                          description: "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`."
-                        sizeLimit:
-                          type: string
-                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                          description: "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi)."
-                        type:
-                          type: string
-                          enum:
-                          - ephemeral
-                          - persistent-claim
-                          description: "Storage type, must be either 'ephemeral' or 'persistent-claim'."
-                      required:
-                      - type
-                    description: List of volumes as Storage objects representing the JBOD disks array.
-                required:
-                - type
-                description: Storage configuration (disk). Cannot be updated.
-              roles:
-                type: array
-                items:
-                  type: string
-                  enum:
-                  - controller
-                  - broker
-                description: "The roles that the nodes in this pool will have when KRaft mode is enabled. Supported values are 'broker' and 'controller'. This field is required. When KRaft mode is disabled, the only allowed value if `broker`."
-              resources:
-                type: object
-                properties:
-                  claims:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
-                      x-kubernetes-int-or-string: true
-                    type: object
-                description: CPU and memory resources to reserve.
-              jvmOptions:
-                type: object
-                properties:
-                  "-XX":
-                    additionalProperties:
-                      type: string
-                    type: object
-                    description: A map of -XX options to the JVM.
-                  "-Xmx":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xmx option to to the JVM.
-                  "-Xms":
-                    type: string
-                    pattern: "^[0-9]+[mMgG]?$"
-                    description: -Xms option to to the JVM.
-                  gcLoggingEnabled:
-                    type: boolean
-                    description: Specifies whether the Garbage Collection logging is enabled. The default is false.
-                  javaSystemProperties:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The system property name.
-                        value:
-                          type: string
-                          description: The system property value.
-                    description: A map of additional system properties which will be passed using the `-D` option to the JVM.
-                description: JVM Options for pods.
-              template:
-                type: object
-                properties:
-                  podSet:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                    description: Template for Kafka `StrimziPodSet` resource.
-                  pod:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                      imagePullSecrets:
-                        type: array
-                        items:
+                          description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
+                        securityContext:
                           type: object
                           properties:
-                            name:
-                              type: string
-                        description: "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored."
-                      securityContext:
-                        type: object
-                        properties:
-                          appArmorProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          fsGroup:
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          supplementalGroups:
-                            type: array
-                            items:
-                              type: integer
-                          sysctls:
-                            type: array
-                            items:
+                            appArmorProfile:
                               type: object
                               properties:
-                                name:
+                                localhostProfile:
                                   type: string
-                                value:
+                                type:
                                   type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Configures pod-level security attributes and common container settings.
-                      terminationGracePeriodSeconds:
-                        type: integer
-                        minimum: 0
-                        description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
-                      affinity:
-                        type: object
-                        properties:
-                          nodeAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    preference:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
+                            fsGroup:
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
                                 type: object
                                 properties:
-                                  nodeSelectorTerms:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                          description: Configures pod-level security attributes and common container settings.
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                          description: "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds."
+                        affinity:
+                          type: object
+                          properties:
+                            nodeAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      preference:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: object
+                                  properties:
+                                    nodeSelectorTerms:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchFields:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                            podAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          namespaceSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      namespaceSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                            podAntiAffinity:
+                              type: object
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      podAffinityTerm:
+                                        type: object
+                                        properties:
+                                          labelSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                          matchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          mismatchLabelKeys:
+                                            type: array
+                                            items:
+                                              type: string
+                                          namespaceSelector:
+                                            type: object
+                                            properties:
+                                              matchExpressions:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                          namespaces:
+                                            type: array
+                                            items:
+                                              type: string
+                                          topologyKey:
+                                            type: string
+                                      weight:
+                                        type: integer
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      labelSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                      matchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      mismatchLabelKeys:
+                                        type: array
+                                        items:
+                                          type: string
+                                      namespaceSelector:
+                                        type: object
+                                        properties:
+                                          matchExpressions:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                      namespaces:
+                                        type: array
+                                        items:
+                                          type: string
+                                      topologyKey:
+                                        type: string
+                          description: The pod's affinity rules.
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                type: integer
+                              value:
+                                type: string
+                          description: The pod's tolerations.
+                        topologySpreadConstraints:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
                                     type: array
                                     items:
                                       type: object
                                       properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchFields:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                          podAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                        matchLabelKeys:
-                                          type: array
-                                          items:
-                                            type: string
-                                        mismatchLabelKeys:
-                                          type: array
-                                          items:
-                                            type: string
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
+                                        key:
                                           type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                    matchLabelKeys:
-                                      type: array
-                                      items:
-                                        type: string
-                                    mismatchLabelKeys:
-                                      type: array
-                                      items:
-                                        type: string
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
-                                      type: string
-                          podAntiAffinity:
-                            type: object
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    podAffinityTerm:
-                                      type: object
-                                      properties:
-                                        labelSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                        matchLabelKeys:
-                                          type: array
-                                          items:
-                                            type: string
-                                        mismatchLabelKeys:
-                                          type: array
-                                          items:
-                                            type: string
-                                        namespaceSelector:
-                                          type: object
-                                          properties:
-                                            matchExpressions:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    type: array
-                                                    items:
-                                                      type: string
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                        namespaces:
-                                          type: array
-                                          items:
-                                            type: string
-                                        topologyKey:
+                                        operator:
                                           type: string
-                                    weight:
-                                      type: integer
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    labelSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
+                                        values:
                                           type: array
                                           items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          additionalProperties:
                                             type: string
-                                          type: object
-                                    matchLabelKeys:
-                                      type: array
-                                      items:
-                                        type: string
-                                    mismatchLabelKeys:
-                                      type: array
-                                      items:
-                                        type: string
-                                    namespaceSelector:
-                                      type: object
-                                      properties:
-                                        matchExpressions:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                type: array
-                                                items:
-                                                  type: string
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                    namespaces:
-                                      type: array
-                                      items:
-                                        type: string
-                                    topologyKey:
+                                  matchLabels:
+                                    additionalProperties:
                                       type: string
-                        description: The pod's affinity rules.
-                      tolerations:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              type: integer
-                            value:
-                              type: string
-                        description: The pod's tolerations.
-                      topologySpreadConstraints:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            labelSelector:
-                              type: object
-                              properties:
-                                matchExpressions:
-                                  type: array
-                                  items:
                                     type: object
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        type: array
-                                        items:
+                              matchLabelKeys:
+                                type: array
+                                items:
+                                  type: string
+                              maxSkew:
+                                type: integer
+                              minDomains:
+                                type: integer
+                              nodeAffinityPolicy:
+                                type: string
+                              nodeTaintsPolicy:
+                                type: string
+                              topologyKey:
+                                type: string
+                              whenUnsatisfiable:
+                                type: string
+                          description: The pod's topology spread constraints.
+                        priorityClassName:
+                          type: string
+                          description: 'The name of the priority class used to assign priority to the pods. '
+                        schedulerName:
+                          type: string
+                          description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
+                        hostAliases:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              hostnames:
+                                type: array
+                                items:
+                                  type: string
+                              ip:
+                                type: string
+                          description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
+                        enableServiceLinks:
+                          type: boolean
+                          description: Indicates whether information about services should be injected into Pod's environment variables.
+                        tmpDirSizeLimit:
+                          type: string
+                          pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                          description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                        volumes:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name to use for the volume. Required.
+                              secret:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
                                           type: string
-                                matchLabels:
-                                  additionalProperties:
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  optional:
+                                    type: boolean
+                                  secretName:
                                     type: string
-                                  type: object
-                            matchLabelKeys:
-                              type: array
-                              items:
-                                type: string
-                            maxSkew:
-                              type: integer
-                            minDomains:
-                              type: integer
-                            nodeAffinityPolicy:
-                              type: string
-                            nodeTaintsPolicy:
-                              type: string
-                            topologyKey:
-                              type: string
-                            whenUnsatisfiable:
-                              type: string
-                        description: The pod's topology spread constraints.
-                      priorityClassName:
-                        type: string
-                        description: 'The name of the priority class used to assign priority to the pods. '
-                      schedulerName:
-                        type: string
-                        description: "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used."
-                      hostAliases:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            hostnames:
-                              type: array
-                              items:
-                                type: string
-                            ip:
-                              type: string
-                        description: The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.
-                      enableServiceLinks:
-                        type: boolean
-                        description: Indicates whether information about services should be injected into Pod's environment variables.
-                      tmpDirSizeLimit:
-                        type: string
-                        pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
-                      volumes:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Name to use for the volume. Required.
-                            secret:
-                              type: object
-                              properties:
-                                defaultMode:
-                                  type: integer
-                                items:
-                                  type: array
+                                description: Secret to use populate the volume.
+                              configMap:
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    type: integer
                                   items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                description: ConfigMap to use to populate the volume.
+                              emptyDir:
+                                type: object
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    type: object
+                                    properties:
+                                      amount:
+                                        type: string
+                                      format:
+                                        type: string
+                                description: EmptyDir to use to populate the volume.
+                              persistentVolumeClaim:
+                                type: object
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                description: PersistentVolumeClaim object to use to populate the volume.
+                            oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                          description: Additional volumes that can be mounted to the pod.
+                      description: Template for Kafka `Pods`.
+                    perPodService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
+                    perPodRoute:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
+                    perPodIngress:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                      description: Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
+                    persistentVolumeClaim:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Labels added to the Kubernetes resource.
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              description: Annotations added to the Kubernetes resource.
+                          description: Metadata applied to the resource.
+                      description: Template for all Kafka `PersistentVolumeClaims`.
+                    kafkaContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
                                     type: object
                                     properties:
                                       key:
                                         type: string
-                                      mode:
-                                        type: integer
-                                      path:
+                                      name:
                                         type: string
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              description: Secret to use populate the volume.
-                            configMap:
-                              type: object
-                              properties:
-                                defaultMode:
-                                  type: integer
-                                items:
-                                  type: array
-                                  items:
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a secret.
+                                  configMapKeyRef:
                                     type: object
                                     properties:
                                       key:
                                         type: string
-                                      mode:
-                                        type: integer
-                                      path:
+                                      name:
                                         type: string
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              description: ConfigMap to use to populate the volume.
-                            emptyDir:
-                              type: object
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  type: object
-                                  properties:
-                                    amount:
-                                      type: string
-                                    format:
-                                      type: string
-                              description: EmptyDir to use to populate the volume.
-                            persistentVolumeClaim:
-                              type: object
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              description: PersistentVolumeClaim object to use to populate the volume.
-                          oneOf:
-                          - properties:
-                              secret: {}
-                              configMap: {}
-                              emptyDir: {}
-                              persistentVolumeClaim: {}
-                        description: Additional volumes that can be mounted to the pod.
-                    description: Template for Kafka `Pods`.
-                  perPodService:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                    description: Template for Kafka per-pod `Services` used for access from outside of Kubernetes.
-                  perPodRoute:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                    description: Template for Kafka per-pod `Routes` used for access from outside of OpenShift.
-                  perPodIngress:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                    description: Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.
-                  persistentVolumeClaim:
-                    type: object
-                    properties:
-                      metadata:
-                        type: object
-                        properties:
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Labels added to the Kubernetes resource.
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                            description: Annotations added to the Kubernetes resource.
-                        description: Metadata applied to the resource.
-                    description: Template for all Kafka `PersistentVolumeClaims`.
-                  kafkaContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a config map.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to the secret or config map property to which the environment variable is set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
+                          description: Environment variables which should be applied to the container.
+                        securityContext:
                           type: object
                           properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                            valueFrom:
-                              type: object
-                              properties:
-                                secretKeyRef:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  description: Reference to a key in a secret.
-                                configMapKeyRef:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  description: Reference to a key in a config map.
-                              oneOf:
-                              - properties:
-                                  secretKeyRef: {}
-                                required:
-                                - secretKeyRef
-                              - properties:
-                                  configMapKeyRef: {}
-                                required:
-                                - configMapKeyRef
-                              description: Reference to the secret or config map property to which the environment variable is set.
-                          oneOf:
-                          - properties:
-                              value: {}
-                            required:
-                            - value
-                          - properties:
-                              valueFrom: {}
-                            required:
-                            - valueFrom
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          appArmorProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
-                                  type: string
-                              drop:
-                                type: array
-                                items:
-                                  type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
-                            type: object
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                        description: Security context for the container.
-                      volumeMounts:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
+                            allowPrivilegeEscalation:
                               type: boolean
-                            recursiveReadOnly:
-                              type: string
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                        description: Additional volume mounts which should be applied to the container.
-                    description: Template for the Kafka broker container.
-                  initContainer:
-                    type: object
-                    properties:
-                      env:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: The environment variable key.
-                            value:
-                              type: string
-                              description: The environment variable value.
-                            valueFrom:
+                            appArmorProfile:
                               type: object
                               properties:
-                                secretKeyRef:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  description: Reference to a key in a secret.
-                                configMapKeyRef:
-                                  type: object
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  description: Reference to a key in a config map.
-                              oneOf:
-                              - properties:
-                                  secretKeyRef: {}
-                                required:
-                                - secretKeyRef
-                              - properties:
-                                  configMapKeyRef: {}
-                                required:
-                                - configMapKeyRef
-                              description: Reference to the secret or config map property to which the environment variable is set.
-                          oneOf:
-                          - properties:
-                              value: {}
-                            required:
-                            - value
-                          - properties:
-                              valueFrom: {}
-                            required:
-                            - valueFrom
-                        description: Environment variables which should be applied to the container.
-                      securityContext:
-                        type: object
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          appArmorProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          capabilities:
-                            type: object
-                            properties:
-                              add:
-                                type: array
-                                items:
+                                localhostProfile:
                                   type: string
-                              drop:
-                                type: array
-                                items:
+                                type:
                                   type: string
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            type: integer
-                          seLinuxOptions:
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                          description: Security context for the container.
+                        volumeMounts:
+                          type: array
+                          items:
                             type: object
                             properties:
-                              level:
+                              mountPath:
                                 type: string
-                              role:
+                              mountPropagation:
                                 type: string
-                              type:
+                              name:
                                 type: string
-                              user:
-                                type: string
-                          seccompProfile:
-                            type: object
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                          windowsOptions:
-                            type: object
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
+                              readOnly:
                                 type: boolean
-                              runAsUserName:
+                              recursiveReadOnly:
                                 type: string
-                        description: Security context for the container.
-                      volumeMounts:
-                        type: array
-                        items:
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                          description: Additional volume mounts which should be applied to the container.
+                      description: Template for the Kafka broker container.
+                    initContainer:
+                      type: object
+                      properties:
+                        env:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: The environment variable key.
+                              value:
+                                type: string
+                                description: The environment variable value.
+                              valueFrom:
+                                type: object
+                                properties:
+                                  secretKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a secret.
+                                  configMapKeyRef:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    description: Reference to a key in a config map.
+                                oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                      - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                      - configMapKeyRef
+                                description: Reference to the secret or config map property to which the environment variable is set.
+                            oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                  - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                  - valueFrom
+                          description: Environment variables which should be applied to the container.
+                        securityContext:
                           type: object
                           properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
+                            allowPrivilegeEscalation:
                               type: boolean
-                            recursiveReadOnly:
+                            appArmorProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                            capabilities:
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    type: string
+                                drop:
+                                  type: array
+                                  items:
+                                    type: string
+                            privileged:
+                              type: boolean
+                            procMount:
                               type: string
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                        description: Additional volume mounts which should be applied to the container.
-                    description: Template for the Kafka init container.
-                description: Template for pool resources. The template allows users to specify how the resources belonging to this pool are generated.
-            required:
-            - replicas
-            - storage
-            - roles
-            description: The specification of the KafkaNodePool.
-          status:
-            type: object
-            properties:
-              conditions:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
-                    status:
-                      type: string
-                      description: "The status of the condition, either True, False or Unknown."
-                    lastTransitionTime:
-                      type: string
-                      description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
-                    reason:
-                      type: string
-                      description: The reason for the condition's last transition (a single word in CamelCase).
-                    message:
-                      type: string
-                      description: Human-readable message indicating details about the condition's last transition.
-                description: List of status conditions.
-              observedGeneration:
-                type: integer
-                description: The generation of the CRD that was last reconciled by the operator.
-              nodeIds:
-                type: array
-                items:
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            seccompProfile:
+                              type: object
+                              properties:
+                                localhostProfile:
+                                  type: string
+                                type:
+                                  type: string
+                            windowsOptions:
+                              type: object
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                hostProcess:
+                                  type: boolean
+                                runAsUserName:
+                                  type: string
+                          description: Security context for the container.
+                        volumeMounts:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              recursiveReadOnly:
+                                type: string
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                          description: Additional volume mounts which should be applied to the container.
+                      description: Template for the Kafka init container.
+                  description: Template for pool resources. The template allows users to specify how the resources belonging to this pool are generated.
+              required:
+                - replicas
+                - storage
+                - roles
+              description: The specification of the KafkaNodePool.
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        description: "The unique identifier of a condition, used to distinguish between other conditions in the resource."
+                      status:
+                        type: string
+                        description: "The status of the condition, either True, False or Unknown."
+                      lastTransitionTime:
+                        type: string
+                        description: "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone."
+                      reason:
+                        type: string
+                        description: The reason for the condition's last transition (a single word in CamelCase).
+                      message:
+                        type: string
+                        description: Human-readable message indicating details about the condition's last transition.
+                  description: List of status conditions.
+                observedGeneration:
                   type: integer
-                description: Node IDs used by Kafka nodes in this pool.
-              clusterId:
-                type: string
-                description: Kafka cluster ID.
-              roles:
-                type: array
-                items:
+                  description: The generation of the CRD that was last reconciled by the operator.
+                nodeIds:
+                  type: array
+                  items:
+                    type: integer
+                  description: Node IDs used by Kafka nodes in this pool.
+                clusterId:
                   type: string
-                  enum:
-                  - controller
-                  - broker
-                description: The roles currently assigned to this pool.
-              replicas:
-                type: integer
-                description: The current number of pods being used to provide this resource.
-              labelSelector:
-                type: string
-                description: Label selector for pods providing this resource.
-            description: The status of the KafkaNodePool.
+                  description: Kafka cluster ID.
+                roles:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - controller
+                      - broker
+                  description: The roles currently assigned to this pool.
+                replicas:
+                  type: integer
+                  description: The current number of pods being used to provide this resource.
+                labelSelector:
+                  type: string
+                  description: Label selector for pods providing this resource.
+              description: The status of the KafkaNodePool.

--- a/packaging/install/Makefile
+++ b/packaging/install/Makefile
@@ -5,7 +5,7 @@ include ../../Makefile.os
 RELEASE_VERSION ?= latest
 RELEASE_PATH ?= ../../strimzi-$(RELEASE_VERSION)/$(PROJECT_NAME)
 
-crd_install_helm3:
+crd_install:
 	$(CP) ./cluster-operator/043-Crd-kafkatopic.yaml ./topic-operator/04-Crd-kafkatopic.yaml
 	$(CP) ./cluster-operator/044-Crd-kafkauser.yaml ./user-operator/04-Crd-kafkauser.yaml
 	$(CP) ./cluster-operator/040-Crd-kafka.yaml ../helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -23,14 +23,13 @@ crd_install_helm3:
 	yq eval -i '.metadata.labels.component="kafkaconnects.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
 	yq eval -i '.metadata.labels.component="stirmzipodsets.core.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
 	yq eval -i '.metadata.labels.component="kafkatopics.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
-	yq eval -i '.metadata.labels.component="kafkausers.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml 
-	yq eval -i '.metadata.labels.component="kafkamirrormakers.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml 
-	yq eval -i '.metadata.labels.component="kafkabridges.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml 
-	yq eval -i '.metadata.labels.component="kafkaconnectors.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml 
-	yq eval -i '.metadata.labels.component="kafkamirrormaker2.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml 
-	yq eval -i '.metadata.labels.component="kafkarebalances.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml 
-
-crd_install: crd_install_helm3
+	yq eval -i '.metadata.labels.component="kafkausers.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+	yq eval -i '.metadata.labels.component="kafkamirrormakers.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
+	yq eval -i '.metadata.labels.component="kafkabridges.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+	yq eval -i '.metadata.labels.component="kafkaconnectors.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
+	yq eval -i '.metadata.labels.component="kafkamirrormaker2.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+	yq eval -i '.metadata.labels.component="kafkarebalances.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
+	yq eval -i '.metadata.labels.component="kafkanodepools.kafka.strimzi.io-crd"' ../helm-charts/helm3/strimzi-kafka-operator/crds/04A-Crd-kafkanodepool.yaml
 
 release:
 	mkdir -p $(RELEASE_PATH)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When adding the `KafkaNodePool` CRD, we did not add the component label to it in the Helm Chart as we do for other CRDs. This PR fixes it. The use of `yq` on the file also slightly changes the whitespaces, that is why the diff is so big. I also removed the old `crd_install_helm3` target from the Makefile and merged it directly under `crd_install`. The old target was just a leftover from when we supported Helm 2.