### PR TITLE
Replace use of JsonObject with JsonNode for CruiseControlApi

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlRebalanceResponse.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Response to rebalance request
@@ -19,7 +19,7 @@ public class CruiseControlRebalanceResponse extends CruiseControlResponse {
      * @param userTaskId    User task ID
      * @param json          JSON data
      */
-    CruiseControlRebalanceResponse(String userTaskId, JsonObject json) {
+    CruiseControlRebalanceResponse(String userTaskId, JsonNode json) {
         super(userTaskId, json);
         // There is sufficient data for proposal unless response from Cruise Control says otherwise
         // Sourced from the NotEnoughValidWindows error from the Cruise Control response

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlResponse.java
@@ -4,14 +4,14 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Cruise Control response
  */
 public class CruiseControlResponse {
     private final String userTaskId;
-    private final JsonObject json;
+    private final JsonNode json;
 
     /**
      * Constructor
@@ -19,7 +19,7 @@ public class CruiseControlResponse {
      * @param userTaskId    User task ID
      * @param json          JSON data
      */
-    CruiseControlResponse(String userTaskId, JsonObject json) {
+    CruiseControlResponse(String userTaskId, JsonNode json) {
         this.userTaskId = userTaskId;
         this.json = json;
     }
@@ -34,12 +34,12 @@ public class CruiseControlResponse {
     /**
      * @return  The JSON data of the response
      */
-    public JsonObject getJson() {
+    public JsonNode getJson() {
         return json;
     }
 
     @Override
     public String toString() {
-        return "User Task ID: " + userTaskId + " JSON: " + json.toString();
+        return "User Task ID: " + userTaskId + " JSON: " + json;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlUserTasksResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlUserTasksResponse.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.operator.cluster.operator.resource.cruisecontrol;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Response to user tasks request
@@ -18,7 +18,7 @@ public class CruiseControlUserTasksResponse extends CruiseControlResponse {
      * @param userTaskId    User task ID
      * @param json          JSON data
      */
-    CruiseControlUserTasksResponse(String userTaskId, JsonObject json) {
+    CruiseControlUserTasksResponse(String userTaskId, JsonNode json) {
         super(userTaskId, json);
         // The maximum number of active user tasks that can run concurrently has reached
         // Sourced from the error message that contains "reached the servlet capacity" from the Cruise Control response

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/JSONObjectMatchers.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/JSONObjectMatchers.java
@@ -4,20 +4,22 @@
  */
 package io.strimzi.operator.cluster;
 
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class JSONObjectMatchers {
 
-    public static Matcher<JsonObject> hasSize(int size) {
+    public static Matcher<JsonNode> hasSize(int size) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(JsonObject actual, Description mismatchDescription) {
+            protected boolean matchesSafely(JsonNode actual, Description mismatchDescription) {
                 mismatchDescription.appendText("was ").appendValue(actual.size());
                 if (size != actual.size()) {
                     mismatchDescription.appendText("\n There are actually ")
@@ -35,13 +37,15 @@ public class JSONObjectMatchers {
             }
         };
     }
-    public static Matcher<JsonObject> hasKey(String key) {
+    public static Matcher<JsonNode> hasKey(String key) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(JsonObject actual, Description mismatchDescription) {
-                mismatchDescription.appendText("was ").appendValue(actual.fieldNames());
-                if (!actual.fieldNames().contains(key)) {
+            protected boolean matchesSafely(JsonNode actual, Description mismatchDescription) {
+                List<String> fieldNames = new ArrayList<>();
+                actual.fieldNames().forEachRemaining(fieldNames::add);
+                mismatchDescription.appendText("was ").appendValue(fieldNames);
+                if (!fieldNames.contains(key)) {
                     mismatchDescription.appendText("\nDoes not contain desired key");
                     return false;
                 }
@@ -55,12 +59,14 @@ public class JSONObjectMatchers {
         };
     }
 
-    public static Matcher<JsonObject> hasKeys(String... keys) {
+    public static Matcher<JsonNode> hasKeys(String... keys) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(JsonObject actual, Description mismatchDescription) {
-                mismatchDescription.appendText("was ").appendValue(actual.fieldNames());
+            protected boolean matchesSafely(JsonNode actual, Description mismatchDescription) {
+                List<String> fieldNames = new ArrayList<>();
+                actual.fieldNames().forEachRemaining(fieldNames::add);
+                mismatchDescription.appendText("was ").appendValue(fieldNames);
                 boolean matches = true;
                 for (String key : keys) {
                     if (!hasKey(key).matches(actual)) {
@@ -80,18 +86,18 @@ public class JSONObjectMatchers {
         };
     }
 
-    public static Matcher<JsonObject> hasEntry(String key, String value) {
+    public static Matcher<JsonNode> hasEntry(String key, String value) {
         return new TypeSafeDiagnosingMatcher<>() {
 
             @Override
-            protected boolean matchesSafely(JsonObject actual, Description mismatchDescription) {
-                mismatchDescription.appendText("was ").appendValue(actual.getString(key));
+            protected boolean matchesSafely(JsonNode actual, Description mismatchDescription) {
+                mismatchDescription.appendText("was ").appendValue(actual.get(key));
                 if (!hasKey(key).matches(actual)) {
                     mismatchDescription.appendText("\nDoes not contain key " + key);
                     return false;
                 }
 
-                String actualValue = actual.getString(key);
+                String actualValue = actual.get(key).asText();
                 if (!value.equals(actualValue)) {
                     mismatchDescription.appendText("\nKey does not have expected value, found " + actualValue);
                     return false;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/cruisecontrol/CruiseControlClientTest.java
@@ -81,7 +81,7 @@ public class CruiseControlClientTest {
 
         CruiseControlApi client = cruiseControlClientProvider();
         client.getCruiseControlState(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, false)
-                .whenComplete((result, ex) -> assertThat(result.getJson().getJsonObject("ExecutorState"),
+                .whenComplete((result, ex) -> assertThat(result.getJson().get("ExecutorState"),
                         hasEntry("state", "NO_TASK_IN_PROGRESS"))).join();
     }
 
@@ -129,7 +129,7 @@ public class CruiseControlClientTest {
 
         client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID).whenComplete((result, ex) -> {
             assertThat(result.getUserTaskId(), is(MockCruiseControl.USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID));
-            assertThat(result.getJson().getJsonObject(CruiseControlRebalanceKeys.SUMMARY.getKey()), is(notNullValue()));
+            assertThat(result.getJson().get(CruiseControlRebalanceKeys.SUMMARY.getKey()), is(notNullValue()));
         }).join();
     }
 
@@ -502,7 +502,7 @@ public class CruiseControlClientTest {
         for (int i = 1; i <= pendingCalls1; i++) {
             statusFuture = statusFuture.thenCompose(response -> {
                 assertThat(
-                    response.getJson().getString("Status"),
+                    response.getJson().get("Status").asText(),
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()));
                 return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
@@ -510,7 +510,7 @@ public class CruiseControlClientTest {
 
         statusFuture = statusFuture.thenCompose(response -> {
             assertThat(
-                response.getJson().getString("Status"),
+                response.getJson().get("Status").asText(),
                 is(CruiseControlUserTaskStatus.COMPLETED.toString()));
             return CompletableFuture.completedFuture(response);
         });
@@ -530,7 +530,7 @@ public class CruiseControlClientTest {
         for (int i = 1; i <= pendingCalls2; i++) {
             statusFuture = statusFuture.thenCompose(response -> {
                 assertThat(
-                    response.getJson().getString("Status"),
+                    response.getJson().get("Status").asText(),
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()));
                 return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
@@ -538,7 +538,7 @@ public class CruiseControlClientTest {
 
         statusFuture.thenCompose(response -> {
             assertThat(
-                response.getJson().getString("Status"),
+                response.getJson().get("Status").asText(),
                 is(CruiseControlUserTaskStatus.COMPLETED.toString()));
             return CompletableFuture.completedFuture(response);
         }).join();
@@ -554,7 +554,7 @@ public class CruiseControlClientTest {
         for (int i = 1; i <= pendingCalls; i++) {
             statusFuture = statusFuture.thenCompose(response -> {
                 assertThat(
-                    response.getJson().getString("Status"),
+                    response.getJson().get("Status").asText(),
                     is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()));
                 return client.getUserTaskStatus(Reconciliation.DUMMY_RECONCILIATION, HOST, cruiseControlPort, userTaskID);
             });
@@ -562,7 +562,7 @@ public class CruiseControlClientTest {
 
         statusFuture.thenCompose(response -> {
             assertThat(
-                    response.getJson().getString("Status"),
+                    response.getJson().get("Status").asText(),
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()));
             return CompletableFuture.completedFuture(response);
         }).join();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

This PR replaces Vertx's JsonObject used for parsing CC API responses with Jackson's JsonNode. So that Vertx is completely removed from CC API. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

