### PR TITLE
Add support for service account annotations in Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Allow rolling update for new cluster CA trust (during Cluster CA key replacement) to continue where it left off before interruption without rolling all pods again.
 * Update HTTP bridge to 0.31.1
 * Add support for mounting CSI volumes using the `template` sections
+* Introduced the ability to add annotations to the Strimzi Kafka Operator's service account.
 
 ### Major changes, deprecations and removals
 

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/010-ServiceAccount-strimzi-cluster-operator.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccountAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.serviceAccountAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app: {{ template "strimzi.name" . }}
     chart: {{ template "strimzi.chart" . }}

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -49,6 +49,7 @@ rbac:
   create: yes
 serviceAccountCreate: yes
 serviceAccount: strimzi-cluster-operator
+serviceAccountAnnotations: {}
 
 leaderElection:
   enable: true


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This update introduces the ability to add annotations to the Strimzi Kafka Operator's service account via the `serviceAccountAnnotations` optional field in `values.yaml`. It provides flexibility for users to configure custom annotations as needed.

For example, to set up AWS IAM Roles for Service Accounts (IRSA) with Strimzi Kafka Operator in order to configure Tiered Stporage aginst AWS S3 bucket. With this change I need only add the following annotation in your values.yaml:
```yaml
serviceAccountAnnotations:
  eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
```
This annotation allows the Strimzi Operator's service account to assume the specified IAM role for AWS service interactions. 

