### PR TITLE
Add support for service account annotations in Helm chart

### DIFF
--- a/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccountAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.serviceAccountAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app: {{ template "strimzi.name" . }}
     chart: {{ template "strimzi.chart" . }}

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -49,6 +49,7 @@ rbac:
   create: yes
 serviceAccountCreate: yes
 serviceAccount: strimzi-cluster-operator
+serviceAccountAnnotations: {}
 
 leaderElection:
   enable: true


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This update introduces the ability to add annotations to the Strimzi Kafka Operator's service account via the `serviceAccountAnnotations` field in `values.yaml`. It provides flexibility for users to configure custom annotations as needed.
