### PR TITLE
Remove Vertx from KafkaConnect API

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApi.java
@@ -8,13 +8,13 @@ import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.vertx.core.Future;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A Java client for the Kafka Connect REST API.
@@ -30,7 +30,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns information about the connector, including its name, config and tasks.
      */
-    Future<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
+    CompletableFuture<Map<String, Object>> createOrUpdatePutRequest(Reconciliation reconciliation, String host, int port, String connectorName, JsonObject configJson);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
@@ -41,7 +41,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's config.
      */
-    Future<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/config}.
@@ -54,7 +54,7 @@ public interface KafkaConnectApi {
      *
      * @return A Future which completes with the result of the request. If the request was successful, this returns the connector's config.
      */
-    Future<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
+    CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}}.
@@ -65,7 +65,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns information about the connector, including its name, config and tasks.
      */
-    Future<Map<String, Object>> getConnector(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Map<String, Object>> getConnector(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code DELETE} request to {@code /connectors/${connectorName}}.
@@ -75,7 +75,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to delete.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
@@ -86,7 +86,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    Future<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}.
@@ -98,7 +98,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    Future<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes);
+    CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/status}, retrying according to {@code backoff}.
@@ -110,7 +110,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's status.
      */
-    Future<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
+    CompletableFuture<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/pause}.
@@ -120,7 +120,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to pause.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/stop}.
@@ -130,7 +130,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to pause.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PUT} request to {@code /connectors/${connectorName}/resume}.
@@ -140,7 +140,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to resume.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> resume(Reconciliation reconciliation,  String host, int port, String connectorName);
+    CompletableFuture<Void> resume(Reconciliation reconciliation,  String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors}
@@ -150,7 +150,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connectors.
      */
-    Future<List<String>> list(Reconciliation reconciliation, String host, int port);
+    CompletableFuture<List<String>> list(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code GET} request to {@code /connector-plugins}.
@@ -160,7 +160,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connector plugins.
      */
-    Future<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port);
+    CompletableFuture<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code GET} request to {@code /admin/loggers/$logger}.
@@ -172,7 +172,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns whether any loggers were actually changed.
      */
-    Future<Boolean> updateConnectLoggers(Reconciliation reconciliation, String host, int port, String desiredLogging, OrderedProperties defaultLogging);
+    CompletableFuture<Boolean> updateConnectLoggers(Reconciliation reconciliation, String host, int port, String desiredLogging, OrderedProperties defaultLogging);
 
     /**
      * Make a {@code GET} request to {@code /admin/loggers}.
@@ -182,7 +182,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the list of connect loggers.
      */
-    Future<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port);
+    CompletableFuture<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/restart}.
@@ -194,7 +194,7 @@ public interface KafkaConnectApi {
      * @param onlyFailed    Specifies whether to restart just the instances with a FAILED status or all instances.
      * @return A Future which completes with the result of the request and the new status of the connector
      */
-    Future<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
+    CompletableFuture<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed);
 
     /**
      * Make a {@code POST} request to {@code /connectors/${connectorName}/tasks/${taskID}/restart}.
@@ -204,7 +204,7 @@ public interface KafkaConnectApi {
      * @param taskID The ID of the connector task to restart.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> restartTask(String host, int port, String connectorName, int taskID);
+    CompletableFuture<Void> restartTask(String host, int port, String connectorName, int taskID);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/topics}.
@@ -215,7 +215,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's topics.
      */
-    Future<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code GET} request to {@code /connectors/${connectorName}/offsets}.
@@ -226,7 +226,7 @@ public interface KafkaConnectApi {
      * @return A Future which completes with the result of the request. If the request was successful,
      * this returns the connector's offsets.
      */
-    Future<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
 
     /**
      * Make a {@code PATCH} request to {@code /connectors/${connectorName}/offsets}.
@@ -237,7 +237,7 @@ public interface KafkaConnectApi {
      * @param newOffsets The new offsets for the connector.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets);
+    CompletableFuture<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets);
 
     /**
      * Make a {@code DELETE} request to {@code /connectors/${connectorName}/offsets}.
@@ -247,7 +247,7 @@ public interface KafkaConnectApi {
      * @param connectorName The name of the connector to reset the offsets of.
      * @return A Future which completes with the result of the request.
      */
-    Future<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
+    CompletableFuture<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName);
 }
 
 class ConnectRestException extends RuntimeException {
@@ -258,8 +258,8 @@ class ConnectRestException extends RuntimeException {
         this.statusCode = statusCode;
     }
 
-    public ConnectRestException(HttpClientResponse response, String message) {
-        this(response.request().getMethod().toString(), response.request().path(), response.statusCode(), response.statusMessage(), message);
+    public ConnectRestException(HttpResponse response, String message) {
+        this(response.request().method(), response.uri().getPath(), response.statusCode(), String.valueOf(response.statusCode()), message);
     }
 
     ConnectRestException(String method, String path, int statusCode, String statusMessage, String message, Throwable cause) {
@@ -267,8 +267,8 @@ class ConnectRestException extends RuntimeException {
         this.statusCode = statusCode;
     }
 
-    public ConnectRestException(HttpClientResponse response, String message, Throwable cause) {
-        this(response.request().getMethod().toString(), response.request().path(), response.statusCode(), response.statusMessage(), message, cause);
+    public ConnectRestException(HttpResponse response, String message, Throwable cause) {
+        this(response.request().method(), response.uri().getPath(), response.statusCode(), String.valueOf(response.statusCode()), message, cause);
     }
 
     public int getStatusCode() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -87,7 +87,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}: {}", statusCode, path, t);
                         return CompletableFuture.completedFuture(t);
                     } else {
-                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress (https://github.com/strimzi/strimzi-kafka-operator/issues/10933)
                         LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", statusCode, path);
                         return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
                     }
@@ -114,6 +114,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         return json;
     }
 
+    // Encodes the invalid characters for a URL because the connector name may contain them
     private String encodeURLString(String toEncode) {
         return toEncode.replace("->", "%2D%3E");
     }
@@ -136,7 +137,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", statusCode, path, json.asText());
                         return CompletableFuture.completedFuture(OBJECT_MAPPER.convertValue(json, type));
                     } else {
-                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress (https://github.com/strimzi/strimzi-kafka-operator/issues/10933)
                         LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", statusCode, path);
                         return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
                     }
@@ -179,7 +180,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                         return withBackoff(reconciliation, new BackOff(200L, 2, 10), connectorName, Collections.singleton(200),
                                 () -> status(reconciliation, host, port, connectorName, Collections.singleton(404)), "status").thenApply(r -> null);
                     } else {
-                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress (https://github.com/strimzi/strimzi-kafka-operator/issues/10933)
                         LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", statusCode, path);
                         return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -218,13 +218,14 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 if (error == null) {
                     statusFuture.complete(result);
                 } else {
-                    if (error.getCause() instanceof ConnectRestException
-                            && retriableStatusCodes.contains(((ConnectRestException) error.getCause()).getStatusCode())) {
+                    Throwable cause = error.getCause();
+                    if (cause instanceof ConnectRestException
+                            && retriableStatusCodes.contains(((ConnectRestException) cause).getStatusCode())) {
                         if (backOff.done()) {
-                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} and we run out of back off time", connectorName, attribute, ((ConnectRestException) error.getCause()).getStatusCode());
-                            statusFuture.completeExceptionally(error);
+                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} and we run out of back off time", connectorName, attribute, ((ConnectRestException) cause).getStatusCode());
+                            statusFuture.completeExceptionally(cause);
                         } else {
-                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} - backing off", connectorName, attribute, ((ConnectRestException) error.getCause()).getStatusCode());
+                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} - backing off", connectorName, attribute, ((ConnectRestException) cause).getStatusCode());
                             long delay1 = backOff.delayMs();
 
                             LOGGER.debugCr(reconciliation, "Status for connector {} not found; " +
@@ -233,7 +234,7 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                             executeBackOffInternal(reconciliation, backOff, connectorName, retriableStatusCodes, singleExecutor, statusFuture, supplier, attribute, delay1);
                         }
                     } else {
-                        statusFuture.completeExceptionally(error);
+                        statusFuture.completeExceptionally(cause);
                     }
                 }
             });

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiImpl.java
@@ -5,27 +5,27 @@
 
 package io.strimzi.operator.cluster.operator.assembly;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.strimzi.api.kafka.model.connect.ConnectorPlugin;
-import io.strimzi.operator.cluster.operator.resource.HttpClientUtils;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.Util;
 import io.strimzi.operator.common.model.OrderedProperties;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,6 +36,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -44,66 +48,54 @@ import static java.util.Arrays.asList;
 
 class KafkaConnectApiImpl implements KafkaConnectApi {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaConnectApiImpl.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static final TypeReference<Map<String, Object>> TREE_TYPE = new TypeReference<>() { };
     public static final TypeReference<Map<String, String>> MAP_OF_STRINGS = new TypeReference<>() { };
     public static final TypeReference<Map<String, Map<String, String>>> MAP_OF_MAP_OF_STRINGS = new TypeReference<>() { };
     public static final TypeReference<Map<String, Map<String, List<String>>>> MAP_OF_MAP_OF_LIST_OF_STRING = new TypeReference<>() { };
-    private final ObjectMapper mapper = new ObjectMapper();
-    private final Vertx vertx;
+    private final HttpClient httpClient;
 
-    public KafkaConnectApiImpl(Vertx vertx) {
-        this.vertx = vertx;
+    public KafkaConnectApiImpl() {
+        this.httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Future<Map<String, Object>> createOrUpdatePutRequest(
+    public CompletableFuture<Map<String, Object>> createOrUpdatePutRequest(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName, JsonObject configJson) {
-        Buffer data = configJson.toBuffer();
+        String data = configJson.toString();
         String path = "/connectors/" + connectorName + "/config";
         LOGGER.debugCr(reconciliation, "Making PUT request to {} with body {}", path, configJson);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-            httpClient.request(HttpMethod.PUT, port, host, path, request -> {
-                if (request.succeeded()) {
-                    request.result().setFollowRedirects(true)
-                            .putHeader("Accept", "application/json")
-                            .putHeader("Content-Type", "application/json")
-                            .putHeader("Content-Length", String.valueOf(data.length()))
-                            .write(data);
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 200 || response.result().statusCode() == 201) {
-                                response.result().bodyHandler(buffer -> {
-                                    try {
-                                        @SuppressWarnings({ "rawtypes" })
-                                        Map t = mapper.readValue(buffer.getBytes(), Map.class);
-                                        LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}: {}", response.result().statusCode(), path, t);
-                                        result.complete(t);
-                                    } catch (IOException e) {
-                                        result.fail(new ConnectRestException(response.result(), "Could not deserialize response: " + e));
-                                    }
-                                });
-                            } else {
-                                // TODO Handle 409 (Conflict) indicating a rebalance in progress
-                                LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", response.result().statusCode(), path);
-                                response.result().bodyHandler(buffer -> {
-                                    result.fail(new ConnectRestException(response.result(), tryToExtractErrorMessage(reconciliation, buffer)));
-                                });
-                            }
-                        } else {
-                            result.tryFail(response.cause());
-                        }
-                    });
-                } else {
-                    result.fail(request.cause());
-                }
-            }));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .PUT(HttpRequest.BodyPublishers.ofString(data))
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200 || statusCode == 201) {
+                        JsonNode json = parseToJsonNode(response);
+                        Map<String, Object> t = OBJECT_MAPPER.convertValue(json, TREE_TYPE);
+                        LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}: {}", statusCode, path, t);
+                        return CompletableFuture.completedFuture(t);
+                    } else {
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", statusCode, path);
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
+                    }
+                });
     }
 
     @Override
-    public Future<Map<String, Object>> getConnector(
+    public CompletableFuture<Map<String, Object>> getConnector(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName) {
@@ -112,44 +104,43 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
                 TREE_TYPE);
     }
 
-    private <T> Future<T> doGet(Reconciliation reconciliation, String host, int port, String path, Set<Integer> okStatusCodes, TypeReference<T> type) {
+    private JsonNode parseToJsonNode(HttpResponse<String> responseBody) {
+        JsonNode json;
+        try {
+            json = OBJECT_MAPPER.readTree(responseBody.body());
+        } catch (JsonProcessingException e) {
+            throw new ConnectRestException(responseBody, "Could not deserialize response: " + e);
+        }
+        return json;
+    }
+
+
+    private <T> CompletableFuture<T> doGet(Reconciliation reconciliation, String host, int port, String path, Set<Integer> okStatusCodes, TypeReference<T> type) {
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-            httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                if (request.succeeded()) {
-                    request.result().setFollowRedirects(true)
-                            .putHeader("Accept", "application/json");
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (okStatusCodes.contains(response.result().statusCode())) {
-                                response.result().bodyHandler(buffer -> {
-                                    try {
-                                        T t = mapper.readValue(buffer.getBytes(), type);
-                                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", response.result().statusCode(), path, t);
-                                        result.complete(t);
-                                    } catch (IOException e) {
-                                        result.fail(new ConnectRestException(response.result(), "Could not deserialize response: " + e));
-                                    }
-                                });
-                            } else {
-                                // TODO Handle 409 (Conflict) indicating a rebalance in progress
-                                LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode(), path);
-                                response.result().bodyHandler(buffer -> {
-                                    result.fail(new ConnectRestException(response.result(), tryToExtractErrorMessage(reconciliation, buffer)));
-                                });
-                            }
-                        } else {
-                            result.tryFail(response.cause());
-                        }
-                    });
-                } else {
-                    result.tryFail(request.cause());
-                }
-            }));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (okStatusCodes.contains(statusCode)) {
+                        JsonNode json = parseToJsonNode(response);
+                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", statusCode, path, json.asText());
+                        return CompletableFuture.completedFuture(OBJECT_MAPPER.convertValue(json, type));
+                    } else {
+                        // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", statusCode, path);
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
+                    }
+                });
     }
 
     @Override
-    public Future<Map<String, String>> getConnectorConfig(
+    public CompletableFuture<Map<String, String>> getConnectorConfig(
             Reconciliation reconciliation,
             String host, int port,
             String connectorName) {
@@ -159,315 +150,268 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
+    public CompletableFuture<Map<String, String>> getConnectorConfig(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
         return withBackoff(reconciliation, backOff, connectorName, Collections.singleton(409),
             () -> getConnectorConfig(reconciliation, host, port, connectorName), "config");
     }
 
     @Override
-    public Future<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Void> delete(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = "/connectors/" + connectorName;
         LOGGER.debugCr(reconciliation, "Making DELETE request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-            httpClient.request(HttpMethod.DELETE, port, host, path, request -> {
-                if (request.succeeded()) {
-                    request.result().setFollowRedirects(true)
-                            .putHeader("Accept", "application/json")
-                            .putHeader("Content-Type", "application/json");
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 204) {
-                                LOGGER.debugCr(reconciliation, "Connector was deleted. Waiting for status deletion!");
-                                withBackoff(reconciliation, new BackOff(200L, 2, 10), connectorName, Collections.singleton(200),
-                                    () -> status(reconciliation, host, port, connectorName, Collections.singleton(404)), "status")
-                                    .onComplete(res -> {
-                                        if (res.succeeded()) {
-                                            result.complete();
-                                        } else {
-                                            result.fail(res.cause());
-                                        }
-                                    });
-                            } else {
-                                // TODO Handle 409 (Conflict) indicating a rebalance in progress
-                                LOGGER.debugCr(reconciliation, "Got {} response to DELETE request to {}", response.result().statusCode(), path);
-                                response.result().bodyHandler(buffer -> {
-                                    result.fail(new ConnectRestException(response.result(), tryToExtractErrorMessage(reconciliation, buffer)));
-                                });
-                            }
-                        } else {
-                            result.tryFail(response.cause());
-                        }
-                    });
-                } else {
-                    result.tryFail(request.cause());
-                }
-            }));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .DELETE()
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        .thenCompose(response -> {
+            int statusCode = response.statusCode();
+            if (statusCode == 204) {
+                LOGGER.debugCr(reconciliation, "Connector was deleted. Waiting for status deletion!");
+                return withBackoff(reconciliation, new BackOff(200L, 2, 10), connectorName, Collections.singleton(200),
+                        () -> status(reconciliation, host, port, connectorName, Collections.singleton(404)), "status").thenApply(r -> null);
+            } else {
+                // TODO Handle 409 (Conflict) indicating a rebalance in progress
+                LOGGER.debugCr(reconciliation, "Got {} response to PUT request to {}", statusCode, path);
+                return CompletableFuture.failedFuture(new ConnectRestException(response, tryToExtractErrorMessage(reconciliation, response.body())));
+            }
+        });
     }
 
     @Override
-    public Future<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
+    public CompletableFuture<Map<String, Object>> statusWithBackOff(Reconciliation reconciliation, BackOff backOff, String host, int port, String connectorName) {
         return withBackoff(reconciliation, backOff, connectorName, Collections.singleton(404),
             () -> status(reconciliation, host, port, connectorName), "status");
     }
 
-    private <T> Future<T> withBackoff(Reconciliation reconciliation,
-                                      BackOff backOff, String connectorName,
-                                      Set<Integer> retriableStatusCodes,
-                                      Supplier<Future<T>> supplier,
-                                      String attribute) {
-        Promise<T> result = Promise.promise();
+    private <T> CompletableFuture<T> withBackoff(Reconciliation reconciliation,
+                                                 BackOff backOff, String connectorName,
+                                                 Set<Integer> retriableStatusCodes,
+                                                 Supplier<CompletableFuture<T>> supplier,
+                                                 String attribute) {
+        CompletableFuture<T> statusFuture = new CompletableFuture<>();
+        ScheduledExecutorService singleExecutor = Executors.newSingleThreadScheduledExecutor(
+                runnable -> new Thread(runnable, "kafka-connect-" + connectorName + "-" + attribute));
 
-        Handler<Long> handler = new Handler<Long>() {
-            @Override
-            public void handle(Long tid) {
-                supplier.get().onComplete(connectorStatus -> {
-                    if (connectorStatus.succeeded()) {
-                        result.complete(connectorStatus.result());
-                    } else {
-                        Throwable cause = connectorStatus.cause();
-                        if (cause instanceof ConnectRestException
-                                && retriableStatusCodes.contains(((ConnectRestException) cause).getStatusCode())) {
-                            if (backOff.done()) {
-                                LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} and we run out of back off time", connectorName, attribute, ((ConnectRestException) cause).getStatusCode());
-                                result.fail(cause);
-                            } else {
-                                LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} - backing off", connectorName, attribute, ((ConnectRestException) cause).getStatusCode());
-                                rescheduleOrComplete(tid);
-                            }
-                        } else {
-                            result.fail(cause);
-                        }
-                    }
-                });
-            }
+        executeBackOffInternal(reconciliation, backOff, connectorName, retriableStatusCodes, singleExecutor, statusFuture, supplier, attribute, 0);
+        statusFuture.whenComplete((r, e) -> singleExecutor.shutdown());
+        return statusFuture;
+    }
 
-            void rescheduleOrComplete(Long tid) {
-                if (backOff.done()) {
-                    LOGGER.warnCr(reconciliation, "Giving up waiting for status of connector {} after {} attempts taking {}ms",
-                            connectorName, backOff.maxAttempts(), backOff.totalDelayMs());
+    private <T> void executeBackOffInternal(Reconciliation reconciliation,
+                                                 BackOff backOff, String connectorName,
+                                                 Set<Integer> retriableStatusCodes,
+                                                 ScheduledExecutorService singleExecutor,
+                                                 CompletableFuture<T> statusFuture,
+                                                 Supplier<CompletableFuture<T>> supplier,
+                                                 String attribute, long delay) {
+        singleExecutor.schedule(() -> {
+            supplier.get().whenComplete((result, error) -> {
+                if (error == null) {
+                    statusFuture.complete(result);
                 } else {
-                    // Schedule ourselves to run again
-                    long delay = backOff.delayMs();
-                    LOGGER.debugCr(reconciliation, "Status for connector {} not found; " +
-                                    "backing off for {}ms (cumulative {}ms)",
-                            connectorName, delay, backOff.cumulativeDelayMs());
-                    if (delay < 1) {
-                        this.handle(tid);
+                    if (error.getCause() instanceof ConnectRestException
+                            && retriableStatusCodes.contains(((ConnectRestException) error.getCause()).getStatusCode())) {
+                        if (backOff.done()) {
+                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} and we run out of back off time", connectorName, attribute, ((ConnectRestException) error.getCause()).getStatusCode());
+                            statusFuture.completeExceptionally(error);
+                        } else {
+                            LOGGER.debugCr(reconciliation, "Connector {} {} returned HTTP {} - backing off", connectorName, attribute, ((ConnectRestException) error.getCause()).getStatusCode());
+                            long delay1 = backOff.delayMs();
+
+                            LOGGER.debugCr(reconciliation, "Status for connector {} not found; " +
+                                            "backing off for {}ms (cumulative {}ms)",
+                                    connectorName, delay, backOff.cumulativeDelayMs());
+                            executeBackOffInternal(reconciliation, backOff, connectorName, retriableStatusCodes, singleExecutor, statusFuture, supplier, attribute, delay1);
+                        }
                     } else {
-                        vertx.setTimer(delay, this);
+                        statusFuture.completeExceptionally(error);
                     }
                 }
-            }
-        };
-
-        handler.handle(null);
-        return result.future();
+            });
+        }, delay, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public Future<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
         return status(reconciliation, host, port, connectorName, Collections.singleton(200));
     }
 
     @Override
-    public Future<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes) {
+    public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName, Set<Integer> okStatusCodes) {
         String path = "/connectors/" + connectorName + "/status";
         return doGet(reconciliation, host, port, path, okStatusCodes, TREE_TYPE);
     }
 
     @Override
-    public Future<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Void> pause(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/pause", 202);
     }
 
     @Override
-    public Future<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Void> stop(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/stop", 204);
     }
 
     @Override
-    public Future<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Void> resume(Reconciliation reconciliation, String host, int port, String connectorName) {
         return updateState(reconciliation, host, port, "/connectors/" + connectorName + "/resume", 202);
     }
 
-    private Future<Void> updateState(Reconciliation reconciliation, String host, int port, String path, int expectedStatusCode) {
+    private CompletableFuture<Void> updateState(Reconciliation reconciliation, String host, int port, String path, int expectedStatusCode) {
         LOGGER.debugCr(reconciliation, "Making PUT request to {} ", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.PUT, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json");
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == expectedStatusCode) {
-                                    response.result().bodyHandler(body -> {
-                                        result.complete();
-                                    });
-                                } else {
-                                    result.fail("Unexpected status code " + response.result().statusCode()
-                                            + " for PUT request to " + host + ":" + port + path);
-                                }
-                            } else {
-                                result.tryFail(response.cause());
-                            }
-                        });
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .PUT(HttpRequest.BodyPublishers.noBody())
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    if (response.statusCode() == expectedStatusCode) {
+                        return CompletableFuture.completedFuture(null);
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                }));
+                });
     }
 
     @Override
-    public Future<List<String>> list(Reconciliation reconciliation, String host, int port) {
+    public CompletableFuture<List<String>> list(Reconciliation reconciliation, String host, int port) {
         String path = "/connectors";
         LOGGER.debugCr(reconciliation, "Making GET request to {} ", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.GET, port, host, path, request -> {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .build();
 
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json");
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        JsonArray objects = buffer.toJsonArray();
-                                        List<String> list = new ArrayList<>(objects.size());
-                                        for (Object o : objects) {
-                                            if (o instanceof String) {
-                                                list.add((String) o);
-                                            } else {
-                                                result.fail(o == null ? "null" : o.getClass().getName());
-                                            }
-                                        }
-                                        result.complete(list);
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                }
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    if (response.statusCode() == 200) {
+                        JsonNode json = parseToJsonNode(response);
+                        if (!json.isArray()) {
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Response body is not a JSON array"));
+                        }
+
+                        ArrayNode objects = (ArrayNode) json;
+                        List<String> list = new ArrayList<>(objects.size());
+
+                        for (Object o : objects) {
+                            if (o instanceof TextNode) {
+                                list.add(((TextNode) o).asText());
                             } else {
-                                result.tryFail(response.cause());
+                                return CompletableFuture.failedFuture(new ConnectRestException(response, o == null ? "null" : o.getClass().getName()));
                             }
-                        });
+                        }
+                        return CompletableFuture.completedFuture(list);
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                }));
+                });
     }
 
     @Override
-    public Future<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port) {
+    public CompletableFuture<List<ConnectorPlugin>> listConnectorPlugins(Reconciliation reconciliation, String host, int port) {
         String path = "/connector-plugins";
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json");
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        try {
-                                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode());
-                                            result.complete(asList(mapper.readValue(buffer.getBytes(), ConnectorPlugin[].class)));
-                                        } catch (IOException e) {
-                                            LOGGER.warnCr(reconciliation, "Failed to parse list of connector plugins", e);
-                                            result.fail(new ConnectRestException(response.result(), "Failed to parse list of connector plugins", e));
-                                        }
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                }
-                            } else {
-                                result.tryFail(response.cause());
-                            }
-                        });
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", statusCode);
+                            return CompletableFuture.completedFuture(asList(OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), ConnectorPlugin[].class)));
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to parse list of connector plugins", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse list of connector plugins", e));
+                        }
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                }));
+                });
     }
 
-    private Future<Void> updateConnectorLogger(Reconciliation reconciliation, String host, int port, String logger, String level) {
+    private CompletableFuture<Void> updateConnectorLogger(Reconciliation reconciliation, String host, int port, String logger, String level) {
         String path = "/admin/loggers/" + logger + "?scope=cluster";
-        JsonObject levelJO = new JsonObject();
+
+        ObjectNode levelJO = OBJECT_MAPPER.createObjectNode();
         levelJO.put("level", level);
+        String data;
+        try {
+            data = OBJECT_MAPPER.writeValueAsString(levelJO);
+        } catch (JsonProcessingException e) {
+            return CompletableFuture.failedFuture(new RuntimeException("Could not deserialize the request data for updating logger " + logger + ": " + e));
+        }
+
         LOGGER.debugCr(reconciliation, "Making PUT request to {} with body {}", path, levelJO);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) -> {
-            Buffer buffer = levelJO.toBuffer();
-            httpClient
-                    .request(HttpMethod.PUT, port, host, path, request -> {
-                        if (request.succeeded()) {
-                            request.result().putHeader("Content-Type", "application/json")
-                                    .setFollowRedirects(true)
-                                    .putHeader("Content-Length", Integer.toString(buffer.toString().length()))
-                                    .write(buffer.toString());
-                            request.result().send(response -> {
-                                if (response.succeeded()) {
-                                    if (List.of(200, 204).contains(response.result().statusCode())) {
-                                        response.result().bodyHandler(body -> {
-                                            LOGGER.debugCr(reconciliation, "Logger {} updated to level {}", logger, level);
-                                            result.complete();
-                                        });
-                                    } else {
-                                        LOGGER.debugCr(reconciliation, "Logger {} did not update to level {} (http code {})", logger, level, response.result().statusCode());
-                                        result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                    }
-                                } else {
-                                    result.tryFail(response.cause());
-                                }
-                            });
-                        } else {
-                            result.tryFail(request.cause());
-                        }
-                    });
-        });
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .PUT(HttpRequest.BodyPublishers.ofString(data))
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (List.of(200, 204).contains(statusCode)) {
+                        LOGGER.debugCr(reconciliation, "Logger {} updated to level {}", logger, level);
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        LOGGER.debugCr(reconciliation, "Logger {} did not update to level {} (http code {})", logger, level, statusCode);
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
+                    }
+                });
     }
 
     @Override
-    public Future<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port) {
+    public CompletableFuture<Map<String, String>> listConnectLoggers(Reconciliation reconciliation, String host, int port) {
         String path = "/admin/loggers/";
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json");
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        try {
-                                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", response.result().statusCode(), path);
-                                            Map<String, Map<String, String>> fetchedLoggers = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_STRINGS);
-                                            Map<String, String> loggerMap = new HashMap<>(fetchedLoggers.size());
-                                            for (var loggerEntry : fetchedLoggers.entrySet()) {
-                                                String level = loggerEntry.getValue().get("level");
-                                                if (level != null) {
-                                                    loggerMap.put(loggerEntry.getKey(), level);
-                                                }
-                                            }
-                                            result.tryComplete(loggerMap);
-                                        } catch (IOException e) {
-                                            LOGGER.warnCr(reconciliation, "Failed to get list of connector loggers", e);
-                                            result.fail(new ConnectRestException(response.result(), "Failed to get connector loggers", e));
-                                        }
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}", statusCode, path);
+                            Map<String, Map<String, String>> fetchedLoggers = OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), MAP_OF_MAP_OF_STRINGS);
+                            Map<String, String> loggerMap = new HashMap<>(fetchedLoggers.size());
+                            for (var loggerEntry : fetchedLoggers.entrySet()) {
+                                String level = loggerEntry.getValue().get("level");
+                                if (level != null) {
+                                    loggerMap.put(loggerEntry.getKey(), level);
                                 }
-                            } else {
-                                result.tryFail(response.cause());
                             }
-                        });
+                            return CompletableFuture.completedFuture(loggerMap);
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to get list of connector loggers", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to get connector loggers", e));
+                        }
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                }));
+                });
     }
 
-    private Future<Boolean> updateLoggers(Reconciliation reconciliation, String host, int port,
+    private CompletableFuture<Boolean> updateLoggers(Reconciliation reconciliation, String host, int port,
                                        String desiredLogging,
                                        Map<String, String> fetchedLoggers,
                                        OrderedProperties defaultLogging) {
@@ -490,14 +434,14 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
         addToLoggers(desiredMap, updateLoggers);
 
         if (updateLoggers.equals(fetchedLoggers)) {
-            return Future.succeededFuture(false);
+            return CompletableFuture.completedFuture(false);
         } else {
-            Future<Void> result = Future.succeededFuture();
+            CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
             for (Map.Entry<String, String> logger : updateLoggers.entrySet()) {
-                result = result.compose(previous -> updateConnectorLogger(reconciliation, host, port,
+                result = result.thenCompose(previous -> updateConnectorLogger(reconciliation, host, port,
                         logger.getKey(), logger.getValue()));
             }
-            return result.map(true);
+            return result.thenApply(r -> true);
         }
     }
 
@@ -553,227 +497,178 @@ class KafkaConnectApiImpl implements KafkaConnectApi {
     }
 
     @Override
-    public Future<Boolean> updateConnectLoggers(Reconciliation reconciliation, String host, int port, String desiredLogging, OrderedProperties defaultLogging) {
+    public CompletableFuture<Boolean> updateConnectLoggers(Reconciliation reconciliation, String host, int port, String desiredLogging, OrderedProperties defaultLogging) {
         return listConnectLoggers(reconciliation, host, port)
-                .compose(fetchedLoggers -> updateLoggers(reconciliation, host, port, desiredLogging, fetchedLoggers, defaultLogging));
+                .thenCompose(fetchedLoggers -> updateLoggers(reconciliation, host, port, desiredLogging, fetchedLoggers, defaultLogging));
     }
 
     @Override
-    public Future<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
+    public CompletableFuture<Map<String, Object>> restart(String host, int port, String connectorName, boolean includeTasks, boolean onlyFailed) {
         return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/restart?includeTasks=" + includeTasks + "&onlyFailed=" + onlyFailed);
     }
 
     @Override
-    public Future<Void> restartTask(String host, int port, String connectorName, int taskID) {
+    public CompletableFuture<Void> restartTask(String host, int port, String connectorName, int taskID) {
         return restartConnectorOrTask(host, port, "/connectors/" + connectorName + "/tasks/" + taskID + "/restart")
-            .compose(result -> Future.succeededFuture());
+            .thenCompose(result -> CompletableFuture.completedFuture(null));
     }
 
-    private Future<Map<String, Object>> restartConnectorOrTask(String host, int port, String path) {
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-            httpClient.request(HttpMethod.POST, port, host, path, request -> {
-                if (request.succeeded()) {
-                    request.result().setFollowRedirects(true)
-                            .putHeader("Accept", "application/json");
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 202) {
-                                response.result().bodyHandler(body -> {
-                                    try {
-                                        var status = mapper.readValue(body.getBytes(), TREE_TYPE);
-                                        result.complete(status);
-                                    } catch (IOException e) {
-                                        result.fail(new ConnectRestException(response.result(), "Failed to parse restart status response", e));
-                                    }
-                                });
-                            } else if (response.result().statusCode() == 204) {
-                                response.result().bodyHandler(body -> {
-                                    result.complete(null);
-                                });
-                            } else {
-                                result.fail("Unexpected status code " + response.result().statusCode()
-                                        + " for POST request to " + host + ":" + port + path);
-                            }
-                        } else {
-                            result.tryFail(response.cause());
+    private CompletableFuture<Map<String, Object>> restartConnectorOrTask(String host, int port, String path) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    if (response.statusCode() == 202) {
+                        try {
+                            return CompletableFuture.completedFuture(OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), TREE_TYPE));
+                        } catch (IOException e) {
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse restart status response", e));
                         }
-                    });
-                } else {
-                    result.tryFail(request.cause());
-                }
-            }));
+                    } else if (response.statusCode() == 204) {
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
+                    }
+                });
     }
 
     @Override
-    public Future<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<List<String>> getConnectorTopics(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/topics", connectorName);
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-            httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                if (request.succeeded()) {
-                    request.result().setFollowRedirects(true)
-                            .putHeader("Accept", "application/json");
-                } else {
-                    result.tryFail(request.cause());
-                }
-                if (request.succeeded()) {
-                    request.result().send(response -> {
-                        if (response.succeeded()) {
-                            if (response.result().statusCode() == 200) {
-                                response.result().bodyHandler(buffer -> {
-                                    try {
-                                        Map<String, Map<String, List<String>>> t = mapper.readValue(buffer.getBytes(), MAP_OF_MAP_OF_LIST_OF_STRING);
-                                        LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", response.result().statusCode(), path, t);
-                                        result.complete(t.get(connectorName).get("topics"));
-                                    } catch (IOException e) {
-                                        LOGGER.warnCr(reconciliation, "Failed to parse list of connector topics", e);
-                                        result.fail(new ConnectRestException(response.result(), "Failed to parse list of connector topics", e));
-                                    }
-                                });
-                            } else {
-                                result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                            }
-                        } else {
-                            result.fail(response.cause());
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            Map<String, Map<String, List<String>>> t = OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), MAP_OF_MAP_OF_LIST_OF_STRING);
+                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", statusCode, path, t);
+                            return CompletableFuture.completedFuture(t.get(connectorName).get("topics"));
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to parse list of connector topics", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse list of connector topics", e));
                         }
-                    });
-                } else {
-                    result.tryFail(request.cause());
-                }
-            }));
+                    } else {
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
+                    }
+                });
     }
 
     @Override
-    public Future<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<String> getConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making GET request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.GET, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json")
-                                .putHeader("Content-Type", "application/json");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .GET()
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            Object offsets = OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), Object.class);
+                            String prettyPrintedOffsets = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(offsets);
+                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", statusCode, path, offsets);
+                            return CompletableFuture.completedFuture(prettyPrintedOffsets);
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse connector offsets", e));
+                        }
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                    if (request.succeeded()) {
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        try {
-                                            Object offsets = mapper.readValue(buffer.getBytes(), Object.class);
-                                            String prettyPrintedOffsets = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(offsets);
-                                            LOGGER.debugCr(reconciliation, "Got {} response to GET request to {}: {}", response.result().statusCode(), path, offsets);
-                                            result.complete(prettyPrintedOffsets);
-                                        } catch (IOException e) {
-                                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets", e);
-                                            result.fail(new ConnectRestException(response.result(), "Failed to parse connector offsets", e));
-                                        }
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                }
-                            } else {
-                                result.fail(response.cause());
-                            }
-                        });
-                    } else {
-                        result.tryFail(request.cause());
-                    }
-                }));
+                });
     }
 
     @Override
-    public Future<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets) {
+    public CompletableFuture<Void> alterConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName, String newOffsets) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making PATCH request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.PATCH, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json")
-                                .putHeader("Content-Type", "application/json")
-                                .putHeader("Content-Length", Integer.toString(newOffsets.length()))
-                                .write(newOffsets);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .method("PATCH", HttpRequest.BodyPublishers.ofString(newOffsets))
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            Map<String, String> body = OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), MAP_OF_STRINGS);
+                            String message = body.get("message");
+                            LOGGER.debugCr(reconciliation, "Got {} response to PATCH request to {}: {}", statusCode, path, message);
+                            return CompletableFuture.completedFuture(null);
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets alter response", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse connector offsets alter response", e));
+                        }
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                    if (request.succeeded()) {
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        try {
-                                            Map<String, String> body = mapper.readValue(buffer.getBytes(), MAP_OF_STRINGS);
-                                            String message = body.get("message");
-                                            LOGGER.debugCr(reconciliation, "Got {} response to PATCH request to {}: {}", response.result().statusCode(), path, message);
-                                            result.complete();
-                                        } catch (IOException e) {
-                                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets alter response", e);
-                                            result.fail(new ConnectRestException(response.result(), "Failed to parse connector offsets alter response", e));
-                                        }
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                }
-                            } else {
-                                result.fail(response.cause());
-                            }
-                        });
-                    } else {
-                        result.tryFail(request.cause());
-                    }
-                }));
+                });
     }
 
     @Override
-    public Future<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
+    public CompletableFuture<Void> resetConnectorOffsets(Reconciliation reconciliation, String host, int port, String connectorName) {
         String path = String.format("/connectors/%s/offsets", connectorName);
         LOGGER.debugCr(reconciliation, "Making DELETE request to {}", path);
-        return HttpClientUtils.withHttpClient(vertx, new HttpClientOptions().setLogActivity(true), (httpClient, result) ->
-                httpClient.request(HttpMethod.DELETE, port, host, path, request -> {
-                    if (request.succeeded()) {
-                        request.result().setFollowRedirects(true)
-                                .putHeader("Accept", "application/json");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://%s:%d%s", host, port, path)))
+                .DELETE()
+                .setHeader("Accept", "application/json")
+                .build();
+
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenCompose(response -> {
+                    int statusCode = response.statusCode();
+                    if (statusCode == 200) {
+                        try {
+                            Map<String, String> body = OBJECT_MAPPER.readValue(response.body().getBytes(StandardCharsets.UTF_8), MAP_OF_STRINGS);
+                            String message = body.get("message");
+                            LOGGER.debugCr(reconciliation, "Got {} response to DELETE request to {}: {}", statusCode, path, message);
+                            return CompletableFuture.completedFuture(null);
+                        } catch (IOException e) {
+                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets reset response", e);
+                            return CompletableFuture.failedFuture(new ConnectRestException(response, "Failed to parse connector offsets reset response", e));
+                        }
                     } else {
-                        result.tryFail(request.cause());
+                        return CompletableFuture.failedFuture(new ConnectRestException(response, "Unexpected status code"));
                     }
-                    if (request.succeeded()) {
-                        request.result().send(response -> {
-                            if (response.succeeded()) {
-                                if (response.result().statusCode() == 200) {
-                                    response.result().bodyHandler(buffer -> {
-                                        try {
-                                            Map<String, String> body = mapper.readValue(buffer.getBytes(), MAP_OF_STRINGS);
-                                            String message = body.get("message");
-                                            LOGGER.debugCr(reconciliation, "Got {} response to DELETE request to {}: {}", response.result().statusCode(), path, message);
-                                            result.complete();
-                                        } catch (IOException e) {
-                                            LOGGER.warnCr(reconciliation, "Failed to parse connector offsets reset response", e);
-                                            result.fail(new ConnectRestException(response.result(), "Failed to parse connector offsets reset response", e));
-                                        }
-                                    });
-                                } else {
-                                    result.fail(new ConnectRestException(response.result(), "Unexpected status code"));
-                                }
-                            } else {
-                                result.fail(response.cause());
-                            }
-                        });
-                    } else {
-                        result.tryFail(request.cause());
-                    }
-                }));
+                });
     }
 
-    /* test */ static String tryToExtractErrorMessage(Reconciliation reconciliation, Buffer buffer)    {
+    /* test */ static String tryToExtractErrorMessage(Reconciliation reconciliation, String body) {
+        JsonNode json;
         try {
-            return buffer.toJsonObject().getString("message");
-        } catch (DecodeException e) {
-            LOGGER.warnCr(reconciliation, "Failed to decode the error message from the response: " + buffer, e);
+            json = OBJECT_MAPPER.readTree(body);
+            if (json.has("message")) {
+                return json.get("message").asText();
+            } else {
+                LOGGER.warnCr(reconciliation, "Failed to decode the error message from the response: " + body);
+            }
+        } catch (JsonProcessingException e) {
+            LOGGER.warnCr(reconciliation, "Failed to deserialize the error message from the response: " + body);
         }
-
         return "Unknown error message";
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiIT.java
@@ -168,8 +168,8 @@ public class KafkaConnectApiIT {
 
             .thenCompose(ignored -> client.getConnectorConfig(Reconciliation.DUMMY_RECONCILIATION, new BackOff(10), "localhost", port, "does-not-exist")
                         .handle((r, e) -> {
-                            assertThat(e.getCause(), is(instanceOf(ConnectRestException.class)));
-                            assertThat(e.getMessage(), containsString("404"));
+                            assertThat(e, is(instanceOf(ConnectRestException.class)));
+                            assertThat(((ConnectRestException) e).getStatusCode(), is(404));
                             if (e == null) {
                                 throw new RuntimeException("Expected failure when getting config for connector that doesn't exist");
                             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectApiMockTest.java
@@ -6,99 +6,84 @@ package io.strimzi.operator.cluster.operator.assembly;
 
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
-@ExtendWith(VertxExtension.class)
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class KafkaConnectApiMockTest {
-    private static Vertx vertx;
     private final BackOff backOff = new BackOff(1L, 2, 3);
 
-    @BeforeAll
-    public static void before() {
-        vertx = Vertx.vertx();
-    }
+    @Test
+    public void testStatusWithBackOffSucceedingImmediately() {
+        Queue<CompletableFuture<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
+        statusResults.add(CompletableFuture.completedFuture(Collections.emptyMap()));
 
-    @AfterAll
-    public static void after() {
-        vertx.close();
+        KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
+        api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
+                .whenComplete((r, e) -> assertThat(e, nullValue())).join();
     }
 
     @Test
-    public void testStatusWithBackOffSucceedingImmediately(VertxTestContext context) {
-        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
-        statusResults.add(Future.succeededFuture(Collections.emptyMap()));
+    public void testStatusWithBackOffSucceedingEventually() {
+        Queue<CompletableFuture<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(3);
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
+        statusResults.add(CompletableFuture.completedFuture(Collections.emptyMap()));
 
-        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
-        Checkpoint async = context.checkpoint();
+        KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
 
         api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-            .onComplete(context.succeeding(res -> async.flag()));
+                .whenComplete((r, e) -> assertThat(e, nullValue())).join();
     }
 
     @Test
-    public void testStatusWithBackOffSucceedingEventually(VertxTestContext context) {
-        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(3);
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
-        statusResults.add(Future.succeededFuture(Collections.emptyMap()));
+    public void testStatusWithBackOffFailingRepeatedly() {
+        Queue<CompletableFuture<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(4);
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 404, null, null))));
 
-        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
-        Checkpoint async = context.checkpoint();
-
-        api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-            .onComplete(context.succeeding(res -> async.flag()));
+        KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
+        assertThrows(Exception.class, api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
+                .whenComplete((r, e) -> {
+                    assertThat(e.getMessage(), containsString("404"));
+                    assertThat(statusResults.size(), is(0));
+                })::join);
     }
 
     @Test
-    public void testStatusWithBackOffFailingRepeatedly(VertxTestContext context) {
-        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(4);
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 404, null, null)));
+    public void testStatusWithBackOffOtherExceptionStillFails() {
+        Queue<CompletableFuture<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
+        statusResults.add(CompletableFuture.failedFuture(new CompletionException(new ConnectRestException(null, null, 500, null, null))));
 
-        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
-        Checkpoint async = context.checkpoint();
+        KafkaConnectApi api = new MockKafkaConnectApi(statusResults);
 
-        api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-            .onComplete(context.failing(res -> async.flag()));
-    }
-
-    @Test
-    public void testStatusWithBackOffOtherExceptionStillFails(VertxTestContext context) {
-        Queue<Future<Map<String, Object>>> statusResults = new ArrayBlockingQueue<>(1);
-        statusResults.add(Future.failedFuture(new ConnectRestException(null, null, 500, null, null)));
-
-        KafkaConnectApi api = new MockKafkaConnectApi(vertx, statusResults);
-        Checkpoint async = context.checkpoint();
-
-        api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
-            .onComplete(context.failing(res -> async.flag()));
+        assertThrows(Exception.class, api.statusWithBackOff(Reconciliation.DUMMY_RECONCILIATION, backOff, "some-host", 8083, "some-connector")
+                .whenComplete((r, e) -> assertThat(e.getMessage(), containsString("500")))::join);
     }
 
     static class MockKafkaConnectApi extends KafkaConnectApiImpl   {
-        private final Queue<Future<Map<String, Object>>> statusResults;
+        private final Queue<CompletableFuture<Map<String, Object>>> statusResults;
 
-        public MockKafkaConnectApi(Vertx vertx, Queue<Future<Map<String, Object>>> statusResults) {
-            super(vertx);
+        public MockKafkaConnectApi(Queue<CompletableFuture<Map<String, Object>>> statusResults) {
+            super();
             this.statusResults = statusResults;
         }
 
         @Override
-        public Future<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
+        public CompletableFuture<Map<String, Object>> status(Reconciliation reconciliation, String host, int port, String connectorName) {
             return statusResults.remove();
         }
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorAutoRestartTest.java
@@ -29,6 +29,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -138,7 +139,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Map.of()));
         AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()
@@ -183,7 +184,7 @@ public class KafkaConnectAssemblyOperatorConnectorAutoRestartTest {
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(false);
 
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of()));
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Map.of()));
         AbstractConnectOperator.ConnectorStatusAndConditions statusAndConditions = new AbstractConnectOperator.ConnectorStatusAndConditions(Map.of("connector", Map.of("state", "FAILED")), List.of(), List.of(), null);
         KafkaConnector connector = new KafkaConnectorBuilder()
                 .withNewMetadata()

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorConnectorOffsetsTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -137,7 +138,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -166,7 +167,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Failed to get ConfigMap")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -195,7 +196,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Create or update ConfigMap failed")));
 
@@ -225,7 +226,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
@@ -258,7 +259,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
 
 
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
@@ -317,7 +318,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 .withData(existingData)
                 .build();
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(existingCM));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
@@ -390,7 +391,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -418,7 +419,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(Map.of("foo", "bar")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(Map.of("foo", "bar")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -446,7 +447,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Failed to get ConfigMap")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -476,7 +477,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -510,7 +511,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of("foo", "bar"))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -544,7 +545,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of("offsets.json", "{\"test\":}"))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -578,9 +579,9 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of("offsets.json", OFFSETS_JSON))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
-        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME, OFFSETS_JSON)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME, OFFSETS_JSON)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -613,9 +614,9 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of("offsets.json", OFFSETS_JSON))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
-        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME, OFFSETS_JSON)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME, OFFSETS_JSON)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -649,7 +650,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -676,7 +677,7 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(Map.of("foo", "bar")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(Map.of("foo", "bar")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -703,8 +704,8 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
-        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())
@@ -732,8 +733,8 @@ public class KafkaConnectAssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig());
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
-        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, CONNECTOR_NAME)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.kafkaConnectorOperator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, CONNECTOR_NAME, connector, connector.getSpec(), new ArrayList<>())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorMockTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -152,8 +153,8 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .endSpec()
             .build()).create();
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
 
         Checkpoint async = context.checkpoint();
         createConnectCluster(context, mock, false)
@@ -181,8 +182,8 @@ public class KafkaConnectAssemblyOperatorMockTest {
                 .endSpec()
                 .build()).create();
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mock.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
 
         Checkpoint async = context.checkpoint();
         createConnectCluster(context, mock, true)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperatorPodSetTest.java
@@ -74,6 +74,7 @@ import org.mockito.Mockito;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
@@ -190,14 +191,14 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
 
         // Mock Connect REST API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
                 .withType("sink")
                 .withVersion("1.0.0")
                 .build();
-        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(singletonList(plugin1)));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,
@@ -327,14 +328,14 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
 
         // Mock Connect REST API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
                 .withType("sink")
                 .withVersion("1.0.0")
                 .build();
-        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(singletonList(plugin1)));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,
@@ -956,14 +957,14 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
 
         // Mock Connect REST API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
                 .withType("sink")
                 .withVersion("1.0.0")
                 .build();
-        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(singletonList(plugin1)));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,
@@ -1197,14 +1198,14 @@ public class KafkaConnectAssemblyOperatorPodSetTest {
 
         // Mock Connect REST API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
         ConnectorPlugin plugin1 = new ConnectorPluginBuilder()
                 .withConnectorClass("io.strimzi.MyClass")
                 .withType("sink")
                 .withVersion("1.0.0")
                 .build();
-        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(singletonList(plugin1)));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.listConnectorPlugins(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(singletonList(plugin1)));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaConnectAssemblyOperator ops = new KafkaConnectAssemblyOperator(
                 vertx,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectorIT.java
@@ -131,7 +131,7 @@ public class KafkaConnectorIT {
 
     @Test
     public void testConnectorNotUpdatedWhenConfigUnchanged(VertxTestContext context) {
-        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
 
@@ -165,7 +165,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
                 ClusterOperatorConfig.buildFromMap(Map.of(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-            connect -> new KafkaConnectApiImpl(vertx),
+            connect -> new KafkaConnectApiImpl(),
             connectCluster.getPort(0)
         ) { };
 
@@ -200,8 +200,8 @@ public class KafkaConnectorIT {
     }
 
     @Test
-    public void testConnectorResourceNotReadyWhenConnectorFailed(VertxTestContext context) {
-        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+    public void     testConnectorResourceNotReadyWhenConnectorFailed(VertxTestContext context) {
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
 
@@ -236,7 +236,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
                 ClusterOperatorConfig.buildFromMap(Map.of(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-                connect -> new KafkaConnectApiImpl(vertx),
+                connect -> new KafkaConnectApiImpl(),
                 connectCluster.getPort(0)
         ) { };
 
@@ -251,7 +251,7 @@ public class KafkaConnectorIT {
 
     @Test
     public void testConnectorResourceNotReadyWhenTaskFailed(VertxTestContext context) {
-        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
 
@@ -286,7 +286,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
                 ClusterOperatorConfig.buildFromMap(Map.of(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-                connect -> new KafkaConnectApiImpl(vertx),
+                connect -> new KafkaConnectApiImpl(),
                 connectCluster.getPort(0)
         ) { };
 
@@ -312,7 +312,7 @@ public class KafkaConnectorIT {
 
     @Test
     public void testConnectorIsAutoRestarted(VertxTestContext context) {
-        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
 
@@ -347,7 +347,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
             ClusterOperatorConfig.buildFromMap(Map.of(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-            connect -> new KafkaConnectApiImpl(vertx),
+            connect -> new KafkaConnectApiImpl(),
             connectCluster.getPort(0)
         ) { };
 
@@ -362,7 +362,7 @@ public class KafkaConnectorIT {
 
     @Test
     public void testTaskIsAutoRestarted(VertxTestContext context) {
-        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl(vertx);
+        KafkaConnectApiImpl connectClient = new KafkaConnectApiImpl();
 
         PlatformFeaturesAvailability pfa = new PlatformFeaturesAvailability(false, KubernetesVersion.MINIMAL_SUPPORTED_VERSION);
 
@@ -397,7 +397,7 @@ public class KafkaConnectorIT {
 
         KafkaConnectAssemblyOperator operator = new KafkaConnectAssemblyOperator(vertx, pfa, ros,
             ClusterOperatorConfig.buildFromMap(Map.of(), KafkaVersionTestUtils.getKafkaVersionLookup()),
-            connect -> new KafkaConnectApiImpl(vertx),
+            connect -> new KafkaConnectApiImpl(),
             connectCluster.getPort(0)
         ) { };
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.platform.KubernetesVersion;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
@@ -37,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -107,12 +107,12 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorAutoRestartTest {
 
     private KafkaConnectApi mockConnectApi(Map<String, Object> status)    {
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        when(mockConnectApi.list(any(), any(), anyInt())).thenReturn(Future.succeededFuture(new ArrayList<>()));
-        when(mockConnectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(EXPECTED_CONNECTOR_CONFIG));
-        when(mockConnectApi.status(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(status));
-        when(mockConnectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(status));
-        when(mockConnectApi.getConnectorTopics(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(List.of()));
-        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of("connector", Map.of("state", "RESTARTING"))));
+        when(mockConnectApi.list(any(), any(), anyInt())).thenReturn(CompletableFuture.completedFuture(new ArrayList<>()));
+        when(mockConnectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(EXPECTED_CONNECTOR_CONFIG));
+        when(mockConnectApi.status(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(status));
+        when(mockConnectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(status));
+        when(mockConnectApi.getConnectorTopics(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(List.of()));
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RESTARTING"))));
 
         return mockConnectApi;
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -271,7 +272,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -308,7 +309,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Failed to get ConfigMap")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -345,7 +346,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Create or update ConfigMap failed")));
 
@@ -383,7 +384,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
@@ -423,7 +424,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
@@ -492,7 +493,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withData(existingData)
                 .build();
 
-        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(OFFSETS_JSON));
+        when(mockConnectApi.getConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(OFFSETS_JSON));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(existingCM));
         when(supplier.configMapOperations.reconcile(any(), any(), any(), any())).thenReturn(Future.succeededFuture());
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
@@ -615,7 +616,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -651,7 +652,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(Map.of("foo", "bar")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(Map.of("foo", "bar")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -687,7 +688,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.failedFuture(new RuntimeException("Failed to get ConfigMap")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -725,7 +726,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(null));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -768,7 +769,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of("foo", "bar"))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -811,7 +812,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of(getConfigmapEntryName(connector), "{\"test\":}"))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -854,9 +855,9 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of(getConfigmapEntryName(connector), OFFSETS_JSON))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
-        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName, OFFSETS_JSON)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName, OFFSETS_JSON)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -898,9 +899,9 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 .withData(Map.of(getConfigmapEntryName(connector), OFFSETS_JSON))
                 .build();
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
         when(supplier.configMapOperations.getAsync(NAMESPACE, CONFIGMAP_NAME)).thenReturn(Future.succeededFuture(alterOffsetsConfigMap));
-        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName, OFFSETS_JSON)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.alterConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName, OFFSETS_JSON)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -975,7 +976,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.failedFuture(new RuntimeException("Rest API call failed")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Rest API call failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(),  new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -1010,7 +1011,7 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(Map.of("foo", "bar")));
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(Map.of("foo", "bar")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
                 .onComplete(context.succeeding(result -> context.verify(() -> {
@@ -1045,8 +1046,8 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
-        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.failedFuture(new RuntimeException("Patch CR failed")));
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())
@@ -1083,8 +1084,8 @@ public class KafkaMirrorMaker2AssemblyOperatorConnectorOffsetsTest {
                 supplier, ResourceUtils.dummyClusterOperatorConfig(), (vertx) -> mockConnectApi);
         Reconciliation reconciliation = Reconciliation.DUMMY_RECONCILIATION;
 
-        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture(STOPPED_STATE_MAP));
-        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(Future.succeededFuture());
+        when(mockConnectApi.status(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(STOPPED_STATE_MAP));
+        when(mockConnectApi.resetConnectorOffsets(reconciliation, CONNECT_HOSTNAME, KafkaConnectCluster.REST_API_PORT, connectorName)).thenReturn(CompletableFuture.completedFuture(null));
         when(supplier.mirrorMaker2Operator.patchAsync(any(), any())).thenReturn(Future.succeededFuture());
 
         op.manageConnectorOffsets(reconciliation, CONNECT_HOSTNAME, mockConnectApi, connectorName, kafkaMirrorMaker2, kafkaMirrorMaker2SourceConnector.getSpec(), new ArrayList<>())

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorMockTest.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -207,21 +208,21 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
         connectorOffsets = LIST_OFFSETS_JSON;
         Map<String, Object> status = Map.of("connector", Map.of("state", state));
         KafkaConnectApi mockConnectApi = mock(KafkaConnectApi.class);
-        when(mockConnectApi.list(any(), any(), anyInt())).thenReturn(Future.succeededFuture(new ArrayList<>()));
-        when(mockConnectApi.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
-        when(mockConnectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(EXPECTED_CONNECTOR_CONFIG));
-        when(mockConnectApi.status(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(status));
-        when(mockConnectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(status));
-        when(mockConnectApi.getConnectorTopics(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(Future.succeededFuture(List.of()));
-        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(Future.succeededFuture(Map.of("connector", Map.of("state", "RESTARTING"))));
-        when(mockConnectApi.getConnectorOffsets(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> Future.succeededFuture(connectorOffsets));
+        when(mockConnectApi.list(any(), any(), anyInt())).thenReturn(CompletableFuture.completedFuture(new ArrayList<>()));
+        when(mockConnectApi.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
+        when(mockConnectApi.getConnectorConfig(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(EXPECTED_CONNECTOR_CONFIG));
+        when(mockConnectApi.status(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(status));
+        when(mockConnectApi.statusWithBackOff(any(), any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(status));
+        when(mockConnectApi.getConnectorTopics(any(), any(), anyInt(), eq("source->target.MirrorSourceConnector"))).thenReturn(CompletableFuture.completedFuture(List.of()));
+        when(mockConnectApi.restart(any(), anyInt(), any(), anyBoolean(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Map.of("connector", Map.of("state", "RESTARTING"))));
+        when(mockConnectApi.getConnectorOffsets(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> CompletableFuture.completedFuture(connectorOffsets));
         when(mockConnectApi.alterConnectorOffsets(any(), any(), anyInt(), anyString(), anyString())).thenAnswer(invocation -> {
             connectorOffsets = invocation.getArgument(4);
-            return Future.succeededFuture();
+            return CompletableFuture.completedFuture(null);
         });
         when(mockConnectApi.resetConnectorOffsets(any(), any(), anyInt(), anyString())).thenAnswer(invocation -> {
             connectorOffsets = RESET_OFFSETS_JSON;
-            return Future.succeededFuture();
+            return CompletableFuture.completedFuture(null);
         });
 
         return mockConnectApi;
@@ -245,8 +246,8 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
             .build()).create();
 
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         Checkpoint async = context.checkpoint();
         createMirrorMaker2Cluster(context, mock, false)
@@ -277,8 +278,8 @@ public class KafkaMirrorMaker2AssemblyOperatorMockTest {
                 .build()).create();
 
         KafkaConnectApi mock = mock(KafkaConnectApi.class);
-        when(mock.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mock.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mock.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         Checkpoint async = context.checkpoint();
         createMirrorMaker2Cluster(context, mock, true)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperatorPodSetTest.java
@@ -68,6 +68,7 @@ import org.mockito.Mockito;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -181,8 +182,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -302,8 +303,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -399,8 +400,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -501,8 +502,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -598,8 +599,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -717,8 +718,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -835,8 +836,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -973,8 +974,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -1254,8 +1255,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -1342,8 +1343,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -1431,8 +1432,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -1520,8 +1521,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         ClusterOperatorConfig coConfig = new ClusterOperatorConfig.ClusterOperatorConfigBuilder(ResourceUtils.dummyClusterOperatorConfig(), VERSIONS).with(ClusterOperatorConfig.FEATURE_GATES.key(), "-ContinueReconciliationOnManualRollingUpdateFailure").build();
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
@@ -1617,8 +1618,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
         // Mock Connect API
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
 
         KafkaMirrorMaker2AssemblyOperator ops = new KafkaMirrorMaker2AssemblyOperator(
                 vertx,
@@ -1646,8 +1647,8 @@ public class KafkaMirrorMaker2AssemblyOperatorPodSetTest {
 
     private KafkaConnectApi createConnectClientMock() {
         KafkaConnectApi mockConnectClient = mock(KafkaConnectApi.class);
-        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(Future.succeededFuture(emptyList()));
-        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(Future.succeededFuture());
+        when(mockConnectClient.list(any(), anyString(), anyInt())).thenReturn(CompletableFuture.completedFuture(emptyList()));
+        when(mockConnectClient.updateConnectLoggers(any(), anyString(), anyInt(), anyString(), any(OrderedProperties.class))).thenReturn(CompletableFuture.completedFuture(null));
         return mockConnectClient;
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

This PR replaces Vertx Future with CompletableFuture in KafkaConnectApi and updates all the relevant classes and tests.

There will be follow up PRs to remove Vertx JsonObject from KafkaConnectApi and Vertx Future from the connect operator.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

