### PR TITLE
Add support for CEL validation to our CRDs

### DIFF
--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/CelValidation.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/CelValidation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for configuring CEL validation rules in Strimzi CRDs. The CEL validation rules should be added only with
+ * backwards compatibility in mind in order to not make previously valid CRs invalid. For example, you can use it to
+ * make previously required field required only in some condition. But should not use it to make a previously optional
+ * field required under some conditions.
+ *
+ * fieldPath and reason fields are support only on Kubernetes 1.28 and newer.
+ *
+ * For more details see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface CelValidation {
+    /**
+     * @return  CEL validation rules that should be applied to this type
+     */
+    CelValidationRule[] rules() default {};
+
+    /**
+     * CEL Validation rule
+     */
+    @interface CelValidationRule {
+        /**
+         * @return  Validation rule
+         */
+        String rule();
+
+        /**
+         * @return  Error message
+         */
+        String message() default "";
+
+        /**
+         * @return  Error message expression
+         */
+        String messageExpression() default "";
+
+        /**
+         * @return  Error reason
+         */
+        String reason() default "";
+
+        /**
+         * @return  Return fieldPath
+         */
+        String fieldPath() default "";
+    }
+}

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -14,6 +14,7 @@ import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.crdgenerator.annotations.AddedIn;
+import io.strimzi.crdgenerator.annotations.CelValidation;
 import io.strimzi.crdgenerator.annotations.Crd;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Example;
@@ -143,6 +144,10 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
     @Description("Example of complex type.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonPropertyOrder({"foo", "bar"})
+    @CelValidation(rules = {
+        @CelValidation.CelValidationRule(rule = "size(self.foo) >= 5", message = "foo needs to be at least 5 characters long", fieldPath = ".foo", reason = "FieldValueInvalid"),
+        @CelValidation.CelValidationRule(rule = "size(self.bar) >= 5", message = "bar needs to be at least 5 characters long", fieldPath = ".bar", reason = "FieldValueInvalid")
+    })
     public static class ObjectProperty {
         private String foo;
         private String bar;

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -75,6 +75,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -677,6 +686,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -81,6 +81,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -683,6 +692,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestWithoutDescriptions.yaml
@@ -73,6 +73,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -668,6 +677,15 @@ spec:
                 type: string
               bar:
                 type: string
+            x-kubernetes-validations:
+            - rule: size(self.foo) >= 5
+              message: foo needs to be at least 5 characters long
+              fieldPath: .foo
+              reason: FieldValueInvalid
+            - rule: size(self.bar) >= 5
+              message: bar needs to be at least 5 characters long
+              fieldPath: .bar
+              reason: FieldValueInvalid
           mapStringObject:
             x-kubernetes-preserve-unknown-fields: true
             type: object


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds support for using [CEL validations](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules) in our CRDs. It uses an annotation to add the CEL validation rules on a type or on a getter.

The CEL validation rules can be used to improve the validation of our CRDs beyond what the OpanAPI allows. Right now, this PR does not add the rules to any actual API classes. But it is expected to be used for example here: https://github.com/strimzi/strimzi-kafka-operator/pull/11051#pullrequestreview-2561087850 to make the `valueFrom` field required when using `jmxPrometheusExporter` metrics.

In general, the CEL validation rules should not be used for any existing fields to make the validation more strict than it was before, as that might cause backward compatibility issues.  It should be used only for new APIs or when we remove some previous restrictions (such as in #11051 where the `valueFrom` field is made conditionally optional instead of required).

The Pr adds support for all the options of the CEL validation rules. However, `fieldPath` and `reason` do not seem to be supported until Kube 1.28. So it should not be used yet in Strimzi

This PR should close #9417.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging