### PR TITLE
bump tiered storage plugin version

### DIFF
--- a/systemtest/src/test/resources/tiered-storage/Dockerfile
+++ b/systemtest/src/test/resources/tiered-storage/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-ARG AIVEN_PLUGIN_VERSION="2024-04-02-1712056402"
+ARG AIVEN_PLUGIN_VERSION="2024-10-23-1729694047"
 ARG TIERED_STORAGE_URL="https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/download/"
 
 USER root:root


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Bump the Aiven's tiered storage plugin version to the latest one.
Ref: https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [V] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

