### PR TITLE
Remove unused fields from `@JsonPropertyOrder` annotation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/AdditionalVolume.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 @Buildable(editableEnabled = false, builderPackage = Constants.FABRIC8_KUBERNETES_API)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "name", "path", "subPath", "secret", "configMap", "emptyDir", "persistentVolumeClaim" })
+@JsonPropertyOrder({ "name", "secret", "configMap", "emptyDir", "persistentVolumeClaim" })
 @OneOf({
     @OneOf.Alternative({
         @OneOf.Alternative.Property(value = "secret", required = false),

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/template/JmxTransTemplate.java
@@ -25,7 +25,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "deployment", "pod", "container", "serviceAccount", "additionalProperties" })
+@JsonPropertyOrder({ "deployment", "pod", "container", "serviceAccount" })
 @EqualsAndHashCode
 @ToString
 public class JmxTransTemplate implements UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -26,11 +26,9 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers",
-    "tls", "authentication", "config", "resources", "livenessProbe",
-    "readinessProbe", "jvmOptions", "jmxOptions", "affinity", "tolerations",
-    "logging", "clientRackInitImage", "rack", "metricsConfig", "tracing",
-    "template", "externalConfiguration", "build" })
+@JsonPropertyOrder({ "version", "replicas", "image", "bootstrapServers", "tls", "authentication", "config", "resources",
+    "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "logging", "clientRackInitImage", "rack",
+    "metricsConfig", "tracing", "template", "externalConfiguration", "build" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaAuthorizationKeycloak.java
@@ -26,11 +26,10 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"type", "clientId", "tokenEndpointUri",
-    "tlsTrustedCertificates", "disableTlsHostnameVerification",
+@JsonPropertyOrder({"type", "clientId", "tokenEndpointUri", "tlsTrustedCertificates", "disableTlsHostnameVerification",
     "delegateToKafkaAcls", "grantsRefreshPeriodSeconds", "grantsRefreshPoolSize", "grantsMaxIdleTimeSeconds",
-    "grantsMaxIdleSeconds", "grantsGcPeriodSeconds", "grantsAlwaysLatest", "KafkaAuthorizationKeycloak", "superUsers",
-    "connectTimeoutSeconds", "readTimeoutSeconds", "httpRetries", "enableMetrics", "includeAcceptHeader"})
+    "grantsGcPeriodSeconds", "grantsAlwaysLatest", "superUsers", "connectTimeoutSeconds", "readTimeoutSeconds",
+    "httpRetries", "enableMetrics", "includeAcceptHeader"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaAuthorizationKeycloak extends KafkaAuthorization {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaSpec.java
@@ -32,9 +32,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "kafka", "zookeeper", "topicOperator",
-    "entityOperator", "clusterCa", "clientsCa",
-    "maintenance", "cruiseControl", "jmxTrans", "kafkaExporter", "maintenanceTimeWindows"})
+@JsonPropertyOrder({ "kafka", "zookeeper", "entityOperator", "clusterCa", "clientsCa", "cruiseControl", "jmxTrans",
+    "kafkaExporter", "maintenanceTimeWindows"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaSpec extends Spec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfiguration.java
@@ -28,10 +28,10 @@ import java.util.Map;
  * Configures Kafka listeners
  */
 @DescriptionFile
-@JsonPropertyOrder({"brokerCertChainAndKey", "class", "preferredAddressType", "externalTrafficPolicy",
-    "loadBalancerSourceRanges", "bootstrap", "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService",
-    "finalizers", "useServiceDnsDomain", "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType",
-    "publishNotReadyAddresses", "hostTemplate", "advertisedHostTemplate", "allocateLoadBalancerNodePorts"})
+@JsonPropertyOrder({"brokerCertChainAndKey", "class", "externalTrafficPolicy", "loadBalancerSourceRanges", "bootstrap",
+    "brokers", "ipFamilyPolicy", "ipFamilies", "createBootstrapService", "finalizers", "useServiceDnsDomain",
+    "maxConnections", "maxConnectionCreationRate", "preferredNodePortAddressType", "publishNotReadyAddresses",
+    "hostTemplate", "advertisedHostTemplate", "allocateLoadBalancerNodePorts"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBootstrap.java
@@ -22,8 +22,7 @@ import java.util.Map;
  * Configures listener bootstrap configuration
  */
 @DescriptionFile
-@JsonPropertyOrder({"alternativeNames", "host", "dnsAnnotations", "nodePort", "loadBalancerIP",
-    "annotations", "labels", "externalIPs"})
+@JsonPropertyOrder({"alternativeNames", "host", "nodePort", "loadBalancerIP", "annotations", "labels", "externalIPs"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/GenericKafkaListenerConfigurationBroker.java
@@ -23,8 +23,7 @@ import java.util.Map;
  * Configures listener per-broker configuration
  */
 @DescriptionFile
-@JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host", "dnsAnnotations", "nodePort",
-    "loadBalancerIP", "annotations", "labels", "externalIPs"})
+@JsonPropertyOrder({"broker", "advertisedHost", "advertisedPort", "host", "nodePort", "loadBalancerIP", "annotations", "labels", "externalIPs"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(
     editableEnabled = false,

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/ListenerAddress.java
@@ -24,7 +24,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "address", "host", "port" })
+@JsonPropertyOrder({ "host", "port" })
 @EqualsAndHashCode
 @ToString
 public class ListenerAddress implements UnknownPropertyPreserving {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerConsumerSpec.java
@@ -23,8 +23,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"numStreams", "offsetCommitInterval", "bootstrapServers", "groupId", "logging",
-    "authentication", "tls", "config", "livenessProbe", "readinessProbe"})
+@JsonPropertyOrder({"numStreams", "offsetCommitInterval", "bootstrapServers", "groupId", "authentication", "tls", "config"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerConsumerSpec extends KafkaMirrorMakerClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker/KafkaMirrorMakerProducerSpec.java
@@ -21,7 +21,7 @@ import java.util.Map;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "bootstrapServers", "abortOnSendFailure", "logging", "authentication", "config", "tls"})
+@JsonPropertyOrder({ "bootstrapServers", "abortOnSendFailure", "authentication", "config", "tls"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaMirrorMakerProducerSpec extends KafkaMirrorMakerClientSpec {

--- a/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/mirrormaker2/KafkaMirrorMaker2Spec.java
@@ -21,10 +21,8 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"version", "replicas", "image", "connectCluster",
-    "clusters", "mirrors", "resources", "livenessProbe", "readinessProbe",
-    "jvmOptions", "jmxOptions", "affinity", "tolerations", "logging",
-    "clientRackInitImage", "rack", "metricsConfig", "tracing",
+@JsonPropertyOrder({"version", "replicas", "image", "connectCluster", "clusters", "mirrors", "resources", "livenessProbe",
+    "readinessProbe", "jvmOptions", "jmxOptions", "logging", "clientRackInitImage", "rack", "metricsConfig", "tracing",
     "template", "externalConfiguration" })
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)

--- a/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/topic/ReplicasChangeStatus.java
@@ -21,7 +21,7 @@ import java.util.Map;
     builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "targetReplicas", "state", "userTaskId", "message", "sessionId" })
+@JsonPropertyOrder({ "targetReplicas", "state", "message", "sessionId" })
 @EqualsAndHashCode
 @ToString(callSuper = true)
 public class ReplicasChangeStatus implements UnknownPropertyPreserving {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -763,20 +763,9 @@ class CrdGenerator {
             }
 
             List<String> expectedOrder = asList(order.value());
-
-            // Check that all properties are in the list
             for (String property : properties) {
                 if (!expectedOrder.contains(property)) {
                     err(crdClass + " has a property " + property + " which is not in the @JsonPropertyOrder");
-                }
-            }
-
-            // Check that the list does not contain any non-existent properties
-            List<String> ignoredTopLevelProperties = List.of("apiVersion", "metadata", "kind");
-            for (String property : expectedOrder) {
-                if (!properties.contains(property) &&
-                        !(CustomResource.class.isAssignableFrom(crdClass) && ignoredTopLevelProperties.contains(property))) { // The top level CRD classes include some inherited fields
-                    err("@JsonPropertyOrder has a property " + property + " that does not exist in " + crdClass);
                 }
             }
         }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -763,9 +763,20 @@ class CrdGenerator {
             }
 
             List<String> expectedOrder = asList(order.value());
+
+            // Check that all properties are in the list
             for (String property : properties) {
                 if (!expectedOrder.contains(property)) {
                     err(crdClass + " has a property " + property + " which is not in the @JsonPropertyOrder");
+                }
+            }
+
+            // Check that the list does not contain any non-existent properties
+            List<String> ignoredTopLevelProperties = List.of("apiVersion", "metadata", "kind");
+            for (String property : expectedOrder) {
+                if (!properties.contains(property) &&
+                        !(CustomResource.class.isAssignableFrom(crdClass) && ignoredTopLevelProperties.contains(property))) { // The top level CRD classes include some inherited fields
+                    err("@JsonPropertyOrder has a property " + property + " that does not exist in " + crdClass);
                 }
             }
         }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The `@JsonPropertyOrder` annotation contains in some cases fields that do not exist - usually as a result of copy-paste errors and similar. This PR removes them.

Originally, I wanted to add support for automatic validation similar to #9831. But it is not easily possible because of CRD versioning that might add or remove fields from different version. So I only cleaned the existing values.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally