### PR TITLE
Add Podman Compatibility and Enhance Kind cluster setup

### DIFF
--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -150,8 +150,8 @@ EOF
     fi
 
     if is_docker; then
-        echo "$docker_config" | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker
+        echo "$docker_config" | $SUDO tee /etc/docker/daemon.json
+        $SUDO systemctl restart docker
     else
         # Ensure the podman_config is inserted correctly after unqualified-search-registries
         sudo awk -v config="$podman_config" '

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -262,7 +262,7 @@ EOF
 
     # Create the KIND cluster
     sudo systemd-run --scope -p "Delegate=yes" kind create cluster \
-        --image "$KIND_NODE_IMAGE}" \
+        --image "$KIND_NODE_IMAGE" \
         --name "$KIND_CLUSTER_NAME" \
         --config=/tmp/kind-config.yaml
 

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -114,8 +114,11 @@ configure_podman_cgroup() {
       # Write the configuration file
       echo -e "[Service]\nDelegate=memory pids cpu cpuset" | sudo tee "$config_file"
 
-      sudo systemctl daemon-reexec
-      sudo systemctl restart podman
+      systemctl --user daemon-reexec
+      systemctl --user restart podman
+
+      # reinitialize user permissions without requiring a logout.
+      sudo systemctl restart systemd-logind
 
       echo "Podman cgroup configuration updated successfully."
     fi

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -267,7 +267,7 @@ EOF
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]
-      c/onfig_path = "/etc/containerd/certs.d"
+      config_path = "/etc/containerd/certs.d"
 EOF
     fi
 

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -229,7 +229,6 @@ function configure_container_runtime_networking {
         KIND_CLUSTER_NAME - Name of the KIND cluster.
         KIND_NODE_IMAGE   - KIND node image to use.
         IP_FAMILY         - Determines whether to configure IPv4 or IPv6 settings
-        SUDO              - Start rootful or rootless kind
 @note: Writes the cluster configuration to a temporary file before creating the cluster.
 '
 function create_kind_cluster {

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -209,7 +209,7 @@ function configure_container_runtime_networking {
     local registry_name="$1"
     local network_name="$2"
 
-    if [ "$($SUDO $DOCKER_CMD inspect -f='{{.NetworkSettings.Networks.kind}}' "${registry_name}" 2>/dev/null)" = '<nil>' ]; then
+    if ! $SUDO $DOCKER_CMD network inspect ${network_name} | grep -q "${registry_name}"; then
         if is_podman; then
             if ! $SUDO $DOCKER_CMD network exists "${network_name}"; then
                 $SUDO $DOCKER_CMD network create "${network_name}"
@@ -379,6 +379,8 @@ ${ula_fixed_ipv6}::1    ${registry_dns}
 EOF
     done
 fi
+
+network_name="kind"
 
 configure_container_runtime_networking "${reg_name}" "${network_name}"
 create_cluster_role_binding_admin

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -36,7 +36,9 @@ function install_kubectl {
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${TEST_KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && chmod +x kubectl
     sudo cp kubectl /usr/local/bin
 
-    sudo ln -s /usr/local/bin/kubectl /usr/bin/kubectl
+    if is_podman; then
+        sudo ln -s /usr/local/bin/kubectl /usr/bin/kubectl
+    fi
 }
 
 function label_node {
@@ -265,7 +267,7 @@ EOF
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]
-      config_path = "/etc/containerd/certs.d"
+      c/onfig_path = "/etc/containerd/certs.d"
 EOF
     fi
 

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -260,7 +260,7 @@ EOF
 
 
     # Create the KIND cluster
-    systemd-run --scope -p "Delegate=yes" kind create cluster \
+    systemd-run --user --scope -p "Delegate=yes" kind create cluster \
         --image "$KIND_NODE_IMAGE" \
         --name "$KIND_CLUSTER_NAME" \
         --config=/tmp/kind-config.yaml

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -81,6 +81,22 @@ function setup_kube_directory {
 }
 
 : '
+@brief: Fixes the "ip6_tables" issue for Podman.
+@note: Ensures the required kernel modules are loaded.
+'
+function load_ip6_tables_module_to_kernel {
+    if is_podman; then
+        echo "Ensuring ip6_tables kernel module is loaded..."
+        if ! lsmod | grep -q ip6_tables; then
+            sudo modprobe ip6_tables || {
+                echo "Error: Failed to load ip6_tables module. Ensure your kernel supports it."
+                exit 1
+            }
+        fi
+    fi
+}
+
+: '
 @brief: Updates container runtime (Docker/Podman) configurations to allow insecure local registries.
 @param:
         1) registry_address - IPv4 registry address, e.g., "192.168.0.2:5000"
@@ -272,6 +288,7 @@ setup_kube_directory
 install_kubectl
 install_kubernetes_provisioner
 adjust_inotify_limits
+load_ip6_tables_module_to_kernel
 
 reg_name='kind-registry'
 reg_port='5001'

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -8,6 +8,7 @@ KIND_VERSION=${KIND_VERSION:-"v0.23.0"}
 # To properly upgrade Kind version check the releases in github https://github.com/kubernetes-sigs/kind/releases and use proper image based on Kind version
 KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-"kindest/node:v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b"}
 COPY_DOCKER_LOGIN=${COPY_DOCKER_LOGIN:-"false"}
+DOCKER_CMD="${DOCKER_CMD:-docker}"
 
 KIND_CLUSTER_NAME="kind-cluster"
 
@@ -20,20 +21,30 @@ if [ -z "$ARCH" ]; then
     ARCH="amd64"
 fi
 
+function is_docker() {
+    [[ "$DOCKER_CMD" == "docker" ]]
+}
+
+function is_podman() {
+    [[ "$DOCKER_CMD" == "podman" ]]
+}
+
 function install_kubectl {
     if [ "${TEST_KUBECTL_VERSION:-latest}" = "latest" ]; then
         TEST_KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
     fi
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${TEST_KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && chmod +x kubectl
     sudo cp kubectl /usr/local/bin
+
+    sudo ln -s /usr/local/bin/kubectl /usr/bin/kubectl
 }
 
 function label_node {
 	# It should work for all clusters
-	for nodeName in $(kubectl get nodes -o custom-columns=:.metadata.name --no-headers);
+	for nodeName in $(sudo kubectl get nodes -o custom-columns=:.metadata.name --no-headers);
 	do
 		echo ${nodeName};
-		kubectl label node ${nodeName} rack-key=zone;
+		sudo kubectl label node ${nodeName} rack-key=zone;
 	done
 }
 
@@ -42,11 +53,22 @@ function install_kubernetes_provisioner {
     KIND_URL=https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}
 
     curl -Lo kind ${KIND_URL} && chmod +x kind
-    sudo cp kind /usr/local/bin
+
+    # Move the binary to a globally accessible location
+    sudo mv kind /usr/local/bin/kind
+    sudo ln -s /usr/local/bin/kind /usr/bin/kind
+
+    if command -v kind >/dev/null 2>&1; then
+        echo "Kind installed successfully at $(command -v kind)"
+        kind version
+    else
+        echo "Error: Kind installation failed."
+        exit 1
+    fi
 }
 
 function create_cluster_role_binding_admin {
-    kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+    sudo kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 }
 
 : '
@@ -59,39 +81,75 @@ function setup_kube_directory {
 }
 
 : '
-@brief: Add Docker Hub credentials to Kubernetes node.
-@param $1: Container name/ID.
-@global: COPY_DOCKER_LOGIN - If "true", copies credentials.
-@note: Uses hosts $HOME/.docker/config.json.
+@brief: Updates container runtime (Docker/Podman) configurations to allow insecure local registries.
+@param:
+        1) registry_address - IPv4 registry address, e.g., "192.168.0.2:5000"
+        2) ula_fixed_ipv6 - Unique local address prefix for IPv6-based setups
+        3) reg_port - Port where the registry is running
+        4) registry_dns - DNS name for registry
+@global:
+        IP_FAMILY - Determines whether to configure IPv4 or IPv6 settings
+@note: Adjusts the container runtime’s config files (/etc/docker/daemon.json
+       or /etc/containers/registries.conf) and restarts the respective service.
 '
-function add_docker_hub_credentials_to_kubernetes {
-    # Add Docker hub credentials to Minikube
-    if [ "$COPY_DOCKER_LOGIN" = "true" ]
-    then
-      for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-        if [[ "$node" != *"external-load-balancer"* ]];
-        then
-          # the -oname format is kind/name (so node/name) we just want name
-          node_name=${node#node/}
-          # copy the config to where kubelet will look
-          docker cp "$HOME/.docker/config.json" "${node_name}:/var/lib/kubelet/config.json"
-          # restart kubelet to pick up the config
-          docker exec "${node_name}" systemctl restart kubelet.service
-        fi
-      done
-    fi
-}
+function updateContainerRuntimeConfiguration {
+    local registry_address="$1"
+    local ula_fixed_ipv6="$2"
+    local reg_port="$3"
+    local registry_dns="$4"
 
-: '
-@brief: Update Docker daemon configuration and restart service.
-@param $1: JSON string for Docker daemon configuration.
-@note: Requires sudo permissions.
-'
-function updateDockerDaemonConfiguration() {
-    # We need to add such host to insecure-registry (as localhost is default)
-    echo $1 | sudo tee /etc/docker/daemon.json
-    # we need to restart docker service to propagate configuration
-    systemctl restart docker
+    local docker_config podman_config
+
+    # Build configurations depending on IP family
+    if [[ "$IP_FAMILY" == "ipv6" ]]; then
+        docker_config=$(cat <<EOF
+{
+  "insecure-registries": ["[${ula_fixed_ipv6}::1]:${reg_port}", "${registry_dns}:${reg_port}"],
+  "experimental": true,
+  "ip6tables": true,
+  "fixed-cidr-v6": "${ula_fixed_ipv6}::/80"
+}
+EOF
+)
+        podman_config=$(cat <<EOF
+[registries.insecure]
+registries = ["[${ula_fixed_ipv6}::1]:${reg_port}", "${registry_dns}:${reg_port}"]
+EOF
+)
+    else
+        docker_config=$(cat <<EOF
+{
+  "insecure-registries": ["${registry_address}"]
+}
+EOF
+)
+        podman_config=$(cat <<EOF
+[[registry]]
+location = "${registry_address}"
+insecure = true
+EOF
+)
+    fi
+
+    if is_docker; then
+        echo "$docker_config" | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+    else
+        # Ensure the podman_config is inserted correctly after unqualified-search-registries
+        sudo awk -v config="$podman_config" '
+        BEGIN { inserted = 0 }
+        /unqualified-search-registries/ && !inserted {
+            print $0
+            print config
+            inserted = 1
+            next
+        }
+        { print $0 }
+        ' /etc/containers/registries.conf > /tmp/registries.conf
+
+        sudo mv /tmp/registries.conf /etc/containers/registries.conf
+        sudo systemctl restart podman
+    fi
 }
 
 : '
@@ -120,6 +178,31 @@ function adjust_inotify_limits {
     echo "Inotify limits adjusted successfully."
 }
 
+: '
+@brief: Configures Docker or Podman networking for the KIND cluster.
+@param:
+        1) registry_name - Name of the local registry container.
+        2) network_name - Name of the KIND network.
+@global:
+        DOCKER_CMD - container runtime CLI.
+@note:  None.
+'
+function configure_container_runtime_networking {
+    local registry_name="$1"
+    local network_name="$2"
+
+    if [ "$($DOCKER_CMD inspect -f='{{.NetworkSettings.Networks.kind}}' "${registry_name}" 2>/dev/null)" = '<nil>' ]; then
+        if is_podman; then
+            if ! $DOCKER_CMD network exists "${network_name}"; then
+                $DOCKER_CMD network create "${network_name}"
+            fi
+            $DOCKER_CMD network connect "${network_name}" "${registry_name}"
+        else
+            $DOCKER_CMD network connect "${network_name}" "${registry_name}"
+        fi
+    fi
+}
+
 setup_kube_directory
 install_kubectl
 install_kubernetes_provisioner
@@ -127,12 +210,17 @@ adjust_inotify_limits
 
 reg_name='kind-registry'
 reg_port='5001'
+control_planes=1
+
+if is_docker; then
+    control_planes=3
+fi
 
 if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     hostname=$(hostname --ip-address | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' | awk '$1 != "127.0.0.1" { print $1 }' | head -1)
 
     # update insecure registries
-    updateDockerDaemonConfiguration "{ \"insecure-registries\" : [\"${hostname}:${reg_port}\"] }"
+    updateContainerRuntimeConfiguration "${hostname}:${reg_port}"
 
     # Create kind cluster with containerd registry config dir enabled
     # TODO: kind will eventually enable this by default and this patch will
@@ -142,27 +230,28 @@ if [[ "$IP_FAMILY" = "ipv4" || "$IP_FAMILY" = "dual" ]]; then
     # https://github.com/kubernetes-sigs/kind/issues/2875
     # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
     # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-    cat <<EOF | kind create cluster --image "${KIND_NODE_IMAGE}" --config=-
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    nodes:
-    - role: control-plane
-    - role: control-plane
-    - role: control-plane
-    - role: worker
-    - role: worker
-    - role: worker
-    name: $KIND_CLUSTER_NAME
-    containerdConfigPatches:
-    - |-
-     [plugins."io.containerd.grpc.v1.cri".registry]
-       config_path = "/etc/containerd/certs.d"
-    networking:
-       ipFamily: $IP_FAMILY
+    cat <<EOF | sudo systemd-run --scope -p "Delegate=yes" /usr/local/bin/kind create cluster --image "${KIND_NODE_IMAGE}" --name "${KIND_CLUSTER_NAME}" --config=-
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        nodes:
+EOF
+    for i in $(seq 1 $control_planes); do
+        echo "    - role: control-plane" >> /tmp/kind-config.yaml
+    done
+    cat <<EOF >> /tmp/kind-config.yaml
+        - role: worker
+        - role: worker
+        - role: worker
+        containerdConfigPatches:
+        - |-
+         [plugins."io.containerd.grpc.v1.cri".registry]
+           config_path = "/etc/containerd/certs.d"
+        networking:
+           ipFamily: $IP_FAMILY
 EOF
     # run local container registry
-    if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
-        docker run \
+    if [ "$($DOCKER_CMD inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+        $DOCKER_CMD run \
           -d --restart=always -p "${hostname}:${reg_port}:5000" --name "${reg_name}" \
           registry:2
     fi
@@ -179,10 +268,10 @@ EOF
     # See https://kind.sigs.k8s.io/docs/user/local-registry/
     REGISTRY_DIR="/etc/containerd/certs.d/${hostname}:${reg_port}"
 
-    for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+    for node in $(sudo kind get nodes --name "${KIND_CLUSTER_NAME}"); do
         echo "Executing command in node:${node}"
-        docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
-        cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+        sudo $DOCKER_CMD exec "${node}" mkdir -p "${REGISTRY_DIR}"
+        cat <<EOF | sudo $DOCKER_CMD exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
     [host."http://${reg_name}:5000"]
 EOF
     done
@@ -198,34 +287,31 @@ elif [[ "$IP_FAMILY" = "ipv6" ]]; then
      # use ULA (i.e., Unique Local Address), which offers a similar "private" scope as link-local
     # but without the interface dependency and some of the other challenges of link-local addresses.
     # (link-local starts as fe80::) but we will use ULA fd01
-    updateDockerDaemonConfiguration "{
-        \"insecure-registries\" : [\"[${ula_fixed_ipv6}::1]:${reg_port}\", \"${registry_dns}:${reg_port}\"],
-        \"experimental\": true,
-        \"ip6tables\": true,
-        \"fixed-cidr-v6\": \"${ula_fixed_ipv6}::/80\"
-    }"
+    updateContainerRuntimeConfiguration "" "${ula_fixed_ipv6}" "${reg_port}" "${registry_dns}"
 
-    cat <<EOF | kind create cluster --image "${KIND_NODE_IMAGE}" --config=-
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    nodes:
-    - role: control-plane
-    - role: control-plane
-    - role: control-plane
-    - role: worker
-    - role: worker
-    - role: worker
-    name: $KIND_CLUSTER_NAME
-    containerdConfigPatches:
-    - |-
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."myregistry.local:5001"]
-          endpoint = ["http://myregistry.local:5001"]
-    networking:
-        ipFamily: $IP_FAMILY
+    cat <<EOF | sudo systemd-run --scope -p "Delegate=yes" /usr/local/bin/kind create cluster --image "${KIND_NODE_IMAGE}" --name "${KIND_CLUSTER_NAME}" --config=-
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        nodes:
+EOF
+    for i in $(seq 1 $control_planes); do
+        echo "    - role: control-plane" >> /tmp/kind-config.yaml
+    done
+    cat <<EOF >> /tmp/kind-config.yaml
+        - role: worker
+        - role: worker
+        - role: worker
+        name: $KIND_CLUSTER_NAME
+        containerdConfigPatches:
+        - |-
+          [plugins."io.containerd.grpc.v1.cri".registry.mirrors."myregistry.local:5001"]
+              endpoint = ["http://myregistry.local:5001"]
+        networking:
+            ipFamily: $IP_FAMILY
 EOF
     # run local container registry
-    if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
-        docker run \
+    if [ "$(sudo $DOCKER_CMD inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+        $DOCKER_CMD run \
           -d --restart=always -p "[${ula_fixed_ipv6}::1]:${reg_port}:5000" --name "${reg_name}" \
           registry:2
     fi
@@ -234,21 +320,14 @@ EOF
 
     # note: kind get nodes (default name `kind` and with specifying new name we have to use --name <cluster-name>
     # See https://kind.sigs.k8s.io/docs/user/local-registry/
-    for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+    for node in $(sudo kind get nodes --name "${KIND_CLUSTER_NAME}"); do
         echo "Executing command in node:${node}"
-        cat <<EOF | docker exec -i "${node}" cp /dev/stdin "/etc/hosts"
+        cat <<EOF | sudo $DOCKER_CMD exec -i "${node}" cp /dev/stdin "/etc/hosts"
 ${ula_fixed_ipv6}::1    ${registry_dns}
 EOF
     done
 fi
 
-# Connect the registry to the cluster network if not already connected
-# This allows kind to bootstrap the network but ensures they're on the same network
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-  docker network connect "kind" "${reg_name}"
-fi
-
-add_docker_hub_credentials_to_kubernetes
-
+configure_container_runtime_networking "${reg_name}" "${network_name}"
 create_cluster_role_binding_admin
 label_node

--- a/.azure/scripts/setup-kind.sh
+++ b/.azure/scripts/setup-kind.sh
@@ -126,9 +126,9 @@ configure_podman_cgroup() {
       local controllers=""
 
       while [[ $attempt -lt $max_attempts ]]; do
-          controllers=$(podman info -f json | jq -r '.host.cgroupControllers')
+          controllers=$(podman info -f json | jq -c '.host.cgroupControllers')
 
-          if echo "$controllers" | grep -q "cpu" && echo "$controllers" | grep -q "cpuset"; then
+          if [[ "$controllers" =~ "cpu" ]] && [[ "$controllers" =~ "cpuset" ]]; then
               echo "✅ Podman cgroup controllers successfully loaded!"
               echo "Available controllers: $controllers"
               return 0
@@ -138,9 +138,10 @@ configure_podman_cgroup() {
           sleep 2
           ((attempt++))
       done
-
-      echo "Podman cgroup configuration updated successfully."
     fi
+
+    echo "❌ Error: 'cpu' and 'cpuset' controllers did not load in time."
+    return 1
 }
 
 : '

--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -4,6 +4,8 @@ set -x
 
 RELEASE_VERSION=$(cat release.version)
 
+cat packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+
 # The commands 1) and 2) are used for change tag in installation files for CO. For each branch only of them match and apply changes
 # 1) The following command is applied only for branches, where release.version contains *SNAPSHOT* (main + others)
 sed -i "s#:latest#:${DOCKER_TAG}#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml

--- a/.azure/scripts/setup_upgrade.sh
+++ b/.azure/scripts/setup_upgrade.sh
@@ -14,7 +14,7 @@ sed -i "s#:${RELEASE_VERSION}#:${DOCKER_TAG}#g" packaging/install/cluster-operat
 
 # Change registry and org
 sed -i "s#/opt/${DOCKER_REGISTRY}#/opt#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
-sed -i "s#quay.io/strimzi/kafka#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
+sed -i "s#quay.io/strimzi/kafka:#${DOCKER_REGISTRY}/${DOCKER_ORG}/kafka:#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/operator#${DOCKER_REGISTRY}/${DOCKER_ORG}/operator#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 sed -i "s#quay.io/strimzi/jmxtrans#${DOCKER_REGISTRY}/${DOCKER_ORG}/jmxtrans#g" packaging/install/cluster-operator/*-Deployment-strimzi-cluster-operator.yaml
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/TestConstants.java
@@ -333,4 +333,10 @@ public interface TestConstants {
     String MIXED_ROLE_PREFIX = "m-";
     String BROKER_ROLE_PREFIX = "b-";
     String CONTROLLER_ROLE_PREFIX = "c-";
+
+    /**
+     * Container runtime constants
+     */
+    String DOCKER = "docker";
+    String PODMAN = "podman";
 }

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.systemtest.utils.specific;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class ContainerRuntimeUtils {
+    private static final String DOCKER = "docker";
+    private static final String PODMAN = "podman";
+    private static final String RUNTIME = detectRuntime();
+
+    private static String detectRuntime() {
+        if (isCommandAvailable(PODMAN)) {
+            return PODMAN;
+        } else if (isCommandAvailable(DOCKER)) {
+            return DOCKER;
+        } else {
+            throw new IllegalStateException("Neither Podman nor Docker is available on the system.");
+        }
+    }
+
+    private static boolean isCommandAvailable(String command) {
+        try {
+            Process process = new ProcessBuilder("which", command).start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                return reader.readLine() != null;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the container runtime detected on the system.
+     *
+     * @return A string indicating the container runtime, either "podman" or "docker".
+     * @throws IllegalStateException if neither Podman nor Docker is available.
+     */
+    public static String getRuntime() {
+        return RUNTIME;
+    }
+}

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
@@ -7,6 +7,7 @@ package io.strimzi.systemtest.utils.specific;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class ContainerRuntimeUtils {
     private static final String DOCKER = "docker";
@@ -26,8 +27,9 @@ public class ContainerRuntimeUtils {
     private static boolean isCommandAvailable(String command) {
         try {
             Process process = new ProcessBuilder("which", command).start();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                return reader.readLine() != null;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                final String output = reader.readLine();
+                return output != null && !output.isEmpty();
             }
         } catch (IOException e) {
             return false;

--- a/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/utils/specific/ContainerRuntimeUtils.java
@@ -4,21 +4,21 @@
  */
 package io.strimzi.systemtest.utils.specific;
 
+import io.strimzi.systemtest.TestConstants;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 public class ContainerRuntimeUtils {
-    private static final String DOCKER = "docker";
-    private static final String PODMAN = "podman";
     private static final String RUNTIME = detectRuntime();
 
     private static String detectRuntime() {
-        if (isCommandAvailable(PODMAN)) {
-            return PODMAN;
-        } else if (isCommandAvailable(DOCKER)) {
-            return DOCKER;
+        if (isCommandAvailable(TestConstants.PODMAN)) {
+            return TestConstants.PODMAN;
+        } else if (isCommandAvailable(TestConstants.DOCKER)) {
+            return TestConstants.DOCKER;
         } else {
             throw new IllegalStateException("Neither Podman nor Docker is available on the system.");
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -203,7 +203,7 @@ public class TieredStorageST extends AbstractST {
         ImageBuild.buildImage(suiteStorage.getNamespaceName(), IMAGE_NAME, TIERED_STORAGE_DOCKERFILE, BUILT_IMAGE_TAG, Environment.KAFKA_TIERED_STORAGE_BASE_IMAGE);
 
         if (cluster.isKind()) {
-            String image = Environment.getImageOutputRegistry(
+            final String image = "kind-registry:5001/" + Environment.getImageOutputRegistry(
                 suiteStorage.getNamespaceName(), IMAGE_NAME, BUILT_IMAGE_TAG);
             Exec.exec("kind", "load", "docker-image", image, "--name", "kind-cluster");
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -34,6 +34,7 @@ import io.strimzi.systemtest.utils.AdminClientUtils;
 import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.specific.MinioUtils;
 import io.strimzi.test.TestUtils;
+import io.strimzi.test.executor.Exec;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -201,6 +202,11 @@ public class TieredStorageST extends AbstractST {
 
         ImageBuild.buildImage(suiteStorage.getNamespaceName(), IMAGE_NAME, TIERED_STORAGE_DOCKERFILE, BUILT_IMAGE_TAG, Environment.KAFKA_TIERED_STORAGE_BASE_IMAGE);
 
+        if (cluster.isKind()) {
+            String image = Environment.getImageOutputRegistry(
+                suiteStorage.getNamespaceName(), IMAGE_NAME, BUILT_IMAGE_TAG);
+            Exec.exec("kind", "load", "docker-image", image, "--name", "kind-cluster");
+        }
         SetupMinio.deployMinio(suiteStorage.getNamespaceName());
         SetupMinio.createBucket(suiteStorage.getNamespaceName(), BUCKET_NAME);
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -35,7 +35,6 @@ import io.strimzi.systemtest.utils.ClientUtils;
 import io.strimzi.systemtest.utils.specific.ContainerRuntimeUtils;
 import io.strimzi.systemtest.utils.specific.MinioUtils;
 import io.strimzi.test.TestUtils;
-import io.strimzi.test.executor.Exec;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/TieredStorageST.java
@@ -32,6 +32,7 @@ import io.strimzi.systemtest.templates.crd.KafkaTopicTemplates;
 import io.strimzi.systemtest.templates.specific.AdminClientTemplates;
 import io.strimzi.systemtest.utils.AdminClientUtils;
 import io.strimzi.systemtest.utils.ClientUtils;
+import io.strimzi.systemtest.utils.specific.ContainerRuntimeUtils;
 import io.strimzi.systemtest.utils.specific.MinioUtils;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.executor.Exec;
@@ -208,7 +209,10 @@ public class TieredStorageST extends AbstractST {
             // Kaniko pushes the image to the local registry, but Podman stores it in an internal storage
             // that is not directly accessible to Kind. Podman must first pull the image from the registry
             // so that it is available in the Podman daemon's local storage before "kind load" can work.
-            Exec.exec("sudo", "podman", "pull", image);
+            if (ContainerRuntimeUtils.getRuntime().equals("podman")) {
+                Exec.exec("sudo", ContainerRuntimeUtils.getRuntime(), "pull", image);
+            }
+            // if container-runtime is docker we do not need to pull
             Exec.exec("sudo", "kind", "load", "docker-image", image, "--name", "kind-cluster");
         }
         SetupMinio.deployMinio(suiteStorage.getNamespaceName());

--- a/systemtest/tmt/plans/main.fmf
+++ b/systemtest/tmt/plans/main.fmf
@@ -118,7 +118,7 @@ prepare:
       # Setup local registry for building images and connect image
       export DOCKER_REGISTRY="${HOST}:5001"
       export DOCKER_ORG="strimzi"
-      export DOCKER_TAG="test"
+      export DOCKER_TAG="latest"
 
       make java_install
 

--- a/systemtest/tmt/tests/strimzi/main.fmf
+++ b/systemtest/tmt/tests/strimzi/main.fmf
@@ -3,7 +3,7 @@ test:
 duration: 2h
 environment:
   DOCKER_ORG: "strimzi"
-  DOCKER_TAG: "test"
+  DOCKER_TAG: "latest"
   TEST_LOG_DIR: "systemtest/target/logs"
   TESTS: ""
   TEST_GROUPS: ""


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR introduces Podman compatibility to the KIND cluster setup script. It seamlessly allows users to use Docker or Podman as their container runtime. The changes ensure proper configuration and support for Kubernetes cluster provisioning.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass