### PR TITLE
Remove unused logger from Docs and test configs - Closes #11047

### DIFF
--- a/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.entityoperator.EntityTopicOperatorSpec.adoc
@@ -42,15 +42,12 @@ spec:
           logger.top.level: DEBUG # <2> 
           logger.toc.name: io.strimzi.operator.topic.TopicOperator # <3>
           logger.toc.level: TRACE # <4>
-          logger.clients.level: DEBUG # <5>
   # ...
 ----
 <1> Creates a logger for the `topic` package.
 <2> Sets the logging level for the `topic` package.
 <3> Creates a logger for the `TopicOperator` class.
 <4> Sets the logging level for the `TopicOperator` class.
-<5> Changes the logging level for the default `clients` logger. The `clients` logger is part of the logging configuration provided with Strimzi.
-By default, it is set to `INFO`.   
 
 NOTE: When investigating an issue with the operator, it's usually sufficient to change the `rootLogger` to `DEBUG` to get more detailed logs. 
 However, keep in mind that setting the log level to `DEBUG` may result in a large amount of log output and may have performance implications.

--- a/mockkube/src/test/resources/log4j2.properties
+++ b/mockkube/src/test/resources/log4j2.properties
@@ -1,4 +1,4 @@
-name = STConfig
+name = MockKubeConfig
 
 appender.console.type = Console
 appender.console.name = STDOUT
@@ -9,7 +9,3 @@ rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
-
-logger.clients.name = org.apache.kafka.clients
-logger.clients.level = info
-

--- a/operator-common/src/test/resources/log4j2.properties
+++ b/operator-common/src/test/resources/log4j2.properties
@@ -1,4 +1,4 @@
-name = STConfig
+name = OperatorCommonConfig
 
 appender.console.type = Console
 appender.console.name = STDOUT
@@ -9,7 +9,3 @@ rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
-
-logger.clients.name = org.apache.kafka.clients
-logger.clients.level = info
-

--- a/systemtest/src/main/resources/log4j2.properties
+++ b/systemtest/src/main/resources/log4j2.properties
@@ -25,7 +25,7 @@ rootLogger.appenderRef.rolling.level = DEBUG
 rootLogger.additivity = false
 
 logger.clients.name = org.apache.kafka.clients
-logger.clients.level = info
+logger.clients.level = INFO
 
 logger.fabric8.name = io.fabric8.kubernetes.client
 logger.fabric8.level = OFF


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

This PR removes the mention of the `logger.clients.level` from the docs. This logger does not exist and that is causing the problems described in #11047.

This logger seems to be also without any obvious reason used in some other Log4j configs used in tests - such as MockKube. It does not seem to have any use there, it is just bad copy-paste. So this is fixed in this PR as well.

This should fix #11047 

### Checklist

- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging