### PR TITLE
Consolidate methods updating `Kafka` CR status in `KafkaReconciler`

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -274,9 +274,7 @@ public class KafkaReconciler {
                 .compose(i -> sharedKafkaConfigurationCleanup())
                 // This has to run after all possible rolling updates which might move the pods to different nodes
                 .compose(i -> nodePortExternalListenerStatus())
-                .compose(i -> addListenersToKafkaStatus(kafkaStatus))
-                .compose(i -> updateKafkaVersion(kafkaStatus))
-                .compose(i -> updateKafkaMetadataState(kafkaStatus));
+                .compose(i -> updateKafkaStatus(kafkaStatus));
     }
 
     private Future<Void> updateKafkaAutoRebalanceStatus(KafkaStatus kafkaStatus) {
@@ -1129,21 +1127,20 @@ public class KafkaReconciler {
         }
     }
 
-    // Adds prepared Listener Statuses to the Kafka Status instance
-    protected Future<Void> addListenersToKafkaStatus(KafkaStatus kafkaStatus) {
+    /**
+     * Updates various fields in the Kafka CR .status section such as listener information, Kafka version, metadata
+     * state etc. This includes the parts of the status that do not need to be updated at a specific point in the
+     * reconciliation.
+     *
+     * @param kafkaStatus   Kafka status where the values should be set
+     *
+     * @return  Future that completes once the status is updated
+     */
+    /* test */ Future<Void> updateKafkaStatus(KafkaStatus kafkaStatus) {
         kafkaStatus.setListeners(listenerReconciliationResults.listenerStatuses);
-        return Future.succeededFuture();
-    }
-
-    // Adds Kafka version to the Kafka Status instance
-    /* test */ Future<Void> updateKafkaVersion(KafkaStatus kafkaStatus) {
         kafkaStatus.setKafkaVersion(kafka.getKafkaVersion().version());
-        return Future.succeededFuture();
-    }
-
-    // Updates the KRaft migration state into the Kafka Status instance
-    /* test */ Future<Void> updateKafkaMetadataState(KafkaStatus kafkaStatus) {
         kafkaStatus.setKafkaMetadataState(KafkaMetadataState.KRaft);
+
         return Future.succeededFuture();
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconcilerStatusTest.java
@@ -11,6 +11,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaMetadataState;
 import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.kafka.KafkaStatus;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
@@ -173,6 +174,9 @@ public class KafkaReconcilerStatusTest {
 
             // Check kafka version
             assertThat(status.getKafkaVersion(), is(VERSIONS.defaultVersion().version()));
+
+            // Check Kafka metadata state
+            assertThat(status.getKafkaMetadataState(), is(KafkaMetadataState.KRaft));
 
             // Check model warning conditions
             assertThat(status.getConditions().size(), is(2));
@@ -970,8 +974,7 @@ public class KafkaReconcilerStatusTest {
                     .compose(i -> listeners())
                     .compose(i -> clusterId(kafkaStatus))
                     .compose(i -> nodePortExternalListenerStatus())
-                    .compose(i -> addListenersToKafkaStatus(kafkaStatus))
-                    .compose(i -> updateKafkaVersion(kafkaStatus))
+                    .compose(i -> updateKafkaStatus(kafkaStatus))
                     .recover(error -> {
                         LOGGER.errorCr(reconciliation, "Reconciliation failed", error);
                         return Future.failedFuture(error);
@@ -1016,7 +1019,7 @@ public class KafkaReconcilerStatusTest {
         public Future<Void> reconcile(KafkaStatus kafkaStatus, Clock clock)    {
             return modelWarnings(kafkaStatus)
                     .compose(i -> Future.failedFuture("Reconciliation step failed"))
-                    .compose(i -> updateKafkaVersion(kafkaStatus))
+                    .compose(i -> updateKafkaStatus(kafkaStatus))
                     .recover(error -> {
                         LOGGER.errorCr(reconciliation, "Reconciliation failed", error);
                         return Future.failedFuture(error);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The `KafkaReconciler` currently has 3 different methods that are all called at the end of the reconciliation chain and just set some field in the `Kafka` CR status. This PR consolidates them into a single method. It also adds check that the metadata state is set in the status to the unit tests.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally