### PR TITLE
[ST] Fix Javadoc warnings in STs about wrong links

### DIFF
--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -231,6 +231,7 @@
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>test-docs-generator-maven-plugin</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This small PR fixes the warnings printed by Javadoc because of the wrong links to the test-doc-generator -> as it was scoped `test`, it wasn't included in the code itself.

### Checklist

- [ ] Make sure all tests pass

