### PR TITLE
Remove unused options from UO and TO logging test configurations

### DIFF
--- a/topic-operator/src/test/resources/log4j2-test.properties
+++ b/topic-operator/src/test/resources/log4j2-test.properties
@@ -26,9 +26,3 @@ logger.kafkaorg.level = WARN
 
 logger.kafkasta.name = state.change
 logger.kafkasta.level = WARN
-
-logger.zookeeper.name = org.apache.zookeeper
-logger.zookeeper.level = WARN
-
-logger.kroxylicious.name = io.kroxylicious
-logger.kroxylicious.level = WARN

--- a/user-operator/src/test/resources/log4j2-test.properties
+++ b/user-operator/src/test/resources/log4j2-test.properties
@@ -27,14 +27,3 @@ logger.kafka.name = kafka
 logger.kafka.level = WARN
 logger.kafka.additivity = false
 logger.kafka.appenderRef.console2.ref = KAFKA
-
-# Zookeeper
-appender.console3.type = Console
-appender.console3.name = ZOOKEEPER
-appender.console3.layout.type = PatternLayout
-appender.console3.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [ZOOKEEPER] %-5p %c{1}:%L - %m%n
-
-logger.zookeeper.name = org.apache.zookeeper
-logger.zookeeper.level = WARN
-logger.zookeeper.additivity = false
-logger.zookeeper.appenderRef.console3.ref = ZOOKEEPER


### PR DESCRIPTION
### Type of change

- Task

### Description

This Pr removes some unused options from the Log4j configuration used in UO and TO unit and integration tests mainly related to ZooKeeper, that is anyway not used there anymore (regardless of the ZooKeeper support removal).

### Checklist

- [x] Make sure all tests pass