### PR TITLE
docs(KafkaNodePool): clean up feature gate description

### DIFF
--- a/documentation/modules/configuring/con-config-node-pools.adoc
+++ b/documentation/modules/configuring/con-config-node-pools.adoc
@@ -7,9 +7,11 @@
 
 [role="_abstract"]
 Update the `spec` properties of the `KafkaNodePool` custom resource to configure a node pool deployment.
+A node pool is a distinct group of Kafka nodes within a Kafka cluster.
+The `strimzi.io/cluster` metadata label identifies the name of the Kafka custom resource the pool belongs to.
 
-A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
-Each pool has its own unique configuration, which includes mandatory settings for the number of replicas, roles, and storage allocation.
+Each pool has its own unique configuration, including mandatory settings for the number of replicas, roles, and storage allocation.
+The `.spec.roles` property defines whether the nodes in the pool act as controllers, brokers, or both.
 
 Optionally, you can also specify values for the following properties:
 

--- a/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
+++ b/documentation/modules/operators/ref-operator-cluster-feature-gates.adoc
@@ -62,20 +62,13 @@ Before upgrading from Strimzi 0.38.0 or older to 0.46.0 or newer, make sure the 
 [id='ref-operator-kafka-node-pools-feature-gate-{context}']
 === KafkaNodePools feature gate
 
-The `KafkaNodePools` feature gate introduced a new `KafkaNodePool` custom resource that enables the configuration of different _pools_ of Apache Kafka nodes.
+The `KafkaNodePools` feature gate introduced the `KafkaNodePool` custom resource, enabling the configuration of distinct _pools_ of Apache Kafka nodes within a Kafka cluster. 
+Each pool can have its own unique configuration, as described in xref:config-node-pools-str[].
 
-A node pool refers to a distinct group of Kafka nodes within a Kafka cluster.
-Each pool has its own unique configuration, which includes mandatory settings such as the number of replicas, storage configuration, and a list of assigned roles.
-You can assign the _controller_ role, _broker_ role, or both roles to all nodes in the pool using the `.spec.roles` property.
-When used with a ZooKeeper-based Apache Kafka cluster, it must be set to the `broker` role.
-When used with a KRaft-based Apache Kafka cluster, it can be set to `broker`, `controller`, or both.
+To use node pools, ensure the following configuration is present:
 
-In addition, a node pool can have its own configuration of resource requests and limits, Java JVM options, and resource templates.
-Configuration options not set in the `KafkaNodePool` resource are inherited from the `Kafka` custom resource.
-
-The `KafkaNodePool` resources use a `strimzi.io/cluster` label to indicate to which Kafka cluster they belong.
-The label must be set to the name of the `Kafka` custom resource.
-The `Kafka` resource configuration must also include the `strimzi.io/node-pools: enabled` annotation, which is required when using node pools.
+* The `strimzi.io/node-pools: enabled` annotation in the `Kafka` resource.
+* The `strimzi.io/cluster: <cluster_name>` label in each `KafkaNodePool` resource to associate it with the `Kafka` resource.
 
 Examples of the `KafkaNodePool` resources can be found in the xref:config-examples-{context}[example configuration files] provided by Strimzi.
 


### PR DESCRIPTION
Documentation

Cleans up the feature gate description for KafkaNodePools
Now it's mature, the details removed are covered elsewhere

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

