### PR TITLE
Clean some ZooKeeper leftovers from `operator-common` module

### DIFF
--- a/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/Annotations.java
@@ -25,7 +25,7 @@ import static java.lang.Integer.parseInt;
 public class Annotations extends ResourceAnnotations {
 
     /**
-     * Annotation for keeping Kafka and ZooKeeper servers' certificate thumbprints.
+     * Annotation for keeping Kafka servers' certificate thumbprints.
      */
     public static final String ANNO_STRIMZI_SERVER_CERT_HASH = STRIMZI_DOMAIN + "server-cert-hash";
 

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Ca.java
@@ -1057,13 +1057,13 @@ public abstract class Ca {
 
     /**
      * @return the name of the annotation bringing the generation of the specific CA certificate type (cluster or clients)
-     *         on the Secrets containing certificates signed by that CA (i.e. ZooKeeper nodes, Kafka brokers, ...)
+     *         on the Secrets containing certificates signed by that CA (i.e. Kafka brokers, ...)
      */
     protected abstract String caCertGenerationAnnotation();
 
     /**
      * It checks if the current (cluster or clients) CA certificate generation is changed compared to the one
-     * brought by the corresponding annotation on the provided Secret (i.e. ZooKeeper nodes, Kafka brokers, ...)
+     * brought by the corresponding annotation on the provided Secret (i.e. Kafka brokers, ...)
      *
      * @param secret Secret containing certificates signed by the current (clients or cluster) CA
      * @return if the current (cluster or clients) CA certificate generation is changed compared to the one

--- a/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/model/Labels.java
@@ -481,7 +481,7 @@ public class Labels extends ResourceLabels {
      * @param resource              Kubernetes resource with metadata. It is used to get the resource name as well as copy
      *                              its labels. This is typically a custom resource which owns the whole deployment.
      * @param strimziComponentName  Name of the component used for the strimzi.io/name label
-     * @param strimziComponentType  Type of the component (e.g. kafka, zookeeper, etc.) used for the strimzi.io/component-type label
+     * @param strimziComponentType  Type of the component (e.g. kafka, etc.) used for the strimzi.io/component-type label
      * @param managedBy             Name of the component managing this resource (e.g. strimzi-cluster-operator)
      *
      * @return  The default set of labels used for the Kubernetes resources

--- a/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/model/LabelsTest.java
@@ -14,6 +14,8 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -153,21 +155,14 @@ public class LabelsTest {
     @Test
     public void testFromResourceWithoutLabels()   {
         Kafka kafka = new KafkaBuilder()
-                    .withNewMetadata()
-                        .withName("my-kafka")
-                    .endMetadata()
-                    .withNewSpec()
-                        .withNewZookeeper()
-                            .withReplicas(3)
-                            .withNewEphemeralStorage()
-                            .endEphemeralStorage()
-                        .endZookeeper()
-                        .withNewKafka()
-                            .withReplicas(3)
-                            .withNewEphemeralStorage()
-                            .endEphemeralStorage()
-                        .endKafka()
-                    .endSpec()
+                .withNewMetadata()
+                    .withName("my-kafka")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
+                        .withListeners(new GenericKafkaListenerBuilder().withName("tls").withPort(9093).withType(KafkaListenerType.INTERNAL).withTls(true).build())
+                    .endKafka()
+                .endSpec()
                 .build();
 
         Labels l = Labels.fromResource(kafka);
@@ -190,15 +185,8 @@ public class LabelsTest {
                     .withLabels(userProvidedLabels)
                 .endMetadata()
                 .withNewSpec()
-                    .withNewZookeeper()
-                        .withReplicas(3)
-                        .withNewEphemeralStorage()
-                        .endEphemeralStorage()
-                    .endZookeeper()
                     .withNewKafka()
-                        .withReplicas(3)
-                        .withNewEphemeralStorage()
-                        .endEphemeralStorage()
+                        .withListeners(new GenericKafkaListenerBuilder().withName("tls").withPort(9093).withType(KafkaListenerType.INTERNAL).withTls(true).build())
                     .endKafka()
                 .endSpec()
                 .build();

--- a/operator-common/src/test/resources/example.yaml
+++ b/operator-common/src/test/resources/example.yaml
@@ -3,7 +3,7 @@ kind: Kafka
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kafka.strimzi.io/v1beta2","kind":"Kafka","metadata":{"annotations":{},"name":"my-cluster","namespace":"myproject"},"spec":{"kafka":{"config":{"log.message.format.version":"2.1","offsets.topic.replication.factor":3,"transaction.state.log.min.isr":2,"transaction.state.log.replication.factor":3},"foo":"bar","listeners":{"plain":{},"tls":{}},"replicas":3,"storage":{"type":"ephemeral"},"version":"2.1.0"},"topicOperator":{},"zookeeper":{"replicas":3,"storage":{"type":"ephemeral"}}}}
+      {"apiVersion":"kafka.strimzi.io/v1beta2","kind":"Kafka","metadata":{"annotations":{},"name":"my-cluster","namespace":"myproject"},"spec":{"kafka":{"config":{"log.message.format.version":"2.1","offsets.topic.replication.factor":3,"transaction.state.log.min.isr":2,"transaction.state.log.replication.factor":3},"foo":"bar","listeners":{"plain":{},"tls":{}},"replicas":3,"storage":{"type":"ephemeral"},"version":"2.1.0"},"topicOperator":{}}}
   creationTimestamp: 2019-01-31T09:45:40Z
   generation: 1
   name: my-cluster
@@ -32,19 +32,12 @@ spec:
         authentication:
           type: oauth
           enableECDSA: true
-    replicas: 3
-    storage:
-      type: ephemeral
     version: 2.8.0
     template:
       pod:
         securityContext:
           supplementalGroups:
             - 971001234
-  zookeeper:
-    replicas: 3
-    storage:
-      type: ephemeral
   kafkaExporter:
     template:
       service:

--- a/operator-common/src/test/resources/example2.yaml
+++ b/operator-common/src/test/resources/example2.yaml
@@ -3,7 +3,7 @@ kind: Kafka
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kafka.strimzi.io/v1beta2","kind":"Kafka","metadata":{"annotations":{},"name":"my-cluster","namespace":"myproject"},"spec":{"kafka":{"config":{"log.message.format.version":"2.1","offsets.topic.replication.factor":3,"transaction.state.log.min.isr":2,"transaction.state.log.replication.factor":3},"foo":"bar","listeners":{"plain":{},"tls":{}},"replicas":3,"storage":{"type":"ephemeral"},"version":"2.1.0"},"topicOperator":{},"zookeeper":{"replicas":3,"storage":{"type":"ephemeral"}}}}
+      {"apiVersion":"kafka.strimzi.io/v1beta2","kind":"Kafka","metadata":{"annotations":{},"name":"my-cluster","namespace":"myproject"},"spec":{"kafka":{"config":{"log.message.format.version":"2.1","offsets.topic.replication.factor":3,"transaction.state.log.min.isr":2,"transaction.state.log.replication.factor":3},"foo":"bar","listeners":{"plain":{},"tls":{}},"replicas":3,"storage":{"type":"ephemeral"},"version":"2.1.0"},"topicOperator":{}}}
   creationTimestamp: 2019-01-31T09:45:40Z
   generation: 1
   name: my-cluster
@@ -28,9 +28,6 @@ spec:
         port: 9093
         type: internal
         tls: true
-    replicas: 3
-    storage:
-      type: ephemeral
     version: 2.8.0
     template:
       bootstrapService:
@@ -39,7 +36,3 @@ spec:
           - IPv6
     tlsSidecar: {}
   topicOperator: {}
-  zookeeper:
-    replicas: 3
-    storage:
-      type: ephemeral


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR cleans up some ZooKeeper leftovers from the `operator-common` module. Mainly some tests using Kafka CRs with ZooKeeper and some comments.

### Checklist

- [x] Make sure all tests pass