### PR TITLE
Update Jetty used by Strimzi operators to Jetty 12

### DIFF
--- a/kafka-agent/pom.xml
+++ b/kafka-agent/pom.xml
@@ -41,11 +41,19 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <version>${jetty-kafka.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
+            <version>${jetty-kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty-kafka.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -104,6 +112,8 @@
                             <ignoredUnusedDeclaredDependencies>
                                 <!-- Used in Kafka Agent through reflection (class org.apache.kafka.server.metrics.KafkaYammerMetrics) -->
                                 <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-server-common</ignoredUnusedDeclaredDependency>
+                                <!-- jetty-http needs to be included to override the version used by Kafka (versus the version used by Strimzi) -->
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-http</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/operator-common/pom.xml
+++ b/operator-common/pom.xml
@@ -88,6 +88,14 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
+++ b/operator-common/src/main/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServer.java
@@ -8,17 +8,17 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.strimzi.operator.common.MetricsProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.util.Callback;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -84,7 +84,7 @@ public class HealthCheckAndMetricsServer {
         ContextHandler contextHandler = new ContextHandler();
         contextHandler.setContextPath(path);
         contextHandler.setHandler(handler);
-        contextHandler.setAllowNullPathInfo(true);
+        contextHandler.setAllowNullPathInContext(true);
         return contextHandler;
     }
 
@@ -115,62 +115,66 @@ public class HealthCheckAndMetricsServer {
     /**
      * Handler responsible for the liveness check
      */
-    class HealthyHandler extends AbstractHandler {
+    class HealthyHandler extends Handler.Abstract {
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
-            response.setContentType("application/json");
+        public boolean handle(Request request, Response response, Callback callback) throws Exception {
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json; charset=UTF-8");
 
             if (liveness.isAlive()) {
                 response.setStatus(HttpServletResponse.SC_OK);
-                response.getWriter().println("{\"status\": \"ok\"}");
+                response.write(true, StandardCharsets.UTF_8.encode("{\"status\": \"ok\"}"), callback);
             } else {
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                response.getWriter().println("{\"status\": \"not-ok\"}");
+                response.write(true, StandardCharsets.UTF_8.encode("{\"status\": \"not-ok\"}"), callback);
             }
+
             LOGGER.debug("Responding {} to GET /healthy", response.getStatus());
-            baseRequest.setHandled(true);
+
+            return true;
         }
     }
 
     /**
      * Handler responsible for the readiness check
      */
-    class ReadyHandler extends AbstractHandler {
+    class ReadyHandler extends Handler.Abstract {
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
-            response.setContentType("application/json");
+        public boolean handle(Request request, Response response, Callback callback) throws Exception {
+            response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json; charset=UTF-8");
 
             if (readiness.isReady()) {
                 response.setStatus(HttpServletResponse.SC_OK);
-                response.getWriter().println("{\"status\": \"ok\"}");
+                response.write(true, StandardCharsets.UTF_8.encode("{\"status\": \"ok\"}"), callback);
             } else {
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                response.getWriter().println("{\"status\": \"not-ok\"}");
-
+                response.write(true, StandardCharsets.UTF_8.encode("{\"status\": \"not-ok\"}"), callback);
             }
-            LOGGER.debug("Responding {} to GET /ready", response.getStatus());
-            baseRequest.setHandled(true);
+
+            LOGGER.debug("Responding {} to GET /healthy", response.getStatus());
+
+            return true;
         }
     }
 
     /**
      * Handler responsible for the metrics
      */
-    class MetricsHandler extends AbstractHandler {
+    class MetricsHandler extends Handler.Abstract {
         @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        public boolean handle(Request request, Response response, Callback callback) throws Exception {
             if (prometheusMeterRegistry != null) {
-                response.setContentType("text/plain; version=0.0.4");
-                response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; version=0.0.4; charset=UTF-8");
                 response.setStatus(HttpServletResponse.SC_OK);
-                prometheusMeterRegistry.scrape(response.getWriter());
+                response.write(true, StandardCharsets.UTF_8.encode(prometheusMeterRegistry.scrape()), callback);
             } else {
-                response.setContentType("text/plain");
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=UTF-8");
                 response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
-                response.getWriter().println("Prometheus metrics are not enabled");
+                response.write(true, StandardCharsets.UTF_8.encode("Prometheus metrics are not enabled"), callback);
             }
 
-            baseRequest.setHandled(true);
+            LOGGER.debug("Responding {} to GET /metrics", response.getStatus());
+
+            return true;
         }
     }
 }

--- a/operator-common/src/test/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServerTest.java
+++ b/operator-common/src/test/java/io/strimzi/operator/common/http/HealthCheckAndMetricsServerTest.java
@@ -55,7 +55,7 @@ public class HealthCheckAndMetricsServerTest {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode(), is(200));
             assertThat(response.headers().map().get("Content-Type").size(), is(1));
-            assertThat(response.headers().map().get("Content-Type").get(0), is("text/plain; version=0.0.4;charset=utf-8"));
+            assertThat(response.headers().map().get("Content-Type").get(0), is("text/plain; version=0.0.4; charset=UTF-8"));
             assertThat(response.body(), containsString("my_metric_total 1.0"));
         } finally {
             server.stop();

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,13 @@
         <quartz.version>2.3.2</quartz.version>
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry-alpha.version>${opentelemetry.version}-alpha</opentelemetry-alpha.version>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>12.0.16</jetty.version>
+        <!--
+        This property is used to track the Jetty version used by Kafka. Kafka uses old Jetty version that is not
+        supported anymore. This also needs to be used by the kafka-agent module. Strimzi operators uses newer supported
+        Jetty version.
+        -->
+        <jetty-kafka.version>9.4.56.v20240826</jetty-kafka.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <netty.version>4.1.117.Final</netty.version>
@@ -811,6 +817,11 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Type of change

- Task

### Description

Jetty is used by Strimzi and Kafka in several places:
* Strimzi Topic and User Operators use it for health checks and metrics endpoints
* Strimzi Kafka Agent uses it to provide additional information from the Kafka Pods
* Kafka Connect uses it for its REST API

All of these are currently using Jetty 9 that is not supported anymore and is collecting CVEs. We cannot really update the Jetty version used by Kafka Connect and by the Strimzi Kafka Agent as that is the Jetty version used by Kafka and needs to be updated there (I think it hasn't been updated yet because od supported Java versions).

The Jetty version used by the Strimzi operators is updated in this PR to Jetty 12 as the latest and only supported version. That includes the changes to the code but also the special handling in the `pom.xml` files to keep the Strimzi Kafka Agent using the old Jetty 9 used by Kafka.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally