### PR TITLE
Fix Crds.kafkaTopic to include status subresource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/Crds.java
+++ b/api/src/main/java/io/strimzi/api/kafka/Crds.java
@@ -98,6 +98,7 @@ public class Crds {
             kind = KafkaTopic.RESOURCE_KIND;
             listKind = KafkaTopic.RESOURCE_LIST_KIND;
             versions = KafkaTopic.VERSIONS;
+            status = new CustomResourceSubresourceStatus();
         } else if (cls.equals(KafkaUser.class)) {
             scope = KafkaUser.SCOPE;
             plural = KafkaUser.RESOURCE_PLURAL;


### PR DESCRIPTION
### Type of change

Bugfix
Fixes #10905 

### Description

Update Crds.crd for KafkaTopic to create the `status` subresource

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

