### PR TITLE
Remove support for storage class overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support for ZooKeeper-based Apache Kafka clusters and for KRaft migration has been removed
 * Support for MirrorMaker 1 has been removed
+* Support for storage class overrides has been removed
 * Added support to configure `dnsPolicy` and `dnsConfig` using the `template` sections.
 
 ### Major changes, deprecations and removals
@@ -16,6 +17,9 @@
   Please use the Apache Kafka [EnvVarConfigProvider](https://github.com/strimzi/kafka-env-var-config-provider?tab=readme-ov-file#deprecation-notice) and [Identity Replication Policy](https://github.com/strimzi/mirror-maker-2-extensions?tab=readme-ov-file#identity-replication-policy) instead.
 * When using Kafka Connect or Kafka MirrorMaker 2 operands and upgrading from Strimzi 0.38 or older, make sure the `StableConnectIdentities` feature gate is enabled and `StrimziPodSets` are used before upgrading.
 * When using the Kafka operand and upgrading from Strimzi 0.34 or older, make sure the `UseStrimziPodSets` feature gate is enabled and `StrimziPodSet` resources are used before upgrading.
+* The storage overrides for configuring per-broker storage class are not supported anymore.
+  If you are using the storage overrides, you should instead use multiple KafkaNodePool resources with a different storage class each.
+  For more details about migrating from storage overrides, please follow the [documentation](https://strimzi.io/docs/operators/0.45.0/full/deploying.html#con-config-storage-zookeeper-str).
 
 ## 0.45.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/PersistentClaimStorage.java
@@ -11,6 +11,7 @@ import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Minimum;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -112,12 +113,11 @@ public class PersistentClaimStorage extends SingleVolumeStorage {
         this.deleteClaim = deleteClaim;
     }
 
-    @Description("Overrides for individual brokers. " +
-            "The `overrides` field allows you to specify a different configuration for different brokers.")
+    @Description("As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @PresentInVersions("v1alpha1-v1beta2")
     @Deprecated
-    @DeprecatedProperty(description = "The storage overrides for individual brokers are deprecated and will be removed in the future. " +
-            "Please use multiple `KafkaNodePool` custom resources with different storage classes instead.")
+    @DeprecatedProperty(description = "The storage overrides for individual brokers are not supported anymore since Strimzi 0.46.0.")
     public List<PersistentClaimStorageOverride> getOverrides() {
         return overrides;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageDiff.java
@@ -8,18 +8,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.zjsonpatch.JsonDiff;
 import io.strimzi.api.kafka.model.kafka.JbodStorage;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorage;
-import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageOverride;
 import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.kafka.Storage;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.AbstractJsonDiff;
 
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -32,7 +28,7 @@ public class StorageDiff extends AbstractJsonDiff {
     private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(StorageDiff.class.getName());
 
     private static final Pattern IGNORABLE_PATHS = Pattern.compile(
-            "^(/deleteClaim|/kraftMetadata|/)$");
+            "^(/deleteClaim|/kraftMetadata|/overrides.*|/)$");
 
     private final boolean isEmpty;
     private final boolean changesType;
@@ -115,7 +111,7 @@ public class StorageDiff extends AbstractJsonDiff {
                 String pathValue = d.get("path").asText();
 
                 if (IGNORABLE_PATHS.matcher(pathValue).matches()) {
-                    LOGGER.debugCr(reconciliation, "Ignoring Storage {}diff {}", volumeDesc, d);
+                    LOGGER.infoCr(reconciliation, "Ignoring Storage {}diff {}", volumeDesc, d);
                     continue;
                 }
 
@@ -133,19 +129,10 @@ public class StorageDiff extends AbstractJsonDiff {
                     }
                 }
 
-                // Some changes to overrides are allowed:
-                // * When scaling up or down, you can set the overrides for new nodes
-                // * You can set overrides for nodes which do nto exist (yet)
-                if (pathValue.startsWith("/overrides")) {
-                    if (isOverrideChangeAllowed(current, desired, currentNodeIds, desiredNodeIds))    {
-                        continue;
-                    }
-                }
-
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debugCr(reconciliation, "Storage {}differs: {}", volumeDesc, d);
-                    LOGGER.debugCr(reconciliation, "Current Storage {}path {} has value {}", volumeDesc, pathValue, lookupPath(source, pathValue));
-                    LOGGER.debugCr(reconciliation, "Desired Storage {}path {} has value {}", volumeDesc, pathValue, lookupPath(target, pathValue));
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.infoCr(reconciliation, "Storage {}differs: {}", volumeDesc, d);
+                    LOGGER.infoCr(reconciliation, "Current Storage {}path {} has value {}", volumeDesc, pathValue, lookupPath(source, pathValue));
+                    LOGGER.infoCr(reconciliation, "Desired Storage {}path {} has value {}", volumeDesc, pathValue, lookupPath(target, pathValue));
                 }
 
                 num++;
@@ -262,57 +249,5 @@ public class StorageDiff extends AbstractJsonDiff {
      */
     public boolean issuesDetected() {
         return !isEmpty || duplicateVolumeIds || tooManyKRaftMetadataVolumes;
-    }
-
-    /**
-     * Validates the changes to the storage overrides and decides whether they are allowed or not. Allowed changes are
-     * those to nodes which will be added, removed or which do nto exist yet.
-     *
-     * @param current           Current Storage configuration
-     * @param desired           New storage configuration
-     * @param currentNodeIds    Node IDs currently used by this node pool
-     * @param desiredNodeIds    Node IDs used in the future by this node pool
-     *
-     * @return                  True if only allowed override changes were done, false otherwise
-     */
-    @SuppressWarnings("deprecation") // Storage overrides are deprecated
-    private boolean isOverrideChangeAllowed(Storage current, Storage desired, Set<Integer> currentNodeIds, Set<Integer> desiredNodeIds)   {
-        List<PersistentClaimStorageOverride> currentOverrides = ((PersistentClaimStorage) current).getOverrides();
-        if (currentOverrides == null)   {
-            currentOverrides = Collections.emptyList();
-        }
-
-        List<PersistentClaimStorageOverride> desiredOverrides = ((PersistentClaimStorage) desired).getOverrides();
-        if (desiredOverrides == null)   {
-            desiredOverrides = Collections.emptyList();
-        }
-
-        // We care only about the nodes which existed before this reconciliation and will still exist after it
-        Set<Integer> existedAndWillExist = new TreeSet<>(currentNodeIds);
-        existedAndWillExist.retainAll(desiredNodeIds);
-
-        for (int nodeId : existedAndWillExist)   {
-            PersistentClaimStorageOverride currentOverride = currentOverrides.stream()
-                    .filter(override -> override.getBroker() == nodeId)
-                    .findFirst()
-                    .orElse(null);
-
-            PersistentClaimStorageOverride desiredOverride = desiredOverrides.stream()
-                    .filter(override -> override.getBroker() == nodeId)
-                    .findFirst()
-                    .orElse(null);
-
-            if (currentOverride != null && desiredOverride != null) {
-                // Both overrides exist but are not equal
-                if (!currentOverride.equals(desiredOverride)) {
-                    return false;
-                }
-            } else if (currentOverride != null || desiredOverride != null) {
-                // One of them is null while the other is not null => they differ
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/PersistentVolumeClaimUtilsTest.java
@@ -250,7 +250,7 @@ public class PersistentVolumeClaimUtilsTest {
                         .withId(0)
                         .withStorageClass("my-storage-class")
                         .withSize("100Gi")
-                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build())
+                        .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build()) // The override is set, but the test checks that it is ignored
                         .build())
                 .build();
 
@@ -268,7 +268,7 @@ public class PersistentVolumeClaimUtilsTest {
         assertThat(pvcs.get(0).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
         assertThat(pvcs.get(0).getSpec().getSelector(), is(nullValue()));
         assertThat(pvcs.get(0).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
-        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("special-storage-class"));
+        assertThat(pvcs.get(0).getSpec().getStorageClassName(), is("my-storage-class"));
     }
 
     @ParallelTest
@@ -280,7 +280,7 @@ public class PersistentVolumeClaimUtilsTest {
                                 .withStorageClass("my-storage-class")
                                 .withSize("100Gi")
                                 .withDeleteClaim(false)
-                                .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build())
+                                .withOverrides(new PersistentClaimStorageOverrideBuilder().withBroker(0).withStorageClass("special-storage-class").build()) // The override is set, but the test checks that it is ignored
                                 .build(),
                         new PersistentClaimStorageBuilder()
                                 .withId(1)
@@ -306,7 +306,7 @@ public class PersistentVolumeClaimUtilsTest {
             assertThat(pvcs.get(i).getSpec().getAccessModes(), is(List.of("ReadWriteOnce")));
             assertThat(pvcs.get(i).getSpec().getSelector(), is(nullValue()));
             assertThat(pvcs.get(i).getSpec().getResources().getRequests(), is(Map.of("storage", new Quantity("100Gi", null))));
-            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is(i == 0 ? "special-storage-class" : "my-storage-class"));
+            assertThat(pvcs.get(i).getSpec().getStorageClassName(), is("my-storage-class"));
         }
 
         for (int i = 3; i < 6; i++)  {

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -679,7 +679,7 @@ It must have the value `persistent-claim` for the type `PersistentClaimStorage`.
 |Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.
 |overrides
 |xref:type-PersistentClaimStorageOverride-{context}[`PersistentClaimStorageOverride`] array
-|**The `overrides` property has been deprecated.** The storage overrides for individual brokers are deprecated and will be removed in the future. Please use multiple `KafkaNodePool` custom resources with different storage classes instead. Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+|**The `overrides` property has been deprecated.** The storage overrides for individual brokers are not supported anymore since Strimzi 0.46.0. As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored.
 |====
 
 [id='type-PersistentClaimStorageOverride-{context}']

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -583,7 +583,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                          description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                         selector:
                           additionalProperties:
                             type: string
@@ -634,7 +634,7 @@ spec:
                                     broker:
                                       type: integer
                                       description: Id of the kafka broker (broker identifier).
-                                description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                                description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                               selector:
                                 additionalProperties:
                                   type: string
@@ -2327,7 +2327,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                          description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                         selector:
                           additionalProperties:
                             type: string

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -91,7 +91,7 @@ spec:
                           broker:
                             type: integer
                             description: Id of the kafka broker (broker identifier).
-                      description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                      description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                     selector:
                       additionalProperties:
                         type: string
@@ -142,7 +142,7 @@ spec:
                                 broker:
                                   type: integer
                                   description: Id of the kafka broker (broker identifier).
-                            description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                            description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                           selector:
                             additionalProperties:
                               type: string

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -582,7 +582,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                        description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                       selector:
                         additionalProperties:
                           type: string
@@ -633,7 +633,7 @@ spec:
                                   broker:
                                     type: integer
                                     description: Id of the kafka broker (broker identifier).
-                              description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                              description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                             selector:
                               additionalProperties:
                                 type: string
@@ -2326,7 +2326,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                        description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                       selector:
                         additionalProperties:
                           type: string

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -90,7 +90,7 @@ spec:
                         broker:
                           type: integer
                           description: Id of the kafka broker (broker identifier).
-                    description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                    description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                   selector:
                     additionalProperties:
                       type: string
@@ -141,7 +141,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
+                          description: "As of Strimzi 0.46.0, the storage overrides for individual brokers are not supported anymore and this option is ignored."
                         selector:
                           additionalProperties:
                             type: string


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR implements the second part of the [SP-080 proposal](https://github.com/strimzi/proposals/blob/main/080-deprecation-and-removal-of-storage-overrides.md) -> it removes support for the storage overrides that allow specifying different storage classes for different nodes.

With this PR:
* For new clusters:
    * Any storage class overrides that are specified in the KafkaNodePool resources will be ignored and only rthe StorageClass configuration from the persistent volume configuration itself will be used
    * The following warnings will be added to resource conditions:
      ```yaml
        - lastTransitionTime: "2025-01-14T14:42:47.398728342Z"
          message: In resource KafkaNodePool(myproject/aston) in API version kafka.strimzi.io/v1beta2
            the overrides property at path spec.storage.volumes.overrides has been deprecated.
            The storage overrides for individual brokers are not supported anymore since
            Strimzi 0.46.0.
          reason: DeprecatedFields
          status: "True"
          type: Warning
      ```
       as well as printed in the log:
      ```
      2025-01-14 14:46:47 WARN  StatusUtils:106 - Reconciliation #10(timer) Kafka(myproject/my-cluster): In resource KafkaNodePool(myproject/aston) in API version kafka.strimzi.io/v1beta2 the overrides property at path spec.storage.volumes.overrides has been deprecated. The storage overrides for individual brokers are not supported anymore since Strimzi 0.46.0.
      ```
* For existing clusters:
    * The same conditions / warnings will be used as for new clusters
    * Any existing PVCs using the storage class from the overrides will be kept and used (We do not patch the storage class or support storage class changes, so they will remain untouched by Strimzi)
    * Any new PVCs created with this configuration under Strimzi 0.46.0 or newer will ignore the overrides and use the storage class directly from the persistent storage configuraton. So e.g. when scaling up, the PVCs for the new nodes will ignore the overrides. Similarly, when the old PVCs with the storage class from the override is deleted and the operator creates a new PVC, the overrides will be ignored.

Users who want this feature should instead have different node pools that use different storage classes each.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md