### PR TITLE
[DOC] Clarify the role of the PKCS12 file in the CA secrets and remove the OpenSSL command

### DIFF
--- a/documentation/modules/security/proc-installing-your-own-ca-certificates.adoc
+++ b/documentation/modules/security/proc-installing-your-own-ca-certificates.adoc
@@ -39,16 +39,9 @@ The chain should be in the following order:
 
 .Before you begin
 The Cluster Operator generates keys and certificates in PEM (Privacy Enhanced Mail) and PKCS #12 (Public-Key Cryptography Standards) formats.
-You can add your own certificates in either format.  
-
-Some applications cannot use PEM certificates and support only PKCS #12 certificates.
-If you don't have a cluster certificate in PKCS #12 format, use the OpenSSL TLS management tool to generate one from your `ca.crt` file.
-
-.Example certificate generation command
-[source,shell,subs="+quotes"]
-openssl pkcs12 -export -in ca.crt -nokeys -out ca.p12 -password pass:<P12_password> -caname ca.crt
-
-Replace <P12_password> with your own password.
+Only the keys and certificates in the PEM format are used internally by Strimzi.
+The PKCS #12 store is there only for user applications that do not support using the PEM format directly.
+When using custom CA certificates, adding the PKCS #12 store and its password to the secret is optional only.
 
 .Procedure
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The OpenSSL command for creating a PKCS12 truststore we have in our documentation of custom CAs does not seem to work as it does not produce a truststore that works in Java (which is the main goal).

There does not seem to be an OpenSSL command that would work with various OpenSSL versions. And using the Java Keytool would require the users to have Java installed. So instead, this PR removes the non-functional OpenSSL command and make it more clear that the PKCS12 store is there only for users and is optional. If the user wants to use the PKCS12 store there, they can figure out their own way how to create it 🤷‍♂️.

This was discussed in https://cloud-native.slack.com/archives/CMH3Q3SNP/p1738008390765249.

### Checklist

- [x] Update documentation