### PR TITLE
[ST] Update test-clients to 0.10.0 after the release

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -197,7 +197,7 @@ public class Environment {
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
     private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.8.0";
-    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.9.1";
+    public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.10.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 
     public static final String IP_FAMILY_DEFAULT = "ipv4";

--- a/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/Environment.java
@@ -196,7 +196,7 @@ public class Environment {
     private static final String RESOURCE_ALLOCATION_STRATEGY_DEFAULT = "SHARE_MEMORY_FOR_ALL_COMPONENTS";
 
     private static final String ST_KAFKA_VERSION_DEFAULT = TestKafkaVersion.getDefaultSupportedKafkaVersion();
-    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.8.0";
+    private static final String ST_CLIENTS_KAFKA_VERSION_DEFAULT = "3.9.0";
     public static final String TEST_CLIENTS_VERSION_DEFAULT = "0.10.0";
     public static final String ST_FILE_PLUGIN_URL_DEFAULT = "https://repo1.maven.org/maven2/org/apache/kafka/connect-file/" + ST_KAFKA_VERSION_DEFAULT + "/connect-file-" + ST_KAFKA_VERSION_DEFAULT + ".jar";
 

--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaClients.java
@@ -42,6 +42,7 @@ public class KafkaClients extends BaseClients {
     private String caCertSecretName;
     private String headers;
     private PodSecurityProfile podSecurityPolicy;
+    private String messagesPerTransaction;
 
     public String getProducerName() {
         return producerName;
@@ -136,6 +137,14 @@ public class KafkaClients extends BaseClients {
     }
     public void setPodSecurityPolicy(final PodSecurityProfile podSecurityPolicy) {
         this.podSecurityPolicy = podSecurityPolicy;
+    }
+
+    public void setMessagesPerTransaction(String messagesPerTransaction) {
+        this.messagesPerTransaction = messagesPerTransaction;
+    }
+
+    public String getMessagesPerTransaction() {
+        return messagesPerTransaction;
     }
 
     public Job producerStrimzi() {
@@ -271,6 +280,22 @@ public class KafkaClients extends BaseClients {
                                 .addNewEnv()
                                     .withName("HEADERS")
                                     .withValue(this.getHeaders())
+                                .endEnv()
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec();
+        }
+
+        if (this.getMessagesPerTransaction() != null) {
+            builder
+                .editSpec()
+                    .editTemplate()
+                        .editSpec()
+                            .editFirstContainer()
+                                .addNewEnv()
+                                    .withName("MESSAGES_PER_TRANSACTION")
+                                    .withValue(this.getMessagesPerTransaction())
                                 .endEnv()
                             .endContainer()
                         .endSpec()

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -100,6 +100,8 @@ class AlternativeReconcileTriggersST extends AbstractST {
         final KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
+            // TODO: needed because of bug in test-clients
+            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(continuousClients.producerStrimzi(), continuousClients.consumerStrimzi());
@@ -362,6 +364,8 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
+            // TODO: needed because of bug in test-clients
+            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());
@@ -503,6 +507,8 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
+            // TODO: needed because of bug in test-clients
+            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());

--- a/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/rollingupdate/AlternativeReconcileTriggersST.java
@@ -100,7 +100,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         final KafkaClients continuousClients = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients
+            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
             .withMessagesPerTransaction("1")
             .build();
 
@@ -364,7 +364,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients
+            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
             .withMessagesPerTransaction("1")
             .build();
 
@@ -507,7 +507,7 @@ class AlternativeReconcileTriggersST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
-            // TODO: needed because of bug in test-clients
+            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
             .withMessagesPerTransaction("1")
             .build();
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/specific/RackAwarenessST.java
@@ -99,18 +99,7 @@ class RackAwarenessST extends AbstractST {
         Pod pod = kubeClient().getPod(testStorage.getNamespaceName(), podName);
 
         resourceManager.createResourceWithWait(
-            AdminClientTemplates.plainAdminClient(testStorage.getNamespaceName(), testStorage.getAdminName(), KafkaResources.plainBootstrapAddress(testStorage.getClusterName()))
-                .editSpec()
-                    .editTemplate()
-                        .editSpec()
-                            .editFirstContainer()
-                                // TODO: once new test-clients are released (0.10.0), this should be removed
-                                .withImage("quay.io/strimzi-test-clients/test-clients:latest-kafka-" + Environment.ST_KAFKA_VERSION)
-                            .endContainer()
-                        .endSpec()
-                    .endTemplate()
-                .endSpec()
-                .build()
+            AdminClientTemplates.plainAdminClient(testStorage.getNamespaceName(), testStorage.getAdminName(), KafkaResources.plainBootstrapAddress(testStorage.getClusterName())).build()
         );
         final AdminClient adminClient = AdminClientUtils.getConfiguredAdminClient(testStorage.getNamespaceName(), testStorage.getAdminName());
 


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

This PR updates test-clients version to `0.10.0`.
During the testing, I found one issue in the test-clients (which is strange that didn't appear until now) - https://github.com/strimzi/test-clients/issues/119 - because of that, I added a small workaround into the three tests that were affected.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

