### PR TITLE
Prepare for Vert.x 5

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ShutdownHook.java
@@ -61,7 +61,7 @@ public class ShutdownHook implements Runnable {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        vertx.close(ar -> {
+        vertx.close().onComplete(ar -> {
             if (!ar.succeeded()) {
                 LOGGER.error("Vert.x close failed", ar.cause());
             }
@@ -89,7 +89,7 @@ public class ShutdownHook implements Runnable {
     public static void undeployVertxVerticle(Vertx vertx, String verticleId, long timeoutMs) {
         LOGGER.info("Shutting down Vert.x verticle {}", verticleId);
         CountDownLatch latch = new CountDownLatch(1);
-        vertx.undeploy(verticleId, ar -> {
+        vertx.undeploy(verticleId).onComplete(ar -> {
             if (!ar.succeeded()) {
                 LOGGER.error("Vert.x verticle failed to undeploy", ar.cause());
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -393,7 +393,7 @@ public abstract class AbstractOperator<
         String name = reconciliation.name();
         final String lockName = getLockName(namespace, name);
         LOGGER.debugCr(reconciliation, "Try to acquire lock {}", lockName);
-        vertx.sharedData().getLockWithTimeout(lockName, lockTimeoutMs, res -> {
+        vertx.sharedData().getLockWithTimeout(lockName, lockTimeoutMs).onComplete(res -> {
             if (res.succeeded()) {
                 LOGGER.debugCr(reconciliation, "Lock {} acquired", lockName);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ClusterOperatorTest.java
@@ -177,7 +177,7 @@ public class ClusterOperatorTest {
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(namespaceList.size()));
                 for (String deploymentId: VERTX.deploymentIDs()) {
-                    VERTX.undeploy(deploymentId, asyncResult -> {
+                    VERTX.undeploy(deploymentId).onComplete(asyncResult -> {
                         if (asyncResult.failed()) {
                             LOGGER.error("Failed to undeploy {}", deploymentId);
                             context.failNow(asyncResult.cause());
@@ -271,7 +271,7 @@ public class ClusterOperatorTest {
             .onComplete(context.succeeding(v -> context.verify(() -> {
                 assertThat("A verticle per namespace", VERTX.deploymentIDs(), hasSize(1));
                 for (String deploymentId: VERTX.deploymentIDs()) {
-                    VERTX.undeploy(deploymentId, asyncResult -> {
+                    VERTX.undeploy(deploymentId).onComplete(asyncResult -> {
                         if (asyncResult.failed()) {
                             LOGGER.error("Failed to undeploy {}", deploymentId);
                             context.failNow(asyncResult.cause());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/PlatformFeaturesAvailabilityTest.java
@@ -347,7 +347,6 @@ public class PlatformFeaturesAvailabilityTest {
         server = httpServer.listen(0).toCompletionStage().toCompletableFuture().get();
     }
 
-
     @AfterEach()
     void teardown() throws ExecutionException, InterruptedException {
         if (server == null) {
@@ -355,7 +354,7 @@ public class PlatformFeaturesAvailabilityTest {
         }
 
         Promise<Void> serverStopped = Promise.promise();
-        server.close(x -> serverStopped.complete());
+        server.close().onComplete(x -> serverStopped.complete());
         serverStopped.future().toCompletionStage().toCompletableFuture().get();
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/OperatorMetricsTest.java
@@ -364,7 +364,7 @@ public class OperatorMetricsTest {
 
         Promise<Void> reconcileAllPromise = Promise.promise();
         ((ReconcileAllMockOperator) operator).setResources(resources);
-        operator.reconcileAll("test", "my-namespace", reconcileAllPromise);
+        operator.reconcileAll("test", "my-namespace", reconcileAllPromise::handle);
 
         Checkpoint async = context.checkpoint();
         reconcileAllPromise.future().onComplete(context.succeeding(v -> context.verify(() -> {
@@ -416,7 +416,7 @@ public class OperatorMetricsTest {
 
         Promise<Void> reconcileAllPromise = Promise.promise();
         ((ReconcileAllMockOperator) operator).setResources(resources);
-        operator.reconcileAll("test", "*", reconcileAllPromise);
+        operator.reconcileAll("test", "*", reconcileAllPromise::handle);
 
         Checkpoint async = context.checkpoint();
         reconcileAllPromise.future()
@@ -449,7 +449,7 @@ public class OperatorMetricsTest {
                     // Reconcile again with resource in my-namespace2 deleted
                     Promise<Void> secondReconcileAllPromise = Promise.promise();
                     ((ReconcileAllMockOperator) operator).setResources(updatedResources);
-                    operator.reconcileAll("test", "*", secondReconcileAllPromise);
+                    operator.reconcileAll("test", "*", secondReconcileAllPromise::handle);
 
                     return secondReconcileAllPromise.future();
                 })

--- a/kafka-agent/pom.xml
+++ b/kafka-agent/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,9 +158,9 @@
         <!-- Test only dependencies -->
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>4.11.0</mockito.version>
-        <junit.platform.version>1.9.3</junit.platform.version>
+        <junit.platform.version>1.8.2</junit.platform.version>
         <opentest4j.version>1.2.0</opentest4j.version>
-        <jupiter.version>5.9.3</jupiter.version>
+        <jupiter.version>5.8.2</jupiter.version>
         <strimzi-test-container.version>0.109.1</strimzi-test-container.version>
         <mockserver.version>5.13.2</mockserver.version>
         <mockwebserver.version>3.14.7</mockwebserver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <netty.version>4.1.117.Final</netty.version>
-        <micrometer.version>1.12.3</micrometer.version>
+        <micrometer.version>1.12.13</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>
         <commons-codec.version>1.13</commons-codec.version>
@@ -158,10 +158,9 @@
         <!-- Test only dependencies -->
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>4.11.0</mockito.version>
-        <junit.platform.version>1.8.2</junit.platform.version>
-        <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
+        <junit.platform.version>1.9.3</junit.platform.version>
         <opentest4j.version>1.2.0</opentest4j.version>
-        <jupiter.version>5.8.2</jupiter.version>
+        <jupiter.version>5.9.3</jupiter.version>
         <strimzi-test-container.version>0.109.1</strimzi-test-container.version>
         <mockserver.version>5.13.2</mockserver.version>
         <mockwebserver.version>3.14.7</mockwebserver.version>

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -58,7 +59,7 @@ public class ExecutionListener implements TestExecutionListener {
      * @return                  true if test suite contains Parallel or Isolated test case. Otherwise, false.
      */
     public static boolean requiresSharedNamespace(final ExtensionContext extensionContext) {
-        Set<TestIdentifier> testCases = testPlan.getChildren(extensionContext.getUniqueId());
+        Set<TestIdentifier> testCases = testPlan.getChildren(UniqueId.parse(extensionContext.getUniqueId()));
 
         // name of suites or tags which indicates need of creation of shared namespace test-suite-namespace
         final Set<String> identifiersRequiringSharedNamespace = Set.of(

--- a/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/listeners/ExecutionListener.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.engine.TestTag;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -59,7 +58,7 @@ public class ExecutionListener implements TestExecutionListener {
      * @return                  true if test suite contains Parallel or Isolated test case. Otherwise, false.
      */
     public static boolean requiresSharedNamespace(final ExtensionContext extensionContext) {
-        Set<TestIdentifier> testCases = testPlan.getChildren(UniqueId.parse(extensionContext.getUniqueId()));
+        Set<TestIdentifier> testCases = testPlan.getChildren(extensionContext.getUniqueId());
 
         // name of suites or tags which indicates need of creation of shared namespace test-suite-namespace
         final Set<String> identifiersRequiringSharedNamespace = Set.of(


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR prepares the code base for Vert.x 5. This should allow us to simplify testing of new Vert.x 5 releases in the future by backporting some of the changes used in #11095.
* It updates some Vert.x methods that will be removed in Vert.x 5
* It updates Micrometer Metrics to use a version used by the current Vert.x 4 version we use
* Removes the unused `junit-platform-surefire-provider` from the `pom.xml`

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally