### PR TITLE
Enable multi version single step downgrade for KRaft based clusters

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
@@ -148,6 +148,7 @@ public class KRaftVersionChangeCreator {
                 versionFrom = versions.version(highestKafkaVersion);
             } catch (KafkaUpgradeException exception) {
                 // From version is unknown but thats ok for downgrade
+                LOGGER.infoCr(reconciliation, "Downgrading from unknown Kafka version {}", highestKafkaVersion);
                 versionFrom = new KafkaVersion(highestKafkaVersion, null, null, null, false, false, null);
             }
             versionTo = versionFromCr;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreator.java
@@ -142,13 +142,14 @@ public class KRaftVersionChangeCreator {
                 LOGGER.warnCr(reconciliation, "Kafka Pods exist, but do not contain the {} annotation to detect their version. Kafka upgrade cannot be detected.", ANNO_STRIMZI_IO_KAFKA_VERSION);
                 throw new KafkaUpgradeException("Kafka Pods exist, but do not contain the " + ANNO_STRIMZI_IO_KAFKA_VERSION + " annotation to detect their version. Kafka upgrade cannot be detected.");
             }
-        } else if (lowestKafkaVersion.equals(highestKafkaVersion)) {
-            // All brokers have the same version. We can use it as the current version.
-            versionFrom = versions.version(lowestKafkaVersion);
-            versionTo = versionFromCr;
         } else if (compareDottedVersions(highestKafkaVersion, versionFromCr.version()) > 0)    {
             // Highest Kafka version used by the brokers is higher than desired => suspected downgrade
-            versionFrom = versions.version(highestKafkaVersion);
+            try {
+                versionFrom = versions.version(highestKafkaVersion);
+            } catch (KafkaUpgradeException exception) {
+                // From version is unknown but thats ok for downgrade
+                versionFrom = new KafkaVersion(highestKafkaVersion, null, null, null, false, false, null);
+            }
             versionTo = versionFromCr;
         } else {
             // Highest Kafka version used by the brokers is equal or lower than desired => suspected upgrade

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -94,4 +94,11 @@ public class KafkaVersionTestUtils {
     public static KafkaVersion getLatestVersion() {
         return getKafkaVersionLookup().version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
     }
+    
+    public static String getHigherVersionThanLatest() {
+        String[] parsedVersion = LATEST_KAFKA_VERSION.split("\\.");
+        int incrementedMinorVersion = Integer.parseInt(parsedVersion[1]) + 1;
+        parsedVersion[1] = Integer.toString(incrementedMinorVersion);
+        return String.join(".", parsedVersion);  
+    }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/KafkaVersionTestUtils.java
@@ -43,6 +43,8 @@ public class KafkaVersionTestUtils {
     public static final String DEFAULT_KAFKA_VERSION = LATEST_KAFKA_VERSION;
     public static final String DEFAULT_KAFKA_IMAGE = LATEST_KAFKA_IMAGE;
     public static final String DEFAULT_KAFKA_CONNECT_IMAGE = LATEST_KAFKA_CONNECT_IMAGE;
+    
+    public static final String UNKNOWN_KAFKA_VERSION = "99.0.0";
 
     public static final KafkaVersionChange DEFAULT_KRAFT_VERSION_CHANGE = new KafkaVersionChange(getKafkaVersionLookup().defaultVersion(), getKafkaVersionLookup().defaultVersion(), null, null, getKafkaVersionLookup().defaultVersion().metadataVersion());
 
@@ -93,12 +95,5 @@ public class KafkaVersionTestUtils {
 
     public static KafkaVersion getLatestVersion() {
         return getKafkaVersionLookup().version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION);
-    }
-    
-    public static String getHigherVersionThanLatest() {
-        String[] parsedVersion = LATEST_KAFKA_VERSION.split("\\.");
-        int incrementedMinorVersion = Integer.parseInt(parsedVersion[1]) + 1;
-        parsedVersion[1] = Integer.toString(incrementedMinorVersion);
-        return String.join(".", parsedVersion);  
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -446,7 +446,7 @@ public class KRaftVersionChangeCreatorTest {
     
     @Test
     public void testDowngradeFromUnknownVersion(VertxTestContext context) {
-        String unknownVersion = getHigherVersionThanLatest();
+        String unknownVersion = KafkaVersionTestUtils.getHigherVersionThanLatest();
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(unknownVersion))
@@ -460,13 +460,6 @@ public class KRaftVersionChangeCreatorTest {
 
             async.flag();
         })));
-    }
-    
-    private String getHigherVersionThanLatest() {
-        String[] parsedVersion = KafkaVersionTestUtils.LATEST_KAFKA_VERSION.split("\\.");
-        int incrementedMinorVersion = Integer.parseInt(parsedVersion[1]) + 1;
-        parsedVersion[1] = Integer.toString(incrementedMinorVersion);
-        return String.join(".", parsedVersion);  
     }
 
     @Test

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -446,7 +446,7 @@ public class KRaftVersionChangeCreatorTest {
     
     @Test
     public void testDowngradeFromUnknownVersion(VertxTestContext context) {
-        String unknownVersion = KafkaVersionTestUtils.getHigherVersionThanLatest();
+        String unknownVersion = KafkaVersionTestUtils.UNKNOWN_KAFKA_VERSION;
         KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
                 mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()),
                 mockRos(mockUniformPods(unknownVersion))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KRaftVersionChangeCreatorTest.java
@@ -443,6 +443,31 @@ public class KRaftVersionChangeCreatorTest {
             async.flag();
         })));
     }
+    
+    @Test
+    public void testDowngradeFromUnknownVersion(VertxTestContext context) {
+        String unknownVersion = getHigherVersionThanLatest();
+        KRaftVersionChangeCreator vcc = mockVersionChangeCreator(
+                mockKafka(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).version(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion(), VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()),
+                mockRos(mockUniformPods(unknownVersion))
+        );
+
+        Checkpoint async = context.checkpoint();
+        vcc.reconcile().onComplete(context.succeeding(c -> context.verify(() -> {
+            assertThat(c.from().version(), is(unknownVersion));
+            assertThat(c.to(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION)));
+            assertThat(c.metadataVersion(), is(VERSIONS.version(KafkaVersionTestUtils.LATEST_KAFKA_VERSION).metadataVersion()));
+
+            async.flag();
+        })));
+    }
+    
+    private String getHigherVersionThanLatest() {
+        String[] parsedVersion = KafkaVersionTestUtils.LATEST_KAFKA_VERSION.split("\\.");
+        int incrementedMinorVersion = Integer.parseInt(parsedVersion[1]) + 1;
+        parsedVersion[1] = Integer.toString(incrementedMinorVersion);
+        return String.join(".", parsedVersion);  
+    }
 
     @Test
     public void testDowngradeWithWrongCurrentMetadataVersion(VertxTestContext context) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
@@ -60,6 +60,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -299,6 +301,28 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
             assertThat(pod.getSpec().getContainers().get(0).getImage(), is(image));
             assertThat(pod.getMetadata().getAnnotations().get(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION), is(kafkaVersion));
         }
+    }
+    
+    private void updateVersionsInStrimziPodSet(String kafkaVersion) {
+        supplier.strimziPodSetOperator.client().inNamespace(namespace).withName(CLUSTER_NAME + "-mixed").edit(podSet -> {
+
+            List<Map<String, Object>> updatedPods = new ArrayList<>();
+            podSet.getSpec().getPods().stream().map(PodSetUtils::mapToPod).forEach(pod -> {
+                pod.getMetadata().getAnnotations().put(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION,
+                        kafkaVersion);
+                updatedPods.add(PodSetUtils.podToMap(pod));
+            });
+            podSet.getSpec().setPods(updatedPods);
+    
+            for (int i = 0; i < 3; i++) {
+                client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-mixed-" + i).edit(pod -> {
+                    pod.getMetadata().getAnnotations().put(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION,
+                            kafkaVersion);
+                    return pod;
+                });
+            }
+            return podSet;
+        });
     }
 
     /*
@@ -552,6 +576,43 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
                     assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_METADATA_VERSION);
                     assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
                     assertMetadataVersion(KafkaVersionTestUtils.LATEST_METADATA_VERSION);
+
+                    reconciliation.flag();
+                })));
+    }
+    
+    // Tests that downgrade succeeds from a Kafka version that is higher than the latest known version
+    @Test
+    public void testDowngradeWithFromUnknownKafkaVersion(VertxTestContext context)  {
+        // Can't deploy higher version than latest, so first deploy latest and then update annotations to make it look like a higher version
+        Kafka initialKafka = kafkaWithVersions(KafkaVersionTestUtils.LATEST_KAFKA_VERSION,
+                KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION
+        );
+        Crds.kafkaOperation(client).inNamespace(namespace).resource(initialKafka).create();
+
+        Checkpoint reconciliation = context.checkpoint();
+        initialize(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION)
+                .onComplete(context.succeeding(v -> context.verify(() -> {
+                    assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                    assertVersionsInStrimziPodSet(KafkaVersionTestUtils.LATEST_KAFKA_VERSION, KafkaVersionTestUtils.LATEST_KAFKA_IMAGE);
+                    assertMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                })))
+                .compose(i -> {
+                    // Update annotations to higher that latest known version
+                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.getHigherVersionThanLatest());
+                    
+                    // Downgrade Kafka
+                    Kafka updatedKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,
+                            KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION
+                    );
+                    Crds.kafkaOperation(client).inNamespace(namespace).resource(updatedKafka).update();
+                    return Future.succeededFuture();
+                })
+                .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
+                .onComplete(context.succeeding(i -> context.verify(() -> {
+                    assertVersionsInKafkaStatus(KafkaAssemblyOperator.OPERATOR_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
+                    assertVersionsInStrimziPodSet(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION, KafkaVersionTestUtils.PREVIOUS_KAFKA_IMAGE);
+                    assertMetadataVersion(KafkaVersionTestUtils.PREVIOUS_METADATA_VERSION);
 
                     reconciliation.flag();
                 })));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaUpgradeDowngradeWithKRaftMockTest.java
@@ -599,7 +599,7 @@ public class KafkaUpgradeDowngradeWithKRaftMockTest {
                 })))
                 .compose(i -> {
                     // Update annotations to higher that latest known version
-                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.getHigherVersionThanLatest());
+                    updateVersionsInStrimziPodSet(KafkaVersionTestUtils.UNKNOWN_KAFKA_VERSION);
                     
                     // Downgrade Kafka
                     Kafka updatedKafka = kafkaWithVersions(KafkaVersionTestUtils.PREVIOUS_KAFKA_VERSION,

--- a/documentation/assemblies/upgrading/assembly-downgrade-cluster-operator.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade-cluster-operator.adoc
@@ -1,0 +1,26 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-downgrade.adoc
+
+[id='assembly-downgrade-cluster-operator-{context}']
+= Downgrading the Cluster Operator
+
+//steps to downgrade the operators
+include::../../modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]
+
+[id='con-downgrade-cluster-operator-unsupported-kafka-{context}']
+== Downgrading the Cluster Operator returns Kafka version error
+
+If you downgrade the Cluster Operator to a version that does not support the current version of Kafka you are using, you get an _unsupported Kafka version_ error.
+This error applies to all installation methods and means that you must downgrade Kafka to a supported Kafka version.
+Change the `spec.kafka.version` in the `Kafka` resource to the supported version.
+
+You can use `kubectl` to check for error messages like this in the `status` of the `Kafka` resource.
+
+.Checking the Kafka status for errors
+[source,shell, subs=+quotes]
+----
+kubectl get kafka <kafka_cluster_name> -n <namespace> -o jsonpath='{.status.conditions}'
+----
+
+Replace <kafka_cluster_name> with the name of your Kafka cluster and <namespace> with the Kubernetes namespace where the pod is running.

--- a/documentation/assemblies/upgrading/assembly-downgrade.adoc
+++ b/documentation/assemblies/upgrading/assembly-downgrade.adoc
@@ -17,8 +17,11 @@ WARNING: The following downgrade instructions are only suitable if you installed
 If you installed Strimzi using another method, like {OperatorHub}, downgrade may not be supported by that method unless specified in their documentation. 
 To ensure a successful downgrade process, it is essential to use a supported approach.
 
+//kafka downgrade paths
+include::../../modules/upgrading/con-downgrade-paths.adoc[leveloffset=+1]
+
 //steps to downgrade the operators
-include::../../modules/upgrading/proc-downgrade-cluster-operator.adoc[leveloffset=+1]
+include::assembly-downgrade-cluster-operator.adoc[leveloffset=+1]
 
 //steps to downgrade Kafka
 include::../../modules/upgrading/proc-downgrade-kafka-kraft.adoc[leveloffset=+1]

--- a/documentation/modules/upgrading/con-downgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-downgrade-paths.adoc
@@ -1,0 +1,43 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-upgrade.adoc
+
+[id='con-downgrade-paths-{context}']
+= Strimzi downgrade paths
+
+[role="_abstract"]
+Two downgrade paths are available for Strimzi.
+
+Incremental downgrade::
+An incremental downgrade involves downgrading Strimzi from version {ProductVersion} to the previous minor version.
+
+Multi-version downgrade::
+A multi-version downgrade involves downgrading from version {ProductVersion} to an older version of Strimzi within a single upgrade, skipping one or more intermediate versions. 
+Downgrading to some older versions may not be sucessful, for example, due to configuration changes or extra steps for a particular Kafka version upgrade path performed by later versions that the target version is unable to undo. It is therefore necessary to validate your wanted downgrade path before attempting in a production environment. See table <<downgrade-version-limitations>> for details on specific paths.
+
+[id='con-downgrade-paths-kafka-versions-{context}']
+== Support for Kafka versions when downgrading
+
+When downgrading Strimzi, it is important to ensure compatibility with the Kafka version being used.
+
+Multi-version downgrades are possible even if the supported Kafka versions differ between the old and new versions. 
+However, if you attempt to downgrade to an older Strimzi version that does not support the current Kafka version, xref:con-downgrade-cluster-operator-unsupported-kafka-str[an error indicating that the Kafka version is not supported is generated]. 
+In this case, you must, if possible, downgrade the Kafka version as part of the Strimzi downgrade by changing the `spec.kafka.version` in the `Kafka` custom resource to the supported version for the target Strimzi version. If it is not possible to downgrade the Kafka version (for example in Strimzi version 0.45.0 or earlier), then the Strimzi downgrade path you are attempting is not supported. 
+
+The following table details known limitations for specific downgrade paths.
+
+.Known limitations in downgrade paths
+[[downgrade-version-limitations]]
+[cols="2,5",options="header"]
+|===
+
+| Target Strimzi Version
+| Limitation
+
+| <= 0.45.0
+| The current Kafka version must be supported by the target Strimzi version.
+
+It is only possible to downgrade from unsupported Kafka versions in Strimzi version 0.46.0 and higher.
+
+|===
+

--- a/documentation/modules/upgrading/con-downgrade-paths.adoc
+++ b/documentation/modules/upgrading/con-downgrade-paths.adoc
@@ -12,7 +12,7 @@ Incremental downgrade::
 An incremental downgrade involves downgrading Strimzi from version {ProductVersion} to the previous minor version.
 
 Multi-version downgrade::
-A multi-version downgrade involves downgrading from version {ProductVersion} to an older version of Strimzi within a single upgrade, skipping one or more intermediate versions. 
+A multi-version downgrade involves downgrading from version {ProductVersion} to an older version of Strimzi within a single step, skipping one or more intermediate versions. 
 Downgrading to some older versions may not be sucessful, for example, due to configuration changes or extra steps for a particular Kafka version upgrade path performed by later versions that the target version is unable to undo. It is therefore necessary to validate your wanted downgrade path before attempting in a production environment. See table <<downgrade-version-limitations>> for details on specific paths.
 
 [id='con-downgrade-paths-kafka-versions-{context}']

--- a/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
+++ b/documentation/modules/upgrading/proc-downgrade-cluster-operator.adoc
@@ -46,6 +46,18 @@ kubectl replace -f install/cluster-operator
 +
 Wait for the rolling updates to complete.
 
+. If the target operator version does not support the current Kafka version, an error message is returned.
++
+To resolve this, downgrade to a supported Kafka version if possible:
++
+--
+.. Edit the `Kafka` custom resource.
+.. Change the `spec.kafka.version` property to a supported Kafka version.
+--
++
+If no error message is returned, you can proceed to the next step and upgrade the Kafka version later.
+
+
 . Get the image for the Kafka pod to ensure the downgrade was successful:
 +
 [source,shell,subs="+quotes,attributes"]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_
- Enhancement / new feature

### Description

Closes #10928 
Introduces handling for encountering an unknown Kafka version in downgrade of a KRaft based cluster in order to enable multi version single step downgrade
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [X] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

