### PR TITLE
Fix network policies to allow CO talk to the controller nodes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1693,8 +1693,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         List<NetworkPolicyIngressRule> rules = new ArrayList<>();
 
         // Control Plane rule covers the control plane listener.
-        // Control plane listener is used by Kafka for internal coordination only
-        rules.add(NetworkPolicyUtils.createIngressRule(CONTROLPLANE_PORT, List.of(kafkaClusterPeer)));
+        // Control plane listener is used by Kafka for internal coordination only, but also by CO during rolling updates
+        rules.add(NetworkPolicyUtils.createIngressRule(CONTROLPLANE_PORT, List.of(kafkaClusterPeer, clusterOperatorPeer)));
 
         // Replication rule covers the replication listener.
         // Replication listener is used by Kafka but also by our own tools => Operators, Cruise Control, and Kafka Exporter

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -1387,6 +1387,12 @@ public class KafkaClusterTest {
                     .withMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "Kafka", Labels.STRIMZI_CLUSTER_LABEL, CLUSTER, Labels.STRIMZI_NAME_LABEL, KafkaResources.kafkaComponentName(CLUSTER)))
                 .endPodSelector()
                 .build();
+        NetworkPolicyPeer clusterOperatorPeer = new NetworkPolicyPeerBuilder()
+                .withNewPodSelector()
+                    .withMatchLabels(Map.of(Labels.STRIMZI_KIND_LABEL, "cluster-operator"))
+                .endPodSelector()
+                .withNewNamespaceSelector().endNamespaceSelector()
+                .build();
 
         // Check Network Policies => Different namespace
         NetworkPolicy np = KC.generateNetworkPolicy("operator-namespace", null);
@@ -1395,8 +1401,9 @@ public class KafkaClusterTest {
 
         List<NetworkPolicyPeer> rules = np.getSpec().getIngress().stream().filter(ing -> ing.getPorts().get(0).getPort().equals(new IntOrString(KafkaCluster.CONTROLPLANE_PORT))).map(NetworkPolicyIngressRule::getFrom).findFirst().orElseThrow();
 
-        assertThat(rules.size(), is(1));
+        assertThat(rules.size(), is(2));
         assertThat(rules.contains(kafkaBrokersPeer), is(true));
+        assertThat(rules.contains(clusterOperatorPeer), is(true));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

#10016 allowed the Cluster operator to talk directly to the dedicated controller nodes. However, it did not update the network policies. So in environments with enabled network policy enforcement, the operator cannot talk with them and attempts to roll the controller nodes fail with following issues:

```
2024-12-11 10:39:22 WARN  KafkaQuorumCheck:64 - Reconciliation #55(watch) Kafka(myproject/my-cluster): Error determining the controller quorum leader id
org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeMetadataQuorum
2024-12-11 10:39:22 INFO  KafkaRoller:389 - Reconciliation #55(watch) Kafka(myproject/my-cluster): Will temporarily skip verifying pod my-cluster-controllers-0/0 is up-to-date due to io.strimzi.operator.cluster.operator.resource.KafkaRoller$UnforceableProblem: An error while trying to determine the quorum leader id, retrying after at least 250ms
```

This PR fixes the network policy and allows CO to talk with Kafka clusters on port 9090 as well.

This should likely be cherry-picked to Strimzi 0.45.0 for an RC2 release.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally