### PR TITLE
Minor refactoring of how the Kubernetes Client is created and used in the Topic Operator

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -4,11 +4,9 @@
  */
 package io.strimzi.operator.topic;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Annotations;
-import io.strimzi.operator.common.OperatorKubernetesClientBuilder;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
@@ -38,19 +36,6 @@ public class TopicOperatorUtil {
     static final int BROKER_DEFAULT = -1;
 
     private TopicOperatorUtil() { }
-
-    /**
-     * Create a new Kubernetes client instance.
-     *
-     * @param id Caller id.
-     * @return Kubernetes client.
-     */
-    public static KubernetesClient createKubernetesClient(String id) {
-        return new OperatorKubernetesClientBuilder(
-            "strimzi-topic-operator-" + id,
-            TopicOperatorMain.class.getPackage().getImplementationVersion())
-            .build();
-    }
 
     /**
      * Create a new Kafka admin client instance.

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -5,6 +5,7 @@
 package io.strimzi.operator.topic;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.Crds;
@@ -117,7 +118,7 @@ class TopicControllerIT implements TestSeparator {
 
     @BeforeAll
     public static void beforeAll() {
-        kubernetesClient = TopicOperatorUtil.createKubernetesClient("test");
+        kubernetesClient = new KubernetesClientBuilder().build();
         TopicOperatorTestUtil.setupKubeCluster(kubernetesClient, NAMESPACE);
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR does a minor cleanup to the Topic Operator:
* It removes the unused method for creating the Kubernetes client
* It unifies the way the naming of the user-agent and the client is done in the Kubernetes Client
* Removes the unnecessary delegate method from the `TopicOperatorUtil` class
* It updates the timing configurations of the informer:
    * It changes the resynch-check interval to 30 second (that means the resynch happens somewhere between the `reconciliationInterval` and `reconciliation interval + 30 seconds`). It was previously set to 2 seconds, which made the window smaller, but also meant we did the check very often. 30 seconds seem sufficient to me, but we can change it if anyone disagrees.
    * It does not seem to make sense to add the interval in addition to the reconciliation interval in the event handler, that seems to make little sense.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally