### PR TITLE
Avoid failing the CI pipelines on "special" commit messages

### DIFF
--- a/.azure/templates/steps/log_variables.yaml
+++ b/.azure/templates/steps/log_variables.yaml
@@ -19,3 +19,6 @@ steps:
     java -version
     which java
   displayName: 'Print environment variables'
+  # Sometimes, the commit message might break the script due to some special characters. As the purpose of this script
+  # is logging only, we set it to continue on error to not fail the pipelines because of this.
+  continueOnError: true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some commit messages with some special characters and structure might break the script that logs the variable values in out CI pipelines. (Unfortunately, one such message is generated when reverting GitHub PRs 🙄). An example of such message is the one used in this PR:

```
Try to debug unusual commit messages such as with "quotes (#1874) like" this in the message
```

Where the combination of `(` inside `"` causes the error:

```
/home/vsts/work/_temp/a34b75bc-d39f-4087-98d3-a314284dde8c.sh: line 3: syntax error near unexpected token `('
/home/vsts/work/_temp/a34b75bc-d39f-4087-98d3-a314284dde8c.sh: line 3: `echo "COMMIT_MESSAGE: Try to debug unusual commit messages such as with "quotes (#1874) like" this in the message"'
```

I did not found any way to automatically escape this in the Azure pipelines. So to avoid this, I marked the step that logs the variables to continue even on error. As it is logging step only, it should be fine and it will not block us in the future as it did with the 0.45.0-rc2.