### PR TITLE
Stop including MirrorMaker2 Extensions and EnvVarConfigProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.46.0
 
+### Major changes, deprecations and removals
+
+* [Strimzi EnvVar Configuration Provider](https://github.com/strimzi/kafka-env-var-config-provider) (deprecated in Strimzi 0.38.0) and [Strimzi MirrorMaker 2 Extensions](https://github.com/strimzi/mirror-maker-2-extensions) (deprecated in Strimzi 0.28.0) plugins were removed from Strimzi container images.
+  Please use the Apache Kafka [EnvVarConfigProvider](https://github.com/strimzi/kafka-env-var-config-provider?tab=readme-ov-file#deprecation-notice) and [Identity Replication Policy](https://github.com/strimzi/mirror-maker-2-extensions?tab=readme-ov-file#identity-replication-policy) instead.
 
 ## 0.45.0
 

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.8.x/pom.xml
@@ -21,9 +21,7 @@
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
-        <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
@@ -347,12 +345,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Mirror Maker 2 Extensions -->
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>${kafka-mirror-maker-2-extensions.version}</version>
-        </dependency>
         <!-- Kafka Quotas Plugin -->
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -402,12 +394,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.16.2</version>
-        </dependency>
-        <!-- EnvVar Configuration Provider for Apache Kafka -->
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>kafka-env-var-config-provider</artifactId>
-            <version>${kafka-env-var-config-provider.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.9.x/pom.xml
@@ -21,9 +21,7 @@
         <cruise-control.version>2.5.141</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
-        <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
         <kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
-        <kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
         <json-smart.version>2.4.9</json-smart.version>
         <jsonevent-layout.version>1.7</jsonevent-layout.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
@@ -347,12 +345,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Mirror Maker 2 Extensions -->
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>mirror-maker-2-extensions</artifactId>
-            <version>${kafka-mirror-maker-2-extensions.version}</version>
-        </dependency>
         <!-- Kafka Quotas Plugin -->
         <dependency>
             <groupId>io.strimzi</groupId>
@@ -402,12 +394,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.16.2</version>
-        </dependency>
-        <!-- EnvVar Configuration Provider for Apache Kafka -->
-        <dependency>
-            <groupId>io.strimzi</groupId>
-            <artifactId>kafka-env-var-config-provider</artifactId>
-            <version>${kafka-env-var-config-provider.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the deprecated MirrorMaker2 Extensions and EnvVarConfigProvider from our container images as planned.

This should resolve #10662.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md