### PR TITLE
Avoid adding futures to immutable list

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -770,7 +770,7 @@ public class KafkaReconciler {
                 .map(secretName -> {
                     LOGGER.debugCr(reconciliation, "Deleting old Secret {}/{} that is no longer used.", reconciliation.namespace(), secretName);
                     return secretOperator.deleteAsync(reconciliation, reconciliation.namespace(), secretName, false);
-                }).toList();
+                }).collect(Collectors.toCollection(ArrayList::new)); // We need to collect to mutable list because we might need to add to the list more items later
 
         // Remove old Secret containing all certs if it exists
         @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When deleting the old certificate Secret, we seem to be adding a Future to an immutable list. While that has no long-lasting impact, it creates an ugly error:
```
2025-01-30 15:55:01 INFO  AbstractOperator:266 - Reconciliation #212(timer) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2025-01-30 15:55:03 ERROR AbstractOperator:285 - Reconciliation #212(timer) Kafka(myproject/my-cluster): createOrUpdate failed
java.lang.UnsupportedOperationException: null
	at java.util.ImmutableCollections.uoe(ImmutableCollections.java:142) ~[?:?]
	at java.util.ImmutableCollections$AbstractImmutableCollection.add(ImmutableCollections.java:147) ~[?:?]
	at io.strimzi.operator.cluster.operator.assembly.KafkaReconciler.lambda$deleteOldCertificateSecrets$52(KafkaReconciler.java:784) ~[io.strimzi.cluster-operator-0.46.0-SNAPSHOT.jar:0.46.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.5.12.jar:4.5.12]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.12.jar:4.5.12]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
2025-01-30 15:55:03 INFO  CrdOperator:123 - Reconciliation #212(timer) Kafka(myproject/my-cluster): Status of Kafka my-cluster in namespace myproject has been updated
2025-01-30 15:55:03 INFO  AbstractOperator:520 - Reconciliation #213(watch) Kafka(myproject/my-cluster): Kafka my-cluster in namespace myproject was MODIFIED
2025-01-30 15:55:03 WARN  AbstractOperator:566 - Reconciliation #212(timer) Kafka(myproject/my-cluster): Failed to reconcile
java.lang.UnsupportedOperationException: null
	at java.util.ImmutableCollections.uoe(ImmutableCollections.java:142) ~[?:?]
	at java.util.ImmutableCollections$AbstractImmutableCollection.add(ImmutableCollections.java:147) ~[?:?]
	at io.strimzi.operator.cluster.operator.assembly.KafkaReconciler.lambda$deleteOldCertificateSecrets$52(KafkaReconciler.java:784) ~[io.strimzi.cluster-operator-0.46.0-SNAPSHOT.jar:0.46.0-SNAPSHOT]
	at io.vertx.core.impl.future.Composition.onSuccess(Composition.java:38) ~[io.vertx.vertx-core-4.5.12.jar:4.5.12]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60) ~[io.vertx.vertx-core-4.5.12.jar:4.5.12]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[io.netty.netty-transport-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty.netty-common-4.1.117.Final.jar:4.1.117.Final]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

This PR makes sure the futures are collected to mutable list so that more of them can be added.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally