### PR TITLE
Fix faulty Cruise control healthcheck 

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -135,7 +135,7 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
 
     protected static final String ENV_VAR_API_SSL_ENABLED = "STRIMZI_CC_API_SSL_ENABLED";
     protected static final String ENV_VAR_API_AUTH_ENABLED = "STRIMZI_CC_API_AUTH_ENABLED";
-    protected static final String ENV_VAR_API_HEALTHCHECK_USERNAME = "API_HEALTHCHECK";
+    protected static final String ENV_VAR_API_HEALTHCHECK_USERNAME = "API_HEALTHCHECK_USERNAME";
     protected static final String ENV_VAR_API_PORT = "API_PORT";
     protected static final String ENV_VAR_API_HEALTHCHECK_PATH = "API_HEALTHCHECK_PATH";
 

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_healthcheck.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_healthcheck.sh
@@ -14,4 +14,4 @@ if [ "$STRIMZI_CC_API_AUTH_ENABLED" = true ] ; then
   ARGS+=(--user "${API_HEALTHCHECK_USERNAME}:$(cat /opt/cruise-control/api-auth-config/healthcheck.password)")
 fi
 
-curl "${ARGS[@]}" "${SCHEME}://localhost:${API_PORT}${API_HEALTHCHECK_PATH}"
+curl -f "${ARGS[@]}" "${SCHEME}://localhost:${API_PORT}${API_HEALTHCHECK_PATH}"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR fixes #10872. With the addition of `-f` in the curl command, we now get a separate exit code of `22` in case there is some error/issue. This also fixes the misnamed env var in the code

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

