### PR TITLE
Fixed check Optional not null

### DIFF
--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -535,7 +535,7 @@ public class BatchingTopicController {
         reconcilableTopics.forEach(reconcilableTopic -> {
             var configChanges = results.getConfigChanges().stream()
                 .filter(pair -> pair.getKey().equals(reconcilableTopic)).findFirst();
-            if (configChanges != null && configChanges.isEmpty()) {
+            if (configChanges.isPresent()) {
                 LOGGER.debugCr(reconcilableTopic.reconciliation(), "Config changes {}", configChanges);
             } else {
                 LOGGER.debugCr(reconcilableTopic.reconciliation(), "No config change");

--- a/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
+++ b/topic-operator/src/main/java/io/strimzi/operator/topic/BatchingTopicController.java
@@ -536,7 +536,7 @@ public class BatchingTopicController {
             var configChanges = results.getConfigChanges().stream()
                 .filter(pair -> pair.getKey().equals(reconcilableTopic)).findFirst();
             if (configChanges.isPresent()) {
-                LOGGER.debugCr(reconcilableTopic.reconciliation(), "Config changes {}", configChanges);
+                LOGGER.debugCr(reconcilableTopic.reconciliation(), "Config changes: {}", configChanges.get());
             } else {
                 LOGGER.debugCr(reconcilableTopic.reconciliation(), "No config change");
             }


### PR DESCRIPTION
While reviewing a TO related PR I came across the following code which I think is "wrong":

```java
if (configChanges != null && configChanges.isEmpty()) {
                LOGGER.debugCr(reconcilableTopic.reconciliation(), "Config changes {}", configChanges);
            } else {
                LOGGER.debugCr(reconcilableTopic.reconciliation(), "No config change");
            }
```

I see a couple of issues here:

- the `configChanges != null` is not needed because it's always true. The `configChanges` is an Optional coming from a `findFirst()` on a stream which always returns an Optional which can be empty or not but never a null.
- the logging seems to be in the opposite order. If empty logs the config changes, if not empty logs "no config change".