### PR TITLE
Remove deprecated EO Secret methods

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
@@ -261,22 +261,6 @@ public class KafkaResources {
         return clusterName + "-entity-operator";
     }
 
-    /**
-     * Returns the name of the Entity Operator {@code Secret} for a {@code Kafka} cluster of the given name.
-     * This {@code Secret} will only exist if {@code Kafka.spec.entityOperator} is configured in the
-     * {@code Kafka} resource with the given name.
-     * 
-     * This secret is not used anymore and is deprecated. This method will be removed in the future.
-     *
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     *
-     * @return The name of the corresponding Entity Operator {@code Secret}.
-     */
-    @Deprecated
-    public static String entityOperatorSecretName(String clusterName) {
-        return entityOperatorDeploymentName(clusterName) + "-certs";
-    }
-
     ////////
     // Entity Topic Operator methods
     ////////

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -116,7 +116,6 @@ public class EntityOperatorReconciler {
                 .compose(i -> topicOperatorConfigMap())
                 .compose(i -> userOperatorConfigMap())
                 .compose(i -> topicOperatorCruiseControlApiSecret())
-                .compose(i -> deleteOldEntityOperatorSecret())
                 .compose(i -> topicOperatorSecret(clock))
                 .compose(i -> userOperatorSecret(clock))
                 .compose(i -> deployment(isOpenShift, imagePullPolicy, imagePullSecrets))
@@ -340,19 +339,6 @@ public class EntityOperatorReconciler {
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorLoggingConfigMapName(reconciliation.name()), null)
                     .map((Void) null);
         }
-    }
-
-    /**
-     * Deletes the Entity Operator secret. This Secret was used in the past when both Topic and User operators were
-     * using the same user account. It is not used anymore, but we delete it if it exists from previous version.
-     *
-     * @return  Future which completes when the reconciliation is done
-     */
-    @SuppressWarnings("deprecation")
-    protected Future<Void> deleteOldEntityOperatorSecret() {
-        return secretOperator
-                .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorSecretName(reconciliation.name()), null)
-                .map((Void) null);
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconcilerTest.java
@@ -55,7 +55,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("deprecation") // Because of deprecated KafkaResources.entityOperatorSecretName
 @ExtendWith(VertxExtension.class)
 public class EntityOperatorReconcilerTest {
     private static final String NAMESPACE = "namespace";
@@ -103,8 +102,6 @@ public class EntityOperatorReconcilerTest {
 
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -156,8 +153,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(notNullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(toSecretCaptor.getAllValues().size(), is(1));
                     assertThat(toSecretCaptor.getAllValues().get(0), is(notNullValue()));
                     assertThat(uoSecretCaptor.getAllValues().size(), is(1));
@@ -208,8 +203,6 @@ public class EntityOperatorReconcilerTest {
 
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -269,8 +262,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(notNullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(toSecretCaptor.getAllValues().size(), is(1));
                     assertThat(toSecretCaptor.getAllValues().get(0), is(notNullValue()));
                     assertThat(uoSecretCaptor.getAllValues().size(), is(1));
@@ -325,8 +316,6 @@ public class EntityOperatorReconcilerTest {
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         if (cruiseControlEnabled) {
@@ -383,8 +372,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(notNullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     if (cruiseControlEnabled) {
                         assertThat(toSecretCaptor.getAllValues().size(), is(2));
                         assertThat(toSecretCaptor.getAllValues().get(0), is(notNullValue()));
@@ -437,8 +424,6 @@ public class EntityOperatorReconcilerTest {
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
         when(mockSecretOps.getAsync(eq(NAMESPACE), eq(KafkaResources.entityUserOperatorSecretName(NAME)))).thenReturn(Future.succeededFuture());
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -488,8 +473,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(notNullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(toSecretCaptor.getAllValues().size(), is(1));
                     assertThat(toSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(uoSecretCaptor.getAllValues().size(), is(1));
@@ -535,8 +518,6 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -584,8 +565,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(nullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(toSecretCaptor.getAllValues().size(), is(1));
                     assertThat(toSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(uoSecretCaptor.getAllValues().size(), is(1));
@@ -628,8 +607,6 @@ public class EntityOperatorReconcilerTest {
         ArgumentCaptor<ServiceAccount> saCaptor = ArgumentCaptor.forClass(ServiceAccount.class);
         when(mockSaOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorDeploymentName(NAME)), saCaptor.capture())).thenReturn(Future.succeededFuture());
 
-        ArgumentCaptor<Secret> operatorSecretCaptor = ArgumentCaptor.forClass(Secret.class);
-        when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityOperatorSecretName(NAME)), operatorSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> toSecretCaptor = ArgumentCaptor.forClass(Secret.class);
         when(mockSecretOps.reconcile(any(), eq(NAMESPACE), eq(KafkaResources.entityTopicOperatorSecretName(NAME)), toSecretCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<Secret> uoSecretCaptor = ArgumentCaptor.forClass(Secret.class);
@@ -670,8 +647,6 @@ public class EntityOperatorReconcilerTest {
                     assertThat(saCaptor.getAllValues().size(), is(1));
                     assertThat(saCaptor.getValue(), is(nullValue()));
 
-                    assertThat(operatorSecretCaptor.getAllValues().size(), is(1));
-                    assertThat(operatorSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(toSecretCaptor.getAllValues().size(), is(1));
                     assertThat(toSecretCaptor.getAllValues().get(0), is(nullValue()));
                     assertThat(uoSecretCaptor.getAllValues().size(), is(1));


### PR DESCRIPTION
### Type of change

- Task

### Description

In Strimzi 0.29 / #6606 we stopped using a shared EO secret and started using separate secrets for TO and UO. SInce then, we were deleting the old secret in case of upgrades. This does not seem necessary anymore, as nobody will be able to upgrade from Strimzi 0.28 and older to Strimzi 0.46. So this PR removes the related methods.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally