### PR TITLE
Update Fabric8 Kubernetes Client to 7.1.0

### DIFF
--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -893,6 +893,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -1039,6 +1041,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -1061,6 +1065,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -2458,6 +2464,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -2622,6 +2630,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -2644,6 +2654,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -3605,6 +3617,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -3772,6 +3786,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -3868,6 +3884,8 @@ spec:
                                 type: object
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                             limits:
                               additionalProperties:
@@ -4019,6 +4037,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -4041,6 +4061,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -5179,6 +5201,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -5266,6 +5290,8 @@ spec:
                             type: object
                             properties:
                               name:
+                                type: string
+                              request:
                                 type: string
                         limits:
                           additionalProperties:
@@ -5467,6 +5493,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -5489,6 +5517,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -6613,6 +6643,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -6702,6 +6734,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -6724,6 +6758,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:
@@ -7483,6 +7519,8 @@ spec:
                             properties:
                               name:
                                 type: string
+                              request:
+                                type: string
                         limits:
                           additionalProperties:
                             anyOf:
@@ -7629,6 +7667,8 @@ spec:
                                   type: boolean
                                 runAsUser:
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   type: object
                                   properties:
@@ -7651,6 +7691,8 @@ spec:
                                   type: array
                                   items:
                                     type: integer
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   type: array
                                   items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -289,6 +289,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -573,6 +575,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -595,6 +599,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -1615,6 +1621,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -1637,6 +1645,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -2605,6 +2615,8 @@ spec:
                             type: object
                             properties:
                               name:
+                                type: string
+                              request:
                                 type: string
                         limits:
                           additionalProperties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkanodepool.yaml
@@ -185,6 +185,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -300,6 +302,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -322,6 +326,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
@@ -346,6 +346,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -562,6 +564,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -584,6 +588,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -506,6 +506,8 @@ spec:
                         properties:
                           name:
                             type: string
+                          request:
+                            type: string
                     limits:
                       additionalProperties:
                         anyOf:
@@ -790,6 +792,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -812,6 +816,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:
@@ -1832,6 +1838,8 @@ spec:
                               type: boolean
                             runAsUser:
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               type: object
                               properties:
@@ -1854,6 +1862,8 @@ spec:
                               type: array
                               items:
                                 type: integer
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               type: array
                               items:

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -892,6 +892,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -1038,6 +1040,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -1060,6 +1064,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -2457,6 +2463,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -2621,6 +2629,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -2643,6 +2653,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -3604,6 +3616,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -3771,6 +3785,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -3867,6 +3883,8 @@ spec:
                               type: object
                               properties:
                                 name:
+                                  type: string
+                                request:
                                   type: string
                           limits:
                             additionalProperties:
@@ -4018,6 +4036,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -4040,6 +4060,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -5178,6 +5200,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                           limits:
                             additionalProperties:
                               anyOf:
@@ -5265,6 +5289,8 @@ spec:
                           type: object
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                       limits:
                         additionalProperties:
@@ -5466,6 +5492,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -5488,6 +5516,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -6612,6 +6642,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -6701,6 +6733,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -6723,6 +6757,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:
@@ -7482,6 +7518,8 @@ spec:
                           properties:
                             name:
                               type: string
+                            request:
+                              type: string
                       limits:
                         additionalProperties:
                           anyOf:
@@ -7628,6 +7666,8 @@ spec:
                                 type: boolean
                               runAsUser:
                                 type: integer
+                              seLinuxChangePolicy:
+                                type: string
                               seLinuxOptions:
                                 type: object
                                 properties:
@@ -7650,6 +7690,8 @@ spec:
                                 type: array
                                 items:
                                   type: integer
+                              supplementalGroupsPolicy:
+                                type: string
                               sysctls:
                                 type: array
                                 items:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -288,6 +288,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -572,6 +574,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -594,6 +598,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -1614,6 +1620,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -1636,6 +1644,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -2604,6 +2614,8 @@ spec:
                           type: object
                           properties:
                             name:
+                              type: string
+                            request:
                               type: string
                       limits:
                         additionalProperties:

--- a/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/045-Crd-kafkanodepool.yaml
@@ -184,6 +184,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -299,6 +301,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -321,6 +325,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/packaging/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -345,6 +345,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -561,6 +563,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -583,6 +587,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -505,6 +505,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        request:
+                          type: string
                   limits:
                     additionalProperties:
                       anyOf:
@@ -789,6 +791,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -811,6 +815,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:
@@ -1831,6 +1837,8 @@ spec:
                             type: boolean
                           runAsUser:
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             type: object
                             properties:
@@ -1853,6 +1861,8 @@ spec:
                             type: array
                             items:
                               type: integer
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             type: array
                             items:

--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,9 @@
         <lombok.version>1.18.32</lombok.version>
 
         <!-- Runtime dependencies -->
-        <fabric8.kubernetes-client.version>7.0.1</fabric8.kubernetes-client.version>
-        <fabric8.openshift-client.version>7.0.1</fabric8.openshift-client.version>
-        <fabric8.kubernetes-model.version>7.0.1</fabric8.kubernetes-model.version>
+        <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
+        <fabric8.openshift-client.version>7.1.0</fabric8.openshift-client.version>
+        <fabric8.kubernetes-model.version>7.1.0</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <fasterxml.jackson-core.version>2.16.2</fasterxml.jackson-core.version>
         <fasterxml.jackson-databind.version>2.16.2</fasterxml.jackson-databind.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates the Fabric8 Kubernetes Client to version 7.1.0. This new version brings an updated Kubernetes model for Kube 1.31 and 1.32 (hence the updated CRDs).

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally