### PR TITLE
Remove Kafka Connect rest.port configuration

### DIFF
--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_config_generator.sh
@@ -122,7 +122,6 @@ cat <<EOF
 # Bootstrap servers
 bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
 # REST Listeners
-rest.port=8083
 rest.advertised.host.name=${ADVERTISED_HOSTNAME}
 rest.advertised.port=8083
 # Plugins


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Kafka Connect rest.port configuration has been removed in Kafka 3.0.0.

https://issues.apache.org/jira/browse/KAFKA-12482

### Checklist
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

