### PR TITLE
[ST] Specify correct registry, org, and tag for Helm and remove unused code for OCP

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -189,6 +189,7 @@ public class Environment {
     /**
      * Defaults
      */
+    public static final String STRIMZI_TAG_DEFAULT = "latest";
     public static final String STRIMZI_ORG_DEFAULT = "strimzi";
     public static final String STRIMZI_REGISTRY_DEFAULT = "quay.io";
     public static final String TEST_CLIENTS_ORG_DEFAULT = "strimzi-test-clients";
@@ -243,7 +244,9 @@ public class Environment {
     private static final String TEST_CLIENTS_VERSION = getOrDefault(TEST_CLIENTS_VERSION_ENV, TEST_CLIENTS_VERSION_DEFAULT);
     private static final String TEST_CLIENTS_IMAGE_DEFAULT = STRIMZI_REGISTRY_DEFAULT + "/" + TEST_CLIENTS_ORG_DEFAULT + "/test-clients:" + TEST_CLIENTS_VERSION + "-kafka-" + CLIENTS_KAFKA_VERSION;
     public static final String TEST_CLIENTS_IMAGE = getOrDefault(TEST_CLIENTS_IMAGE_ENV, TEST_CLIENTS_IMAGE_DEFAULT);
-    private static final String SCRAPER_IMAGE_DEFAULT = STRIMZI_REGISTRY + "/" + STRIMZI_ORG + "/kafka:" + STRIMZI_TAG + "-kafka-" + ST_KAFKA_VERSION;
+    private static final String SCRAPER_IMAGE_DEFAULT = getIfNotEmptyOrDefault(STRIMZI_REGISTRY, STRIMZI_REGISTRY_DEFAULT) + "/" +
+        getIfNotEmptyOrDefault(STRIMZI_ORG, STRIMZI_ORG_DEFAULT) + "/kafka:" +
+        getIfNotEmptyOrDefault(STRIMZI_TAG, STRIMZI_TAG_DEFAULT) + "-kafka-" + ST_KAFKA_VERSION;
     public static final String SCRAPER_IMAGE = getOrDefault(SCRAPER_IMAGE_ENV, SCRAPER_IMAGE_DEFAULT);
 
     // variables for kafka bridge image
@@ -448,5 +451,9 @@ public class Environment {
 
     public static boolean isEnvVarSet(String envVarName) {
         return System.getenv(envVarName) != null;
+    }
+
+    public static String getIfNotEmptyOrDefault(String envVar, String defaultValue) {
+        return envVar.isEmpty() ? defaultValue : envVar;
     }
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/operator/specific/HelmResource.java
@@ -57,15 +57,15 @@ public class HelmResource implements SpecificResourceType {
 
         Map<String, Object> values = new HashMap<>();
         // image registry config
-        values.put("defaultImageRegistry", Environment.STRIMZI_REGISTRY);
+        values.put("defaultImageRegistry", Environment.getIfNotEmptyOrDefault(Environment.STRIMZI_REGISTRY, Environment.STRIMZI_REGISTRY_DEFAULT));
         values.put("kafkaBridge.image.registry", Environment.STRIMZI_REGISTRY_DEFAULT);
 
         // image repository config
-        values.put("defaultImageRepository", Environment.STRIMZI_ORG);
+        values.put("defaultImageRepository", Environment.getIfNotEmptyOrDefault(Environment.STRIMZI_ORG, Environment.STRIMZI_ORG_DEFAULT));
         values.put("kafkaBridge.image.repository", Environment.STRIMZI_ORG_DEFAULT);
 
         // image tags config
-        values.put("defaultImageTag", Environment.STRIMZI_TAG);
+        values.put("defaultImageTag", Environment.getIfNotEmptyOrDefault(Environment.STRIMZI_TAG, Environment.STRIMZI_TAG_DEFAULT));
         values.put("kafkaBridge.image.tag", BridgeUtils.getBridgeVersion());
 
         // Additional config


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In #10947 I changed the default values for the image registry, org, and tag values -> from our specific values to the empty one. Together with that, the check for changing the image parts was changed as well.
Now, this works for the K8s clusters and regular installation type, but it doesn't work for Helm.

Also, I'm removing unused code for adding the image-puller role, as it was not used for a long time in our tests on OCP -> and now it caused issues with running the tests, when the `STRIMZI_ORG` was empty.

### Checklist

- [x] Make sure all tests pass

