### PR TITLE
Improve Cruise Control client creation and testing

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -15,10 +15,15 @@ import io.strimzi.operator.common.config.ConfigParameterParser;
 import io.strimzi.operator.common.featuregates.FeatureGates;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties;
+import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -128,6 +133,7 @@ public class TopicOperatorConfig {
         return topicOperatorConfig;
     }
 
+<<<<<<< HEAD
     private static Set<String> keyNames() {
         return Collections.unmodifiableSet(CONFIG_VALUES.keySet());
     }
@@ -416,6 +422,32 @@ public class TopicOperatorConfig {
 
         kafkaClientProps.put(SaslConfigs.SASL_MECHANISM, saslMechanism);
         kafkaClientProps.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
+    }
+
+    /**
+     * @return Cruise Control client configuration.
+     */
+    public CruiseControlClient.Config cruiseControlClientConfig() {
+        return new CruiseControlClient.Config(
+            cruiseControlHostname(),
+            cruiseControlPort(),
+            cruiseControlRackEnabled(),
+            cruiseControlSslEnabled(),
+            cruiseControlSslEnabled() ? getFileContent(cruiseControlCrtFilePath()) : null,
+            cruiseControlAuthEnabled(),
+            cruiseControlAuthEnabled()
+                ? new String(getFileContent(cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
+            cruiseControlAuthEnabled()
+                ? new String(getFileContent(cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
+        );
+    }
+
+    private static byte[] getFileContent(String filePath) {
+        try {
+            return Files.readAllBytes(Path.of(filePath));
+        } catch (IOException ioe) {
+            throw new IllegalArgumentException(String.format("File not found: %s", filePath), ioe);
+        }
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -428,17 +428,19 @@ public class TopicOperatorConfig {
      * @return Cruise Control client configuration.
      */
     public CruiseControlClient.Config cruiseControlClientConfig() {
+        var sslCertificate = cruiseControlSslEnabled() ? getFileContent(cruiseControlCrtFilePath()) : null;
+        var apiUsername = cruiseControlAuthEnabled() ? new String(getFileContent(cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null;
+        var apiPassword = cruiseControlAuthEnabled() ? new String(getFileContent(cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null;
+        
         return new CruiseControlClient.Config(
             cruiseControlHostname(),
             cruiseControlPort(),
             cruiseControlRackEnabled(),
             cruiseControlSslEnabled(),
-            cruiseControlSslEnabled() ? getFileContent(cruiseControlCrtFilePath()) : null,
+            sslCertificate,
             cruiseControlAuthEnabled(),
-            cruiseControlAuthEnabled()
-                ? new String(getFileContent(cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
-            cruiseControlAuthEnabled()
-                ? new String(getFileContent(cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
+            apiUsername,
+            apiPassword
         );
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -132,8 +132,7 @@ public class TopicOperatorConfig {
         LOGGER.infoOp("TopicOperator configuration is {}", topicOperatorConfig);
         return topicOperatorConfig;
     }
-
-<<<<<<< HEAD
+    
     private static Set<String> keyNames() {
         return Collections.unmodifiableSet(CONFIG_VALUES.keySet());
     }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorConfig.java
@@ -15,12 +15,10 @@ import io.strimzi.operator.common.config.ConfigParameterParser;
 import io.strimzi.operator.common.featuregates.FeatureGates;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlApiProperties;
-import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,7 +127,7 @@ public class TopicOperatorConfig {
         LOGGER.infoOp("TopicOperator configuration is {}", topicOperatorConfig);
         return topicOperatorConfig;
     }
-    
+
     private static Set<String> keyNames() {
         return Collections.unmodifiableSet(CONFIG_VALUES.keySet());
     }
@@ -418,41 +416,6 @@ public class TopicOperatorConfig {
 
         kafkaClientProps.put(SaslConfigs.SASL_MECHANISM, saslMechanism);
         kafkaClientProps.put(SaslConfigs.SASL_JAAS_CONFIG, jaasConfig);
-    }
-
-    /**
-     * @return Cruise Control client.
-     */
-    public CruiseControlClient cruiseControlClient() {
-        var sslCertificate = cruiseControlSslEnabled() ? TopicOperatorUtil.getFileContent(cruiseControlCrtFilePath()) : null;
-        var apiUsername = cruiseControlAuthEnabled() ? new String(TopicOperatorUtil.getFileContent(cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null;
-        var apiPassword = cruiseControlAuthEnabled() ? new String(TopicOperatorUtil.getFileContent(cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null;
-        
-        if (cruiseControlHostname() == null || cruiseControlHostname().isBlank()) {
-            throw new IllegalArgumentException("Cruise Control hostname is not set");
-        }
-        if (cruiseControlSslEnabled() && (sslCertificate == null || sslCertificate.length == 0)) {
-            throw new IllegalArgumentException("Cruise Control certificate is not set");
-        }
-        if (cruiseControlAuthEnabled()) {
-            if (apiUsername == null || apiUsername.isBlank()) {
-                throw new IllegalArgumentException("Cruise Control username is not set");
-            }
-            if (apiPassword == null || apiPassword.isBlank()) {
-                throw new IllegalArgumentException("Cruise Control password is not set");
-            }
-        }
-        
-        return CruiseControlClient.create(
-            cruiseControlHostname(),
-            cruiseControlPort(),
-            cruiseControlRackEnabled(),
-            cruiseControlSslEnabled(),
-            sslCertificate,
-            cruiseControlAuthEnabled(),
-            apiUsername,
-            apiPassword
-        );
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -66,7 +66,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             TopicOperatorMain.class.getPackage().getImplementationVersion()
         ).build();
         this.kafkaAdminClient = kafkaAdminClient;
-        this.cruiseControlClient = CruiseControlClient.create(config.cruiseControlClientConfig());
+        this.cruiseControlClient = config.cruiseControlClient();
         
         var metricsProvider = createMetricsProvider();
         var metricsHolder = new TopicOperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -66,7 +66,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             TopicOperatorMain.class.getPackage().getImplementationVersion()
         ).build();
         this.kafkaAdminClient = kafkaAdminClient;
-        this.cruiseControlClient = CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config));
+        this.cruiseControlClient = CruiseControlClient.create(config.cruiseControlClientConfig());
         
         var metricsProvider = createMetricsProvider();
         var metricsHolder = new TopicOperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -66,7 +66,7 @@ public class TopicOperatorMain implements Liveness, Readiness {
             TopicOperatorMain.class.getPackage().getImplementationVersion()
         ).build();
         this.kafkaAdminClient = kafkaAdminClient;
-        this.cruiseControlClient = config.cruiseControlClient();
+        this.cruiseControlClient = TopicOperatorUtil.createCruiseControlClient(config);
         
         var metricsProvider = createMetricsProvider();
         var metricsHolder = new TopicOperatorMetricsHolder(KafkaTopic.RESOURCE_KIND, Labels.fromMap(selector), metricsProvider);

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorMain.java
@@ -61,8 +61,10 @@ public class TopicOperatorMain implements Liveness, Readiness {
         Objects.requireNonNull(config.resourceLabels());
         this.config = config;
         var selector = config.resourceLabels().toMap();
-        this.kubernetesClient = new OperatorKubernetesClientBuilder("strimzi-topic-operator", 
-            TopicOperatorMain.class.getPackage().getImplementationVersion()).build();
+        this.kubernetesClient = new OperatorKubernetesClientBuilder(
+            "strimzi-topic-operator",
+            TopicOperatorMain.class.getPackage().getImplementationVersion()
+        ).build();
         this.kafkaAdminClient = kafkaAdminClient;
         this.cruiseControlClient = CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config));
         
@@ -98,6 +100,11 @@ public class TopicOperatorMain implements Liveness, Readiness {
                 // (topics need to be added to removed from TopicController.topics if KafkaTopics transition between
                 // selected and unselected).
                 .runnableInformer(INFORMER_RESYNC_CHECK_PERIOD_MS)
+                // The informer resync check interval acts like a heartbeat, then each handler interval will cause a resync at
+                // some interval of the overall heartbeat. The closer these values are together the more likely it 
+                // is that the handler skips one informer intervals. Setting both intervals to the same value generates 
+                // just enough skew that when the informer checks if the handler is ready for resync it sees that 
+                // it still needs another couple of micro-seconds and skips to the next informer level resync.
                 .addEventHandlerWithResyncPeriod(resourceEventHandler, config.fullReconciliationIntervalMs())
                 .itemStore(itemStore);
         LOGGER.infoOp("Starting informer");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -15,7 +15,6 @@ import io.strimzi.operator.topic.model.Pair;
 import io.strimzi.operator.topic.model.PartitionedByError;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
 import io.strimzi.operator.topic.model.TopicOperatorException;
-import org.apache.kafka.clients.admin.Admin;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -38,33 +37,23 @@ public class TopicOperatorUtil {
     private TopicOperatorUtil() { }
 
     /**
-     * Create a new Kafka admin client instance.
-     *
-     * @param config Topic Operator configuration.
-     * @return Kafka admin client.
+     * Map TO configuration to CC client configuration.
+     * 
+     * @param operatorCfg Topic Operator configuration.
+     * @return Cruise Control client configuration.
      */
-    public static Admin createKafkaAdminClient(TopicOperatorConfig config) {
-        return Admin.create(config.adminClientConfig());
-    }
-
-    /**
-     * Create a new Cruise Control client instance.
-     *
-     * @param config Topic Operator configuration.
-     * @return Cruise Control client.
-     */
-    public static CruiseControlClient createCruiseControlClient(TopicOperatorConfig config) {
-        return CruiseControlClient.create(
-            config.cruiseControlHostname(),
-            config.cruiseControlPort(),
-            config.cruiseControlRackEnabled(),
-            config.cruiseControlSslEnabled(),
-            config.cruiseControlSslEnabled() ? getFileContent(config.cruiseControlCrtFilePath()) : null,
-            config.cruiseControlAuthEnabled(),
-            config.cruiseControlAuthEnabled() 
-                ? new String(getFileContent(config.cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
-            config.cruiseControlAuthEnabled() 
-                ? new String(getFileContent(config.cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
+    public static CruiseControlClient.Config mapToCcClientCfg(TopicOperatorConfig operatorCfg) {
+        return new CruiseControlClient.Config(
+            operatorCfg.cruiseControlHostname(),
+            operatorCfg.cruiseControlPort(),
+            operatorCfg.cruiseControlRackEnabled(),
+            operatorCfg.cruiseControlSslEnabled(),
+            operatorCfg.cruiseControlSslEnabled() ? getFileContent(operatorCfg.cruiseControlCrtFilePath()) : null,
+            operatorCfg.cruiseControlAuthEnabled(),
+            operatorCfg.cruiseControlAuthEnabled()
+                ? new String(getFileContent(operatorCfg.cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
+            operatorCfg.cruiseControlAuthEnabled()
+                ? new String(getFileContent(operatorCfg.cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
         );
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -39,21 +39,21 @@ public class TopicOperatorUtil {
     /**
      * Map TO configuration to CC client configuration.
      * 
-     * @param operatorCfg Topic Operator configuration.
+     * @param config Topic Operator configuration.
      * @return Cruise Control client configuration.
      */
-    public static CruiseControlClient.Config mapToCcClientCfg(TopicOperatorConfig operatorCfg) {
+    public static CruiseControlClient.Config mapToCcClientCfg(TopicOperatorConfig config) {
         return new CruiseControlClient.Config(
-            operatorCfg.cruiseControlHostname(),
-            operatorCfg.cruiseControlPort(),
-            operatorCfg.cruiseControlRackEnabled(),
-            operatorCfg.cruiseControlSslEnabled(),
-            operatorCfg.cruiseControlSslEnabled() ? getFileContent(operatorCfg.cruiseControlCrtFilePath()) : null,
-            operatorCfg.cruiseControlAuthEnabled(),
-            operatorCfg.cruiseControlAuthEnabled()
-                ? new String(getFileContent(operatorCfg.cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
-            operatorCfg.cruiseControlAuthEnabled()
-                ? new String(getFileContent(operatorCfg.cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
+            config.cruiseControlHostname(),
+            config.cruiseControlPort(),
+            config.cruiseControlRackEnabled(),
+            config.cruiseControlSslEnabled(),
+            config.cruiseControlSslEnabled() ? getFileContent(config.cruiseControlCrtFilePath()) : null,
+            config.cruiseControlAuthEnabled(),
+            config.cruiseControlAuthEnabled()
+                ? new String(getFileContent(config.cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
+            config.cruiseControlAuthEnabled()
+                ? new String(getFileContent(config.cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
         );
     }
 

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -15,6 +15,9 @@ import io.strimzi.operator.topic.model.PartitionedByError;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
 import io.strimzi.operator.topic.model.TopicOperatorException;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -223,5 +226,19 @@ public class TopicOperatorUtil {
                 String.format("Invalid value for topic config '%s': %s", key, value));
         }
         return valueStr;
+    }
+
+    /**
+     * Get file content.
+     * 
+     * @param filePath File path.
+     * @return file content as bytes.
+     */
+    public static byte[] getFileContent(String filePath) {
+        try {
+            return Files.readAllBytes(Path.of(filePath));
+        } catch (IOException ioe) {
+            throw new IllegalArgumentException(String.format("File not found: %s", filePath), ioe);
+        }
     }
 }

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -8,7 +8,6 @@ import io.micrometer.core.instrument.Timer;
 import io.strimzi.api.kafka.model.topic.KafkaTopic;
 import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.model.InvalidResourceException;
-import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.model.Either;
 import io.strimzi.operator.topic.model.Pair;
@@ -16,11 +15,6 @@ import io.strimzi.operator.topic.model.PartitionedByError;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
 import io.strimzi.operator.topic.model.TopicOperatorException;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -35,35 +29,6 @@ public class TopicOperatorUtil {
     static final int BROKER_DEFAULT = -1;
 
     private TopicOperatorUtil() { }
-
-    /**
-     * Map TO configuration to CC client configuration.
-     * 
-     * @param config Topic Operator configuration.
-     * @return Cruise Control client configuration.
-     */
-    public static CruiseControlClient.Config mapToCcClientCfg(TopicOperatorConfig config) {
-        return new CruiseControlClient.Config(
-            config.cruiseControlHostname(),
-            config.cruiseControlPort(),
-            config.cruiseControlRackEnabled(),
-            config.cruiseControlSslEnabled(),
-            config.cruiseControlSslEnabled() ? getFileContent(config.cruiseControlCrtFilePath()) : null,
-            config.cruiseControlAuthEnabled(),
-            config.cruiseControlAuthEnabled()
-                ? new String(getFileContent(config.cruiseControlApiUserPath()), StandardCharsets.UTF_8) : null,
-            config.cruiseControlAuthEnabled()
-                ? new String(getFileContent(config.cruiseControlApiPassPath()), StandardCharsets.UTF_8) : null
-        );
-    }
-
-    private static byte[] getFileContent(String filePath) {
-        try {
-            return Files.readAllBytes(Path.of(filePath));
-        } catch (IOException ioe) {
-            throw new UncheckedIOException(String.format("File not found: %s", filePath), ioe);
-        }
-    }
 
     /**
      * Get the topic name from a {@link KafkaTopic} resource.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/TopicOperatorUtil.java
@@ -277,7 +277,7 @@ public class TopicOperatorUtil {
      * @param filePath File path.
      * @return file content as bytes.
      */
-    public static byte[] getFileContent(String filePath) {
+    /* test */ static byte[] getFileContent(String filePath) {
         try {
             return Files.readAllBytes(Path.of(filePath));
         } catch (IOException ioe) {

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Cruise Control REST API client.
+ * Cruise Control client.
  * <br/><br/>
  * The server runs one task execution at a time, additional 
  * requests are queued up to {@code max.active.user.tasks}.
@@ -26,13 +26,13 @@ public interface CruiseControlClient {
     long HTTP_REQUEST_TIMEOUT_SEC = 60;
 
     /**
-     * Create default Cruise Control client instance.
+     * Create a new Cruise Control client with the given configuration.
      *
      * @param config Configuration.
      * @return Cruise Control client.
      */
     static CruiseControlClient create(Config config) {
-        return new CruiseControlClientImpl(config);
+        return CruiseControlClientImpl.createInternal(config);
     }
 
     /**
@@ -68,103 +68,26 @@ public interface CruiseControlClient {
 
     /**
      * Client configuration.
+     *
+     * @param serverHostname Server hostname.
+     * @param serverPort Server port.
+     * @param rackEnabled Whether rack awareness is enabled.
+     * @param sslEnabled Whether SSL is enabled.
+     * @param sslCertificate SSL certificate.
+     * @param authEnabled Whether authentication is enabled.
+     * @param authUsername Authentication username.
+     * @param authPassword Authentication password.
      */
-    class Config {
-        private String serverHostname;
-        private int serverPort;
-        private boolean rackEnabled;
-        private boolean sslEnabled;
-        private byte[] sslCertificate;
-        private boolean authEnabled;
-        private String authUsername;
-        private String authPassword;
-        
-        /**
-         * Create new configuration.
-         *
-         * @param serverHostname Server hostname.
-         * @param serverPort Server port.
-         * @param rackEnabled Whether rack awareness is enabled.
-         * @param sslEnabled Whether SSL is enabled.
-         * @param sslCertificate SSL certificate.
-         * @param authEnabled Whether authentication is enabled.
-         * @param authUsername Authentication username.
-         * @param authPassword Authentication password.
-         */
-        public Config(String serverHostname,
-                      int serverPort,
-                      boolean rackEnabled,
-                      boolean sslEnabled,
-                      byte[] sslCertificate,
-                      boolean authEnabled,
-                      String authUsername,
-                      String authPassword) {
-            if (serverHostname == null || serverHostname.isBlank()) {
-                throw new IllegalArgumentException("Hostname is not set");
-            }
-            if (serverPort <= 0) {
-                throw new IllegalArgumentException("Port number is invalid");
-            }
-            if (sslEnabled && (sslCertificate == null || sslCertificate.length == 0)) {
-                throw new IllegalArgumentException("SSL certificate is not set");
-            }
-            if (authEnabled && (authUsername == null || authUsername.isBlank())) {
-                throw new IllegalArgumentException("Authentication username is not set");
-            }
-            if (authEnabled && (authPassword == null || authPassword.isBlank())) {
-                throw new IllegalArgumentException("Authentication password is not set");
-            }
-            
-            this.serverHostname = serverHostname;
-            this.serverPort = serverPort;
-            this.rackEnabled = rackEnabled;
-            this.sslEnabled = sslEnabled;
-            this.sslCertificate = sslCertificate;
-            this.authEnabled = authEnabled;
-            this.authUsername = authUsername;
-            this.authPassword = authPassword;
-        }
-
-        /** @return Server hostname. */
-        public String serverHostname() {
-            return serverHostname;
-        }
-
-        /** @return Server port. */
-        public int serverPort() {
-            return serverPort;
-        }
-
-        /** @return Rack enabled. */
-        public boolean rackEnabled() {
-            return rackEnabled;
-        }
-
-        /** @return SSL enabled. */
-        public boolean sslEnabled() {
-            return sslEnabled;
-        }
-
-        /** @return SSL certificate. */
-        public byte[] sslCertificate() {
-            return sslCertificate;
-        }
-
-        /** @return Authentication enabled. */
-        public boolean authEnabled() {
-            return authEnabled;
-        }
-
-        /** @return Authentication username. */
-        public String authUsername() {
-            return authUsername;
-        }
-
-        /** @return Authentication password. */
-        public String authPassword() {
-            return authPassword;
-        }
-    }
+    record Config(
+        String serverHostname,
+        int serverPort,
+        boolean rackEnabled,
+        boolean sslEnabled,
+        byte[] sslCertificate,
+        boolean authEnabled,
+        String authUsername,
+        String authPassword
+    ) { }
     
     /**
      * Topic names grouped by replication factor value.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
@@ -26,13 +26,36 @@ public interface CruiseControlClient {
     long HTTP_REQUEST_TIMEOUT_SEC = 60;
 
     /**
-     * Create a new Cruise Control client with the given configuration.
+     * Create default Cruise Control client instance.
      *
-     * @param config Configuration.
+     * @param serverHostname Server hostname.
+     * @param serverPort Server port.
+     * @param rackEnabled Whether rack awareness is enabled.
+     * @param sslEnabled Whether SSL is enabled.
+     * @param sslCertificate SSL certificate.
+     * @param authEnabled Whether authentication is enabled.
+     * @param authUsername Authentication username.
+     * @param authPassword Authentication password.
      * @return Cruise Control client.
      */
-    static CruiseControlClient create(Config config) {
-        return new CruiseControlClientImpl(config);
+    static CruiseControlClient create(String serverHostname,
+                                      int serverPort,
+                                      boolean rackEnabled,
+                                      boolean sslEnabled,
+                                      byte[] sslCertificate,
+                                      boolean authEnabled,
+                                      String authUsername,
+                                      String authPassword) {
+        return new CruiseControlClientImpl(
+            serverHostname,
+            serverPort,
+            rackEnabled,
+            sslEnabled,
+            sslCertificate,
+            authEnabled,
+            authUsername,
+            authPassword
+        );
     }
 
     /**
@@ -65,106 +88,6 @@ public interface CruiseControlClient {
      * @return The error message.
      */
     Optional<String> errorMessage(HttpResponse<String> response);
-
-    /**
-     * Client configuration.
-     */
-    class Config {
-        private final String serverHostname;
-        private final int serverPort;
-        private final boolean rackEnabled;
-        private final boolean sslEnabled;
-        private final byte[] sslCertificate;
-        private final boolean authEnabled;
-        private final String authUsername;
-        private final String authPassword;
-
-        /**
-         * Create new configuration.
-         *
-         * @param serverHostname Server hostname.
-         * @param serverPort Server port.
-         * @param rackEnabled Whether rack awareness is enabled.
-         * @param sslEnabled Whether SSL is enabled.
-         * @param sslCertificate SSL certificate.
-         * @param authEnabled Whether authentication is enabled.
-         * @param authUsername Authentication username.
-         * @param authPassword Authentication password.
-         */
-        public Config(String serverHostname,
-                      int serverPort,
-                      boolean rackEnabled,
-                      boolean sslEnabled,
-                      byte[] sslCertificate,
-                      boolean authEnabled,
-                      String authUsername,
-                      String authPassword) {
-            if (serverHostname == null || serverHostname.isBlank()) {
-                throw new IllegalArgumentException("Hostname is not set");
-            }
-            if (serverPort <= 0) {
-                throw new IllegalArgumentException("Port number is invalid");
-            }
-            if (sslEnabled && (sslCertificate == null || sslCertificate.length == 0)) {
-                throw new IllegalArgumentException("SSL certificate is not set");
-            }
-            if (authEnabled && (authUsername == null || authUsername.isBlank())) {
-                throw new IllegalArgumentException("Authentication username is not set");
-            }
-            if (authEnabled && (authPassword == null || authPassword.isBlank())) {
-                throw new IllegalArgumentException("Authentication password is not set");
-            }
-
-            this.serverHostname = serverHostname;
-            this.serverPort = serverPort;
-            this.rackEnabled = rackEnabled;
-            this.sslEnabled = sslEnabled;
-            this.sslCertificate = sslCertificate;
-            this.authEnabled = authEnabled;
-            this.authUsername = authUsername;
-            this.authPassword = authPassword;
-        }
-
-        /** @return Server hostname. */
-        public String serverHostname() {
-            return serverHostname;
-        }
-
-        /** @return Server port. */
-        public int serverPort() {
-            return serverPort;
-        }
-
-        /** @return Rack enabled. */
-        public boolean rackEnabled() {
-            return rackEnabled;
-        }
-
-        /** @return SSL enabled. */
-        public boolean sslEnabled() {
-            return sslEnabled;
-        }
-
-        /** @return SSL certificate. */
-        public byte[] sslCertificate() {
-            return sslCertificate;
-        }
-
-        /** @return Authentication enabled. */
-        public boolean authEnabled() {
-            return authEnabled;
-        }
-
-        /** @return Authentication username. */
-        public String authUsername() {
-            return authUsername;
-        }
-
-        /** @return Authentication password. */
-        public String authPassword() {
-            return authPassword;
-        }
-    }
     
     /**
      * Topic names grouped by replication factor value.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
@@ -68,24 +68,103 @@ public interface CruiseControlClient {
 
     /**
      * Client configuration.
-     * 
-     * @param serverHostname Server hostname.
-     * @param serverPort Server port.
-     * @param rackEnabled Whether rack awareness is enabled.
-     * @param sslEnabled Whether SSL is enabled.
-     * @param sslCertificate SSL certificate.
-     * @param authEnabled Whether authentication is enabled.
-     * @param authUsername Authentication username.
-     * @param authPassword Authentication password.
      */
-    record Config(String serverHostname,
-                  int serverPort,
-                  boolean rackEnabled,
-                  boolean sslEnabled,
-                  byte[] sslCertificate,
-                  boolean authEnabled,
-                  String authUsername,
-                  String authPassword) { }
+    class Config {
+        private String serverHostname;
+        private int serverPort;
+        private boolean rackEnabled;
+        private boolean sslEnabled;
+        private byte[] sslCertificate;
+        private boolean authEnabled;
+        private String authUsername;
+        private String authPassword;
+        
+        /**
+         * Create new configuration.
+         *
+         * @param serverHostname Server hostname.
+         * @param serverPort Server port.
+         * @param rackEnabled Whether rack awareness is enabled.
+         * @param sslEnabled Whether SSL is enabled.
+         * @param sslCertificate SSL certificate.
+         * @param authEnabled Whether authentication is enabled.
+         * @param authUsername Authentication username.
+         * @param authPassword Authentication password.
+         */
+        public Config(String serverHostname,
+                      int serverPort,
+                      boolean rackEnabled,
+                      boolean sslEnabled,
+                      byte[] sslCertificate,
+                      boolean authEnabled,
+                      String authUsername,
+                      String authPassword) {
+            if (serverHostname == null || serverHostname.isBlank()) {
+                throw new IllegalArgumentException("Hostname is not set");
+            }
+            if (serverPort <= 0) {
+                throw new IllegalArgumentException("Port number is invalid");
+            }
+            if (sslEnabled && (sslCertificate == null || sslCertificate.length == 0)) {
+                throw new IllegalArgumentException("SSL certificate is not set");
+            }
+            if (authEnabled && (authUsername == null || authUsername.isBlank())) {
+                throw new IllegalArgumentException("Authentication username is not set");
+            }
+            if (authEnabled && (authPassword == null || authPassword.isBlank())) {
+                throw new IllegalArgumentException("Authentication password is not set");
+            }
+            
+            this.serverHostname = serverHostname;
+            this.serverPort = serverPort;
+            this.rackEnabled = rackEnabled;
+            this.sslEnabled = sslEnabled;
+            this.sslCertificate = sslCertificate;
+            this.authEnabled = authEnabled;
+            this.authUsername = authUsername;
+            this.authPassword = authPassword;
+        }
+
+        /** @return Server hostname. */
+        public String serverHostname() {
+            return serverHostname;
+        }
+
+        /** @return Server port. */
+        public int serverPort() {
+            return serverPort;
+        }
+
+        /** @return Rack enabled. */
+        public boolean rackEnabled() {
+            return rackEnabled;
+        }
+
+        /** @return SSL enabled. */
+        public boolean sslEnabled() {
+            return sslEnabled;
+        }
+
+        /** @return SSL certificate. */
+        public byte[] sslCertificate() {
+            return sslCertificate;
+        }
+
+        /** @return Authentication enabled. */
+        public boolean authEnabled() {
+            return authEnabled;
+        }
+
+        /** @return Authentication username. */
+        public String authUsername() {
+            return authUsername;
+        }
+
+        /** @return Authentication password. */
+        public String authPassword() {
+            return authPassword;
+        }
+    }
     
     /**
      * Topic names grouped by replication factor value.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
@@ -32,7 +32,7 @@ public interface CruiseControlClient {
      * @return Cruise Control client.
      */
     static CruiseControlClient create(Config config) {
-        return CruiseControlClientImpl.createInternal(config);
+        return new CruiseControlClientImpl(config);
     }
 
     /**
@@ -68,26 +68,103 @@ public interface CruiseControlClient {
 
     /**
      * Client configuration.
-     *
-     * @param serverHostname Server hostname.
-     * @param serverPort Server port.
-     * @param rackEnabled Whether rack awareness is enabled.
-     * @param sslEnabled Whether SSL is enabled.
-     * @param sslCertificate SSL certificate.
-     * @param authEnabled Whether authentication is enabled.
-     * @param authUsername Authentication username.
-     * @param authPassword Authentication password.
      */
-    record Config(
-        String serverHostname,
-        int serverPort,
-        boolean rackEnabled,
-        boolean sslEnabled,
-        byte[] sslCertificate,
-        boolean authEnabled,
-        String authUsername,
-        String authPassword
-    ) { }
+    class Config {
+        private final String serverHostname;
+        private final int serverPort;
+        private final boolean rackEnabled;
+        private final boolean sslEnabled;
+        private final byte[] sslCertificate;
+        private final boolean authEnabled;
+        private final String authUsername;
+        private final String authPassword;
+
+        /**
+         * Create new configuration.
+         *
+         * @param serverHostname Server hostname.
+         * @param serverPort Server port.
+         * @param rackEnabled Whether rack awareness is enabled.
+         * @param sslEnabled Whether SSL is enabled.
+         * @param sslCertificate SSL certificate.
+         * @param authEnabled Whether authentication is enabled.
+         * @param authUsername Authentication username.
+         * @param authPassword Authentication password.
+         */
+        public Config(String serverHostname,
+                      int serverPort,
+                      boolean rackEnabled,
+                      boolean sslEnabled,
+                      byte[] sslCertificate,
+                      boolean authEnabled,
+                      String authUsername,
+                      String authPassword) {
+            if (serverHostname == null || serverHostname.isBlank()) {
+                throw new IllegalArgumentException("Hostname is not set");
+            }
+            if (serverPort <= 0) {
+                throw new IllegalArgumentException("Port number is invalid");
+            }
+            if (sslEnabled && (sslCertificate == null || sslCertificate.length == 0)) {
+                throw new IllegalArgumentException("SSL certificate is not set");
+            }
+            if (authEnabled && (authUsername == null || authUsername.isBlank())) {
+                throw new IllegalArgumentException("Authentication username is not set");
+            }
+            if (authEnabled && (authPassword == null || authPassword.isBlank())) {
+                throw new IllegalArgumentException("Authentication password is not set");
+            }
+
+            this.serverHostname = serverHostname;
+            this.serverPort = serverPort;
+            this.rackEnabled = rackEnabled;
+            this.sslEnabled = sslEnabled;
+            this.sslCertificate = sslCertificate;
+            this.authEnabled = authEnabled;
+            this.authUsername = authUsername;
+            this.authPassword = authPassword;
+        }
+
+        /** @return Server hostname. */
+        public String serverHostname() {
+            return serverHostname;
+        }
+
+        /** @return Server port. */
+        public int serverPort() {
+            return serverPort;
+        }
+
+        /** @return Rack enabled. */
+        public boolean rackEnabled() {
+            return rackEnabled;
+        }
+
+        /** @return SSL enabled. */
+        public boolean sslEnabled() {
+            return sslEnabled;
+        }
+
+        /** @return SSL certificate. */
+        public byte[] sslCertificate() {
+            return sslCertificate;
+        }
+
+        /** @return Authentication enabled. */
+        public boolean authEnabled() {
+            return authEnabled;
+        }
+
+        /** @return Authentication username. */
+        public String authUsername() {
+            return authUsername;
+        }
+
+        /** @return Authentication password. */
+        public String authPassword() {
+            return authPassword;
+        }
+    }
     
     /**
      * Topic names grouped by replication factor value.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClient.java
@@ -28,34 +28,11 @@ public interface CruiseControlClient {
     /**
      * Create default Cruise Control client instance.
      *
-     * @param serverHostname Server hostname.
-     * @param serverPort Server port.
-     * @param rackEnabled Whether rack awareness is enabled.
-     * @param sslEnabled Whether SSL is enabled.
-     * @param sslCertificate SSL certificate.
-     * @param authEnabled Whether authentication is enabled.
-     * @param authUsername Authentication username.
-     * @param authPassword Authentication password.
+     * @param config Configuration.
      * @return Cruise Control client.
      */
-    static CruiseControlClient create(String serverHostname,
-                                      int serverPort,
-                                      boolean rackEnabled,
-                                      boolean sslEnabled,
-                                      byte[] sslCertificate,
-                                      boolean authEnabled,
-                                      String authUsername,
-                                      String authPassword) {
-        return new CruiseControlClientImpl(
-            serverHostname,
-            serverPort,
-            rackEnabled,
-            sslEnabled,
-            sslCertificate,
-            authEnabled,
-            authUsername,
-            authPassword
-        );
+    static CruiseControlClient create(Config config) {
+        return new CruiseControlClientImpl(config);
     }
 
     /**
@@ -88,6 +65,27 @@ public interface CruiseControlClient {
      * @return The error message.
      */
     Optional<String> errorMessage(HttpResponse<String> response);
+
+    /**
+     * Client configuration.
+     * 
+     * @param serverHostname Server hostname.
+     * @param serverPort Server port.
+     * @param rackEnabled Whether rack awareness is enabled.
+     * @param sslEnabled Whether SSL is enabled.
+     * @param sslCertificate SSL certificate.
+     * @param authEnabled Whether authentication is enabled.
+     * @param authUsername Authentication username.
+     * @param authPassword Authentication password.
+     */
+    record Config(String serverHostname,
+                  int serverPort,
+                  boolean rackEnabled,
+                  boolean sslEnabled,
+                  byte[] sslCertificate,
+                  boolean authEnabled,
+                  String authUsername,
+                  String authPassword) { }
     
     /**
      * Topic names grouped by replication factor value.

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -54,31 +54,17 @@ public class CruiseControlClientImpl implements CruiseControlClient {
     private final ExecutorService httpClientExecutor;
     private HttpClient httpClient;
     private final ObjectMapper objectMapper;
-    
-    private CruiseControlClientImpl(Config config) {
+
+    /**
+     * Create a new instance.
+     * 
+     * @param config Cruise Control configuration.
+     */
+    public CruiseControlClientImpl(Config config) {
         this.config = config;
         this.httpClientExecutor = Executors.newCachedThreadPool();
         this.httpClient = buildHttpClient();
         this.objectMapper = new ObjectMapper();
-    }
-    
-    static CruiseControlClient createInternal(Config config) {
-        if (config.serverHostname() == null || config.serverHostname().isBlank()) {
-            throw new IllegalArgumentException("Hostname is not set");
-        }
-        if (config.serverPort() <= 0) {
-            throw new IllegalArgumentException("Port number is invalid");
-        }
-        if (config.sslEnabled() && (config.sslCertificate() == null || config.sslCertificate().length == 0)) {
-            throw new IllegalArgumentException("SSL certificate is not set");
-        }
-        if (config.authEnabled() && (config.authUsername() == null || config.authUsername().isBlank())) {
-            throw new IllegalArgumentException("Authentication username is not set");
-        }
-        if (config.authEnabled() && (config.authPassword() == null || config.authPassword().isBlank())) {
-            throw new IllegalArgumentException("Authentication password is not set");
-        }
-        return new CruiseControlClientImpl(config);
     }
 
     @Override

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlClientImpl.java
@@ -63,22 +63,15 @@ public class CruiseControlClientImpl implements CruiseControlClient {
     private HttpClient httpClient;
     private final ObjectMapper objectMapper;
     
-    CruiseControlClientImpl(String serverHostname,
-                            int serverPort,
-                            boolean rackEnabled,
-                            boolean sslEnabled,
-                            byte[] sslCertificate,
-                            boolean authEnabled,
-                            String authUsername,
-                            String authPassword) {
-        this.serverHostname = serverHostname;
-        this.serverPort = serverPort;
-        this.rackEnabled = rackEnabled;
-        this.sslEnabled = sslEnabled;
-        this.sslCertificate = sslCertificate;
-        this.authEnabled = authEnabled;
-        this.authUsername = authUsername;
-        this.authPassword = authPassword;
+    CruiseControlClientImpl(Config config) {
+        this.serverHostname = config.serverHostname();
+        this.serverPort = config.serverPort();
+        this.rackEnabled = config.rackEnabled();
+        this.sslEnabled = config.sslEnabled();
+        this.sslCertificate = config.sslCertificate();
+        this.authEnabled = config.authEnabled();
+        this.authUsername = config.authUsername();
+        this.authPassword = config.authPassword();
         this.httpClientExecutor = Executors.newCachedThreadPool();
         this.httpClient = buildHttpClient();
         this.objectMapper = new ObjectMapper();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
@@ -156,7 +156,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         
         var batch = List.of(new ReconcilableTopic(
             new Reconciliation("test", "KafkaTopic", NAMESPACE, TopicOperatorUtil.topicName(kafkaTopic)), kafkaTopic, TopicOperatorUtil.topicName(kafkaTopic)));
@@ -530,7 +530,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
 
         verifyNoInteractions(kafkaAdmin);
     }
@@ -571,7 +571,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(
             new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
@@ -621,7 +621,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -696,7 +696,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -754,7 +754,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -833,7 +833,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -880,7 +880,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -937,7 +937,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
+            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
@@ -13,6 +13,7 @@ import io.strimzi.api.kafka.model.topic.KafkaTopicStatusBuilder;
 import io.strimzi.api.kafka.model.topic.ReplicasChangeState;
 import io.strimzi.api.kafka.model.topic.ReplicasChangeStatusBuilder;
 import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlHandler;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsProvider;
@@ -154,7 +155,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         
         var batch = List.of(new ReconcilableTopic(
             new Reconciliation("test", "KafkaTopic", NAMESPACE, TopicOperatorUtil.topicName(kafkaTopic)), kafkaTopic, TopicOperatorUtil.topicName(kafkaTopic)));
@@ -522,7 +523,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
 
         verifyNoInteractions(kafkaAdmin);
     }
@@ -559,7 +560,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(
             new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
@@ -605,7 +606,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -678,7 +679,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -734,7 +735,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -811,7 +812,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -856,7 +857,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -911,7 +912,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/BatchingTopicControllerIT.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.topic.KafkaTopicStatusBuilder;
 import io.strimzi.api.kafka.model.topic.ReplicasChangeState;
 import io.strimzi.api.kafka.model.topic.ReplicasChangeStatusBuilder;
 import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.topic.cruisecontrol.CruiseControlClient;
 import io.strimzi.operator.topic.cruisecontrol.CruiseControlHandler;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsProvider;
@@ -157,7 +156,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         
         var batch = List.of(new ReconcilableTopic(
             new Reconciliation("test", "KafkaTopic", NAMESPACE, TopicOperatorUtil.topicName(kafkaTopic)), kafkaTopic, TopicOperatorUtil.topicName(kafkaTopic)));
@@ -531,7 +530,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdmin), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
 
         verifyNoInteractions(kafkaAdmin);
     }
@@ -572,7 +571,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(
             new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
@@ -622,7 +621,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -697,7 +696,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -755,7 +754,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -834,7 +833,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.times(1)).incrementalAlterConfigs(any());
@@ -881,7 +880,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());
@@ -938,7 +937,7 @@ class BatchingTopicControllerIT implements TestSeparator {
         var controller = new BatchingTopicController(config, Map.of("key", "VALUE"),
             new KubernetesHandler(config, metricsHolder, kubernetesClient),
             new KafkaHandler(config, metricsHolder, kafkaAdminClientSpy), metricsHolder,
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig())));
+            new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient()));
         controller.onUpdate(List.of(new ReconcilableTopic(new Reconciliation("test", KafkaTopic.RESOURCE_KIND, NAMESPACE, "my-topic"), testTopic, "my-topic")));
 
         Mockito.verify(kafkaAdminClientSpy, Mockito.never()).incrementalAlterConfigs(any());

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -2035,8 +2035,7 @@ class TopicControllerIT implements TestSeparator {
         startKafkaCluster(1, 1, Map.of("auto.create.topics.enable", "false", "num.partitions", "4", "default.replication.factor", "1"));
 
         // given
-        String ns = createNamespace(NAMESPACE);
-
+        var ns = createNamespace(NAMESPACE);
         var config = TopicOperatorConfig.buildFromMap(Map.of(
             TopicOperatorConfig.NAMESPACE.key(), ns,
             TopicOperatorConfig.RESOURCE_LABELS.key(), Labels.fromMap(SELECTOR).toSelectorString(),

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorConfigTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -423,15 +422,14 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), inputFile.getAbsolutePath()
         ));
         
-        var cruiseControlConfig = config.cruiseControlClientConfig();
         assertTrue(config.cruiseControlEnabled());
-        assertEquals("my-cruise-control", cruiseControlConfig.serverHostname());
-        assertEquals(9090, cruiseControlConfig.serverPort());
+        assertEquals("my-cruise-control", config.cruiseControlHostname());
+        assertEquals(9090, config.cruiseControlPort());
         assertTrue(config.cruiseControlSslEnabled());
-        assertArrayEquals(expectedBytes, cruiseControlConfig.sslCertificate());
+        assertArrayEquals(expectedBytes, TopicOperatorUtil.getFileContent(config.cruiseControlCrtFilePath()));
         assertTrue(config.cruiseControlAuthEnabled());
-        assertEquals(new String(expectedBytes, StandardCharsets.UTF_8), cruiseControlConfig.authUsername());
-        assertEquals(new String(expectedBytes, StandardCharsets.UTF_8), cruiseControlConfig.authPassword());
+        assertArrayEquals(expectedBytes, TopicOperatorUtil.getFileContent(config.cruiseControlApiUserPath()));
+        assertArrayEquals(expectedBytes, TopicOperatorUtil.getFileContent(config.cruiseControlApiPassPath()));
     }
 
     @Test
@@ -446,7 +444,7 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_CRT_FILE_PATH.key(), "/4sa654a/d65sa65da"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClientConfig);
+        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
         assertEquals("File not found: /4sa654a/d65sa65da", thrown.getMessage());
     }
 
@@ -475,7 +473,7 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_API_USER_PATH.key(), "/d4sa6a/das45da4s"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClientConfig);
+        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
         assertEquals("File not found: /d4sa6a/das45da4s", thrown.getMessage());
     }
     
@@ -494,7 +492,7 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), "/sd4sa6/fds6f7sfs"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClientConfig);
+        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
         assertEquals("File not found: /sd4sa6/fds6f7sfs", thrown.getMessage());
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorConfigTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorConfigTest.java
@@ -444,7 +444,8 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_CRT_FILE_PATH.key(), "/4sa654a/d65sa65da"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
+        var thrown = assertThrows(IllegalArgumentException.class,
+            () -> TopicOperatorUtil.createCruiseControlClient(config));
         assertEquals("File not found: /4sa654a/d65sa65da", thrown.getMessage());
     }
 
@@ -473,7 +474,8 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_API_USER_PATH.key(), "/d4sa6a/das45da4s"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
+        var thrown = assertThrows(IllegalArgumentException.class,
+            () -> TopicOperatorUtil.createCruiseControlClient(config));
         assertEquals("File not found: /d4sa6a/das45da4s", thrown.getMessage());
     }
     
@@ -492,7 +494,8 @@ class TopicOperatorConfigTest {
             TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), "/sd4sa6/fds6f7sfs"
         ));
 
-        var thrown = assertThrows(IllegalArgumentException.class, config::cruiseControlClient);
+        var thrown = assertThrows(IllegalArgumentException.class,
+            () -> TopicOperatorUtil.createCruiseControlClient(config));
         assertEquals("File not found: /sd4sa6/fds6f7sfs", thrown.getMessage());
     }
 }

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
@@ -17,6 +17,7 @@ import io.strimzi.operator.common.model.StatusUtils;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.topic.TopicOperatorConfig;
 import io.strimzi.operator.topic.TopicOperatorTestUtil;
+import io.strimzi.operator.topic.TopicOperatorUtil;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsProvider;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
@@ -92,7 +93,7 @@ public class CruiseControlHandlerTest {
     @ParameterizedTest
     @MethodSource("operatorConfigs")
     public void replicasChangeShouldShouldCompleteWithValidConfig(TopicOperatorConfig config) {
-        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
+        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
 
         server.expectTopicConfigSuccessResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -114,7 +115,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort))
         ));
         
-        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
+        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
         
         var pending = buildPendingReconcilableTopics();
         var pendingAndOngoing = handler.requestPendingChanges(pending);
@@ -139,7 +140,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
+        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
 
         server.expectTopicConfigErrorResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -167,7 +168,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
+        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
 
         server.expectTopicConfigRequestTimeout(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -194,7 +195,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
+        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
 
         server.expectTopicConfigRequestUnauthorized(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
@@ -92,7 +92,7 @@ public class CruiseControlHandlerTest {
     @ParameterizedTest
     @MethodSource("operatorConfigs")
     public void replicasChangeShouldShouldCompleteWithValidConfig(TopicOperatorConfig config) {
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
+        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
 
         server.expectTopicConfigSuccessResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -114,7 +114,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort))
         ));
         
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
+        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
         
         var pending = buildPendingReconcilableTopics();
         var pendingAndOngoing = handler.requestPendingChanges(pending);
@@ -139,7 +139,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
+        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
 
         server.expectTopicConfigErrorResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -167,7 +167,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
+        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
 
         server.expectTopicConfigRequestTimeout(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -194,7 +194,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
+        var handler = new CruiseControlHandler(config, metricsHolder, config.cruiseControlClient());
 
         server.expectTopicConfigRequestUnauthorized(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
@@ -94,7 +94,7 @@ public class CruiseControlHandlerTest {
     @ParameterizedTest
     @MethodSource("validConfigs")
     public void shouldSucceedWithValidConfig(TopicOperatorConfig config) {
-        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
 
         server.expectTopicConfigSuccessResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -119,7 +119,7 @@ public class CruiseControlHandlerTest {
         ));
 
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         assertThat(thrown.getMessage(), is("File not found: /invalid/ca.crt"));
     }
 
@@ -136,7 +136,7 @@ public class CruiseControlHandlerTest {
         ));
 
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         assertThat(thrown.getMessage(), is("File not found: /invalid/username"));
     }
 
@@ -153,7 +153,7 @@ public class CruiseControlHandlerTest {
         ));
 
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config)));
+            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
         assertThat(thrown.getMessage(), is("File not found: /invalid/password"));
     }
 
@@ -166,7 +166,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort))
         ));
         
-        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
         
         var pending = buildPendingReconcilableTopics();
         var pendingAndOngoing = handler.requestPendingChanges(pending);
@@ -191,7 +191,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
 
         server.expectTopicConfigErrorResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -219,7 +219,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
 
         server.expectTopicConfigRequestTimeout(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -246,7 +246,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, TopicOperatorUtil.createCruiseControlClient(config));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
 
         server.expectTopicConfigRequestUnauthorized(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/cruisecontrol/CruiseControlHandlerTest.java
@@ -17,7 +17,6 @@ import io.strimzi.operator.common.model.StatusUtils;
 import io.strimzi.operator.common.operator.MockCertManager;
 import io.strimzi.operator.topic.TopicOperatorConfig;
 import io.strimzi.operator.topic.TopicOperatorTestUtil;
-import io.strimzi.operator.topic.TopicOperatorUtil;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsHolder;
 import io.strimzi.operator.topic.metrics.TopicOperatorMetricsProvider;
 import io.strimzi.operator.topic.model.ReconcilableTopic;
@@ -44,7 +43,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CruiseControlHandlerTest {
     private static final String NAMESPACE = TopicOperatorTestUtil.namespaceName(CruiseControlHandlerTest.class);
@@ -92,9 +90,9 @@ public class CruiseControlHandlerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("validConfigs")
-    public void shouldSucceedWithValidConfig(TopicOperatorConfig config) {
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
+    @MethodSource("operatorConfigs")
+    public void replicasChangeShouldShouldCompleteWithValidConfig(TopicOperatorConfig config) {
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
 
         server.expectTopicConfigSuccessResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -106,56 +104,6 @@ public class CruiseControlHandlerTest {
         var completedAndFailed = handler.requestOngoingChanges(ongoing);
         assertCompleted(ongoing, completedAndFailed);
     }
-    
-    @Test
-    public void shouldFailWithSslEnabledAndMissingCrtFile() {
-        var config = TopicOperatorConfig.buildFromMap(Map.ofEntries(
-            entry(TopicOperatorConfig.BOOTSTRAP_SERVERS.key(), "localhost:9092"),
-            entry(TopicOperatorConfig.NAMESPACE.key(), NAMESPACE),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_HOSTNAME.key(), "localhost"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort)),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_SSL_ENABLED.key(), "true"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_CRT_FILE_PATH.key(), "/invalid/ca.crt")
-        ));
-
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
-        assertThat(thrown.getMessage(), is("File not found: /invalid/ca.crt"));
-    }
-
-    @Test
-    public void shouldFailWithAuthEnabledAndUsernameFileNotFound() {
-        var config = TopicOperatorConfig.buildFromMap(Map.ofEntries(
-            entry(TopicOperatorConfig.BOOTSTRAP_SERVERS.key(), "localhost:9092"),
-            entry(TopicOperatorConfig.NAMESPACE.key(), NAMESPACE),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_HOSTNAME.key(), "localhost"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort)),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_AUTH_ENABLED.key(), "true"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_API_USER_PATH.key(), "/invalid/username"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
-        ));
-
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
-        assertThat(thrown.getMessage(), is("File not found: /invalid/username"));
-    }
-
-    @Test
-    public void shouldFailWithAuthEnabledAndPasswordFileNotFound() {
-        var config = TopicOperatorConfig.buildFromMap(Map.ofEntries(
-            entry(TopicOperatorConfig.BOOTSTRAP_SERVERS.key(), "localhost:9092"),
-            entry(TopicOperatorConfig.NAMESPACE.key(), NAMESPACE),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_HOSTNAME.key(), "localhost"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort)),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_AUTH_ENABLED.key(), "true"),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_API_USER_PATH.key(), apiUserFile.getAbsolutePath()),
-            entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), "/invalid/password")
-        ));
-
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> 
-            new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config))));
-        assertThat(thrown.getMessage(), is("File not found: /invalid/password"));
-    }
 
     @Test
     public void replicasChangeShouldFailWhenCruiseControlEndpointNotReachable() {
@@ -166,7 +114,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_PORT.key(), String.valueOf(serverPort))
         ));
         
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
         
         var pending = buildPendingReconcilableTopics();
         var pendingAndOngoing = handler.requestPendingChanges(pending);
@@ -191,7 +139,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
 
         server.expectTopicConfigErrorResponse(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -219,7 +167,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
 
         server.expectTopicConfigRequestTimeout(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -246,7 +194,7 @@ public class CruiseControlHandlerTest {
             entry(TopicOperatorConfig.CRUISE_CONTROL_API_PASS_PATH.key(), apiPassFile.getAbsolutePath())
         ));
 
-        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(TopicOperatorUtil.mapToCcClientCfg(config)));
+        var handler = new CruiseControlHandler(config, metricsHolder, CruiseControlClient.create(config.cruiseControlClientConfig()));
 
         server.expectTopicConfigRequestUnauthorized(apiUserFile, apiPassFile);
         var pending = buildPendingReconcilableTopics();
@@ -344,7 +292,7 @@ public class CruiseControlHandlerTest {
             kafkaTopic, topicName));
     }
 
-    private static List<TopicOperatorConfig> validConfigs() {
+    private static List<TopicOperatorConfig> operatorConfigs() {
         return Arrays.asList(
             // encryption and authentication disabled
             TopicOperatorConfig.buildFromMap(Map.ofEntries(


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This patch improves Cruise Control client creation and testing.
It also removes the Kafka admin client creation method.

Closes #10916.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

