### PR TITLE
Add Metrics Reporter StrimziReporterMetricsModel to Cluster Operator and to api

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
         property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = JmxPrometheusExporterMetrics.TYPE_JMX_EXPORTER, value = JmxPrometheusExporterMetrics.class),
+    @JsonSubTypes.Type(name = StrimziReporterMetrics.TYPE_STRIMZI_REPORTER_METRICS, value = StrimziReporterMetrics.class)
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
@@ -30,7 +31,7 @@ import java.util.Map;
 public abstract class MetricsConfig implements UnknownPropertyPreserving {
     private Map<String, Object> additionalProperties;
 
-    @Description("Metrics type. Only 'jmxPrometheusExporter' supported currently.")
+    @Description("Metrics type. Currently supports 'strimziReporterMetrics' and 'jmxPrometheusExporter'.")
     public abstract String getType();
 
     @Override

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.crdgenerator.annotations.Description;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * Class representing the values section in the YAML.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"allowList"})
+public class StrimziMetricsReporterValues {
+    private List<String> allowList;
+    public static final String ALLOWLIST_CONFIG = "prometheus.metrics.reporter.allowlist";
+
+    /**
+     * @return The allowList of metrics to be collected
+     */
+    @Description("A list of allowed metrics for the Strimzi Metrics Reporter.")
+    public Optional<String> getAllowlist() throws Exception {
+        if (allowList == null || allowList.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(allowList.stream().map(Pattern::compile).map(Pattern::pattern).collect(Collectors.joining("|")));
+        } catch (PatternSyntaxException e) {
+            throw new Exception("Invalid regular expression in " + ALLOWLIST_CONFIG + ": " + e.getMessage());
+        }
+    }
+
+    // for tests
+    public void setAllowList(List<String> allowList) {
+        this.allowList = allowList;
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziReporterMetrics.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziReporterMetrics.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.common.metrics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Strimzi Metrics Reporter config
+ */
+@Setter
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonPropertyOrder({"type", "values"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class StrimziReporterMetrics extends MetricsConfig {
+    public static final String TYPE_STRIMZI_REPORTER_METRICS = "strimziMetricsReporter";
+
+    private StrimziMetricsReporterValues values;
+
+    @Description("Must be `" + TYPE_STRIMZI_REPORTER_METRICS + "`")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Override
+    public String getType() {
+        return TYPE_STRIMZI_REPORTER_METRICS;
+    }
+
+    @Description("List configuration values for Strimzi Metrics Reporter.")
+    @JsonProperty(required = true)
+    public StrimziMetricsReporterValues getValues() {
+        return values;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -75,6 +75,7 @@ import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziReporterMetricsModel;
 import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
 import io.strimzi.operator.cluster.model.securityprofiles.ContainerSecurityProviderContextImpl;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderContextImpl;
@@ -222,6 +223,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     private JmxModel jmx;
     private CruiseControlMetricsReporter ccMetricsReporter;
     private MetricsModel metrics;
+    private StrimziReporterMetricsModel strimziMetrics;
     private LoggingModel logging;
     private QuotasPlugin quotas;
     /* test */ KafkaConfiguration configuration;
@@ -1281,6 +1283,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         // Metrics port is enabled on all node types regardless their role
         if (metrics.isEnabled()) {
             ports.add(ContainerUtils.createContainerPort(MetricsModel.METRICS_PORT_NAME, MetricsModel.METRICS_PORT));
+        }
+        else if (strimziMetrics.isEnabled()) {
+            ports.add(ContainerUtils.createContainerPort(StrimziReporterMetricsModel.METRICS_PORT_NAME, StrimziReporterMetricsModel.METRICS_PORT));
         }
 
         // JMX port is enabled on all node types regardless their role

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterValues;
+import io.strimzi.api.kafka.model.common.metrics.StrimziReporterMetrics;
+import io.strimzi.kafka.oauth.common.ConfigException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents a model for components with configurable metrics using Strimzi Reporter
+ */
+public class StrimziReporterMetricsModel {
+
+    /**
+     * Name of the Strimzi metrics port
+     */
+    public static final String METRICS_PORT_NAME = "tcp-strimzi-reporter-metrics";
+
+    /**
+     * Number of the Strimzi metrics port
+     */
+    public static final int METRICS_PORT = 9404;
+    private final boolean isEnabled;
+    private final Optional<String> allowlist;
+
+    /**
+     * Constructs the StrimziReporterMetricsModel for managing configurable metrics with Strimzi Reporter
+     *
+     * @param specSection StrimziReporterMetrics object containing the metrics configuration
+     */
+    public StrimziReporterMetricsModel(HasConfigurableMetrics specSection) throws Exception {
+        if (specSection.getMetricsConfig() != null) {
+            if (specSection.getMetricsConfig() instanceof StrimziReporterMetrics strimziMetrics) {
+                // Retrieve the values object
+                StrimziMetricsReporterValues metricsConfig = strimziMetrics.getValues();
+                // Check if the values object is null
+                if (metricsConfig != null) {
+                    validateStrimziReporterMetricsConfiguration(metricsConfig);
+                    this.isEnabled = true;
+                    this.allowlist = metricsConfig.getAllowlist();
+                } else {
+                    throw new ConfigException("StrimziReporterMetrics configuration values cannot be null.");
+                }
+            } else {
+                throw new ConfigException("Unsupported metrics type " + specSection.getMetricsConfig().getType());
+            }
+        } else {
+            this.isEnabled = false;
+            this.allowlist = Optional.empty();
+        }
+    }
+
+    /**
+     * @return True if metrics are enabled. False otherwise.
+     */
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    /**
+     * Validates the Strimzi Reporter Metrics configuration
+     *
+     * @param metricsConfig StrimziReporterMetrics configuration to validate
+     */
+    private void validateStrimziReporterMetricsConfiguration(StrimziMetricsReporterValues metricsConfig) throws Exception {
+        List<String> errors = new ArrayList<>();
+        if (metricsConfig.getAllowlist().isEmpty()){
+            errors.add("Allowlist configuration is missing");
+        }
+
+        if (!errors.isEmpty())  {
+            throw new ConfigException("StrimziReporterMetrics configuration is invalid: " + errors);
+        }
+    }
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModelTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterValues;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertThrows;
+
+public class StrimziReporterMetricsModelTest {
+
+    @Test
+    public void testGetAllowlistWithValidPatterns() throws Exception {
+        StrimziMetricsReporterValues values = new StrimziMetricsReporterValues();
+        values.setAllowList(Arrays.asList("metric1.*", "metric2.*"));
+
+        Optional<String> allowlist = values.getAllowlist();
+        Assertions.assertTrue(allowlist.isPresent());
+        Assertions.assertEquals("metric1.*|metric2.*", allowlist.get());
+    }
+
+    @Test
+    public void testGetAllowlistWithEmptyList() throws Exception {
+        StrimziMetricsReporterValues values = new StrimziMetricsReporterValues();
+        values.setAllowList(Collections.emptyList());
+
+        Optional<String> allowlist = values.getAllowlist();
+        Assertions.assertFalse(allowlist.isPresent());
+    }
+
+    @Test
+    public void testGetAllowlistWithNullList() throws Exception {
+        StrimziMetricsReporterValues values = new StrimziMetricsReporterValues();
+        values.setAllowList(null);
+
+        Optional<String> allowlist = values.getAllowlist();
+        Assertions.assertFalse(allowlist.isPresent());
+    }
+
+    @Test
+    public void testGetAllowlistWithInvalidPattern() {
+        StrimziMetricsReporterValues values = new StrimziMetricsReporterValues();
+        values.setAllowList(Arrays.asList("metric1.*", "metric["));
+
+        Exception exception = assertThrows(Exception.class, values::getAllowlist);
+        Assertions.assertTrue(exception.getMessage().contains("Invalid regular expression in prometheus.metrics.reporter.allowlist"));
+    }
+}

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+        <strimzi-metrics-reporter.version>0.1.0</strimzi-metrics-reporter.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -35,6 +36,10 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1231/</url>
+        </repository>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
@@ -325,6 +330,27 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Metrics Reporter -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>metrics-reporter</artifactId>
+            <version>${strimzi-metrice-reporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+        <strimzi-metrics-reporter.version>0.1.0</strimzi-metrics-reporter.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -35,6 +36,10 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1231/</url>
+        </repository>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
@@ -325,6 +330,27 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Metrics Reporter -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>metrics-reporter</artifactId>
+            <version>${strimzi-metrice-reporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+        <strimzi-metrics-reporter.version>0.1.0</strimzi-metrics-reporter.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -35,6 +36,10 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1231/</url>
+        </repository>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
@@ -325,6 +330,27 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Metrics Reporter -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>metrics-reporter</artifactId>
+            <version>${strimzi-metrice-reporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+        <strimzi-metrics-reporter.version>0.1.0</strimzi-metrics-reporter.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
@@ -35,6 +36,10 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1231/</url>
+        </repository>
         <repository>
             <id>cruise-control</id>
             <url>https://linkedin.jfrog.io/artifactory/cruise-control/</url>
@@ -325,6 +330,27 @@
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Metrics Reporter -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>metrics-reporter</artifactId>
+            <version>${strimzi-metrice-reporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
         <!-- Open Policy Authorization plugin -->
         <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This pull request introduces the Strimzi Metrics Reporter to the project, adding new configurations and dependencies to support it. The changes include the addition of new API classes for the metrics reporter, updates to existing classes to integrate the new metrics type, and additions to the project's dependencies.

* Add Metrics Reporter and Prometheus dependencies to the `kafka_third_party_libs`
* Create new api classes for `StrimziReporterMetrics`. These extend `MetricsConfig
* Create a new `StrimziReporterMetricsModel` class in the Cluster Operator to parse and validate the logic from the Custom Resource.
* Write an initial test for `StrimziReporterMetricsModel` that validates the allowList of metrics to be collected and validated as a regular expression. 


### Integration of Strimzi Metrics Reporter:

* [`api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java`](diffhunk://#diff-d99209142c66fb53ae5d2089d49bd781b4e8718c000467bf78d863efbe96cc10R26-R34): Updated to support the new `StrimziReporterMetrics` type.
* [`api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziReporterMetrics.java`](diffhunk://#diff-382a232a3d28857ef6ea6e916a0ba5efa9753920ce5328a8012599d5b38353c3R1-R46): Added new class for Strimzi Metrics Reporter configuration.
* [`api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java`](diffhunk://#diff-48bce5e5b297b703abb412a46c7e5f7dd02ad0782acf5f00bcae35833d612b74R1-R45): Added new class representing the values section in the YAML for Strimzi Metrics Reporter.

### Codebase modifications for metrics integration:

* [`cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java`](diffhunk://#diff-0cff3903f247e94097b35401fee301169d9e352aee8c0954a325ee27bb35dcc9R78): Integrated `StrimziReporterMetricsModel` into the KafkaCluster class and added logic to handle the new metrics type in container ports. [[1]](diffhunk://#diff-0cff3903f247e94097b35401fee301169d9e352aee8c0954a325ee27bb35dcc9R78) [[2]](diffhunk://#diff-0cff3903f247e94097b35401fee301169d9e352aee8c0954a325ee27bb35dcc9R226) [[3]](diffhunk://#diff-0cff3903f247e94097b35401fee301169d9e352aee8c0954a325ee27bb35dcc9R1287-R1289)
* [`cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModel.java`](diffhunk://#diff-1cc38c99a2678a28d68333cf3ea22fce24ba6ca555786bca562693fa4e451453R1-R82): Added new class representing a model for components with configurable metrics using Strimzi Reporter.

### Dependency updates:

* `docker-images/artifacts/kafka-thirdparty-libs/3.7.0/pom.xml`, `docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml`, `docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml`, `docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml`: Added dependencies for the Strimzi Metrics Reporter and Prometheus metrics libraries. [[1]](diffhunk://#diff-635b56f170d43948e274869218a8b570e1e3187e558fd9a9454c6d4775bf7fe9R20) [[2]](diffhunk://#diff-635b56f170d43948e274869218a8b570e1e3187e558fd9a9454c6d4775bf7fe9R39-R42) [[3]](diffhunk://#diff-635b56f170d43948e274869218a8b570e1e3187e558fd9a9454c6d4775bf7fe9R334-R354) [[4]](diffhunk://#diff-91fc251c62290482cb91fe526255dfd8820240d6ee19c5d4871829f2aee81ee4R20) [[5]](diffhunk://#diff-91fc251c62290482cb91fe526255dfd8820240d6ee19c5d4871829f2aee81ee4R39-R42) [[6]](diffhunk://#diff-91fc251c62290482cb91fe526255dfd8820240d6ee19c5d4871829f2aee81ee4R334-R354)

### Testing:

* [`cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziReporterMetricsModelTest.java`](diffhunk://#diff-22539e8d3c79ddc076d86f7d750e5c65223d479cc50cf28e8bbc6ad4f6f0a4feR1-R55): Added unit tests for the `StrimziReporterMetricsModel` to ensure correct functionality.



