### PR TITLE
Improve memory consumption on large Kubernetes clusters when NodePort listeners are used

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -95,6 +95,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1107,46 +1109,59 @@ public class KafkaReconciler {
      * types are done because it requires the Kafka brokers to be scheduled and running to collect their node addresses.
      * Without that, we do not know on which node would they be running.
      *
+     * Note: To avoid issues with bg clusters with many nodes, we first get the used nodes from the Pods and then get
+     * the node information individually for each node instead of listing all nodes and then picking up the information
+     * we need. This means more Kubernetes API calls, but helps us to avoid running out of memory.
+     *
      * @return  Future which completes when the Listener status is created for all node port listeners
      */
     protected Future<Void> nodePortExternalListenerStatus() {
-        List<Node> allNodes = new ArrayList<>();
-
         if (!ListenersUtils.nodePortListeners(kafka.getListeners()).isEmpty())   {
-            return nodeOperator.listAsync(Labels.EMPTY)
-                    .compose(result -> {
-                        allNodes.addAll(result);
-                        return podOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels());
-                    })
-                    .map(pods -> {
-                        Map<Integer, Node> brokerNodes = new HashMap<>();
+            Map<Integer, String> brokerNodes = new HashMap<>();
+            ConcurrentMap<String, Node> nodes = new ConcurrentHashMap<>();
 
+            // First we collect all the broker pods we have so that we can find out on which worker nodes they run
+            return podOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels().withStrimziBrokerRole(true))
+                    .compose(pods -> {
+                        // We collect the nodes used by the brokers upfront to avid asking for the same node multiple times later
                         for (Pod broker : pods) {
-                            String podName = broker.getMetadata().getName();
-                            Integer podIndex = ReconcilerUtils.getPodIndexFromPodName(podName);
-
-                            if (broker.getStatus() != null && broker.getStatus().getHostIP() != null) {
-                                String hostIP = broker.getStatus().getHostIP();
-                                allNodes.stream()
-                                        .filter(node -> {
-                                            if (Labels.booleanLabel(broker, Labels.STRIMZI_BROKER_ROLE_LABEL, false)
-                                                    && node.getStatus() != null
-                                                    && node.getStatus().getAddresses() != null) {
-                                                return node.getStatus().getAddresses().stream().anyMatch(address -> hostIP.equals(address.getAddress()));
-                                            } else {
-                                                return false;
-                                            }
-                                        })
-                                        .findFirst()
-                                        .ifPresent(podNode -> brokerNodes.put(podIndex, podNode));
+                            if (broker.getSpec() != null && broker.getSpec().getNodeName() != null) {
+                                Integer podIndex = ReconcilerUtils.getPodIndexFromPodName(broker.getMetadata().getName());
+                                brokerNodes.put(podIndex, broker.getSpec().getNodeName());
+                            } else {
+                                // This should not happen, but to avoid some chain of errors downstream we check it and raise exception
+                                LOGGER.warnCr(reconciliation, "Kafka Pod {} has no node name specified", broker.getMetadata().getName());
+                                return Future.failedFuture(new RuntimeException("Kafka Pod " + broker.getMetadata().getName() + " has no node name specified"));
                             }
                         }
 
+                        List<Future<Void>> nodeFutures = new ArrayList<>();
+
+                        // We get the full node resource for each node with a broker
+                        for (String nodeName : brokerNodes.values().stream().distinct().toList()) {
+                            LOGGER.debugCr(reconciliation, "Getting information on worker node {} used by one or more brokers", nodeName);
+                            Future<Void> nodeFuture = nodeOperator.getAsync(nodeName).compose(node -> {
+                                if (node != null) {
+                                    nodes.put(nodeName, node);
+                                } else {
+                                    // Node was not found, but we do not want to fail because of this as it might be just some race condition
+                                    LOGGER.warnCr(reconciliation, "Worker node {} does not seem to exist", nodeName);
+                                }
+
+                                return Future.succeededFuture();
+                            });
+                            nodeFutures.add(nodeFuture);
+                        }
+
+                        return Future.join(nodeFutures);
+                    })
+                    .map(i -> {
+                        // We extract the address information from the nodes
                         for (GenericKafkaListener listener : ListenersUtils.nodePortListeners(kafka.getListeners())) {
                             // Set is used to ensure each node/port is listed only once. It is later converted to List.
                             Set<ListenerAddress> statusAddresses = new HashSet<>(brokerNodes.size());
 
-                            for (Map.Entry<Integer, Node> entry : brokerNodes.entrySet())   {
+                            for (Map.Entry<Integer, String> entry : brokerNodes.entrySet())   {
                                 String advertisedHost = ListenersUtils.brokerAdvertisedHost(listener, kafka.nodePoolForNodeId(entry.getKey()).nodeRef(entry.getKey()));
                                 ListenerAddress address;
 
@@ -1155,11 +1170,15 @@ public class KafkaReconciler {
                                             .withHost(advertisedHost)
                                             .withPort(listenerReconciliationResults.bootstrapNodePorts.get(ListenersUtils.identifier(listener)))
                                             .build();
-                                } else {
+                                } else if (nodes.get(entry.getValue()) != null) {
                                     address = new ListenerAddressBuilder()
-                                            .withHost(NodeUtils.findAddress(entry.getValue().getStatus().getAddresses(), ListenersUtils.preferredNodeAddressType(listener)))
+                                            .withHost(NodeUtils.findAddress(nodes.get(entry.getValue()).getStatus().getAddresses(), ListenersUtils.preferredNodeAddressType(listener)))
                                             .withPort(listenerReconciliationResults.bootstrapNodePorts.get(ListenersUtils.identifier(listener)))
                                             .build();
+                                } else {
+                                    // Node was not found, but we do not want to fail because of this as it might be just some race condition
+                                    LOGGER.warnCr(reconciliation, "Kafka node {} is running on an unknown node and its node port address cannot be found", entry.getKey());
+                                    continue;
                                 }
 
                                 statusAddresses.add(address);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -1109,7 +1109,7 @@ public class KafkaReconciler {
      * types are done because it requires the Kafka brokers to be scheduled and running to collect their node addresses.
      * Without that, we do not know on which node would they be running.
      *
-     * Note: To avoid issues with bg clusters with many nodes, we first get the used nodes from the Pods and then get
+     * Note: To avoid issues with big clusters with many nodes, we first get the used nodes from the Pods and then get
      * the node information individually for each node instead of listing all nodes and then picking up the information
      * we need. This means more Kubernetes API calls, but helps us to avoid running out of memory.
      *
@@ -1123,7 +1123,7 @@ public class KafkaReconciler {
             // First we collect all the broker pods we have so that we can find out on which worker nodes they run
             return podOperator.listAsync(reconciliation.namespace(), kafka.getSelectorLabels().withStrimziBrokerRole(true))
                     .compose(pods -> {
-                        // We collect the nodes used by the brokers upfront to avid asking for the same node multiple times later
+                        // We collect the nodes used by the brokers upfront to avoid asking for the same node multiple times later
                         for (Pod broker : pods) {
                             if (broker.getSpec() != null && broker.getSpec().getNodeName() != null) {
                                 Integer podIndex = ReconcilerUtils.getPodIndexFromPodName(broker.getMetadata().getName());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -70,7 +70,6 @@ import io.strimzi.operator.cluster.operator.resource.kubernetes.CrdOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.DeploymentOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.IngressOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.NetworkPolicyOperator;
-import io.strimzi.operator.cluster.operator.resource.kubernetes.NodeOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodDisruptionBudgetOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PodOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.PvcOperator;
@@ -603,10 +602,6 @@ public class KafkaAssemblyOperatorTest {
         when(mockIngressOps.batchReconcile(any(), eq(NAMESPACE), any(), any())).thenCallRealMethod();
         when(mockIngressOps.listAsync(eq(NAMESPACE), any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
-        // Nodes
-        NodeOperator mockNodeOps = supplier.nodeOperator;
-        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
-
         KafkaAssemblyOperator ops = new KafkaAssemblyOperator(vertx, new PlatformFeaturesAvailability(openShift, kubernetesVersion),
                 CERT_MANAGER,
                 PASSWORD_GENERATOR,
@@ -976,10 +971,6 @@ public class KafkaAssemblyOperatorTest {
         // PDBs
         PodDisruptionBudgetOperator mockPdbOps = supplier.podDisruptionBudgetOperator;
         when(mockPdbOps.reconcile(any(), eq(NAMESPACE), any(), any())).thenReturn(Future.succeededFuture());
-
-        // Nodes
-        NodeOperator mockNodeOps = supplier.nodeOperator;
-        when(mockNodeOps.listAsync(any(Labels.class))).thenReturn(Future.succeededFuture(emptyList()));
 
         // Ingress resources
         IngressOperator mockIngressOps = supplier.ingressOperations;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When using node port listeners, the cluster operator needs to figure out the bootstrap address for the node port listener in order to add it to the status section of the Kafka CR.

Right now, we do it the following way:
1. We list all worker nodes
2. We list all Kafka pods
3. We match the pods to the nodes and collect the addresses of the nodes they are running on

But this approach can cause the operator to run out of memory on large Kubernetes clusters because:
* We keep the list of the nodes in memory
* A single node resource can be pretty big because its status contains lists of container images etc.

So this can easily lead to running out of memory, even with a small Kafka cluster. Reports from users suggest problems with 250 worker node OpenShift cluster with one Kafka cluster. I was able to reproduce it on a cluster with ~160 worker nodes with the help of 3 small Kafka clusters.

This PR updates the way how we collect the addresses for the status. It:
* Gets the list of broker pods
* From the pods, it gets a list of nodes they are running on
* Gets the nodes from Kubernetes one-by-one with GET instead of LIST API
* Extracts the addresses from the nodes

This has the trade-off of making more Kubernetes API calls and spending more CPU while being more carefull with the used memory.

It should help with the most common use case where the Kube cluster is large with many nodes, but the Kafka cluster is much smaller. For situations where the Kafka cluster is large as well, we will still need the memory to store many nodes. So users might need to increase the operator memory, but that is not unexpected for large Kafka cluster. For a large Kafka cluster, it might also make a large number of GET calls for the individual nodes instead of one LIST command. But I think overall this is a reasonable trade-off.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally