### PR TITLE
Remove last ZooKeeper methods from KafkaResources

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaResources.java
@@ -181,58 +181,6 @@ public class KafkaResources {
     }
 
     ////////
-    // ZooKeeper methods => still used in system tests
-    ////////
-
-    /**
-     * Returns the name of the ZooKeeper {@code StrimziPodSet} for a {@code Kafka} cluster of the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The name of the corresponding ZooKeeper {@code StrimziPodSet}.
-     */
-    public static String zookeeperComponentName(String clusterName) {
-        return clusterName + "-zookeeper";
-    }
-
-    /**
-     * Returns the name of the ZooKeeper {@code Pod} for a {@code Kafka} cluster of the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @param podNum The number of the ZooKeeper pod
-     * @return The name of the corresponding ZooKeeper {@code Pod}.
-     */
-    public static String zookeeperPodName(String clusterName, int podNum) {
-        return zookeeperComponentName(clusterName) + "-" + podNum;
-    }
-
-    /**
-     * Returns the name of the ZooKeeper metrics and log {@code ConfigMap} for a {@code Kafka} cluster of the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The name of the corresponding ZooKeeper metrics and log {@code ConfigMap}.
-     */
-    public static String zookeeperMetricsAndLogConfigMapName(String clusterName) {
-        return clusterName + "-zookeeper-config";
-    }
-
-    /**
-     * Returns the name of the ZooKeeper headless service name for a {@code Kafka} cluster of the given name.
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     * @return The name of the corresponding ZooKeeper headless service name.
-     */
-    public static String zookeeperHeadlessServiceName(String clusterName) {
-        return clusterName + "-zookeeper-nodes";
-    }
-
-    /**
-     * Returns the name of the ZooKeeper Network Policy.
-     *
-     * @param clusterName  The {@code metadata.name} of the {@code Kafka} resource.
-     *
-     * @return The name of the corresponding ZooKeeper Network Policy.
-     */
-    public static String zookeeperNetworkPolicyName(String clusterName) {
-        return clusterName + "-network-policy-zookeeper";
-    }
-
-    ////////
     // Entity Operator methods
     ////////
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/CaReconcilerTest.java
@@ -2114,7 +2114,6 @@ public class CaReconcilerTest {
         when(mockPodOps.listAsync(any(), any(Labels.class))).thenReturn(Future.succeededFuture(pods));
 
         StrimziPodSetOperator spsOps = supplier.strimziPodSetOperator;
-        when(spsOps.getAsync(eq(NAMESPACE), eq(KafkaResources.zookeeperComponentName(NAME)))).thenReturn(Future.succeededFuture());
         StrimziPodSet controllerPodSet = new StrimziPodSetBuilder()
                 .withNewMetadata()
                     .withName(NAME + "-controller")

--- a/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/resources/crd/StrimziPodSetResource.java
@@ -60,7 +60,6 @@ public class StrimziPodSetResource implements ResourceType<StrimziPodSet> {
     /**
      * Based on used mode - ZK, KRaft separate role, KRaft mixed role - returns the name of the controller's StrimziPodSet
      * In case of:
-     *      - ZK mode, it returns {@link KafkaResources#zookeeperComponentName(String)}
      *      - KRaft mode - separate role, it returns {@link KafkaResource#getStrimziPodSetName(String, String)} with Pool name from
      *              {@link KafkaNodePoolResource#getControllerPoolName(String)}
      *      - KRaft mode - mixed role, it returns {@link KafkaResource#getStrimziPodSetName(String, String)} with Pool name from
@@ -69,13 +68,10 @@ public class StrimziPodSetResource implements ResourceType<StrimziPodSet> {
      * @return component name of controller
      */
     public static String getControllerComponentName(String clusterName) {
-        if (Environment.isKRaftModeEnabled()) {
-            if (!Environment.isSeparateRolesMode()) {
-                return KafkaResource.getStrimziPodSetName(clusterName, KafkaNodePoolResource.getMixedPoolName(clusterName));
-            }
-            return KafkaResource.getStrimziPodSetName(clusterName, KafkaNodePoolResource.getControllerPoolName(clusterName));
+        if (!Environment.isSeparateRolesMode()) {
+            return KafkaResource.getStrimziPodSetName(clusterName, KafkaNodePoolResource.getMixedPoolName(clusterName));
         }
-        return KafkaResources.zookeeperComponentName(clusterName);
+        return KafkaResource.getStrimziPodSetName(clusterName, KafkaNodePoolResource.getControllerPoolName(clusterName));
     }
 
     /**

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/VerificationUtils.java
@@ -14,7 +14,6 @@ import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.connect.KafkaConnect;
 import io.strimzi.api.kafka.model.connect.KafkaConnectResources;
 import io.strimzi.api.kafka.model.kafka.Kafka;
-import io.strimzi.api.kafka.model.kafka.KafkaResources;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.systemtest.Environment;
@@ -350,14 +349,6 @@ public class VerificationUtils {
         List<String> brokerPods = kubeClient().listPodNames(clusterOperatorNamespaceName, KafkaResource.getLabelSelector(clusterName, StrimziPodSetResource.getBrokerComponentName(clusterName)));
 
         final String kafkaVersion = Optional.ofNullable(Crds.kafkaOperation(kubeClient(kafkaNamespaceName).getClient()).inNamespace(kafkaNamespaceName).withName(clusterName).get().getSpec().getKafka().getVersion()).orElse(Environment.ST_KAFKA_VERSION);
-
-        if (!Environment.isKRaftModeEnabled()) {
-            //Verifying docker image for zookeeper pods
-            for (int i = 0; i < controllerPods; i++) {
-                String imgFromPod = PodUtils.getContainerImageNameFromPod(kafkaNamespaceName, KafkaResources.zookeeperPodName(clusterName, i), "zookeeper");
-                assertThat("ZooKeeper Pod: " + i + " uses wrong image", imgFromPod, containsString(StUtils.parseImageMap(imgFromDeplConf.get(TestConstants.KAFKA_IMAGE_MAP)).get(kafkaVersion)));
-            }
-        }
 
         //Verifying docker image for kafka pods
         brokerPods.forEach(brokerPod -> {


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR removes the last traces of ZooKeeper from the `Kafkaresources` class along with the last rmeaining uses of these methods that should not be needed anymore.

### Checklist

- [x] Make sure all tests pass