### PR TITLE
Update default logging configurations for Kafka brokers and MM2

### DIFF
--- a/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaCluster.properties
@@ -15,5 +15,5 @@ log4j.logger.kafka.controller=TRACE
 # KRaft mode controller
 log4j.logger.org.apache.kafka.controller=INFO
 log4j.logger.kafka.log.LogCleaner=INFO
-log4j.logger.state.change.logger=TRACE
+log4j.logger.state.change.logger=INFO
 log4j.logger.kafka.authorizer.logger=INFO

--- a/cluster-operator/src/main/resources/default-logging/KafkaMirrorMaker2Cluster.properties
+++ b/cluster-operator/src/main/resources/default-logging/KafkaMirrorMaker2Cluster.properties
@@ -3,5 +3,4 @@ log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %p %X{connector.context}%m (%c) [%t]%n
 connect.root.logger.level=INFO
 log4j.rootLogger=${connect.root.logger.level}, CONSOLE
-log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the logging configuration for Kafka brokers/controllers and MM2 to bring it in-sync with Kafka's own default configuration. This helps to avoid confusion among users why are they seeing some TRACE messages in the Kafka logs from Strimzi when they did not enable them.

_(While Kafka 4.0 will have a new logging configuration based on Log4j2, this will be still useful for Kafka 3.9.0)_

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally