### PR TITLE
Fix naming of bootstrap service for oddly named listener

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ListenersUtils.java
@@ -259,13 +259,7 @@ public class ListenersUtils {
      * @return          Name of the bootstrap service
      */
     public static String backwardsCompatibleBootstrapServiceName(String clusterName, GenericKafkaListener listener) {
-        if (listener.getPort() == 9092 && "plain".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
-            return clusterName + "-kafka-bootstrap";
-        } else if (listener.getPort() == 9093 && "tls".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
-            return clusterName + "-kafka-bootstrap";
-        } else if (listener.getPort() == 9094 && "external".equals(listener.getName()))   {
-            return clusterName + "-kafka-external-bootstrap";
-        } else if (KafkaListenerType.INTERNAL == listener.getType()) {
+        if (KafkaListenerType.INTERNAL == listener.getType()) {
             return clusterName + "-kafka-bootstrap";
         } else {
             return clusterName + "-kafka-" + listener.getName() + "-bootstrap";
@@ -280,14 +274,10 @@ public class ListenersUtils {
      * @return          Name of the bootstrap service
      */
     public static String backwardsCompatibleBootstrapRouteOrIngressName(String clusterName, GenericKafkaListener listener) {
-        if (listener.getPort() == 9092 && "plain".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
-            throw new UnsupportedOperationException("Bootstrap routes or ingresses are not used for internal listeners");
-        } else if (listener.getPort() == 9093 && "tls".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
+        if (KafkaListenerType.INTERNAL == listener.getType()) {
             throw new UnsupportedOperationException("Bootstrap routes or ingresses are not used for internal listeners");
         } else if (listener.getPort() == 9094 && "external".equals(listener.getName()))   {
             return clusterName + "-kafka-bootstrap";
-        } else if (KafkaListenerType.INTERNAL == listener.getType()) {
-            throw new UnsupportedOperationException("Bootstrap routes or ingresses are not used for internal listeners");
         } else {
             return clusterName + "-kafka-" + listener.getName() + "-bootstrap";
         }
@@ -306,14 +296,10 @@ public class ListenersUtils {
      * @return          Name of the bootstrap service
      */
     public static String backwardsCompatiblePerBrokerServiceName(String baseName, int pod, GenericKafkaListener listener) {
-        if (listener.getPort() == 9092 && "plain".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
-            throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
-        } else if (listener.getPort() == 9093 && "tls".equals(listener.getName()) && KafkaListenerType.INTERNAL == listener.getType())   {
+        if (KafkaListenerType.INTERNAL == listener.getType()) {
             throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
         } else if (listener.getPort() == 9094 && "external".equals(listener.getName()))   {
             return baseName + "-" + pod;
-        } else if (KafkaListenerType.INTERNAL == listener.getType()) {
-            throw new UnsupportedOperationException("Per-broker services are not used for internal listener");
         } else {
             return baseName + "-" + listener.getName() + "-" + pod;
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ListenersUtilsTest.java
@@ -420,6 +420,15 @@ public class ListenersUtilsTest {
         assertThat(ListenersUtils.backwardsCompatibleBootstrapServiceName(clusterName, newTls), is(clusterName + "-kafka-bootstrap"));
         assertThat(ListenersUtils.backwardsCompatibleBootstrapServiceName(clusterName, newLoadBalancer), is(clusterName + "-kafka-lb1-bootstrap"));
         assertThat(ListenersUtils.backwardsCompatibleBootstrapServiceName(clusterName, newNodePort), is(clusterName + "-kafka-np1-bootstrap"));
+
+        // Test internal listener with old external naming -> should have a regular internal service name
+        GenericKafkaListener internalWithOldExternalNaming = new GenericKafkaListenerBuilder()
+                .withName("external")
+                .withPort(9094)
+                .withType(KafkaListenerType.INTERNAL)
+                .withTls(true)
+                .build();
+        assertThat(ListenersUtils.backwardsCompatibleBootstrapServiceName(clusterName, internalWithOldExternalNaming), is(clusterName + "-kafka-bootstrap"));
     }
 
     @ParallelTest


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using a `type: internal` listener with the name `external` and port `9094`, the backward compatibility naming will use the `my-cluster-kafka-external-bootstrap` as the service name for it. This name is wrong and should be used only for listeners named `external` with port `9094` that are not `type: internal`. This service is never created, but the incorrect name is used in the Kafka CR `.status` section.

This PR also simplifies some other methods that provide some backward compatible naming to really distinguish the backward compatible cases only where needed and simply the conditions where it is not needed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally