### PR TITLE
Fix minor typo

### DIFF
--- a/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
+++ b/documentation/modules/configuring/con-maintenance-time-window-definition.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 Schedule Cluster Operator certificate renewals for Kafka clusters to minimize impact on client applications.
-Use time windows in conjunction with the xref:con-certificate-renewal-str[renewal periods of the CA certificates created by the Cluster Operator] (`Kafka.spec.clusterCa.renewalDays` and `Kafka.spec.clusterCa.renewalDays`).
+Use time windows in conjunction with the xref:con-certificate-renewal-str[renewal periods of the CA certificates created by the Cluster Operator] (`Kafka.spec.clusterCa.renewalDays` and `Kafka.spec.clientsCa.renewalDays`).
 
 Updates are usually triggered by changes to the `Kafka` resource by the user or through user tooling.
 Rolling restarts for certificate expiration may occur without `Kafka` resource changes.


### PR DESCRIPTION
clusterCA is mentioned twice instead of clientsCA

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
- [x] Supply screenshots for visual changes, such as Grafana dashboards

