### PR TITLE
Revert "Allow KafkaRoller talk to controller directly (#10016)" from 0.45.x release

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -124,10 +124,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final String REPLICATION_PORT_NAME = "tcp-replication";
     protected static final int KAFKA_AGENT_PORT = 8443;
     protected static final String KAFKA_AGENT_PORT_NAME = "tcp-kafkaagent";
-    /**
-     * Port number used for control plane
-     */
-    public static final int CONTROLPLANE_PORT = 9090;
+    protected static final int CONTROLPLANE_PORT = 9090;
     protected static final String CONTROLPLANE_PORT_NAME = "tcp-ctrlplane"; // port name is up to 15 characters
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -20,7 +20,6 @@ import io.strimzi.operator.cluster.operator.VertxUtil;
 import io.strimzi.operator.cluster.operator.resource.events.KubernetesRestartEventPublisher;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.common.AdminClientProvider;
-import io.strimzi.operator.common.Annotations;
 import io.strimzi.operator.common.BackOff;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
@@ -36,8 +35,10 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SslAuthenticationException;
 
@@ -110,6 +111,7 @@ public class KafkaRoller {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(KafkaRoller.class);
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME = "controller.quorum.fetch.timeout.ms";
     private static final String CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT = "2000";
+
     private final PodOperator podOperations;
     private final long pollingIntervalMs;
     protected final long operationTimeoutMs;
@@ -196,7 +198,7 @@ public class KafkaRoller {
     private boolean maybeInitBrokerAdminClient() {
         if (this.brokerAdminClient == null) {
             try {
-                this.brokerAdminClient = brokerAdminClient(nodes);
+                this.brokerAdminClient = adminClient(nodes.stream().filter(NodeRef::broker).collect(Collectors.toSet()), false);
             } catch (ForceableProblem | FatalProblem e) {
                 LOGGER.warnCr(reconciliation, "Failed to create brokerAdminClient.", e);
                 return false;
@@ -209,19 +211,16 @@ public class KafkaRoller {
      * Initializes controllerAdminClient if it has not been initialized yet
      * @return true if the creation of AC succeeded, false otherwise
      */
-    private boolean maybeInitControllerAdminClient(String currentVersion) {
+    private boolean maybeInitControllerAdminClient() {
         if (this.controllerAdminClient == null) {
-            // Prior to 3.9.0, Kafka did not support directly connecting to controllers nodes
-            // via Kafka Admin API when running in KRaft mode.
-            // Therefore, use brokers to initialise adminClient for quorum health check
-            // when the version is older than 3.9.0.
             try {
-                if (KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
-                    this.controllerAdminClient = controllerAdminClient(nodes);
-                } else {
-                    this.controllerAdminClient = brokerAdminClient(Set.of());
-
-                }
+                // TODO: Currently, when running in KRaft mode Kafka does not support using Kafka Admin API with controller
+                //       nodes. This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9692.
+                //       Therefore use broker nodes of the cluster to initialise adminClient for quorum health check.
+                //       Once Kafka Admin API is supported for controllers, nodes.stream().filter(NodeRef:controller)
+                //       can be used here. Until then pass an empty set of nodes so the client is initialized with
+                //       the brokers service.
+                this.controllerAdminClient = adminClient(Set.of(), false);
             } catch (ForceableProblem | FatalProblem e) {
                 LOGGER.warnCr(reconciliation, "Failed to create controllerAdminClient.", e);
                 return false;
@@ -455,11 +454,9 @@ public class KafkaRoller {
         // change and the desired roles still apply.
         boolean isBroker = Labels.booleanLabel(pod, Labels.STRIMZI_BROKER_ROLE_LABEL, nodeRef.broker());
         boolean isController = Labels.booleanLabel(pod, Labels.STRIMZI_CONTROLLER_ROLE_LABEL, nodeRef.controller());
-        // This is relevant when creating admin client for controllers
-        String currentVersion = Annotations.stringAnnotation(pod, KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION, "0.0.0", null);
 
         try {
-            checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext, currentVersion);
+            checkIfRestartOrReconfigureRequired(nodeRef, isController, isBroker, restartContext);
             if (restartContext.forceRestart) {
                 LOGGER.debugCr(reconciliation, "Pod {} can be rolled now", nodeRef);
                 restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS, restartContext);
@@ -589,7 +586,7 @@ public class KafkaRoller {
      * Determine whether the pod should be restarted, or the broker reconfigured.
      */
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
-    private void checkIfRestartOrReconfigureRequired(NodeRef nodeRef, boolean isController, boolean isBroker, RestartContext restartContext, String currentVersion) throws ForceableProblem, InterruptedException, FatalProblem, UnforceableProblem {
+    private void checkIfRestartOrReconfigureRequired(NodeRef nodeRef, boolean isController, boolean isBroker, RestartContext restartContext) throws ForceableProblem, InterruptedException, FatalProblem, UnforceableProblem {
         RestartReasons reasonToRestartPod = restartContext.restartReasons;
         if (restartContext.podStuck && !reasonToRestartPod.contains(RestartReason.POD_HAS_OLD_REVISION)) {
             // If the pod is unschedulable then deleting it, or trying to open an Admin client to it will make no difference
@@ -610,13 +607,35 @@ public class KafkaRoller {
         KafkaBrokerLoggingConfigurationDiff brokerLoggingDiff = null;
         boolean needsReconfig = false;
 
-        // if it is a pure controller, initialise the admin client specifically for controllers
-        if (isController && !isBroker) {
-            if (!maybeInitControllerAdminClient(currentVersion)) {
-                handleFailedAdminClientForController(nodeRef, restartContext, reasonToRestartPod, currentVersion);
-                return;
+        if (isController) {
+            if (maybeInitControllerAdminClient()) {
+                String controllerQuorumFetchTimeout = CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT;
+                String desiredConfig = kafkaConfigProvider.apply(nodeRef.nodeId());
+
+                if (desiredConfig != null) {
+                    OrderedProperties orderedProperties = new OrderedProperties();
+                    controllerQuorumFetchTimeout = orderedProperties.addStringPairs(desiredConfig).asMap().getOrDefault(CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT);
+                }
+
+                restartContext.quorumCheck = quorumCheck(controllerAdminClient, Long.parseLong(controllerQuorumFetchTimeout));
+            } else {
+                //TODO When https://github.com/strimzi/strimzi-kafka-operator/issues/9692 is complete
+                // we should change this logic to immediately restart this pod because we cannot connect to it.
+                if (isBroker) {
+                    // If it is a combined node (controller and broker) and the admin client cannot be initialised,
+                    // restart this pod. There is no reason to continue as we won't be able to
+                    // connect an admin client to this pod for other checks later.
+                    LOGGER.infoCr(reconciliation, "KafkaQuorumCheck cannot be initialised for {} because none of the brokers do not seem to responding to connection attempts. " +
+                            "Restarting pod because it is a combined node so it is one of the brokers that is not responding.", nodeRef);
+                    reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
+                    markRestartContextWithForceRestart(restartContext);
+                    return;
+                } else {
+                    // If it is a controller only node throw an UnforceableProblem, so we try again until the backOff
+                    // is finished, then it will move on to the next controller and eventually the brokers.
+                    throw new UnforceableProblem("KafkaQuorumCheck cannot be initialised for " + nodeRef + " because none of the brokers do not seem to responding to connection attempts");
+                }
             }
-            restartContext.quorumCheck = quorumCheck(controllerAdminClient, nodeRef);
         }
 
         if (isBroker) {
@@ -625,11 +644,6 @@ public class KafkaRoller {
                 reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
                 markRestartContextWithForceRestart(restartContext);
                 return;
-            }
-
-            // If it is a mixed node, initialise quorum check with the broker admin client
-            if (isController) {
-                restartContext.quorumCheck = quorumCheck(brokerAdminClient, nodeRef);
             }
 
             // Always get the broker config. This request gets sent to that specific broker, so it's a proof that we can
@@ -675,21 +689,6 @@ public class KafkaRoller {
         restartContext.forceRestart = false;
         restartContext.brokerConfigDiff = brokerConfigDiff;
         restartContext.brokerLoggingDiff = brokerLoggingDiff;
-    }
-
-    private void handleFailedAdminClientForController(NodeRef nodeRef, RestartContext restartContext, RestartReasons reasonToRestartPod, String currentVersion) throws UnforceableProblem {
-        if (KafkaVersion.compareDottedVersions(currentVersion, "3.9.0") >= 0) {
-            // If the version supports talking to controllers, force restart this pod when the admin client cannot be initialised.
-            // There is no reason to continue as we won't be able to connect an admin client to this pod for other checks later.
-            LOGGER.infoCr(reconciliation, "KafkaQuorumCheck cannot be initialised for {} because none of the controllers do not seem to responding to connection attempts.", nodeRef);
-            reasonToRestartPod.add(RestartReason.POD_UNRESPONSIVE);
-            markRestartContextWithForceRestart(restartContext);
-        } else {
-            // If the version does not support talking to controllers, the admin client should be connecting to the broker nodes.
-            // Since connection to the brokers failed, throw an UnforceableProblem so that broker nodes can be checked later
-            // which may potentially resolve the connection issue.
-            throw new UnforceableProblem("KafkaQuorumCheck cannot be initialised for " + nodeRef + " because none of the brokers do not seem to responding to connection attempts");
-        }
     }
 
     /**
@@ -906,48 +905,34 @@ public class KafkaRoller {
      * Returns an AdminClient instance bootstrapped from the given nodes. If nodes is an
      * empty set, use the brokers service to bootstrap the client.
      */
-    /* test */ Admin brokerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
-        // If no nodes are passed, initialize the admin client using the bootstrap service
-        // This is still needed for versions older than 3.9.0, so that when only controller nodes being rolled,
-        // it can use brokers to get quorum information via AdminClient.
+    /* test */ Admin adminClient(Set<NodeRef> nodes, boolean ceShouldBeFatal) throws ForceableProblem, FatalProblem {
+        // If no nodes are passed initialize the admin client using the brokers service
+        // TODO when https://github.com/strimzi/strimzi-kafka-operator/issues/9692 is completed review whether
+        //      this function can be reverted to expect nodes to be non empty
         String bootstrapHostnames;
         if (nodes.isEmpty()) {
             bootstrapHostnames = String.format("%s:%s", DnsNameGenerator.of(namespace, KafkaResources.bootstrapServiceName(cluster)).serviceDnsName(), KafkaCluster.REPLICATION_PORT);
         } else {
-            bootstrapHostnames = nodes.stream().filter(NodeRef::broker).map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.REPLICATION_PORT).collect(Collectors.joining(","));
+            bootstrapHostnames = nodes.stream().map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.REPLICATION_PORT).collect(Collectors.joining(","));
         }
 
         try {
             LOGGER.debugCr(reconciliation, "Creating AdminClient for {}", bootstrapHostnames);
             return adminClientProvider.createAdminClient(bootstrapHostnames, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
+        } catch (KafkaException e) {
+            if (ceShouldBeFatal && (e instanceof ConfigException
+                    || e.getCause() instanceof ConfigException)) {
+                throw new FatalProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
+            } else {
+                throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
+            }
         } catch (RuntimeException e) {
             throw new ForceableProblem("An error while try to create an admin client with bootstrap brokers " + bootstrapHostnames, e);
         }
     }
 
-    /**
-     * Returns an AdminClient instance bootstrapped from the given controller nodes.
-     */
-    /* test */ Admin controllerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
-        String bootstrapHostnames = nodes.stream().filter(NodeRef::controller).map(node -> DnsNameGenerator.podDnsName(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.CONTROLPLANE_PORT).collect(Collectors.joining(","));
-
-        try {
-            LOGGER.debugCr(reconciliation, "Creating AdminClient for {}", bootstrapHostnames);
-            return adminClientProvider.createControllerAdminClient(bootstrapHostnames, coTlsPemIdentity.pemTrustSet(), coTlsPemIdentity.pemAuthIdentity());
-        } catch (RuntimeException e) {
-            throw new ForceableProblem("An error while try to create an admin client with bootstrap controllers " + bootstrapHostnames, e);
-        }
-    }
-
-    /* test */ KafkaQuorumCheck quorumCheck(Admin ac, NodeRef nodeRef) {
-        String controllerQuorumFetchTimeout = CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT;
-        String desiredConfig = kafkaConfigProvider.apply(nodeRef.nodeId());
-
-        if (desiredConfig != null) {
-            OrderedProperties orderedProperties = new OrderedProperties();
-            controllerQuorumFetchTimeout = orderedProperties.addStringPairs(desiredConfig).asMap().getOrDefault(CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_NAME, CONTROLLER_QUORUM_FETCH_TIMEOUT_MS_CONFIG_DEFAULT);
-        }
-        return new KafkaQuorumCheck(reconciliation, ac, vertx, Long.parseLong(controllerQuorumFetchTimeout));
+    /* test */ KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
+        return new KafkaQuorumCheck(reconciliation, ac, vertx, controllerQuorumFetchTimeoutMs);
     }
 
     /* test */ KafkaAvailability availability(Admin ac) {
@@ -990,7 +975,7 @@ public class KafkaRoller {
             //      This is tracked in https://github.com/strimzi/strimzi-kafka-operator/issues/9373.
             // Use admin client connected directly to this broker here, then any exception or timeout trying to connect to
             // the current node will be caught and handled from this method, rather than appearing elsewhere.
-            try (Admin ac = brokerAdminClient(Set.of(nodeRef))) {
+            try (Admin ac = adminClient(Set.of(nodeRef), false)) {
                 Node controllerNode = null;
 
                 try {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -519,17 +519,7 @@ public class ResourceUtils {
             }
 
             @Override
-            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
-                return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
-            }
-
-            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-                return mockAdminClient;
-            }
-
-            @Override
-            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return mockAdminClient;
             }
         };

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaRollerTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
-import io.strimzi.operator.cluster.model.KafkaCluster;
 import io.strimzi.operator.cluster.model.NodeRef;
 import io.strimzi.operator.cluster.model.RestartReason;
 import io.strimzi.operator.cluster.model.RestartReasons;
@@ -158,43 +157,6 @@ public class KafkaRollerTest {
         AdminClientProvider mock = mock(AdminClientProvider.class);
         when(mock.createAdminClient(anyString(), any(), any())).thenReturn(admin);
         return mock;
-    }
-
-    @Test
-    public void testTalkingToControllersLatestVersion(VertxTestContext testContext) {
-        PodOperator podOps = mockPodOpsWithVersion(podId -> succeededFuture(), KafkaVersionTestUtils.getLatestVersion().version());
-        AdminClientProvider mock = mock(AdminClientProvider.class);
-        when(mock.createControllerAdminClient(anyString(), any(), any())).thenThrow(new RuntimeException("An error while try to create an admin client with bootstrap controllers"));
-
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps,
-                noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true),
-                true, mock, mockKafkaAgentClientProvider(), true, null, -1);
-
-        // When admin client cannot be created for a controller node, we expect it to be force restarted.
-        doSuccessfulRollingRestart(testContext, kafkaRoller,
-                asList(0),
-                asList(0));
-    }
-
-    @Test
-    public void testTalkingToControllersWithOldVersion(VertxTestContext testContext) throws InterruptedException {
-        PodOperator podOps = mockPodOpsWithVersion(podId -> succeededFuture(), "3.8.0");
-
-        AdminClientProvider mock = mock(AdminClientProvider.class);
-        when(mock.createAdminClient(anyString(), any(), any())).thenThrow(new RuntimeException("An error while try to create an admin client with bootstrap brokers"));
-
-        TestingKafkaRoller kafkaRoller = new TestingKafkaRoller(addKraftPodNames(0, 0, 1), podOps,
-                noException(), null, noException(), noException(), noException(),
-                brokerId -> succeededFuture(true),
-                true, mock, mockKafkaAgentClientProvider(), true, null, -1);
-
-        // If the controller has older version (< 3.9.0), we should only be creating admin client for brokers
-        // and when the operator cannot connect to brokers, we expect to fail initialising KafkaQuorumCheck
-        doFailingRollingRestart(testContext, kafkaRoller,
-                asList(0),
-                KafkaRoller.UnforceableProblem.class, "KafkaQuorumCheck cannot be initialised for c-kafka-0/0 because none of the brokers do not seem to responding to connection attempts",
-                emptyList());
     }
 
     private static KafkaAgentClientProvider mockKafkaAgentClientProvider() {
@@ -835,17 +797,12 @@ public class KafkaRollerTest {
     }
 
     private PodOperator mockPodOps(Function<Integer, Future<Void>> readiness) {
-        return mockPodOpsWithVersion(readiness, KafkaVersionTestUtils.getLatestVersion().version());
-    }
-
-    private PodOperator mockPodOpsWithVersion(Function<Integer, Future<Void>> readiness, String version) {
         PodOperator podOps = mock(PodOperator.class);
         when(podOps.get(any(), any())).thenAnswer(
                 invocation -> new PodBuilder()
                         .withNewMetadata()
-                        .withNamespace(invocation.getArgument(0))
-                        .withName(invocation.getArgument(1))
-                        .addToAnnotations(KafkaCluster.ANNO_STRIMZI_IO_KAFKA_VERSION, version)
+                            .withNamespace(invocation.getArgument(0))
+                            .withName(invocation.getArgument(1))
                         .endMetadata()
                         .build()
         );
@@ -944,33 +901,9 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected Admin brokerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
+        protected Admin adminClient(Set<NodeRef> nodes, boolean b) throws ForceableProblem, FatalProblem {
             if (delegateAdminClientCall) {
-                return super.brokerAdminClient(nodes);
-            }
-            RuntimeException exception = acOpenException.apply(nodes);
-            if (exception != null) {
-                throw new ForceableProblem("An error while try to create the admin client", exception);
-            }
-            Admin ac = mock(AdminClient.class, invocation -> {
-                if ("close".equals(invocation.getMethod().getName())) {
-                    Admin mock = (Admin) invocation.getMock();
-                    unclosedAdminClients.remove(mock);
-                    if (acCloseException != null) {
-                        throw acCloseException;
-                    }
-                    return null;
-                }
-                throw new RuntimeException("Not mocked " + invocation.getMethod());
-            });
-            unclosedAdminClients.put(ac, new Throwable("Pod " + nodes));
-            return ac;
-        }
-
-        @Override
-        protected Admin controllerAdminClient(Set<NodeRef> nodes) throws ForceableProblem, FatalProblem {
-            if (delegateAdminClientCall) {
-                return super.controllerAdminClient(nodes);
+                return super.adminClient(nodes, b);
             }
             RuntimeException exception = acOpenException.apply(nodes);
             if (exception != null) {
@@ -1012,7 +945,7 @@ public class KafkaRollerTest {
         }
 
         @Override
-        protected KafkaQuorumCheck quorumCheck(Admin ac, NodeRef nodeRef) {
+        protected KafkaQuorumCheck quorumCheck(Admin ac, long controllerQuorumFetchTimeoutMs) {
             Admin admin = mock(Admin.class);
             DescribeMetadataQuorumResult qrmResult = mock(DescribeMetadataQuorumResult.class);
             when(admin.describeMetadataQuorum()).thenReturn(qrmResult);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/events/KubernetesRestartEventsMockTest.java
@@ -617,17 +617,7 @@ public class KubernetesRestartEventsMockTest {
             }
 
             @Override
-            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
-                return adminClientSupplier.get();
-            }
-
-            @Override
             public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-                return adminClientSupplier.get();
-            }
-
-            @Override
-            public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
                 return adminClientSupplier.get();
             }
         };

--- a/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/AdminClientProvider.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 public interface AdminClientProvider {
 
     /**
-     * Create a Kafka Admin interface instance for brokers
+     * Create a Kafka Admin interface instance
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -26,17 +26,7 @@ public interface AdminClientProvider {
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
 
     /**
-     * Create a Kafka Admin interface instance for controllers
-     *
-     * @param controllerBootstrapHostnames Kafka controller hostname to connect to for administration operations
-     * @param kafkaCaTrustSet Trust set for connecting to Kafka
-     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
-     * @return Instance of Kafka Admin interface
-     */
-    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity);
-
-    /**
-     * Create a Kafka Admin interface instance for brokers
+     * Create a Kafka Admin interface instance
      *
      * @param bootstrapHostnames Kafka hostname to connect to for administration operations
      * @param kafkaCaTrustSet Trust set for connecting to Kafka
@@ -46,16 +36,4 @@ public interface AdminClientProvider {
      * @return Instance of Kafka Admin interface
      */
     Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
-
-    /**
-     * Create a Kafka Admin interface instance for controllers
-     *
-     * @param controllerBootstrapHostnames Kafka hostname to connect to for administration operations
-     * @param kafkaCaTrustSet Trust set for connecting to Kafka
-     * @param authIdentity Identity for TLS client authentication for connecting to Kafka
-     * @param config Additional configuration for the Kafka Admin Client
-     *
-     * @return Instance of Kafka Admin interface
-     */
-    Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config);
 }

--- a/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/DefaultAdminClientProvider.java
@@ -21,11 +21,6 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
         return createAdminClient(bootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
     }
 
-    @Override
-    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity) {
-        return createControllerAdminClient(controllerBootstrapHostnames, kafkaCaTrustSet, authIdentity, new Properties());
-    }
-
     /**
      * Create a Kafka Admin interface instance handling the following different scenarios:
      *
@@ -49,29 +44,25 @@ public class DefaultAdminClientProvider implements AdminClientProvider {
      */
     @Override
     public Admin createAdminClient(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
-        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
-    }
-
-    @Override
-    public Admin createControllerAdminClient(String controllerBootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config) {
-        config.setProperty(AdminClientConfig.BOOTSTRAP_CONTROLLERS_CONFIG, controllerBootstrapHostnames);
-        return Admin.create(adminClientConfiguration(kafkaCaTrustSet, authIdentity, config));
+        return Admin.create(adminClientConfiguration(bootstrapHostnames, kafkaCaTrustSet, authIdentity, config));
     }
 
     /**
      * Utility method for preparing the Admin client configuration
      *
+     * @param bootstrapHostnames    Kafka bootstrap address
      * @param kafkaCaTrustSet       Trust set for connecting to Kafka
      * @param authIdentity          Identity for TLS client authentication for connecting to Kafka
      * @param config                Custom Admin client configuration or empty properties instance
      *
      * @return  Admin client configuration
      */
-    /* test */ Properties adminClientConfiguration(PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
+    /* test */ static Properties adminClientConfiguration(String bootstrapHostnames, PemTrustSet kafkaCaTrustSet, PemAuthIdentity authIdentity, Properties config)    {
         if (config == null) {
             throw new InvalidConfigurationException("The config parameter should not be null");
         }
+
+        config.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapHostnames);
 
         // configuring TLS encryption if requested
         if (kafkaCaTrustSet != null) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This reverts commit 1f1a16d2a57a13df990ef3fab9cc60386e4c0719.

This commit caused Warning messages indicating that describeQuorum request was sent to a non active controller therefore failed rolling a controller-only node. We discovered that non active controller does not forward the request to the active controller like broker does, but returns NOT_LEADER_OR_FOLLOWER error. This issue gets resolved by itself eventually after retrying the request several times, because the describeQuorum gets sent to the active controller at some point. However, it could cause some delay in rolling controller-only nodes, due to the number of retrying.

Reverting this commit from 0.45.0 release branch, and the issue will be fixed properly in the main branch to target the next release.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

