### PR TITLE
Fix TO logging configuration when deployed by the CO

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
+++ b/cluster-operator/src/main/resources/default-logging/EntityTopicOperator.properties
@@ -3,21 +3,14 @@ name = TOConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,nnnnn} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
+# Keeps separate level for Jetty
 logger.jetty.name = org.eclipse.jetty
 logger.jetty.level = INFO
 logger.jetty.additivity = false
-
-logger.clients.name = org.apache.kafka.clients
-logger.clients.level = INFO
-logger.clients.additivity = false
-
-logger.streams.name = org.apache.kafka.streams
-logger.streams.level = INFO
-logger.streams.additivity = false


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The default logging configuration pattern of the Topic Operator when deployed through the `Kafka` CR is currently for some reason different from the one used by CO and UO - but also from the pattern used by TO when deployed as a standalone operator.

It also contains some leftover logging configuration from the bidirectional Topic Operator such as configuration for the Streams API classes etc. This is not needed anymore and is removed.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally