### PR TITLE
Update Maven Builder image to 1.21

### DIFF
--- a/docker-images/maven-builder/Dockerfile
+++ b/docker-images/maven-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.21
 
 LABEL org.opencontainers.image.source='https://github.com/strimzi/strimzi-kafka-operator'
 


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Maven Builder container image to OpenJDK 1.21.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally