### PR TITLE
[system test] Remove un-necessary vertx Description annotation from t…

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -42,7 +42,6 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.StrimziPodSetUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PersistentVolumeClaimUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.test.TestUtils;
-import io.vertx.core.cli.annotations.Description;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -179,8 +178,11 @@ class AlternativeReconcileTriggersST extends AbstractST {
     }
 
     // This test is affected by https://github.com/strimzi/strimzi-kafka-operator/issues/3913 so it needs longer operation timeout set in CO
-    @Description("Test for checking that overriding of bootstrap server, triggers the rolling update and verifying that" +
-            " new bootstrap DNS is appended inside certificate in subject alternative names property.")
+
+    /**
+     * Test for checking that overriding of bootstrap server, triggers the rolling update and verifying that,
+     * new bootstrap DNS is appended inside certificate in subject alternative names property.
+     */
     @ParallelNamespaceTest
     @Tag(ROLLING_UPDATE)
     void testTriggerRollingUpdateAfterOverrideBootstrap() throws CertificateException {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthAuthorizationST.java
@@ -36,7 +36,6 @@ import io.strimzi.systemtest.utils.kubeUtils.objects.PodUtils;
 import io.strimzi.systemtest.utils.kubeUtils.objects.SecretUtils;
 import io.strimzi.systemtest.utils.specific.KeycloakUtils;
 import io.strimzi.test.WaitException;
-import io.vertx.core.cli.annotations.Description;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
@@ -86,7 +85,9 @@ public class OauthAuthorizationST extends OauthAbstractST {
 
     private static final String TEST_REALM = "kafka-authz";
 
-    @Description("As a member of team A, I should be able to read and write to all topics starting with a-")
+    /**
+     * As a member of team A, I should be able to read and write to all topics starting with a-.
+     */
     @ParallelTest
     @Order(1)
     void smokeTestForClients() {
@@ -117,8 +118,10 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAConsumerName, testStorage.getMessageCount());
     }
 
-    @Description("As a member of team A, I should be able to write to topics that starts with x- on any cluster and " +
-            "and should also write and read to topics starting with 'a-'")
+    /**
+     * As a member of team A, I should be able to write to topics that starts with x- on any cluster and " +
+     * and should also write and read to topics starting with 'a-'.
+     */
     @ParallelTest
     @Order(2)
     void testTeamAWriteToTopic() {
@@ -181,7 +184,9 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
     }
 
-    @Description("As a member of team A, I should be able only read from consumer that starts with a_")
+    /**
+     * As a member of team A, I should be able only read from consumer that starts with a_.
+     */
     @ParallelTest
     @Order(3)
     void testTeamAReadFromTopic() {
@@ -232,7 +237,9 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamAProducerName, testStorage.getMessageCount());
     }
 
-    @Description("As a member of team B, I should be able to write and read from topics that starts with b-")
+    /**
+     * As a member of team B, I should be able to write and read from topics that starts with b-.
+     */
     @ParallelTest
     @Order(4)
     void testTeamBWriteToTopic() {
@@ -276,8 +283,10 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientsSuccess(Environment.TEST_SUITE_NAMESPACE, teamBConsumerName, teamBProducerName, testStorage.getMessageCount());
     }
 
-    @Description("As a member of team A, I can write to topics starting with 'x-' and " +
-            "as a member of team B can read from topics starting with 'x-'")
+    /**
+     * As a member of team A, I can write to topics starting with 'x-' and " +
+     *             "as a member of team B can read from topics starting with 'x-'.
+     */
     @ParallelTest
     @Order(5)
     void testTeamAWriteToTopicStartingWithXAndTeamBReadFromTopicStartingWithX() {
@@ -330,7 +339,9 @@ public class OauthAuthorizationST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, teamBConsumerName, testStorage.getMessageCount());
     }
 
-    @Description("As a superuser of team A and team B, i am able to break defined authorization rules")
+    /**
+     * As a superuser of team A and team B, i am able to break defined authorization rules.
+     */
     @ParallelTest
     @Order(6)
     void testSuperUserWithOauthAuthorization() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthPlainST.java
@@ -55,7 +55,6 @@ import io.strimzi.systemtest.utils.specific.MetricsUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.WaitException;
 import io.strimzi.test.k8s.KubeClusterResource;
-import io.vertx.core.cli.annotations.Description;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -109,9 +108,10 @@ public class OauthPlainST extends OauthAbstractST {
 
     private MetricsCollector metricsCollector;
 
-    @Description(
-            "As an OAuth producer, I should be able to produce messages to the Kafka Broker\n" +
-            "As an OAuth consumer, I should be able to consumer messages from the Kafka Broker.")
+    /**
+     * As an OAuth producer, I should be able to produce messages to the Kafka Broker,
+     * As an OAuth consumer, I should be able to consumer messages from the Kafka Broker."
+     */
     @ParallelTest
     @Tag(METRICS)
     void testProducerConsumerWithOauthMetrics() {
@@ -289,7 +289,9 @@ public class OauthPlainST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
     }
 
-    @Description("As an OAuth KafkaConnect, I should be able to sink messages from kafka Broker Topic.")
+    /**
+     * As an OAuth KafkaConnect, I should be able to sink messages from kafka Broker Topic.
+     */
     @ParallelTest
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
@@ -531,7 +533,9 @@ public class OauthPlainST extends OauthAbstractST {
         );
     }
 
-    @Description("As a OAuth bridge, I should be able to send messages to bridge endpoint.")
+    /**
+     * As a OAuth bridge, I should be able to send messages to bridge endpoint.
+     */
     @ParallelTest
     @Tag(BRIDGE)
     @Tag(METRICS)

--- a/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/security/oauth/OauthTlsST.java
@@ -46,7 +46,6 @@ import io.strimzi.systemtest.utils.kubeUtils.controllers.JobUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.WaitException;
 import io.strimzi.test.k8s.KubeClusterResource;
-import io.vertx.core.cli.annotations.Description;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,9 +74,10 @@ public class OauthTlsST extends OauthAbstractST {
 
     private final String oauthClusterName = "oauth-cluster-tls-name";
 
-    @Description(
-            "As an OAuth producer, I am able to produce messages to the Kafka Broker\n" +
-            "As an OAuth consumer, I am able to consumer messages from the Kafka Broker using encrypted communication")
+    /**
+     * As an OAuth producer, I am able to produce messages to the Kafka Brokers,
+     * As an OAuth consumer, I am able to consumer messages from the Kafka Broker using encrypted communication
+     */
     @ParallelTest
     void testProducerConsumer() {
         final TestStorage testStorage = new TestStorage(ResourceManager.getTestContext());
@@ -105,7 +105,9 @@ public class OauthTlsST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, consumerName, testStorage.getMessageCount());
     }
 
-    @Description("As an OAuth KafkaConnect, I am able to sink messages from Kafka Broker topic using encrypted communication.")
+    /**
+     * As an OAuth KafkaConnect, I am able to sink messages from Kafka Broker topic using encrypted communication.
+     */
     @ParallelTest
     @Tag(CONNECT)
     @Tag(CONNECT_COMPONENTS)
@@ -180,7 +182,9 @@ public class OauthTlsST extends OauthAbstractST {
         KafkaConnectUtils.waitForMessagesInKafkaConnectFileSink(Environment.TEST_SUITE_NAMESPACE, kafkaConnectPodName, TestConstants.DEFAULT_SINK_FILE_PATH, testStorage.getMessageCount());
     }
 
-    @Description("As a OAuth bridge, i am able to send messages to bridge endpoint using encrypted communication")
+    /**
+     * As a OAuth bridge, i am able to send messages to bridge endpoint using encrypted communication
+     */
     @ParallelTest
     @Tag(BRIDGE)
     @Tag(ACCEPTANCE)
@@ -251,7 +255,9 @@ public class OauthTlsST extends OauthAbstractST {
         ClientUtils.waitForClientSuccess(Environment.TEST_SUITE_NAMESPACE, producerName, testStorage.getMessageCount());
     }
 
-    @Description("As a OAuth MirrorMaker 2, I am able to replicate Topic data using using encrypted communication")
+    /**
+     * As a OAuth MirrorMaker 2, I am able to replicate Topic data using encrypted communication
+     */
     @IsolatedTest("Using more tha one Kafka cluster in one Namespace")
     @Tag(MIRROR_MAKER2)
     @Tag(NODEPORT_SUPPORTED)


### PR DESCRIPTION
…ests

### Type of change

- Bugfix
- Documentation

### Description

This PR removes dependency from `io.vertx.core.cli.annotations.Description;` and adds a normal javadoc to the tests. Solves [1].

[1] - https://github.com/strimzi/strimzi-kafka-operator/issues/10971

### Checklist

- [x] Make sure all tests pass