### PR TITLE
Add content type to the operator metric endpoints

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/Main.java
@@ -269,7 +269,9 @@ public class Main {
                         request.response().setStatusCode(204).end();
                     } else if (request.path().equals("/metrics")) {
                         PrometheusMeterRegistry metrics = (PrometheusMeterRegistry) metricsProvider.meterRegistry();
-                        request.response().setStatusCode(200)
+                        request.response()
+                                .putHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                                .setStatusCode(200)
                                 .end(metrics.scrape());
                     }
                 })

--- a/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Jetty based web server used for health checks and metrics
@@ -158,12 +159,13 @@ public class HealthCheckAndMetricsServer {
     class MetricsHandler extends AbstractHandler {
         @Override
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
-            response.setContentType("text/plain");
-
             if (prometheusMeterRegistry != null) {
+                response.setContentType("text/plain; version=0.0.4");
+                response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
                 response.setStatus(HttpServletResponse.SC_OK);
                 prometheusMeterRegistry.scrape(response.getWriter());
             } else {
+                response.setContentType("text/plain");
                 response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
                 response.getWriter().println("Prometheus metrics are not enabled");
             }

--- a/operator-common/src/test/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServerTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServerTest.java
@@ -54,6 +54,8 @@ public class HealthCheckAndMetricsServerTest {
             request = HttpRequest.newBuilder().uri(new URI("http://localhost:" + port + "/metrics")).GET().build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode(), is(200));
+            assertThat(response.headers().map().get("Content-Type").size(), is(1));
+            assertThat(response.headers().map().get("Content-Type").get(0), is("text/plain; version=0.0.4;charset=utf-8"));
             assertThat(response.body(), containsString("my_metric_total 1.0"));
         } finally {
             server.stop();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

As described in #10902, we seem to be currently missing the content type on the operator metric endpoints. This PR adds them as described in the Prometheus docs: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format.

I do not have any Prometheus 3 installation, so all I was able to test was that it still works with my old Prometheus and that the Content-Type is there when trying with `curl` and looks the same as for the Prometheus JMX Exporter.

This should resolve #10902.

### Checklist

- [x] Write tests
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging