### PR TITLE
docs(edit): removes some mm1 content

### DIFF
--- a/documentation/modules/con-common-configuration-properties.adoc
+++ b/documentation/modules/con-common-configuration-properties.adoc
@@ -318,14 +318,13 @@ These components are not version dependent, so no additional configuration is ne
 
 *Configuring the `image` property for Kafka, Kafka Connect, and Kafka MirrorMaker*
 
-Kafka, Kafka Connect, and Kafka MirrorMaker support multiple versions of Kafka.
+Kafka, Kafka Connect, and Kafka MirrorMaker 2 support multiple versions of Kafka.
 Each component requires its own image.
 The default images for the different Kafka versions are configured in the following environment variables:
 
 * `STRIMZI_KAFKA_IMAGES`
 * `STRIMZI_KAFKA_CONNECT_IMAGES`
 * `STRIMZI_KAFKA_MIRROR_MAKER2_IMAGES`
-* (Deprecated) `STRIMZI_KAFKA_MIRROR_MAKER_IMAGES`
 
 These environment variables contain mappings between Kafka versions and corresponding images.
 The mappings are used together with the `image` and `version` properties to determine the image used:

--- a/documentation/modules/configuring/con-config-mirrormaker2.adoc
+++ b/documentation/modules/configuring/con-config-mirrormaker2.adoc
@@ -31,9 +31,6 @@ The configuration must specify:
 
 For a deeper understanding of the Kafka MirrorMaker 2 cluster configuration options, refer to the link:{BookURLConfiguring}[Strimzi Custom Resource API Reference^].
 
-NOTE: MirrorMaker 2 resource configuration differs from the previous version of MirrorMaker, which is now deprecated.
-There is currently no legacy support, so any resources must be manually converted into the new format.
-
 .Default configuration 
 MirrorMaker 2 provides default configuration values for properties such as replication factors.
 A minimal configuration, with defaults left unchanged, would be something like this example:

--- a/documentation/modules/configuring/con-pod-management.adoc
+++ b/documentation/modules/configuring/con-pod-management.adoc
@@ -13,4 +13,4 @@ You must not create, update, or delete `StrimziPodSet` resources.
 The `StrimziPodSet` custom resource is used internally and resources are managed solely by the Cluster Operator.
 As a consequence, the Cluster Operator must be running properly to avoid the possibility of pods not starting and Kafka clusters not being available.
 
-NOTE: Kubernetes `Deployment` resources are used for creating and managing the pods of other components: Kafka Bridge, Kafka Exporter, Cruise Control, (deprecated) MirrorMaker 1, User Operator and Topic Operator.
+NOTE: Kubernetes `Deployment` resources are used for creating and managing the pods of other components: Kafka Bridge, Kafka Exporter, Cruise Control, User Operator and Topic Operator.

--- a/documentation/modules/operators/con-configuring-cluster-operator.adoc
+++ b/documentation/modules/operators/con-configuring-cluster-operator.adoc
@@ -140,10 +140,6 @@ For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher
 The mapping from the Kafka version to the corresponding image of MirrorMaker 2 for that version.
 For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
 
-(Deprecated) `STRIMZI_KAFKA_MIRROR_MAKER_IMAGES`:: Required.
-The mapping from the Kafka version to the corresponding image of MirrorMaker for that version.
-For example `{KafkaVersionLower}={DockerKafkaImagePrevious}, {KafkaVersionHigher}={DockerKafkaImageCurrent}`.
-
 `STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE`:: Optional.
 The default is `{DockerTopicOperator}`.
 The image name to use as the default when deploying the Topic Operator


### PR DESCRIPTION
Documentation

A few minor edits to the docs to remove MirrorMaker 1 content, which is no longer supported.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

