### PR TITLE
Try fix race condition inside TopicControllerIT and KafkaHandlerIT

### DIFF
--- a/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaHandlerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/KafkaHandlerIT.java
@@ -222,7 +222,7 @@ public class KafkaHandlerIT implements TestSeparator {
 
         // Wait until both topics actually exist
         try (var admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers()))) {
-            TestUtils.waitFor("Wait for topic creation", Duration.ofMillis(500).toMillis(), Duration.ofSeconds(30).toMillis(), () -> {
+            TestUtils.waitFor("topic creation", Duration.ofMillis(500).toMillis(), Duration.ofSeconds(30).toMillis(), () -> {
                 try {
                     var existingTopics = admin.listTopics().names().get();
                     return existingTopics.containsAll(List.of(t1Name, t2Name));

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -16,6 +16,7 @@ import io.strimzi.api.kafka.model.topic.KafkaTopicStatus;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.topic.model.KubeRef;
 import io.strimzi.operator.topic.model.TopicOperatorException;
+import io.strimzi.test.TestUtils;
 import io.strimzi.test.container.StrimziKafkaCluster;
 import io.strimzi.test.interfaces.TestSeparator;
 import org.apache.kafka.clients.admin.Admin;
@@ -59,6 +60,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -863,8 +865,14 @@ class TopicControllerIT implements TestSeparator {
         // when
         modifyTopicAndAwait(kt, changer, readyIsTrue());
 
-        // then
-        assertEquals(expectedConfigs, topicConfigMap(expectedTopicName));
+        // then with dynamic wait (ensuring that race-condition never happen)
+        TestUtils.waitFor("Waiting for config update", Duration.ofMillis(500).toMillis(), Duration.ofSeconds(30).toMillis(), () -> {
+            try {
+                return topicConfigMap(expectedTopicName).equals(expectedConfigs);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     @Test

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicControllerIT.java
@@ -866,7 +866,7 @@ class TopicControllerIT implements TestSeparator {
         modifyTopicAndAwait(kt, changer, readyIsTrue());
 
         // then with dynamic wait (ensuring that race-condition never happen)
-        TestUtils.waitFor("Waiting for config update", Duration.ofMillis(500).toMillis(), Duration.ofSeconds(30).toMillis(), () -> {
+        TestUtils.waitFor("config update", Duration.ofMillis(500).toMillis(), Duration.ofSeconds(30).toMillis(), () -> {
             try {
                 return topicConfigMap(expectedTopicName).equals(expectedConfigs);
             } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- Refactoring

### Description

This PR tries to fix the current race condition within TopicControllerIT, which happens in one of 5/10 runs. 
```java
[ERROR] Failures: 
[ERROR] io.strimzi.operator.topic.TopicControllerIT.shouldUpdateTopicInKafkaWhenConfigRemovedInKube
[ERROR]   Run 1: TopicControllerIT.shouldUpdateTopicInKafkaWhenConfigRemovedInKube:987->shouldUpdateTopicInKafkaWhenConfigChangedInKube:867 expected: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234}> but was: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=true}>
[ERROR]   Run 2: TopicControllerIT.shouldUpdateTopicInKafkaWhenConfigRemovedInKube:987->shouldUpdateTopicInKafkaWhenConfigChangedInKube:867 expected: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234}> but was: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=true}>
[ERROR]   Run 3: TopicControllerIT.shouldUpdateTopicInKafkaWhenConfigRemovedInKube:987->shouldUpdateTopicInKafkaWhenConfigChangedInKube:867 expected: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234}> but was: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=true}>
[INFO] 
[WARNING] Flakes: 
[WARNING] io.strimzi.operator.topic.TopicControllerIT.shouldUpdateTopicInKafkaWhenBooleanConfigChangedInKube
[ERROR]   Run 1: TopicControllerIT.shouldUpdateTopicInKafkaWhenBooleanConfigChangedInKube:949->shouldUpdateTopicInKafkaWhenConfigChangedInKube:867 expected: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=false}> but was: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=true}>
[INFO]   Run 2: PASS
[INFO] 
[WARNING] io.strimzi.operator.topic.TopicControllerIT.shouldUpdateTopicInKafkaWhenDoubleConfigChangedInKube
[ERROR]   Run 1: TopicControllerIT.shouldUpdateTopicInKafkaWhenDoubleConfigChangedInKube:930->shouldUpdateTopicInKafkaWhenConfigChangedInKube:867 expected: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.1, index.interval.bytes=1234, unclean.leader.election.enable=true}> but was: <{compression.type=producer, cleanup.policy=compact, flush.ms=1234, min.cleanable.dirty.ratio=0.6, index.interval.bytes=1234, unclean.leader.election.enable=true}>
[INFO]   Run 2: PASS
[INFO] 
[INFO] 
[ERROR] Tests run: 102, Failures: 1, Errors: 0, Skipped: 2, Flakes: 2
```

Moreover, during fixing this problem, I have encountered another one:
```java
[ERROR] Errors: 
[ERROR] io.strimzi.operator.topic.KafkaHandlerIT.shouldDescribeTopics
[ERROR]   Run 1: KafkaHandlerIT.shouldDescribeTopics:246 » NoSuchElement No value present
[ERROR]   Run 2: KafkaHandlerIT.shouldDescribeTopics:246 » NoSuchElement No value present
[ERROR]   Run 3: KafkaHandlerIT.shouldDescribeTopics:246 » NoSuchElement No value present
[INFO]
```
The race condition occurs because Kafka’s topic metadata updates asynchronously after configuration changes in Kubernetes. In **slower** environments, describeConfigs may query metadata before Kafka completes the update, causing tests to fail prematurely. The dynamic wait ensures the configuration update is reflected in Kafka before the test checks, preventing flakiness due to timing mismatches.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation