### PR TITLE
docs(oauth): updates example client config for truststore

### DIFF
--- a/documentation/modules/oauth/con-oauth-authentication-client.adoc
+++ b/documentation/modules/oauth/con-oauth-authentication-client.adoc
@@ -108,7 +108,7 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
 <4> URI of the authorization server token endpoint.
 <5> Client ID, which is the name used when creating the _client_ in the authorization server.
 <6> Client secret created when creating the _client_ in the authorization server.
-<7> The location contains the public key certificate (`truststore.p12`) for the authorization server.
+<7> The location of the public key certificate for the authorization server.
 <8> The password for accessing the truststore.
 <9> The truststore type.
 <10> (Optional) The `scope` for requesting the token from the token endpoint.

--- a/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
+++ b/documentation/modules/oauth/proc-oauth-authorization-keycloak-example.adoc
@@ -328,8 +328,6 @@ The Kafka image used in this example contains Kafka producer and consumer binari
 
 * ZooKeeper and Kafka are running in the Kubernetes cluster to be able to send and receive messages.
 * The xref:proc-oauth-authorization-keycloak-example-authentication_{context}[interactive CLI Kafka client session] is started.
-+
-{ApacheKafkaDownload}.
 
 .Setting up client and admin user configuration
 
@@ -348,7 +346,7 @@ sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
   oauth.client.id="team-a-client" \
   oauth.client.secret="team-a-client-secret" \
-  oauth.ssl.truststore.location="/tmp/truststore.p12" \
+  oauth.ssl.truststore.location="/tmp/oauth-truststore.p12" \
   oauth.ssl.truststore.password="$STOREPASS" \
   oauth.ssl.truststore.type="PKCS12" \
   oauth.token.endpoint.uri="https://$SSO_HOST/realms/kafka-authz/protocol/openid-connect/token" ;
@@ -373,7 +371,7 @@ sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
   oauth.client.id="team-b-client" \
   oauth.client.secret="team-b-client-secret" \
-  oauth.ssl.truststore.location="/tmp/truststore.p12" \
+  oauth.ssl.truststore.location="/tmp/oauth-truststore.p12" \
   oauth.ssl.truststore.password="$STOREPASS" \
   oauth.ssl.truststore.type="PKCS12" \
   oauth.token.endpoint.uri="https://$SSO_HOST/realms/kafka-authz/protocol/openid-connect/token" ;
@@ -408,7 +406,7 @@ sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
   oauth.refresh.token="$REFRESH_TOKEN" \
   oauth.client.id="kafka-cli" \
-  oauth.ssl.truststore.location="/tmp/truststore.p12" \
+  oauth.ssl.truststore.location="/tmp/oauth-truststore.p12" \
   oauth.ssl.truststore.password="$STOREPASS" \
   oauth.ssl.truststore.type="PKCS12" \
   oauth.token.endpoint.uri="https://$SSO_HOST/realms/kafka-authz/protocol/openid-connect/token" ;

--- a/documentation/shared/attributes.adoc
+++ b/documentation/shared/attributes.adoc
@@ -103,7 +103,6 @@
 :ApacheKafkaConsumerConfig: link:https://kafka.apache.org/documentation/#consumerconfigs[Apache Kafka configuration documentation for consumers^]
 :ApacheKafkaProducerConfig: link:https://kafka.apache.org/documentation/#producerconfigs[Apache Kafka configuration documentation for producers^]
 :ApacheKafkaFileSystem: link:https://kafka.apache.org/documentation/#filesystems[Filesystem Selection^]
-:ApacheKafkaDownload: link:http://kafka.apache.org/[Apache Kafka download^]
 :ApacheLoggers: link:https://logging.apache.org/[Apache logging services^]
 :CruiseControlProject: https://github.com/linkedin/cruise-control[Cruise Control^]
 :CruiseControlConfigDocs: link:https://github.com/linkedin/cruise-control/wiki/Configurations[Cruise Control documentation^]


### PR DESCRIPTION
Documentation

Updates the keycloak example
Changes the truststore config for the authorization server in the example clients
The examples were using the same filename as the truststore config for the cluster

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

