### PR TITLE
Update Fabric8 Kubernetes client to 7.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.0.0</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.0.0</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.0.0</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.0.1</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.0.1</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.0.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr updates the Fabric8 Kubernetes Client to 7.0.1. There are no bugfixes that should affect us, but using the latest version might help us in case we run into some new issues.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally