### PR TITLE
Deprecate Secrets field in custom server authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Removed the `statefulset.kubernetes.io/pod-name` label from pods and external listeners Kubernetes Services.
   * If you have any custom setup leveraging such label, please use the `strimzi.io/pod-name` one instead.
 * The `secrets` list for mounting additional Kubernetes Secrets in `type: custom` authentication was deprecated and will be removed in the future.
-  Please use the template section instead to configure additional volumes instead.
+  Please use the template section to configure additional volumes instead.
 
 ## 0.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   For more details about migrating from storage overrides, please follow the [documentation](https://strimzi.io/docs/operators/0.45.0/full/deploying.html#con-config-storage-zookeeper-str).
 * Removed the `statefulset.kubernetes.io/pod-name` label from pods and external listeners Kubernetes Services.
   * If you have any custom setup leveraging such label, please use the `strimzi.io/pod-name` one instead.
+* The `secrets` list for mounting additional Kubernetes Secrets in `type: custom` authentication was deprecated and will be removed in the future.
+  Please use the template section instead to configure additional volumes instead.
 
 ## 0.45.0
 

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -6,10 +6,12 @@ package io.strimzi.api.kafka.model.kafka.listener;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.annotations.DeprecatedProperty;
 import io.strimzi.api.kafka.model.common.Constants;
 import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.DescriptionFile;
+import io.strimzi.crdgenerator.annotations.PresentInVersions;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -67,6 +69,9 @@ public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthenticati
 
     @Description("Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Deprecated
+    @DeprecatedProperty(description = "Please use the template section instead to configure additional volumes instead.")
+    @PresentInVersions("v1alpha1-v1beta2")
     public List<GenericSecretSource> getSecrets() {
         return secrets;
     }

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/listener/KafkaListenerAuthenticationCustom.java
@@ -70,7 +70,7 @@ public class KafkaListenerAuthenticationCustom extends KafkaListenerAuthenticati
     @Description("Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Deprecated
-    @DeprecatedProperty(description = "Please use the template section instead to configure additional volumes instead.")
+    @DeprecatedProperty(description = "Please use the template section to configure additional volumes instead.")
     @PresentInVersions("v1alpha1-v1beta2")
     public List<GenericSecretSource> getSecrets() {
         return secrets;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1370,6 +1370,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return List of non-data volumes used by the Kafka pods
      */
+    @SuppressWarnings("deprecation") // Secrets in custom authentication are deprecated
     private List<Volume> getNonDataVolumes(boolean isOpenShift, NodeRef node, PodTemplate templatePod) {
         List<Volume> volumeList = new ArrayList<>();
 
@@ -1462,6 +1463,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return  List of volume mounts
      */
+    @SuppressWarnings("deprecation") // Secrets in custom authentication are deprecated
     private List<VolumeMount> getVolumeMounts(Storage storage, ContainerTemplate containerTemplate, boolean isBroker) {
         List<VolumeMount> volumeMountList = new ArrayList<>(VolumeUtils.createVolumeMounts(storage, false));
         volumeMountList.add(VolumeUtils.createTempDirVolumeMount());

--- a/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
+++ b/documentation/api/io.strimzi.api.kafka.model.kafka.listener.KafkaListenerAuthenticationCustom.adoc
@@ -26,8 +26,16 @@ spec:
             sasl.enabled.mechanisms: oauthbearer
             oauthbearer.sasl.jaas.config: |
               org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ;
-          secrets:
-            - secretName: example
+    template:
+      pod:
+        volumes:
+          - name: example-secret
+            secret:
+              secretName: example
+      kafkaContainer:
+        volumeMounts:
+          - name: example-secret
+            mountPath: /mnt/secret-volume
 ----
 
 A protocol map is generated that uses the `sasl` and `tls` values to determine which protocol to map to the listener.
@@ -37,8 +45,8 @@ A protocol map is generated that uses the `sasl` and `tls` values to determine w
 * SASL = True, TLS = False -> SASL_PLAINTEXT
 * SASL = False, TLS = False -> PLAINTEXT
 
-Secrets are mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>` in the Kafka broker nodes' containers.
-For example, the mounted secret (`example`) in the example configuration would be located at `/opt/kafka/custom-authn-secrets/custom-listener-oauth-bespoke-9093/example`.
+Secrets are mounted to the `/mnt` directory in the Kafka broker nodes' containers.
+For example, the mounted secret (`example`) in the example configuration would be located at `/mnt/secret-volume`.
 
 = Configuring customized TLS Client Authentication
 
@@ -62,11 +70,18 @@ spec:
           listenerConfig:
             ssl.client.auth: required
             ssl.principal.mapping.rules: RULE:^CN=(.*?),(.*)$/$1@my-cluster.com/
-            ssl.truststore.location: /opt/kafka/custom-authn-secrets/custom-listener-tls-9093/custom-truststore/ca.crt
+            ssl.truststore.location: /mnt/my-truststore/ca.crt
             ssl.truststore.type: PEM
-          secrets:
-            - key: ca.crt
+    template:
+      pod:
+        volumes:
+          - name: my-truststore
+            secret:
               secretName: custom-truststore
+      kafkaContainer:
+        volumeMounts:
+          - name: my-truststore
+            mountPath: /mnt/my-truststore
 ----
 
 = Setting a custom principal builder

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -410,7 +410,7 @@ It must have the value `custom` for the type `KafkaListenerAuthenticationCustom`
 |Configuration to be used for a specific listener. All values are prefixed with `listener.name.<listener_name>`.
 |secrets
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`] array
-|Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`.
+|**The `secrets` property has been deprecated.** Please use the template section instead to configure additional volumes instead. Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`.
 |====
 
 [id='type-GenericKafkaListenerConfiguration-{context}']

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -410,7 +410,7 @@ It must have the value `custom` for the type `KafkaListenerAuthenticationCustom`
 |Configuration to be used for a specific listener. All values are prefixed with `listener.name.<listener_name>`.
 |secrets
 |xref:type-GenericSecretSource-{context}[`GenericSecretSource`] array
-|**The `secrets` property has been deprecated.** Please use the template section instead to configure additional volumes instead. Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`.
+|**The `secrets` property has been deprecated.** Please use the template section to configure additional volumes instead. Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`.
 |====
 
 [id='type-GenericKafkaListenerConfiguration-{context}']


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR deprecates the `secrets` field in the `type: custom` authentication in the Kafka CR as approved in [SP-094](https://github.com/strimzi/proposals/blob/main/094-deprecate-secrets-field-in-custom-server-authentication.md). It also updates the documentation examples using this to use the additional volumes from template instead.

The warning about using the deprecated field is produced automatically by the deprecation check, so it is not part of this PR:
```
2025-01-31 22:10:54 INFO  ClusterOperator:135 - Triggering periodic reconciliation for namespace myproject
2025-01-31 22:10:54 WARN  StatusUtils:106 - Reconciliation #82(timer) Kafka(myproject/my-cluster): In resource Kafka(myproject/my-cluster) in API version kafka.strimzi.io/v1beta2 the secrets property at path spec.kafka.listeners.auth.secrets has been deprecated. Please use the template section instead to configure additional volumes instead.
2025-01-31 22:10:54 WARN  StatusUtils:106 - Reconciliation #82(timer) Kafka(myproject/my-cluster): In resource Kafka(myproject/my-cluster) in API version kafka.strimzi.io/v1beta2 the secrets property at path spec.kafka.listeners.auth.secrets has been deprecated. Please use the template section instead to configure additional volumes instead.
2025-01-31 22:10:54 INFO  AbstractOperator:266 - Reconciliation #82(timer) Kafka(myproject/my-cluster): Kafka my-cluster will be checked for creation or modification
2025-01-31 22:10:58 INFO  AbstractOperator:546 - Reconciliation #82(timer) Kafka(myproject/my-cluster): reconciled
```

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Update CHANGELOG.md