### PR TITLE
Refactoring to use mapEmpty() to map to a Future<Void>

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -329,7 +329,7 @@ public class CaReconciler {
                     );
 
                     return secretOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.clusterOperatorCertsSecretName(reconciliation.name()), coSecret)
-                            .map((Void) null);
+                            .mapEmpty();
                 });
     }
 
@@ -523,7 +523,7 @@ public class CaReconciler {
 
             if (clusterCa.certsRemoved()) {
                 return secretOperator.reconcile(reconciliation, reconciliation.namespace(), AbstractModel.clusterCaCertSecretName(reconciliation.name()), clusterCa.caCertSecret())
-                        .map((Void) null);
+                        .mapEmpty();
             } else {
                 return Future.succeededFuture();
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CruiseControlReconciler.java
@@ -153,7 +153,7 @@ public class CruiseControlReconciler {
                             CruiseControlResources.networkPolicyName(reconciliation.name()),
                             cruiseControl != null ? cruiseControl.generateNetworkPolicy(
                                 operatorNamespace, operatorNamespaceLabels, isTopicOperatorEnabled) : null
-                    ).map((Void) null);
+                    ).mapEmpty();
         } else {
             return Future.succeededFuture();
         }
@@ -171,7 +171,7 @@ public class CruiseControlReconciler {
                         reconciliation.namespace(),
                         CruiseControlResources.serviceAccountName(reconciliation.name()),
                         cruiseControl != null ? cruiseControl.generateServiceAccount() : null
-                ).map((Void) null);
+                ).mapEmpty();
     }
 
     /**
@@ -197,11 +197,11 @@ public class CruiseControlReconciler {
                                         reconciliation.namespace(),
                                         CruiseControlResources.configMapName(reconciliation.name()),
                                         configMap
-                                ).map((Void) null);
+                                ).mapEmpty();
                     });
         } else {
             return configMapOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.configMapName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -229,7 +229,7 @@ public class CruiseControlReconciler {
                     });
         } else {
             return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.secretName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -276,12 +276,12 @@ public class CruiseControlReconciler {
 
                         this.apiSecretHash = ReconcilerUtils.hashSecretContent(newCcApiUsersSecret);
                         return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()), newCcApiUsersSecret)
-                            .map((Void) null);
+                            .mapEmpty();
                     }
                 );
         } else {
             return secretOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.apiSecretName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -297,7 +297,7 @@ public class CruiseControlReconciler {
                         reconciliation.namespace(),
                         CruiseControlResources.serviceName(reconciliation.name()),
                         cruiseControl != null ? cruiseControl.generateService() : null
-                ).map((Void) null);
+                ).mapEmpty();
     }
 
     /**
@@ -319,10 +319,10 @@ public class CruiseControlReconciler {
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.componentName(reconciliation.name()), deployment)
-                    .map((Void) null);
+                    .mapEmpty();
         } else {
             return deploymentOperator.reconcile(reconciliation, reconciliation.namespace(), CruiseControlResources.componentName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/DefaultKafkaQuotasManager.java
@@ -203,7 +203,7 @@ public class DefaultKafkaQuotasManager {
 
         return VertxUtil
             .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.alterClientQuotas(List.of(clientQuotaAlteration)).values().get(DEFAULT_USER_ENTITY))
-            .map((Void) null);
+            .mapEmpty();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/EntityOperatorReconciler.java
@@ -137,11 +137,11 @@ public class EntityOperatorReconciler {
                         Secret newSecret = entityOperator.topicOperator().generateCruiseControlApiSecret(oldSecret);
                         this.ccApiSecretHash = ReconcilerUtils.hashSecretContent(newSecret);
                         return secretOperator.reconcile(reconciliation, reconciliation.namespace(), ccApiSecretName, newSecret)
-                            .map((Void) null);
+                            .mapEmpty();
                     });
             } else {
                 return secretOperator.reconcile(reconciliation, reconciliation.namespace(), ccApiSecretName, null)
-                    .map((Void) null);
+                    .mapEmpty();
             }
         }
         return Future.succeededFuture();
@@ -159,7 +159,7 @@ public class EntityOperatorReconciler {
                         reconciliation.namespace(),
                         KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
                         entityOperator != null ? entityOperator.generateServiceAccount() : null
-                ).map((Void) null);
+                ).mapEmpty();
     }
 
     /**
@@ -176,7 +176,7 @@ public class EntityOperatorReconciler {
                         reconciliation.namespace(),
                         KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
                         entityOperator != null ? entityOperator.generateRole(reconciliation.namespace(), reconciliation.namespace()) : null
-                ).map((Void) null);
+                ).mapEmpty();
     }
 
     /**
@@ -196,7 +196,7 @@ public class EntityOperatorReconciler {
                                 watchedNamespace,
                                 KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
                                 entityOperator.generateRole(reconciliation.namespace(), watchedNamespace)
-                        ).map((Void) null);
+                        ).mapEmpty();
             } else {
                 return Future.succeededFuture();
             }
@@ -222,7 +222,7 @@ public class EntityOperatorReconciler {
                                 watchedNamespace,
                                 KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
                                 entityOperator.generateRole(reconciliation.namespace(), watchedNamespace)
-                        ).map((Void) null);
+                        ).mapEmpty();
             } else {
                 return Future.succeededFuture();
             }
@@ -254,11 +254,11 @@ public class EntityOperatorReconciler {
                     KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()), entityOperator.topicOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace()));
 
             return Future.join(ownNamespaceFuture, watchedNamespaceFuture)
-                    .map((Void) null);
+                    .mapEmpty();
         } else {
             return roleBindingOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityTopicOperatorRoleBinding(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -285,11 +285,11 @@ public class EntityOperatorReconciler {
                     KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()), entityOperator.userOperator().generateRoleBindingForRole(reconciliation.namespace(), reconciliation.namespace()));
 
             return Future.join(ownNamespaceFuture, watchedNamespaceFuture)
-                    .map((Void) null);
+                    .mapEmpty();
         } else {
             return roleBindingOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorRoleBinding(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -309,11 +309,11 @@ public class EntityOperatorReconciler {
                                     KafkaResources.entityTopicOperatorLoggingConfigMapName(reconciliation.name()),
                                     entityOperator.topicOperator().generateMetricsAndLogConfigMap(logging)
                             )
-                    ).map((Void) null);
+                    ).mapEmpty();
         } else {
             return configMapOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityTopicOperatorLoggingConfigMapName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -333,11 +333,11 @@ public class EntityOperatorReconciler {
                                     KafkaResources.entityUserOperatorLoggingConfigMapName(reconciliation.name()),
                                     entityOperator.userOperator().generateMetricsAndLogConfigMap(logging)
                             )
-                    ).map((Void) null);
+                    ).mapEmpty();
         } else {
             return configMapOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorLoggingConfigMapName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -366,7 +366,7 @@ public class EntityOperatorReconciler {
         } else {
             return secretOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityTopicOperatorSecretName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -395,7 +395,7 @@ public class EntityOperatorReconciler {
         } else {
             return secretOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityUserOperatorSecretName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
     /**
@@ -411,7 +411,7 @@ public class EntityOperatorReconciler {
                             reconciliation.namespace(),
                             KafkaResources.entityOperatorDeploymentName(reconciliation.name()),
                             entityOperator != null ? entityOperator.generateNetworkPolicy() : null
-                    ).map((Void) null);
+                    ).mapEmpty();
         } else {
             return Future.succeededFuture();
         }
@@ -438,11 +438,11 @@ public class EntityOperatorReconciler {
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), deployment)
-                    .map((Void) null);
+                    .mapEmpty();
         } else  {
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.entityOperatorDeploymentName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMetadataManager.java
@@ -166,6 +166,6 @@ public class KRaftMetadataManager {
 
         return VertxUtil
                 .kafkaFutureToVertxFuture(reconciliation, vertx, kafkaAdmin.updateFeatures(Map.of(METADATA_VERSION_KEY, featureUpdate), options).values().get(METADATA_VERSION_KEY))
-                .map((Void) null);
+                .mapEmpty();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaConnectAssemblyOperator.java
@@ -288,7 +288,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                         noConnectCluster(reconciliation.namespace(), reconciliation.name())));
             }
             return Future.join(connectorFutures);
-        }).map((Void) null);
+        }).mapEmpty();
     }
 
     /**
@@ -343,7 +343,7 @@ public class KafkaConnectAssemblyOperator extends AbstractConnectOperator<Kubern
                             ? maybeUpdateConnectorStatus(reconciliation, connector, null, null)
                             : maybeUpdateConnectorStatus(reconciliation, connector, null, zeroReplicas(namespace, connectName)))
                         .collect(Collectors.toList())
-                )).map((Void) null);
+                )).mapEmpty();
         } else {
             String host = KafkaConnectResources.qualifiedServiceName(connectName, namespace);
             KafkaConnectApi apiClient = connectClientProvider.apply(vertx);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaExporterReconciler.java
@@ -112,7 +112,7 @@ public class KafkaExporterReconciler {
                         reconciliation.namespace(),
                         KafkaExporterResources.componentName(reconciliation.name()),
                         kafkaExporter != null ? kafkaExporter.generateServiceAccount() : null
-                ).map((Void) null);
+                ).mapEmpty();
     }
 
     /**
@@ -140,7 +140,7 @@ public class KafkaExporterReconciler {
         } else {
             return secretOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.secretName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 
@@ -157,7 +157,7 @@ public class KafkaExporterReconciler {
                             reconciliation.namespace(),
                             KafkaExporterResources.componentName(reconciliation.name()),
                             kafkaExporter != null ? kafkaExporter.generateNetworkPolicy() : null
-                    ).map((Void) null);
+                    ).mapEmpty();
         } else {
             return Future.succeededFuture();
         }
@@ -183,11 +183,11 @@ public class KafkaExporterReconciler {
 
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.componentName(reconciliation.name()), deployment)
-                    .map((Void) null);
+                    .mapEmpty();
         } else  {
             return deploymentOperator
                     .reconcile(reconciliation, reconciliation.namespace(), KafkaExporterResources.componentName(reconciliation.name()), null)
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaListenersReconciler.java
@@ -145,7 +145,7 @@ public class KafkaListenersReconciler {
         services.addAll(kafka.generateExternalBootstrapServices());
         services.addAll(kafka.generatePerPodServices());
 
-        return serviceOperator.batchReconcile(reconciliation, reconciliation.namespace(), services, kafka.getSelectorLabels()).map((Void) null);
+        return serviceOperator.batchReconcile(reconciliation, reconciliation.namespace(), services, kafka.getSelectorLabels()).mapEmpty();
     }
 
     /**
@@ -158,7 +158,7 @@ public class KafkaListenersReconciler {
         routes.addAll(kafka.generateExternalRoutes());
 
         if (pfa.hasRoutes()) {
-            return routeOperator.batchReconcile(reconciliation, reconciliation.namespace(), routes, kafka.getSelectorLabels()).map((Void) null);
+            return routeOperator.batchReconcile(reconciliation, reconciliation.namespace(), routes, kafka.getSelectorLabels()).mapEmpty();
         } else {
             if (!routes.isEmpty()) {
                 LOGGER.warnCr(reconciliation, "The OpenShift route API is not available in this Kubernetes cluster. Exposing Kafka cluster {} using routes is not possible.", reconciliation.name());
@@ -178,7 +178,7 @@ public class KafkaListenersReconciler {
         List<Ingress> ingresses = new ArrayList<>(kafka.generateExternalBootstrapIngresses());
         ingresses.addAll(kafka.generateExternalIngresses());
 
-        return ingressOperator.batchReconcile(reconciliation, reconciliation.namespace(), ingresses, kafka.getSelectorLabels()).map((Void) null);
+        return ingressOperator.batchReconcile(reconciliation, reconciliation.namespace(), ingresses, kafka.getSelectorLabels()).mapEmpty();
     }
 
     /**
@@ -453,7 +453,7 @@ public class KafkaListenersReconciler {
 
         return Future
                 .join(listenerFutures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -534,7 +534,7 @@ public class KafkaListenersReconciler {
 
         return Future
                 .join(listenerFutures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -619,7 +619,7 @@ public class KafkaListenersReconciler {
 
         return Future
                 .join(listenerFutures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -691,7 +691,7 @@ public class KafkaListenersReconciler {
 
         return Future
                 .join(listenerFutures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaNodeUnregistration.java
@@ -61,7 +61,7 @@ public class KafkaNodeUnregistration {
                         adminClient.close();
                         return Future.succeededFuture();
                     })
-                    .map((Void) null);
+                    .mapEmpty();
         } catch (KafkaException e) {
             LOGGER.warnCr(reconciliation, "Failed to unregister nodes", e);
             return Future.failedFuture(e);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -347,7 +347,7 @@ public class KafkaReconciler {
     protected Future<Void> networkPolicy() {
         if (isNetworkPolicyGeneration) {
             return networkPolicyOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaNetworkPolicyName(reconciliation.name()), kafka.generateNetworkPolicy(operatorNamespace, operatorNamespaceLabels))
-                    .map((Void) null);
+                    .mapEmpty();
         } else {
             return Future.succeededFuture();
         }
@@ -527,7 +527,7 @@ public class KafkaReconciler {
     protected Future<Void> serviceAccount() {
         return serviceAccountOperator
                 .reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaComponentName(reconciliation.name()), kafka.generateServiceAccount())
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -549,7 +549,7 @@ public class KafkaReconciler {
                                 desired
                         ),
                 desired
-        ).map((Void) null);
+        ).mapEmpty();
     }
 
     /**
@@ -593,7 +593,7 @@ public class KafkaReconciler {
                             }
                         }
 
-                        return Future.join(ops).map((Void) null);
+                        return Future.join(ops).mapEmpty();
                     }
                 });
     }
@@ -719,7 +719,7 @@ public class KafkaReconciler {
 
                     return Future
                             .join(ops)
-                            .map((Void) null);
+                            .mapEmpty();
                 });
     }
 
@@ -1101,7 +1101,7 @@ public class KafkaReconciler {
         // Deleting resource which likely does not exist would cause more load on the Kubernetes API then trying to get
         // it first because of the watch if it was deleted etc.
         return configMapOperator.reconcile(reconciliation, reconciliation.namespace(), KafkaResources.kafkaMetricsAndLogConfigMapName(reconciliation.name()), null)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -1259,7 +1259,7 @@ public class KafkaReconciler {
 
             // Return future
             return Future.join(statusUpdateFutures)
-                    .map((Void) null);
+                    .mapEmpty();
         } else {
             return Future.succeededFuture();
         }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleaner.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ManualPodCleaner.java
@@ -172,7 +172,7 @@ public class ManualPodCleaner {
 
                     return strimziPodSetOperator.reconcile(reconciliation, reconciliation.namespace(), podSetName, reducedPodSet)
                             .compose(ignore -> deletePodAndPvc(podName, deletePvcs))
-                            .map((Void) null);
+                            .mapEmpty();
                 });
     }
 
@@ -209,6 +209,6 @@ public class ManualPodCleaner {
                     }
                     return Future.join(deleteResults);
                 })
-                .map((Void) null);
+                .mapEmpty();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/PvcReconciler.java
@@ -70,7 +70,7 @@ public class PvcReconciler {
                             // * The PVC doesn't exist yet, we should create it
                             // * The PVC is not Bound, we should reconcile it
                             return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), desiredPvc.getMetadata().getName(), desiredPvc)
-                                    .map((Void) null);
+                                    .mapEmpty();
                         } else if (currentPvc.getStatus().getConditions().stream().anyMatch(cond -> "Resizing".equals(cond.getType()) && "true".equals(cond.getStatus().toLowerCase(Locale.ENGLISH))))  {
                             // The PVC is Bound, but it is already resizing => Nothing to do, we should let it resize
                             LOGGER.debugCr(reconciliation, "The PVC {} is resizing, nothing to do", desiredPvc.getMetadata().getName());
@@ -91,7 +91,7 @@ public class PvcReconciler {
                             } else  {
                                 // size didn't change, just reconcile
                                 return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), desiredPvc.getMetadata().getName(), desiredPvc)
-                                        .map((Void) null);
+                                        .mapEmpty();
                             }
                         }
                     });
@@ -136,7 +136,7 @@ public class PvcReconciler {
                             // Resizing supported by SC => We can reconcile the PVC to have it resized
                             LOGGER.infoCr(reconciliation, "Resizing PVC {} from {} to {}.", desired.getMetadata().getName(), current.getStatus().getCapacity().get("storage").getAmount(), desired.getSpec().getResources().getRequests().get("storage").getAmount());
                             return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), desired.getMetadata().getName(), desired)
-                                    .map((Void) null);
+                                    .mapEmpty();
                         }
                     });
         } else {
@@ -166,7 +166,7 @@ public class PvcReconciler {
         }
 
         return Future.all(futures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -183,7 +183,7 @@ public class PvcReconciler {
                     if (pvc != null && Annotations.booleanAnnotation(pvc, Annotations.ANNO_STRIMZI_IO_DELETE_CLAIM, false)) {
                         LOGGER.infoCr(reconciliation, "Deleting PVC {}", pvcName);
                         return pvcOperator.reconcile(reconciliation, reconciliation.namespace(), pvcName, null)
-                                .map((Void) null);
+                                .mapEmpty();
                     } else {
                         return Future.succeededFuture();
                     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconcilerUtils.java
@@ -94,7 +94,7 @@ public class ReconcilerUtils {
         }
 
         return Future.join(podFutures)
-                .map((Void) null);
+                .mapEmpty();
     }
 
     /**
@@ -253,11 +253,11 @@ public class ReconcilerUtils {
                     if (desiredJmxSecret != null)  {
                         // Desired secret is not null => should be updated
                         return secretOperator.reconcile(reconciliation, reconciliation.namespace(), cluster.jmx().secretName(), desiredJmxSecret)
-                                .map((Void) null);
+                                .mapEmpty();
                     } else if (currentJmxSecret != null)    {
                         // Desired secret is null but current is not => we should delete the secret
                         return secretOperator.reconcile(reconciliation, reconciliation.namespace(), cluster.jmx().secretName(), null)
-                                .map((Void) null);
+                                .mapEmpty();
                     } else {
                         // Both current and desired secret are null => nothing to do
                         return Future.succeededFuture();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/AbstractNamespacedResourceOperator.java
@@ -401,7 +401,7 @@ public abstract class AbstractNamespacedResourceOperator<C extends KubernetesCli
      * @return                  A Future with True if the deletion succeeded and False when it failed.
      */
     public Future<Void> deleteAsync(Reconciliation reconciliation, String namespace, String name, boolean cascading) {
-        return internalDelete(reconciliation, namespace, name, cascading).map((Void) null);
+        return internalDelete(reconciliation, namespace, name, cascading).mapEmpty();
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaStatusTest.java
@@ -523,7 +523,7 @@ public class KafkaStatusTest {
         @Override
         Future<Void> reconcile(ReconciliationState reconcileState)  {
             return reconcileState.initialStatus()
-                    .map((Void) null);
+                    .mapEmpty();
         }
     }
 }


### PR DESCRIPTION
Trivial refactoring PR to use the `mapEmpty()` instead of `map((Void) null)` where a `Future<Void>` is needed.