### PR TITLE
Refactor use of Informers in UO and SPS controller

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -404,34 +404,6 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
         return internalDelete(reconciliation, namespace, name, cascading).map((Void) null);
     }
 
-    ///**
-    // * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
-    // * informer returned by this method is not running and has to be started by the code using it.
-    // *
-    // * @param namespace         Namespace on which to inform
-    // * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-    // *
-    // * @return          Informer instance
-    // */
-    //public Informer<T> informer(String namespace, long resyncIntervalMs)   {
-    //    return new Informer<>(runnableInformer(applyNamespace(namespace), resyncIntervalMs));
-    //}
-    //
-    ///**
-    // * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-    // * matching the selector. The informer returned by this method is not running and has to be started by the code
-    // * using it.
-    // *
-    // * @param namespace         Namespace on which to inform
-    // * @param selectorLabels    Selector which should be matched by the resources
-    // * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-    // *
-    // * @return                  Informer instance
-    // */
-    //public Informer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs)   {
-    //    return new Informer<>(runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs));
-    //}
-
     /**
      * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
      * matching the selector. The informer returned by this method is not running and has to be started by the code

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -23,6 +23,7 @@ import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.config.ConfigParameter;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.ReconcileResult;
+import io.strimzi.operator.common.operator.resource.concurrent.Informer;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -403,33 +404,33 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
         return internalDelete(reconciliation, namespace, name, cascading).map((Void) null);
     }
 
-    /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
-     * informer returned by this method is not running and has to be started by the code using it.
-     *
-     * @param namespace         Namespace on which to inform
-     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-     *
-     * @return          Informer instance
-     */
-    public SharedIndexInformer<T> informer(String namespace, long resyncIntervalMs)   {
-        return runnableInformer(applyNamespace(namespace), resyncIntervalMs);
-    }
-
-    /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-     * matching the selector. The informer returned by this method is not running and has to be started by the code
-     * using it.
-     *
-     * @param namespace         Namespace on which to inform
-     * @param selectorLabels    Selector which should be matched by the resources
-     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-     *
-     * @return                  Informer instance
-     */
-    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs)   {
-        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs);
-    }
+    ///**
+    // * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
+    // * informer returned by this method is not running and has to be started by the code using it.
+    // *
+    // * @param namespace         Namespace on which to inform
+    // * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+    // *
+    // * @return          Informer instance
+    // */
+    //public Informer<T> informer(String namespace, long resyncIntervalMs)   {
+    //    return new Informer<>(runnableInformer(applyNamespace(namespace), resyncIntervalMs));
+    //}
+    //
+    ///**
+    // * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
+    // * matching the selector. The informer returned by this method is not running and has to be started by the code
+    // * using it.
+    // *
+    // * @param namespace         Namespace on which to inform
+    // * @param selectorLabels    Selector which should be matched by the resources
+    // * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
+    // *
+    // * @return                  Informer instance
+    // */
+    //public Informer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs)   {
+    //    return new Informer<>(runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs));
+    //}
 
     /**
      * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
@@ -442,8 +443,8 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncIntervalMs)   {
-        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncIntervalMs);
+    public Informer<T> informer(String namespace, LabelSelector labelSelector, long resyncIntervalMs)   {
+        return new Informer<>(runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncIntervalMs));
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -150,7 +150,7 @@ public class ClusterOperatorTest {
                 return mockCmInformer;
             });
 
-            when(mockNamespacedCms.withLabels(any())).thenReturn(mockNamespacedCms);
+            when(mockNamespacedCms.withLabelSelector(any(LabelSelector.class))).thenReturn(mockNamespacedCms);
             when(mockCms.inNamespace(namespace)).thenReturn(mockNamespacedCms);
 
             // Mock Pods
@@ -230,7 +230,7 @@ public class ClusterOperatorTest {
         when(mockCmInformer.stopped()).thenReturn(CompletableFuture.completedFuture(null));
 
         AnyNamespaceOperation mockFilteredCms = mock(AnyNamespaceOperation.class);
-        when(mockFilteredCms.withLabels(any())).thenReturn(mockFilteredCms);
+        when(mockFilteredCms.withLabelSelector(any(LabelSelector.class))).thenReturn(mockFilteredCms);
         when(mockFilteredCms.watch(any())).thenAnswer(invo -> {
             numWatchers.incrementAndGet();
             Watch mockWatch = mock(Watch.class);

--- a/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/InformerUtils.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.operator.common;
 
-import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.strimzi.operator.common.operator.resource.concurrent.Informer;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -17,56 +17,20 @@ public class InformerUtils {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(InformerUtils.class);
 
     /**
-     * Logs exceptions in the informers to give us a better overview of what is happening.
-     *
-     * @param type          Type of the informer
-     * @param isStarted     Flag indicating whether the informer is already started
-     * @param throwable     Throwable describing the exception which occurred
-     *
-     * @return  Boolean indicating whether the informer should retry or not.
-     */
-    public static boolean loggingExceptionHandler(String type, boolean isStarted, Throwable throwable) {
-        LOGGER.errorOp("Caught exception in the " + type + " informer which is " + (isStarted ? "started" : "not started"), throwable);
-        // We always want the informer to retry => we just want to log the error
-        return true;
-    }
-
-    /**
-     * Watches for informers to not stop unless we are shutting down the controller. If it stops unexpectedly, we will
-     * terminate the operator.
-     *
-     * @param type      Type of the informer
-     * @param reason    Reason why the informer stopped
-     * @param stopping  Flag indicating if the controller shutdown is in progress (in which case the informer is expected to stop)
-     */
-    public static void stoppedInformerHandler(String type, Throwable reason, boolean stopping) {
-        if (!stopping) {
-            // the informer is not being stopped, so this is unexpected!
-            if (reason != null) {
-                LOGGER.errorOp("{} informer stopped unexpectedly", type, reason);
-            } else {
-                LOGGER.errorOp("{} informer stopped unexpectedly without a reason", type);
-            }
-        } else {
-            LOGGER.infoOp("{} informer stopped", type);
-        }
-    }
-
-    /**
      * Synchronously stops one or more informers. It will stop them and then wait for up to the specified timeout for
      * each of them to actually stop.
      *
      * @param timeoutMs     Timeout in milliseconds for how long we will wait for each informer to stop
      * @param informers     Informers which should be stopped.
      */
-    public static void stopAll(long timeoutMs, SharedIndexInformer<?>... informers) {
+    public static void stopAll(long timeoutMs, Informer<?>... informers) {
         LOGGER.infoOp("Stopping informers");
-        for (SharedIndexInformer<?> informer : informers)    {
+        for (Informer<?> informer : informers)    {
             informer.stop();
         }
 
         try {
-            for (SharedIndexInformer<?> informer : informers)    {
+            for (Informer<?> informer : informers)    {
                 informer.stopped().toCompletableFuture().get(timeoutMs, TimeUnit.MILLISECONDS);
             }
         } catch (InterruptedException | TimeoutException | ExecutionException e) {

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/AbstractNamespacedResourceOperator.java
@@ -26,7 +26,6 @@ import io.strimzi.operator.common.operator.resource.ReconcileResult;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -438,50 +437,22 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
     }
 
     /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide). The
-     * informer returned by this method is not running and has to be started by the code using it.
-     *
-     * @param namespace         Namespace on which to inform
-     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-     *
-     * @return          Informer instance
-     */
-    public SharedIndexInformer<T> informer(String namespace, long resyncIntervalMs) {
-        return runnableInformer(applyNamespace(namespace), resyncIntervalMs);
-    }
-
-    /**
      * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
      * matching the selector. The informer returned by this method is not running and has to be started by the code
      * using it.
      *
      * @param namespace         Namespace on which to inform
-     * @param selectorLabels    Selector which should be matched by the resources
+     * @param selector    Selector which should be matched by the resources
      * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
      *
      * @return                  Informer instance
      */
-    public SharedIndexInformer<T> informer(String namespace, Map<String, String> selectorLabels, long resyncIntervalMs) {
-        return runnableInformer(applyNamespace(namespace).withLabels(selectorLabels), resyncIntervalMs);
+    public Informer<T> informer(String namespace, LabelSelector selector, long resyncIntervalMs) {
+        return new Informer<>(runnableInformer(applyNamespace(namespace).withLabelSelector(selector), resyncIntervalMs));
     }
 
     /**
-     * Creates the informer for given resource type to inform on all instances in given namespace (or cluster-wide)
-     * matching the selector. The informer returned by this method is not running and has to be started by the code
-     * using it.
-     *
-     * @param namespace         Namespace on which to inform
-     * @param labelSelector     Labels Selector which should be matched by the resources
-     * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds
-     *
-     * @return                  Informer instance
-     */
-    public SharedIndexInformer<T> informer(String namespace, LabelSelector labelSelector, long resyncIntervalMs) {
-        return runnableInformer(applyNamespace(namespace).withLabelSelector(labelSelector), resyncIntervalMs);
-    }
-
-    /**
-     * Creates a runnable informer. Runnable informer is not running yet and need to be started by the code using it.
+     * Creates a runnable informer. Runnable informer is not running yet and needs to be started by the code using it.
      *
      * @param informable        Instance of the Informable interface for creating informers
      * @param resyncIntervalMs  The interval in which the resync of the informer should happen in milliseconds

--- a/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/Informer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/operator/resource/concurrent/Informer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.common.operator.resource.concurrent;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.cache.Lister;
+import io.strimzi.operator.common.ReconciliationLogger;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A class that wraps the Fabric8 Informer and Lister for particular resource
+ *
+ * @param <T>   Type of the resource handled by this informer
+ */
+public class Informer<T extends HasMetadata> {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(Informer.class);
+
+    private final SharedIndexInformer<T> informer;
+    private final Lister<T> lister;
+
+    /**
+     * Constructor.
+     *
+     * @param informer  The Fabric8 informer that will be wrapped inside this class
+     */
+    public Informer(SharedIndexInformer<T> informer) {
+        this.informer = informer;
+        this.lister = new Lister<>(informer.getIndexer());
+
+        // Setup the exception handler to log errors
+        informer.exceptionHandler((isStarted, t) -> {
+            LOGGER.errorOp("Caught exception in the {} informer which is {}", informer.getApiTypeClass().getSimpleName(), (isStarted ? "started" : "not started"), t);
+            // We always want the informer to retry => we just want to log the error
+            return true;
+        });
+    }
+
+    //////////////////////////////
+    /// Methods for working with the lister cache and querying the informer
+    //////////////////////////////
+
+    /**
+     * Finds the resource based on its namespace and name
+     *
+     * @param namespace     Namespace of the resource
+     * @param name          Name of the resource
+     *
+     * @return  The resource matching the name and namespace or null if it was not found
+     */
+    public T get(String namespace, String name)   {
+        return lister.namespace(namespace).get(name);
+    }
+
+    /**
+     * Lists the resource from a namespace
+     *
+     * @param namespace     Namespace of the resource
+     *
+     * @return  List of resources that exist in a given namespace
+     */
+    public List<T> list(String namespace)   {
+        return lister.namespace(namespace).list();
+    }
+
+
+    //////////////////////////////
+    /// "Inherited" methods for working with the informers -> just call the corresponding informer method
+    //////////////////////////////
+
+    /**
+     * Configures the event handler for this informer
+     *
+     * @param handler   Event handler
+     */
+    public void addEventHandler(ResourceEventHandler<T> handler)   {
+        informer.addEventHandler(handler);
+    }
+
+    /**
+     * Starts the informer
+     *
+     * @return  CompletionStage that completes when the informer is started
+     */
+    public CompletionStage<Void> start() {
+        CompletionStage<Void> start = informer.start();
+
+        // Setup logging for when the informer stops -> this is useful to debug various failures with the informers
+        informer.stopped().whenComplete((v, t) -> {
+            if (t != null) {
+                LOGGER.warnOp("{} informer stopped", informer.getApiTypeClass().getSimpleName(), t);
+            } else {
+                LOGGER.infoOp("{} informer stopped", informer.getApiTypeClass().getSimpleName());
+            }
+        });
+
+        return start;
+    }
+
+    /**
+     * Stops the informer
+     */
+    public void stop() {
+        informer.stop();
+    }
+
+    /**
+     * Waits until the informer is stopped
+     *
+     * @return  CompletionStage that completes when the informer is stopped
+     */
+    public CompletionStage<Void> stopped() {
+        return informer.stopped();
+    }
+
+    /**
+     * Indicates whether the informer is synced
+     *
+     * @return  True if the informer is synced. False otherwise.
+     */
+    public boolean hasSynced()    {
+        return informer.hasSynced();
+    }
+
+    /**
+     * Indicates whether the informer is running
+     *
+     * @return  True if the informer is running. False otherwise.
+     */
+    public boolean isRunning()    {
+        return informer.isRunning();
+    }
+}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR refactors how we use Informers in our current code base (User Operator and StrimziPodSetController). It creates a new wrapper/encapsulation of the informer and lister to make it easier to share them through the code and query the cache. This should simplify the existing code and make it easier to introduce informers in other parts of the code base.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally