### PR TITLE
Update Prometheus JMX Exporter to 1.1.0

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/ignorelist
@@ -1,2 +1,0 @@
-jmx_prometheus_javaagent-1.0.1.jar
-snakeyaml-2.2.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -24,7 +24,6 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
@@ -70,12 +69,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
-        <dependency>
-            <groupId>io.prometheus.jmx</groupId>
-            <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx-prometheus-javaagent.version}</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/net.logstash.log4j/jsonevent-layout -->
         <dependency>
             <groupId>net.logstash.log4j</groupId>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/ignorelist
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/ignorelist
@@ -1,2 +1,0 @@
-jmx_prometheus_javaagent-1.0.1.jar
-snakeyaml-2.2.jar

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -24,7 +24,6 @@
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
         <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-        <jmx-prometheus-javaagent.version>1.0.1</jmx-prometheus-javaagent.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
@@ -70,12 +69,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/io.prometheus.jmx/jmx_prometheus_javaagent -->
-        <dependency>
-            <groupId>io.prometheus.jmx</groupId>
-            <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx-prometheus-javaagent.version}</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/net.logstash.log4j/jsonevent-layout -->
         <dependency>
             <groupId>net.logstash.log4j</groupId>

--- a/docker-images/kafka-based/kafka/Dockerfile
+++ b/docker-images/kafka-based/kafka/Dockerfile
@@ -77,6 +77,21 @@ RUN set -ex; \
 COPY ./exporter-scripts $KAFKA_EXPORTER_HOME
 
 #####
+# Add Prometheus JMX Exporter
+#####
+ENV JMX_EXPORTER_HOME=/opt/prometheus-jmx-exporter
+ENV JMX_EXPORTER_VERSION=1.1.0
+ENV JMX_EXPORTER_CHECKSUM="63f9ff5297c6add9ecd19633a54300ffcec0df2e09afca7212e80506b801ea20aa009efc4b582b6ed8a4616b1ed68c98e30cc5b9dbf2cf6fe68b7cf2e3c5db3c  jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar"
+
+RUN set -ex; \
+    curl -LO https://github.com/prometheus/jmx_exporter/releases/download/${JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar; \
+    echo $JMX_EXPORTER_CHECKSUM > jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha512; \
+    sha512sum --check jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha512; \
+    mkdir $JMX_EXPORTER_HOME; \
+    mv jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar $JMX_EXPORTER_HOME/; \
+    rm -f jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar.sha512;
+
+#####
 # Add Strimzi agents
 #####
 COPY ./tmp/kafka-agent-${STRIMZI_VERSION}.jar ${KAFKA_HOME}/libs/

--- a/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
+++ b/docker-images/kafka-based/kafka/cruise-control-scripts/cruise_control_run.sh
@@ -36,7 +36,7 @@ fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$CRUISE_CONTROL_METRICS_ENABLED" = "true" ]; then
-  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$CRUISE_CONTROL_HOME/custom-config/metrics-config.json"
+  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$CRUISE_CONTROL_HOME/custom-config/metrics-config.json"
   export KAFKA_OPTS
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -45,7 +45,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
-    KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
+    KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
     export KAFKA_OPTS
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_mirror_maker_run.sh
@@ -61,7 +61,7 @@ export KAFKA_OPTS
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then
-  KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
+  KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
   export KAFKA_OPTS
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_run.sh
@@ -30,7 +30,7 @@ fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then
-  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
+  KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
   export KAFKA_OPTS
 fi
 

--- a/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/zookeeper_run.sh
@@ -51,7 +51,7 @@ fi
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$ZOOKEEPER_METRICS_ENABLED" = "true" ]; then
-  KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$KAFKA_HOME"/libs/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
+  KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
   export KAFKA_OPTS
 fi
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Prometheus JMX Exporter to 1.1.0. Prometheus does not plan to push anymore to Maven Central but only to GitHub releases. So this PR moves the download of the library to the Dockerfile and updates the startup scripts as well. The JAR is not added to a separate directory `/opt/prometheus-jmx-exporter`.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally