### PR TITLE
[system test] Add CruiseControl removeDisks test case

### DIFF
--- a/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
@@ -131,7 +131,7 @@
 | - | - | - |
 | 1. | Initialize JBOD storage configuration with multiple volumes (disks). | JBOD storage with disk IDs 0, 1, and 2 are initialized. |
 | 2. | Deploy Kafka with Cruise Control enabled. | Kafka with Cruise Control is successfully created. |
-| 3. | Create KafkaTopic resources and produce data to them. | KafkaTopic resources are created and data is produced to them. |
+| 3. | Create KafkaTopic resource and produce data to it. | KafkaTopic resource is created and data is produced to it. |
 | 4. | Retrieve initial data directory sizes and partition replicas for the disks being removed. | Initial data directory sizes and partition replicas are retrieved. |
 | 5. | Create a KafkaRebalance resource with 'remove-disks' mode, specifying the brokers and volume IDs. | KafkaRebalance resource is created with 'remove-disks' mode and moveReplicasOffVolumes settings. |
 | 6. | Wait for the KafkaRebalance to reach the ProposalReady state. | KafkaRebalance reaches the ProposalReady state. |

--- a/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
@@ -130,14 +130,15 @@
 | Step | Action | Result |
 | - | - | - |
 | 1. | Initialize JBOD storage configuration with multiple volumes (disks). | JBOD storage with disk IDs 0, 1, and 2 are initialized. |
-| 2. | Deploy Kafka with Cruise Control enabled. | Kafka deployment with Cruise Control is successfully created. |
-| 3. | Create topics and produce data to them. | Topics are created and data is produced to them. |
-| 4. | Retrieve initial data directory sizes for the disks being removed. | Initial data directory sizes are retrieved. |
+| 2. | Deploy Kafka with Cruise Control enabled. | Kafka with Cruise Control is successfully created. |
+| 3. | Create KafkaTopic resources and produce data to them. | KafkaTopic resources are created and data is produced to them. |
+| 4. | Retrieve initial data directory sizes and partition replicas for the disks being removed. | Initial data directory sizes and partition replicas are retrieved. |
 | 5. | Create a KafkaRebalance resource with 'remove-disks' mode, specifying the brokers and volume IDs. | KafkaRebalance resource is created with 'remove-disks' mode and moveReplicasOffVolumes settings. |
 | 6. | Wait for the KafkaRebalance to reach the ProposalReady state. | KafkaRebalance reaches the ProposalReady state. |
 | 7. | Approve the KafkaRebalance proposal. | KafkaRebalance is approved. |
 | 8. | Wait for the KafkaRebalance to reach Ready state. | KafkaRebalance reaches the Ready state. |
 | 9. | Verify that data has been moved off the specified disks by checking data directory sizes in the broker pods. | Data directories for the specified volumes are empty or have minimal data, confirming data has been moved off. |
+| 10. | Verify that partitions have been moved off the specified disks. | Partitions are no longer present on the specified disks, confirming successful removal. |
 
 **Labels:**
 

--- a/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
+++ b/development-docs/systemtests/io.strimzi.systemtest.cruisecontrol.CruiseControlST.md
@@ -121,6 +121,29 @@
 * [cruise-control](labels/cruise-control.md)
 
 
+## testCruiseControlRemoveDisksMode
+
+**Description:** Test verifying the 'remove-disks' mode in Cruise Control, which allows moving data between JBOD disks on the same broker.
+
+**Steps:**
+
+| Step | Action | Result |
+| - | - | - |
+| 1. | Initialize JBOD storage configuration with multiple volumes (disks). | JBOD storage with disk IDs 0, 1, and 2 are initialized. |
+| 2. | Deploy Kafka with Cruise Control enabled. | Kafka deployment with Cruise Control is successfully created. |
+| 3. | Create topics and produce data to them. | Topics are created and data is produced to them. |
+| 4. | Retrieve initial data directory sizes for the disks being removed. | Initial data directory sizes are retrieved. |
+| 5. | Create a KafkaRebalance resource with 'remove-disks' mode, specifying the brokers and volume IDs. | KafkaRebalance resource is created with 'remove-disks' mode and moveReplicasOffVolumes settings. |
+| 6. | Wait for the KafkaRebalance to reach the ProposalReady state. | KafkaRebalance reaches the ProposalReady state. |
+| 7. | Approve the KafkaRebalance proposal. | KafkaRebalance is approved. |
+| 8. | Wait for the KafkaRebalance to reach Ready state. | KafkaRebalance reaches the Ready state. |
+| 9. | Verify that data has been moved off the specified disks by checking data directory sizes in the broker pods. | Data directories for the specified volumes are empty or have minimal data, confirming data has been moved off. |
+
+**Labels:**
+
+* [cruise-control](labels/cruise-control.md)
+
+
 ## testCruiseControlReplicaMovementStrategy
 
 **Description:** Test that verifies the configuration and application of custom Cruise Control replica movement strategies.

--- a/development-docs/systemtests/labels/cruise-control.md
+++ b/development-docs/systemtests/labels/cruise-control.md
@@ -20,6 +20,7 @@ Ensuring the correctness of Cruise Control behavior under different configuratio
 - [testCruiseControlChangesFromRebalancingtoProposalReadyWhenSpecUpdated](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
 - [testCruiseControlIntraBrokerBalancing](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
 - [testDeployAndUnDeployCruiseControl](../io.strimzi.systemtest.cruisecontrol.CruiseControlConfigurationST.md)
+- [testCruiseControlRemoveDisksMode](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
 - [testCruiseControlReplicaMovementStrategy](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)
 - [testCruiseControlBasicAPIRequestsWithSecurityDisabled](../io.strimzi.systemtest.cruisecontrol.CruiseControlApiST.md)
 - [testCruiseControlTopicExclusion](../io.strimzi.systemtest.cruisecontrol.CruiseControlST.md)

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -607,7 +607,8 @@ public class KafkaTopicUtils {
      */
     public static void verifyPartitionsMovedOffDisks(final Map<String, Set<Integer>> initialPartitionDirs,
                                                final Map<String, Set<Integer>> finalPartitionDirs) {
-        for (final String key : initialPartitionDirs.keySet()) {
+        for (final Map.Entry<String, Set<Integer>> entry : initialPartitionDirs.entrySet()) {
+            final String key = entry.getKey();
             final Set<Integer> initialPartitions = initialPartitionDirs.get(key);
             final Set<Integer> finalPartitions = finalPartitionDirs.getOrDefault(key, Collections.emptySet());
 
@@ -646,7 +647,8 @@ public class KafkaTopicUtils {
                                                         final Map<String, Long> finalDataDirSizes) {
         LOGGER.info("Verifying that data has been moved off the specified disks...");
 
-        for (final String key : initialDataDirSizes.keySet()) {
+        for (final Map.Entry<String, Long> entry : initialDataDirSizes.entrySet()) {
+            final String key = entry.getKey();
             final long initialSize = initialDataDirSizes.get(key);
             final long finalSize = finalDataDirSizes.getOrDefault(key, 0L);
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/kafkaUtils/KafkaTopicUtils.java
@@ -525,7 +525,6 @@ public class KafkaTopicUtils {
             }).toList();
     }
 
-
     public static void waitForTopicWithPrefixDeletion(String namespaceName, String topicPrefix, int start, int end) {
         TestUtils.waitFor("deletion of all topics with prefix: " + topicPrefix + " from " + start + " to " + end,
             TestConstants.GLOBAL_POLL_INTERVAL, TestConstants.GLOBAL_TIMEOUT,
@@ -633,6 +632,13 @@ public class KafkaTopicUtils {
         return dataDirSizes;
     }
 
+    /**
+     * Verifies that data has been moved off the specified disks after a rebalance.
+     *
+     * @param initialDataDirSizes   a map of initial data directory paths to their sizes in bytes.
+     * @param finalDataDirSizes     a map of final data directory paths to their sizes in bytes.
+     * @throws AssertionError       if the size of any data directory has not been sufficiently reduced.
+     */
     public static void verifyDataMovedOffSpecifiedDisks(final Map<String, Long> initialDataDirSizes,
                                                         final Map<String, Long> finalDataDirSizes) {
         LOGGER.info("Verifying that data has been moved off the specified disks...");

--- a/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/cruisecontrol/CruiseControlST.java
@@ -971,7 +971,7 @@ public class CruiseControlST extends AbstractST {
             //  cluster-ef377b8e-b-45e0111e-0:/var/lib/kafka/data-2 -> 37,416 bytes (~37 KB)
             //  cluster-ef377b8e-b-45e0111e-2:/var/lib/kafka/data-1 -> 24,983 bytes (~25 KB)
             assertThat("Expected data directory " + key + " to have reduced size after rebalance.",
-                finalSize, Matchers.lessThan(initialSize / 100)); // Adjust the threshold as needed
+                finalSize, Matchers.lessThan(initialSize / 100));
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR covers a feature implemented [#10644 Ability to move data between JBOD disks using Cruise Control](https://github.com/strimzi/strimzi-kafka-operator/pull/10644). 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass