### PR TITLE
[ST] Update mechanism for changing the Docker registry, repository, and tag - main branch

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -190,7 +190,6 @@ public class Environment {
      * Defaults
      */
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
-    public static final String STRIMZI_TAG_DEFAULT = "latest";
     public static final String STRIMZI_REGISTRY_DEFAULT = "quay.io";
     public static final String TEST_CLIENTS_ORG_DEFAULT = "strimzi-test-clients";
     private static final String TEST_LOG_DIR_DEFAULT = TestUtils.USER_PATH + "/../systemtest/target/logs/";

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -225,9 +225,9 @@ public class Environment {
      * Set values
      */
     public static final String SYSTEM_TEST_STRIMZI_IMAGE_PULL_SECRET = getOrDefault(STRIMZI_IMAGE_PULL_SECRET_ENV, "");
-    public static final String STRIMZI_ORG = getOrDefault(STRIMZI_ORG_ENV, STRIMZI_ORG_DEFAULT);
-    public static final String STRIMZI_TAG = getOrDefault(STRIMZI_TAG_ENV, STRIMZI_TAG_DEFAULT);
-    public static final String STRIMZI_REGISTRY = getOrDefault(STRIMZI_REGISTRY_ENV, STRIMZI_REGISTRY_DEFAULT);
+    public static final String STRIMZI_ORG = getOrDefault(STRIMZI_ORG_ENV, "");
+    public static final String STRIMZI_TAG = getOrDefault(STRIMZI_TAG_ENV, "");
+    public static final String STRIMZI_REGISTRY = getOrDefault(STRIMZI_REGISTRY_ENV, "");
     public static final String TEST_LOG_DIR = getOrDefault(TEST_LOG_DIR_ENV, TEST_LOG_DIR_DEFAULT);
     public static final String PERFORMANCE_DIR = getOrDefault(PERFORMANCE_DIR_ENV, PERFORMANCE_DIR_DEFAULT);
     public static final String ST_KAFKA_VERSION = getOrDefault(ST_KAFKA_VERSION_ENV, ST_KAFKA_VERSION_DEFAULT);

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/StUtils.java
@@ -108,14 +108,14 @@ public class StUtils {
     public static String changeOrgAndTag(String image) {
         Matcher m = IMAGE_PATTERN_FULL_PATH.matcher(image);
         if (m.find()) {
-            String registry = setImageProperties(m.group("registry"), Environment.STRIMZI_REGISTRY, Environment.STRIMZI_REGISTRY_DEFAULT);
-            String org = setImageProperties(m.group("org"), Environment.STRIMZI_ORG, Environment.STRIMZI_ORG_DEFAULT);
+            String registry = setImageProperties(m.group("registry"), Environment.STRIMZI_REGISTRY);
+            String org = setImageProperties(m.group("org"), Environment.STRIMZI_ORG);
 
             return registry + "/" + org + "/" + m.group("image") + ":" + buildTag(m.group("tag"));
         }
         m = IMAGE_PATTERN.matcher(image);
         if (m.find()) {
-            String org = setImageProperties(m.group("org"), Environment.STRIMZI_ORG, Environment.STRIMZI_ORG_DEFAULT);
+            String org = setImageProperties(m.group("org"), Environment.STRIMZI_ORG);
 
             return Environment.STRIMZI_REGISTRY + "/" + org + "/" + m.group("image") + ":"  + buildTag(m.group("tag"));
         }
@@ -132,15 +132,15 @@ public class StUtils {
         return sb.toString();
     }
 
-    private static String setImageProperties(String current, String envVar, String defaultEnvVar) {
-        if (!envVar.equals(defaultEnvVar) && !current.equals(envVar)) {
+    private static String setImageProperties(String current, String envVar) {
+        if (!envVar.isEmpty() && !current.equals(envVar)) {
             return envVar;
         }
         return current;
     }
 
     private static String buildTag(String currentTag) {
-        if (!currentTag.equals(Environment.STRIMZI_TAG) && !Environment.STRIMZI_TAG_DEFAULT.equals(Environment.STRIMZI_TAG)) {
+        if (!Environment.STRIMZI_TAG.isEmpty() && !currentTag.equals(Environment.STRIMZI_TAG)) {
             Matcher t = KAFKA_COMPONENT_PATTERN.matcher(currentTag);
             if (t.find()) {
                 currentTag = Environment.STRIMZI_TAG + t.group("kafka") + t.group("version");


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes the logic about how we are replacing the images inside the CO deployment file -> the check we had there until now was wrong, as we checked that the env variables are set to the defaults -> which was true for the whole time, thus if we executed the AZPs on the release branches, the built images were never used.

The PR changes the logic to check if the env variables are empty or if are same as the values currently specified in the deployment file -> which makes more sense.

### Checklist

- [x] Make sure all tests pass

