### PR TITLE
Cherry-pick bumped Vert.x 4.5.12 and Netty 4.1.117.Final to 0.45.x release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.11</vertx.version>
-        <vertx-junit5.version>4.5.11</vertx-junit5.version>
+        <vertx.version>4.5.12</vertx.version>
+        <vertx-junit5.version>4.5.12</vertx-junit5.version>
         <kafka.version>3.9.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <zookeeper.version>3.8.4</zookeeper.version>
@@ -144,7 +144,7 @@
         <jetty.version>9.4.56.v20240826</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
-        <netty.version>4.1.115.Final</netty.version>
+        <netty.version>4.1.117.Final</netty.version>
         <micrometer.version>1.12.3</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>


### PR DESCRIPTION
Trivial PR to cherry-pick the bump of Vert.x and Netty from PR https://github.com/strimzi/strimzi-kafka-operator/pull/11076 to the 0.45 release branch for the next patch release.