### PR TITLE
Store Kafka node certificates in separate Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for ZooKeeper-based Apache Kafka clusters and for KRaft migration has been removed
 * Support for MirrorMaker 1 has been removed
 * Added support to configure `dnsPolicy` and `dnsConfig` using the `template` sections.
+* Store Kafka node certificates in separate Secrets, one Secret per pod.
 
 ### Major changes, deprecations and removals
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
@@ -154,6 +154,7 @@ public class KafkaResources {
      *
      * @return The name of the corresponding Kafka Secret.
      */
+    @Deprecated // Kafka server certificates are now kept in per-node Secrets
     public static String kafkaSecretName(String clusterName) {
         return clusterName + "-kafka-brokers";
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CertUtils.java
@@ -132,6 +132,21 @@ public class CertUtils {
         return data;
     }
 
+    /**
+     * Constructs a Map containing the provided certificates to be stored in a Kubernetes Secret.
+     *
+     * @param certificateName Name to use to create identifier for storing the data in the Secret.
+     * @param certAndKey Private key and public cert pair to store in the Secret.
+     *
+     * @return Map of certificate identifier to base64 encoded certificate or key
+     */
+    public static Map<String, String> buildSecretData(String certificateName, CertAndKey certAndKey) {
+        return Map.of(
+                Ca.SecretEntry.KEY.asKey(certificateName), certAndKey.keyAsBase64String(),
+                Ca.SecretEntry.CRT.asKey(certificateName), certAndKey.certAsBase64String()
+        );
+    }
+
     private static byte[] decodeFromSecret(Secret secret, String key) {
         if (secret.getData().get(key) != null && !secret.getData().get(key).isEmpty()) {
             return Util.decodeBytesFromBase64(secret.getData().get(key));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ClusterCa.java
@@ -107,7 +107,6 @@ public class ClusterCa extends Ca {
      * @param existingCertificates                  Existing certificates (or null if they do not exist yet)
      * @param nodes                                 Nodes that are part of the Cruise Control cluster
      * @param isMaintenanceTimeWindowsSatisfied     Flag indicating whether we can do maintenance tasks or not
-     * @param caCertGenerationChanged               Flag indicating whether the CA cert generation has changed since the existing certificates were issued
      *
      * @return Map with CertAndKey object containing the public and private key
      *
@@ -118,8 +117,7 @@ public class ClusterCa extends Ca {
             String clusterName,
             Map<String, CertAndKey> existingCertificates,
             Set<NodeRef> nodes,
-            boolean isMaintenanceTimeWindowsSatisfied,
-            boolean caCertGenerationChanged
+            boolean isMaintenanceTimeWindowsSatisfied
     ) throws IOException {
         DnsNameGenerator ccDnsGenerator = DnsNameGenerator.of(namespace, CruiseControlResources.serviceName(clusterName));
 
@@ -143,8 +141,8 @@ public class ClusterCa extends Ca {
             nodes,
             subjectFn,
             existingCertificates,
-            isMaintenanceTimeWindowsSatisfied,
-            caCertGenerationChanged);
+            isMaintenanceTimeWindowsSatisfied
+        );
     }
 
     /**
@@ -158,7 +156,6 @@ public class ClusterCa extends Ca {
      * @param externalBootstrapAddresses            List of external bootstrap addresses (used for certificate SANs)
      * @param externalAddresses                     Map with external listener addresses for the different nodes (used for certificate SANs)
      * @param isMaintenanceTimeWindowsSatisfied     Flag indicating whether we can do maintenance tasks or not
-     * @param caCertGenerationChanged               Flag indicating whether the CA cert generation has changed since the existing certificates were issued
      *
      * @return Map with CertAndKey objects containing the public and private keys for the different brokers
      *
@@ -171,8 +168,7 @@ public class ClusterCa extends Ca {
             Set<NodeRef> nodes,
             Set<String> externalBootstrapAddresses,
             Map<Integer, Set<String>> externalAddresses,
-            boolean isMaintenanceTimeWindowsSatisfied,
-            boolean caCertGenerationChanged
+            boolean isMaintenanceTimeWindowsSatisfied
     ) throws IOException {
         Function<NodeRef, Subject> subjectFn = node -> {
             Subject.Builder subject = new Subject.Builder()
@@ -219,8 +215,8 @@ public class ClusterCa extends Ca {
             nodes,
             subjectFn,
             existingCertificates,
-            isMaintenanceTimeWindowsSatisfied,
-            caCertGenerationChanged);
+            isMaintenanceTimeWindowsSatisfied
+        );
     }
 
     @Override
@@ -237,7 +233,6 @@ public class ClusterCa extends Ca {
      * @param subjectFn                             Function to generate certificate subject for given node / pod
      * @param existingCertificates                  Existing certificates (or null if they do not exist yet)
      * @param isMaintenanceTimeWindowsSatisfied     Flag indicating if we are inside a maintenance window or not
-     * @param caCertGenerationChanged               Flag indicating whether the CA cert generation has changed since the existing certificates were issued
      *
      * @return Returns map with node certificates which can be used to create or update the stored certificates
      *
@@ -248,8 +243,7 @@ public class ClusterCa extends Ca {
             Set<NodeRef> nodes,
             Function<NodeRef, Subject> subjectFn,
             Map<String, CertAndKey> existingCertificates,
-            boolean isMaintenanceTimeWindowsSatisfied,
-            boolean caCertGenerationChanged
+            boolean isMaintenanceTimeWindowsSatisfied
     ) throws IOException {
         // Maps for storing the certificates => will be used in the new or updated certificate store. This map is filled in this method and returned at the end.
         Map<String, CertAndKey> certs = new HashMap<>();
@@ -269,7 +263,6 @@ public class ClusterCa extends Ca {
 
             if (!this.certRenewed() // No CA renewal is happening
                     && certAndKey != null // There is a public cert and private key for this pod
-                    && !caCertGenerationChanged // The CA cert generation has not changed since the existing certificates were issued
             )   {
                 // A certificate for this node already exists, so we will try to reuse it
                 LOGGER.debugCr(reconciliation, "Certificate for node {} already exists", node);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -434,8 +434,10 @@ public class CruiseControl extends AbstractModel implements SupportsMetrics, Sup
         LOGGER.debugCr(reconciliation, "Generating certificates");
         try {
             Set<NodeRef> nodes = Set.of(new NodeRef(CruiseControl.COMPONENT_TYPE, 0, null, false, false));
-            ccCerts = clusterCa.generateCcCerts(namespace, clusterName, CertUtils.extractCertsAndKeysFromSecret(existingSecret, nodes),
-                    nodes, isMaintenanceTimeWindowsSatisfied, clusterCa.hasCaCertGenerationChanged(existingSecret));
+            ccCerts = clusterCa.generateCcCerts(namespace, clusterName,
+                    // Only pass existing certificates if the CA cert generation hasn't changed since they were generated
+                    clusterCa.hasCaCertGenerationChanged(existingSecret) ? Map.of() : CertUtils.extractCertsAndKeysFromSecret(existingSecret, nodes),
+                    nodes, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1268,6 +1268,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare Kafka certificates", e);
         }
+
         return updatedCerts.entrySet()
                 .stream()
                 .map(entry -> ModelUtils.createSecret(entry.getKey(), namespace, labels, ownerReference,

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1230,37 +1230,54 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     }
 
     /**
-     * Generates the private keys for the Kafka brokers (if needed) and the secret with them which contains both the
+     * Generates the private keys for the Kafka nodes (if needed) and the Secrets with them which contain both the
      * public and private keys.
      *
      * @param clusterCa                             The CA for cluster certificates
      * @param clientsCa                             The CA for clients certificates
-     * @param existingSecret                        The existing secret with Kafka certificates
+     * @param existingSecrets                       The existing secrets containing Kafka certificates
      * @param externalBootstrapDnsName              Map with bootstrap DNS names which should be added to the certificate
      * @param externalDnsNames                      Map with broker DNS names  which should be added to the certificate
      * @param isMaintenanceTimeWindowsSatisfied     Indicates whether we are in a maintenance window or not
      *
-     * @return  The generated Secret with broker certificates
+     * @return  The generated Secrets containing Kafka node certificates
      */
-    public Secret generateCertificatesSecret(ClusterCa clusterCa, ClientsCa clientsCa, Secret existingSecret, Set<String> externalBootstrapDnsName, Map<Integer, Set<String>> externalDnsNames, boolean isMaintenanceTimeWindowsSatisfied) {
+    public List<Secret> generateCertificatesSecrets(ClusterCa clusterCa, ClientsCa clientsCa, List<Secret> existingSecrets, Set<String> externalBootstrapDnsName, Map<Integer, Set<String>> externalDnsNames, boolean isMaintenanceTimeWindowsSatisfied) {
+        Map<String, Secret> existingSecretWithName = existingSecrets.stream().collect(Collectors.toMap(secret -> secret.getMetadata().getName(), secret -> secret));
         Set<NodeRef> nodes = nodes();
-        Map<String, CertAndKey> brokerCerts;
+        Map<String, CertAndKey> existingCerts = new HashMap<>();
+        for (NodeRef node : nodes) {
+            String podName = node.podName();
+            // Reuse existing certificate if it exists and the CA cert generation hasn't changed since they were generated
+            if (existingSecretWithName.get(podName) != null) {
+                if (clusterCa.hasCaCertGenerationChanged(existingSecretWithName.get(podName))) {
+                    LOGGER.debugCr(reconciliation, "Certificate for pod {}/{} has old cert generation", namespace, podName);
+                } else {
+                    existingCerts.put(podName, CertUtils.keyStoreCertAndKey(existingSecretWithName.get(podName), podName));
+                }
+            } else {
+                LOGGER.debugCr(reconciliation, "No existing certificate found for pod {}/{}", namespace, podName);
+            }
+        }
 
+        Map<String, CertAndKey> updatedCerts;
         try {
-            brokerCerts = clusterCa.generateBrokerCerts(namespace, cluster, CertUtils.extractCertsAndKeysFromSecret(existingSecret, nodes),
-                    nodes, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied, clusterCa.hasCaCertGenerationChanged(existingSecret));
+            updatedCerts = clusterCa.generateBrokerCerts(namespace, cluster, existingCerts,
+                    nodes, externalBootstrapDnsName, externalDnsNames, isMaintenanceTimeWindowsSatisfied);
         } catch (IOException e) {
             LOGGER.warnCr(reconciliation, "Error while generating certificates", e);
             throw new RuntimeException("Failed to prepare Kafka certificates", e);
         }
-
-        return ModelUtils.createSecret(KafkaResources.kafkaSecretName(cluster), namespace, labels, ownerReference,
-                CertUtils.buildSecretData(brokerCerts),
-                Map.ofEntries(
-                        clusterCa.caCertGenerationFullAnnotation(),
-                        clientsCa.caCertGenerationFullAnnotation()
-                ),
-                emptyMap());
+        return updatedCerts.entrySet()
+                .stream()
+                .map(entry -> ModelUtils.createSecret(entry.getKey(), namespace, labels, ownerReference,
+                        CertUtils.buildSecretData(entry.getKey(), entry.getValue()),
+                        Map.ofEntries(
+                                clusterCa.caCertGenerationFullAnnotation(),
+                                clientsCa.caCertGenerationFullAnnotation()
+                        ),
+                        emptyMap()))
+                .toList();
     }
 
     /**
@@ -1354,7 +1371,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
         volumeList.add(VolumeUtils.createTempDirVolume(templatePod));
         volumeList.add(VolumeUtils.createSecretVolume(CLUSTER_CA_CERTS_VOLUME, AbstractModel.clusterCaCertSecretName(cluster), isOpenShift));
-        volumeList.add(VolumeUtils.createSecretVolume(BROKER_CERTS_VOLUME, KafkaResources.kafkaSecretName(cluster), isOpenShift));
+        volumeList.add(VolumeUtils.createSecretVolume(BROKER_CERTS_VOLUME, node.podName(), isOpenShift));
         volumeList.add(VolumeUtils.createSecretVolume(CLIENT_CA_CERTS_VOLUME, KafkaResources.clientsCaCertificateSecretName(cluster), isOpenShift));
         volumeList.add(VolumeUtils.createConfigMapVolume(LOG_AND_METRICS_CONFIG_VOLUME_NAME, node.podName()));
         volumeList.add(VolumeUtils.createEmptyDirVolume("ready-files", "1Ki", "Memory"));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -108,7 +108,10 @@ import static java.util.Collections.singletonMap;
  */
 @SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling", "checkstyle:ClassFanOutComplexity"})
 public class KafkaCluster extends AbstractModel implements SupportsMetrics, SupportsLogging, SupportsJmx {
-    protected static final String COMPONENT_TYPE = "kafka";
+    /**
+     * Component type used by Kubernetes labels
+     */
+    public static final String COMPONENT_TYPE = "kafka";
 
     protected static final String ENV_VAR_KAFKA_INIT_EXTERNAL_ADDRESS = "EXTERNAL_ADDRESS";
     private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -742,7 +742,7 @@ public class KafkaReconciler {
      * @return      Completes when the Secrets were successfully created, deleted or updated
      */
     protected Future<Void> certificateSecrets(Clock clock) {
-        return secretOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels().withStrimziComponentType("kafka"))
+        return secretOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels().withStrimziComponentType(KafkaCluster.COMPONENT_TYPE))
                 .compose(existingSecrets -> {
                     List<Secret> desiredCertSecrets = kafka.generateCertificatesSecrets(clusterCa, clientsCa, existingSecrets,
                             listenerReconciliationResults.bootstrapDnsNames, listenerReconciliationResults.brokerDnsNames,

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ClusterCaRenewalTest.java
@@ -52,8 +52,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 null,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
@@ -88,43 +88,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
-
-        assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
-        assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
-        assertThat(new String(newCerts.get("pod0").keyStore()), is("new-keystore0"));
-        assertThat(newCerts.get("pod0").storePassword(), is("new-password0"));
-
-        assertThat(new String(newCerts.get("pod1").cert()), is("new-cert1"));
-        assertThat(new String(newCerts.get("pod1").key()), is("new-key1"));
-        assertThat(new String(newCerts.get("pod1").keyStore()), is("new-keystore1"));
-        assertThat(newCerts.get("pod1").storePassword(), is("new-password1"));
-
-        assertThat(new String(newCerts.get("pod2").cert()), is("new-cert2"));
-        assertThat(new String(newCerts.get("pod2").key()), is("new-key2"));
-        assertThat(new String(newCerts.get("pod2").keyStore()), is("new-keystore2"));
-        assertThat(newCerts.get("pod2").storePassword(), is("new-password2"));
-    }
-
-    @ParallelTest
-    public void renewalOfCertificatesWithForcedCaRenewal() throws IOException {
-        MockedClusterCa mockedCa = new MockedClusterCa(Reconciliation.DUMMY_RECONCILIATION, null, null, null, null, null, 2, 1, true, null);
-
-        Map<String, CertAndKey> initialCerts = new HashMap<>();
-        initialCerts.put("pod0", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod1", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-        initialCerts.put("pod2", new CertAndKey("old-key".getBytes(), "old-cert".getBytes()));
-
-        boolean isMaintenanceTimeWindowsSatisfied = true;
-
-        Map<String, CertAndKey> newCerts = mockedCa.maybeCopyOrGenerateCerts(
-                Reconciliation.DUMMY_RECONCILIATION,
-                NODES,
-                SUBJECT_FN,
-                initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                true);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
@@ -159,8 +124,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));
@@ -195,8 +160,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
@@ -224,8 +189,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
@@ -251,8 +216,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                true,
-                false);
+                true
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
@@ -276,8 +241,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                true,
-                false);
+                true
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
@@ -302,8 +267,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 SUBJECT_FN,
                 initialCerts,
-                true,
-                false);
+                true
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("old-cert"));
         assertThat(new String(newCerts.get("pod0").key()), is("old-key"));
@@ -329,8 +294,8 @@ public class ClusterCaRenewalTest {
                 Set.of(new NodeRef("pod1", 1, null, false, true)),
                 SUBJECT_FN,
                 initialCerts,
-                true,
-                false);
+                true
+        );
 
         assertThat(newCerts.get("pod0"), is(nullValue()));
 
@@ -357,8 +322,8 @@ public class ClusterCaRenewalTest {
                 NODES,
                 node -> new Subject.Builder().withCommonName(node.podName()).build(),
                 initialCerts,
-                isMaintenanceTimeWindowsSatisfied,
-                false);
+                isMaintenanceTimeWindowsSatisfied
+        );
 
         assertThat(new String(newCerts.get("pod0").cert()), is("new-cert0"));
         assertThat(new String(newCerts.get("pod0").key()), is("new-key0"));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -7,7 +7,6 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.strimzi.api.ResourceAnnotations;
@@ -1664,11 +1663,6 @@ public class CaReconcilerTest {
 
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
 
-        // Kafka brokers Secret with old annotation
-        Secret kafkaBrokersSecret = kafkaBrokersSecretWithAnnotations(Map.of(
-                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
                         Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
@@ -1686,8 +1680,7 @@ public class CaReconcilerTest {
 
         initTrustRolloutTestMocks(supplier,
                 List.of(clusterCaKeySecret, clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1),
-                        kafkaBrokersSecret),
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
                 controllerPods,
                 brokerPods);
 
@@ -1754,11 +1747,6 @@ public class CaReconcilerTest {
 
         List<Secret> clientsCaSecrets = initialClientsCaSecrets(certificateAuthority);
 
-        // Kafka brokers Secret with old annotation
-        Secret kafkaBrokersSecret = kafkaBrokersSecretWithAnnotations(Map.of(
-                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
                         Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
@@ -1776,8 +1764,7 @@ public class CaReconcilerTest {
 
         initTrustRolloutTestMocks(supplier,
                 List.of(clusterCaSecrets.get(0), clusterCaCertSecret,
-                        clientsCaSecrets.get(0), clientsCaSecrets.get(1),
-                        kafkaBrokersSecret),
+                        clientsCaSecrets.get(0), clientsCaSecrets.get(1)),
                 controllerPods,
                 brokerPods);
 
@@ -1985,11 +1972,6 @@ public class CaReconcilerTest {
                 .endMetadata()
                 .build();
 
-        // Kafka brokers Secret with old annotation
-        Secret kafkaBrokersSecret = kafkaBrokersSecretWithAnnotations(Map.of(
-                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
                         Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
@@ -2007,8 +1989,7 @@ public class CaReconcilerTest {
 
         initTrustRolloutTestMocks(supplier,
                 List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaKeySecret, clientsCaCertSecret,
-                        kafkaBrokersSecret),
+                        clientsCaKeySecret, clientsCaCertSecret),
                 controllerPods,
                 brokerPods);
 
@@ -2051,11 +2032,6 @@ public class CaReconcilerTest {
                 .endMetadata()
                 .build();
 
-        // Kafka brokers Secret with old annotation
-        Secret kafkaBrokersSecret = kafkaBrokersSecretWithAnnotations(Map.of(
-                Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
-                Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
-
         Map<String, String> generationAnnotations =
                 Map.of(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0",
                         Ca.ANNO_STRIMZI_IO_CLUSTER_CA_KEY_GENERATION, "0",
@@ -2073,8 +2049,7 @@ public class CaReconcilerTest {
 
         initTrustRolloutTestMocks(supplier,
                 List.of(clusterCaSecrets.get(0), clusterCaSecrets.get(1),
-                        clientsCaSecrets.get(0), clientsCaCertSecret,
-                        kafkaBrokersSecret),
+                        clientsCaSecrets.get(0), clientsCaCertSecret),
                 controllerPods,
                 brokerPods);
 
@@ -2192,15 +2167,6 @@ public class CaReconcilerTest {
         return new DeploymentBuilder()
                 .withNewMetadata()
                     .withName(name)
-                .endMetadata()
-                .build();
-    }
-
-    private static Secret kafkaBrokersSecretWithAnnotations(Map<String, String> annotations) {
-        return new SecretBuilder()
-                .withNewMetadata()
-                    .withName(KafkaResources.kafkaSecretName(NAME))
-                    .withAnnotations(annotations)
                 .endMetadata()
                 .build();
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorKRaftMockTest.java
@@ -228,9 +228,9 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
             assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
 
-            Secret brokersSecret = client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
-            assertThat(desiredPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(brokersSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
-            assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(brokersSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
+            Secret certSecret = client.secrets().inNamespace(namespace).withName(desiredPod.getMetadata().getName()).get();
+            assertThat(desiredPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(certSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
+            assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(certSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
 
             assertThat(client.configMaps().inNamespace(namespace).withName(desiredPod.getMetadata().getName()).get(), is(notNullValue()));
         });
@@ -246,9 +246,9 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLIENTS_CA_CERT_GENERATION, "0"));
             assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Ca.ANNO_STRIMZI_IO_CLUSTER_CA_CERT_GENERATION, "0"));
 
-            Secret brokersSecret = client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get();
-            assertThat(desiredPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(brokersSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
-            assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(brokersSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
+            Secret certSecret = client.secrets().inNamespace(namespace).withName(desiredPod.getMetadata().getName()).get();
+            assertThat(desiredPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(certSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
+            assertThat(actualPod.getMetadata().getAnnotations(), hasEntry(Annotations.ANNO_STRIMZI_SERVER_CERT_HASH, CertUtils.getCertificateThumbprint(certSecret, Ca.SecretEntry.CRT.asKey(desiredPod.getMetadata().getName()))));
 
             assertThat(client.configMaps().inNamespace(namespace).withName(desiredPod.getMetadata().getName()).get(), is(notNullValue()));
         });
@@ -301,7 +301,12 @@ public class KafkaAssemblyOperatorKRaftMockTest {
         List<String> secrets = List.of(KafkaResources.clientsCaKeySecretName(CLUSTER_NAME),
                 KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME),
                 KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME),
-                KafkaResources.kafkaSecretName(CLUSTER_NAME),
+                CLUSTER_NAME + "-controllers-0",
+                CLUSTER_NAME + "-controllers-1",
+                CLUSTER_NAME + "-controllers-2",
+                CLUSTER_NAME + "-brokers-10",
+                CLUSTER_NAME + "-brokers-11",
+                CLUSTER_NAME + "-brokers-12",
                 KafkaResources.clusterOperatorCertsSecretName(CLUSTER_NAME));
 
         Checkpoint async = context.checkpoint();
@@ -533,7 +538,9 @@ public class KafkaAssemblyOperatorKRaftMockTest {
 
         operator.reconcile(new Reconciliation("initial-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(12));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(6));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(nullValue()));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(nullValue()));
@@ -547,7 +554,9 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             })))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(16));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(8));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(notNullValue()));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(notNullValue()));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(8));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(notNullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(notNullValue()));
@@ -578,7 +587,9 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             })))
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(12));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(6));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(nullValue()));
+                assertThat(client.secrets().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-13").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-brokers-14").get(), is(nullValue()));
@@ -620,7 +631,7 @@ public class KafkaAssemblyOperatorKRaftMockTest {
 
         operator.reconcile(new Reconciliation("initial-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME))
             .onComplete(context.succeeding(v -> context.verify(() -> {
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(12));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(6));
 
                 KafkaNodePool newPool = new KafkaNodePoolBuilder()
@@ -645,7 +656,7 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Assert that the new pool is added
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(18));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(9));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(9));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-new-pool-13").get(), is(notNullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-new-pool-14").get(), is(notNullValue()));
@@ -681,7 +692,7 @@ public class KafkaAssemblyOperatorKRaftMockTest {
             .compose(v -> operator.reconcile(new Reconciliation("test-trigger2", Kafka.RESOURCE_KIND, namespace, CLUSTER_NAME)))
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 // Assert that the new pool is deleted
-                assertThat(client.secrets().inNamespace(namespace).withName(KafkaResources.kafkaSecretName(CLUSTER_NAME)).get().getData().size(), is(12));
+                assertThat(client.secrets().inNamespace(namespace).withLabels(Labels.fromMap(kafkaLabels).withStrimziComponentType("kafka").toMap()).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withLabels(kafkaLabels).list().getItems().size(), is(6));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-new-pool-13").get(), is(nullValue()));
                 assertThat(client.pods().inNamespace(namespace).withName(CLUSTER_NAME + "-new-pool-14").get(), is(nullValue()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -527,8 +527,10 @@ public class KafkaAssemblyOperatorTest {
                 KafkaResources.clientsCaCertificateSecretName(CLUSTER_NAME),
                 KafkaResources.clusterCaCertificateSecretName(CLUSTER_NAME),
                 KafkaResources.clusterCaKeySecretName(CLUSTER_NAME),
-                KafkaResources.kafkaSecretName(CLUSTER_NAME),
                 KafkaResources.clusterOperatorCertsSecretName(CLUSTER_NAME));
+
+        // Kafka node certificate Secrets
+        kafkaCluster.nodes().forEach(node -> expectedSecrets.add(node.podName()));
 
         if (metrics)    {
             expectedSecrets.add(KafkaExporterResources.secretName(CLUSTER_NAME));

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -39,7 +39,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 `<kafka_cluster_name>-kafka-<listener_name>-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `<kafka_cluster_name>-kafka-<listener_name>-<pod_id>`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `<kafka_cluster_name>-kafka-config`:: ConfigMap containing the Kafka ancillary configuration, which is mounted as a volume by the broker pods when the `UseStrimziPodSets` feature gate is disabled.
-`<kafka_cluster_name>-<pool_name>-<pod_id>_`:: Secret with Kafka pod public and private keys.
+`<kafka_cluster_name>-<pool_name>-<pod_id>_`:: Secret with Kafka node public and private keys.
 `<kafka_cluster_name>-network-policy-kafka`:: Network policy managing access to the Kafka services.
 `strimzi-_namespace-name_-<kafka_cluster_name>-kafka-init`:: Cluster role binding used by the Kafka brokers.
 `<kafka_cluster_name>-jmx`:: Secret with JMX username and password used to secure the Kafka broker port. This resource is created only when JMX is enabled in Kafka.

--- a/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
+++ b/documentation/modules/configuring/ref-list-of-kafka-cluster-resources.adoc
@@ -39,7 +39,7 @@ The following resources are created by the Cluster Operator in the Kubernetes cl
 `<kafka_cluster_name>-kafka-<listener_name>-bootstrap`:: Bootstrap route for clients connecting from outside the Kubernetes cluster. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `<kafka_cluster_name>-kafka-<listener_name>-<pod_id>`:: Route for traffic from outside the Kubernetes cluster to individual pods. This resource is created only when an external listener is enabled and set to type `route`. The new route name will be used for all other external listeners.
 `<kafka_cluster_name>-kafka-config`:: ConfigMap containing the Kafka ancillary configuration, which is mounted as a volume by the broker pods when the `UseStrimziPodSets` feature gate is disabled.
-`<kafka_cluster_name>-kafka-brokers`:: Secret with Kafka broker keys.
+`<kafka_cluster_name>-<pool_name>-<pod_id>_`:: Secret with Kafka pod public and private keys.
 `<kafka_cluster_name>-network-policy-kafka`:: Network policy managing access to the Kafka services.
 `strimzi-_namespace-name_-<kafka_cluster_name>-kafka-init`:: Cluster role binding used by the Kafka brokers.
 `<kafka_cluster_name>-jmx`:: Secret with JMX username and password used to secure the Kafka broker port. This resource is created only when JMX is enabled in Kafka.

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -97,8 +97,8 @@ Contains the public key of the clients CA. Kafka brokers use the public key to v
 
 Secrets for communication between Strimzi components contain a private key and a public key certificate signed by the cluster CA.
 
-`_<cluster_name>_-kafka-brokers`::
-Contains the private and public keys for Kafka brokers.
+`_<cluster_name>_-_<pool_name>_-_<pod_id>_`::
+Contains the private and public keys for a Kafka pod. Each pod has its own secret.
 `_<cluster_name>_-cluster-operator-certs`:: Contains the private and public keys for encrypting communication between the Cluster Operator and Kafka.
 `_<cluster_name>_-entity-topic-operator-certs`::
 Contains the private and public keys for encrypting communication between the Topic Operator and Kafka.
@@ -149,24 +149,24 @@ m¦ca.crt
 
 |===
 
-.Fields in the `_<cluster_name>_-kafka-brokers` secret
+.Fields in the `_<cluster_name>_-_<pool_name>_-_<node_id>_` secret
 [cols="40,60",options="header",stripes="none",separator=¦]
 |===
 
 ¦Field
 ¦Description
 
-m¦_<cluster_name>_-kafka-_<num>_.p12
+m¦_<cluster_name>_-kafka-_<pod_id>_.p12
 ¦PKCS #12 store for storing certificates and keys.
 
-m¦_<cluster_name>_-kafka-_<num>_.password
+m¦_<cluster_name>_-kafka-_<pod_id>_.password
 ¦Password for protecting the PKCS #12 store.
 
-m¦_<cluster_name>_-kafka-_<num>_.crt
-¦Certificate for a Kafka broker pod _<num>_. Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.
+m¦_<cluster_name>_-kafka-_<pod_id>_.crt
+¦Certificate for a Kafka pod _<num>_. Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.
 
-m¦_<cluster_name>_-kafka-_<num>_.key
-¦Private key for a Kafka broker pod `_<num>_`.
+m¦_<cluster_name>_-kafka-_<pod_id>_.key
+¦Private key for a Kafka pod `_<num>_`.
 
 |===
 

--- a/documentation/modules/security/ref-certificates-and-secrets.adoc
+++ b/documentation/modules/security/ref-certificates-and-secrets.adoc
@@ -98,7 +98,7 @@ Contains the public key of the clients CA. Kafka brokers use the public key to v
 Secrets for communication between Strimzi components contain a private key and a public key certificate signed by the cluster CA.
 
 `_<cluster_name>_-_<pool_name>_-_<pod_id>_`::
-Contains the private and public keys for a Kafka pod. Each pod has its own secret.
+Contains the private and public keys for a Kafka node. Each pod has its own secret.
 `_<cluster_name>_-cluster-operator-certs`:: Contains the private and public keys for encrypting communication between the Cluster Operator and Kafka.
 `_<cluster_name>_-entity-topic-operator-certs`::
 Contains the private and public keys for encrypting communication between the Topic Operator and Kafka.
@@ -155,12 +155,6 @@ m¦ca.crt
 
 ¦Field
 ¦Description
-
-m¦_<cluster_name>_-kafka-_<pod_id>_.p12
-¦PKCS #12 store for storing certificates and keys.
-
-m¦_<cluster_name>_-kafka-_<pod_id>_.password
-¦Password for protecting the PKCS #12 store.
 
 m¦_<cluster_name>_-kafka-_<pod_id>_.crt
 ¦Certificate for a Kafka pod _<num>_. Signed by a current or former cluster CA private key in `_<cluster_name>_-cluster-ca`.

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/listeners/ListenersST.java
@@ -2762,12 +2762,12 @@ public class ListenersST extends AbstractST {
                 .endSpec()
                 .build());
 
-        Map<String, String> secretData = kubeClient().getSecret(testStorage.getNamespaceName(), KafkaResources.brokersServiceName(testStorage.getClusterName())).getData();
         List<String> brokerPods = kubeClient().listPodNamesInSpecificNamespace(testStorage.getNamespaceName(), Labels.STRIMZI_KIND_LABEL, Kafka.RESOURCE_KIND)
             .stream().filter(podName -> podName.contains("kafka")).collect(Collectors.toList());
 
         int index = 0;
         for (String kafkaBroker : brokerPods) {
+            Map<String, String> secretData = kubeClient().getSecret(testStorage.getNamespaceName(), kafkaBroker).getData();
             String cert = secretData.get(kafkaBroker + ".crt");
 
             LOGGER.info("Encoding {}.crt", kafkaBroker);

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorage;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.KRaftMetadataStorage;
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/SecurityST.java
@@ -1280,7 +1280,7 @@ class SecurityST extends AbstractST {
         Date initialCertEndTime = cacert.getNotAfter();
 
         // Check Broker kafka certificate dates
-        Secret brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getClusterName() + "-kafka-brokers");
+        Secret brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), brokerPodName);
         X509Certificate kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret,
             brokerPodName + ".crt");
         Date initialKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
@@ -1308,7 +1308,7 @@ class SecurityST extends AbstractST {
         Date changedCertEndTime = cacert.getNotAfter();
 
         // Check renewed Broker kafka certificate dates
-        brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getClusterName() + "-kafka-brokers");
+        brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), brokerPodName);
         kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret, brokerPodName + ".crt");
         Date changedKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
         Date changedKafkaBrokerCertEndTime = kafkaBrokerCert.getNotAfter();

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/custom/CustomCaST.java
@@ -250,7 +250,7 @@ public class CustomCaST extends AbstractST {
         LOGGER.info("Check Kafka(s) certificates");
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
         final X509Certificate kafkaCert = SecretUtils.getCertificateFromSecret(kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(),
-            testStorage.getClusterName() + "-kafka-brokers"), brokerPodName + ".crt");
+                brokerPodName), brokerPodName + ".crt");
         assertThat("KafkaCert does not have expected test Issuer: " + kafkaCert.getIssuerDN(),
                 SystemTestCertManager.containsAllDN(kafkaCert.getIssuerX500Principal().getName(), clusterCa.getSubjectDn()));
 
@@ -304,7 +304,7 @@ public class CustomCaST extends AbstractST {
 
         // Check Broker kafka certificate dates
         String brokerPodName = kubeClient().listPods(testStorage.getNamespaceName(), testStorage.getBrokerSelector()).get(0).getMetadata().getName();
-        Secret brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getClusterName() + "-kafka-brokers");
+        Secret brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), brokerPodName);
         X509Certificate kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret, brokerPodName + ".crt");
         final Date initialKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
         final Date initialKafkaBrokerCertEndTime = kafkaBrokerCert.getNotAfter();
@@ -343,7 +343,7 @@ public class CustomCaST extends AbstractST {
         final Date changedCertEndTime = cacert.getNotAfter();
 
         // Check renewed Broker kafka certificate dates
-        brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), testStorage.getClusterName() + "-kafka-brokers");
+        brokerCertCreationSecret = kubeClient(testStorage.getNamespaceName()).getSecret(testStorage.getNamespaceName(), brokerPodName);
         kafkaBrokerCert = SecretUtils.getCertificateFromSecret(brokerCertCreationSecret, brokerPodName + ".crt");
         final Date changedKafkaBrokerCertStartTime = kafkaBrokerCert.getNotBefore();
         final Date changedKafkaBrokerCertEndTime = kafkaBrokerCert.getNotAfter();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Store Kafka node certificates in separate Secrets rather than in a single shared Secret.

This addresses issue #7687 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

