### PR TITLE
Remove unused certs method in Ca.java

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -42,9 +42,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
@@ -911,34 +909,6 @@ public abstract class Ca {
             return x509Certificate(bytes);
         } catch (CertificateException e) {
             throw new RuntimeException("Failed to decode certificate in data." + key.replace(".", "\\.") + " of Secret " + secret.getMetadata().getName(), e);
-        }
-    }
-
-    /**
-     * Returns set of all public keys (all .crt records) from a secret
-     *
-     * @param secret    Kubernetes Secret with certificates
-     *
-     * @return          Set with X509Certificate instances
-     */
-    public static Set<X509Certificate> certs(Secret secret)  {
-        if (secret == null || secret.getData() == null) {
-            return Set.of();
-        } else {
-            return secret
-                    .getData()
-                    .entrySet()
-                    .stream()
-                    .filter(record -> SecretEntry.CRT.matchesType(record.getKey()))
-                    .map(record -> {
-                        byte[] bytes = Util.decodeBytesFromBase64(record.getValue());
-                        try {
-                            return x509Certificate(bytes);
-                        } catch (CertificateException e) {
-                            throw new RuntimeException("Failed to decode certificate in data." + record.getKey().replace(".", "\\.") + " of Secret " + secret.getMetadata().getName(), e);
-                        }
-                    })
-                    .collect(Collectors.toSet());
         }
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove unused method certs() from Ca.java

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

