### PR TITLE
Minor CRD Generator cleanup

### DIFF
--- a/crd-generator/pom.xml
+++ b/crd-generator/pom.xml
@@ -26,6 +26,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>crd-annotations</artifactId>
         </dependency>

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -65,8 +65,6 @@ import static io.strimzi.crdgenerator.Property.subtypes;
 import static java.lang.Integer.parseInt;
 import static java.lang.reflect.Modifier.isAbstract;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 
 /**
  * <p>Generates a Kubernetes {@code CustomResourceDefinition} YAML file
@@ -174,32 +172,18 @@ class CrdGenerator {
     private final ApiVersion storageVersion;
     private final VersionRange<ApiVersion> servedVersion;
     private final VersionRange<ApiVersion> describeVersions;
-    // TODO CrdValidator
-    // extraProperties
-    // @Buildable
 
     public interface Reporter {
-        void warn(String s);
-
         void err(String s);
     }
 
     public static class DefaultReporter implements Reporter {
-
-        public void warn(String s) {
-            System.err.println("CrdGenerator: warn: " + s);
-        }
-
         public void err(String s) {
             System.err.println("CrdGenerator: error: " + s);
         }
     }
 
     Reporter reporter;
-
-    public void warn(String s) {
-        reporter.warn(s);
-    }
 
     public static void argParseErr(String s) {
         System.err.println("CrdGenerator: error: " + s);
@@ -266,11 +250,6 @@ class CrdGenerator {
     private final ConversionStrategy conversionStrategy;
 
     private int numErrors;
-
-    public CrdGenerator(VersionRange<KubeVersion> targetKubeVersions, ApiVersion crdApiVersion) {
-        this(targetKubeVersions, crdApiVersion, CrdGenerator.YAML_MAPPER, emptyMap(), new DefaultReporter(),
-                emptyList(), null, null, new NoneConversionStrategy(), null);
-    }
 
     /**
      * @param targetKubeVersions The targeted version(s) of Kubernetes.
@@ -358,7 +337,7 @@ class CrdGenerator {
             // "Webhook": must be None if spec.preserveUnknownFields is true
             result.put("preserveUnknownFields", false);
         }
-        result.set("conversion", buildConversion(crdApiVersion));
+        result.set("conversion", buildConversion());
 
         for (Crd.Spec.Version version : crd.versions()) {
             ApiVersion crApiVersion = ApiVersion.parse(version.name());
@@ -387,20 +366,10 @@ class CrdGenerator {
 
         result.set("versions", versions);
 
-        if (crdApiVersion.compareTo(V1) < 0
-                && targetKubeVersions.intersects(KubeVersion.parseRange("1.11-1.15"))) {
-            result.put("version", Arrays.stream(crd.versions())
-                    .map(v -> ApiVersion.parse(v.name()))
-                    .filter(this::shouldIncludeVersion)
-                    .findFirst()
-                    .map(ApiVersion::toString)
-                    .orElseThrow());
-        }
-
         return result;
     }
 
-    private ObjectNode buildConversion(ApiVersion crdApiVersion) {
+    private ObjectNode buildConversion() {
         ObjectNode conversion = nf.objectNode();
         if (conversionStrategy instanceof NoneConversionStrategy) {
             conversion.put("strategy", "None");
@@ -569,31 +538,23 @@ class CrdGenerator {
 
     private ObjectNode buildValidation(Class<? extends CustomResource> crdClass, ApiVersion crApiVersion, boolean description) {
         ObjectNode result = nf.objectNode();
-        // OpenShift Origin 3.10-rc0 doesn't like the `type: object` in schema root
-        boolean noTopLevelTypeProperty = targetKubeVersions.intersects(KubeVersion.parseRange("1.11-1.15"));
-        result.set("openAPIV3Schema", buildObjectSchema(crApiVersion, crdClass, crdApiVersion.compareTo(V1) >= 0 || !noTopLevelTypeProperty, description));
+        result.set("openAPIV3Schema", buildObjectSchema(crApiVersion, crdClass, description));
         return result;
     }
 
     private ObjectNode buildObjectSchema(ApiVersion crApiVersion, Class<?> crdClass, boolean description) {
-        return buildObjectSchema(crApiVersion, crdClass, true, description);
-    }
-
-    private ObjectNode buildObjectSchema(ApiVersion crApiVersion, Class<?> crdClass, boolean printType, boolean description) {
         ObjectNode result = nf.objectNode();
-        buildObjectSchema(crApiVersion, result, crdClass, printType, description);
+        buildObjectSchema(crApiVersion, result, crdClass, description);
         return result;
     }
 
-    private void buildObjectSchema(ApiVersion crApiVersion, ObjectNode result, Class<?> crdClass, boolean printType, boolean description) {
+    private void buildObjectSchema(ApiVersion crApiVersion, ObjectNode result, Class<?> crdClass, boolean description) {
         if (!crdClass.getName().startsWith("java.lang.")) {
             // java.lang.* class does not require class validation as i.e. JsonIgnore and Builder does not apply
             checkClass(crdClass);
         }
 
-        if (printType) {
-            result.put("type", "object");
-        }
+        result.put("type", "object");
 
         result.set("properties", buildSchemaProperties(crApiVersion, crdClass, description));
         ArrayNode oneOf = buildSchemaOneOf(crdClass);
@@ -637,7 +598,6 @@ class CrdGenerator {
     }
 
     private void checkClass(Class<?> crdClass) {
-
         if (!isAbstract(crdClass.getModifiers())) {
             checkForBuilderClass(crdClass, crdClass.getName() + "Builder");
             checkForBuilderClass(crdClass, crdClass.getName() + "Fluent");
@@ -677,11 +637,10 @@ class CrdGenerator {
         }
     }
 
-    private void checkDiscriminatorIsIncluded(Class<?> crdClass, Class c) {
+    private void checkDiscriminatorIsIncluded(Class<?> crdClass, Class<?> c) {
         try {
             String typePropertyName = crdClass.getAnnotation(JsonTypeInfo.class).property();
             String methodName = "get" + typePropertyName.substring(0, 1).toUpperCase(Locale.ENGLISH) + typePropertyName.substring(1).toLowerCase(Locale.ENGLISH);
-            @SuppressWarnings("unchecked")
             Method method = c.getMethod(methodName);
 
             if (!isAnnotatedWithIncludeNonNull(method)) {
@@ -887,12 +846,13 @@ class CrdGenerator {
 
             try {
                 Method valuesMethod = elementType.getMethod("values");
+
                 itemResult.set("enum", enumCaseArray((Enum[]) valuesMethod.invoke(null)));
             } catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);
             }
         } else  {
-            buildObjectSchema(crApiVersion, itemResult, elementType, true, description);
+            buildObjectSchema(crApiVersion, itemResult, elementType, description);
         }
         return result;
     }
@@ -909,7 +869,7 @@ class CrdGenerator {
         return keyType.equals(types[0]) && valueType.equals(types[1]);
     }
 
-    private ObjectNode buildBasicTypeSchema(Property element, Class type) {
+    private ObjectNode buildBasicTypeSchema(Property element, Class<?> type) {
         ObjectNode result = nf.objectNode();
 
         String typeName;
@@ -933,9 +893,6 @@ class CrdGenerator {
 
     private ObjectNode buildQuantityTypeSchema() {
         ObjectNode result = nf.objectNode();
-
-        if (crdApiVersion.compareTo(V1) < 0)
-            return result;
 
         ObjectNode additionalProperties = result.putObject("additionalProperties");
         ArrayNode anyOf = additionalProperties.putArray("anyOf");
@@ -1053,8 +1010,7 @@ class CrdGenerator {
 
     @SuppressWarnings("unchecked")
     private <T> void checkDisjointVersions(AnnotatedElement annotated, T[] wrapperAnnotation, Class<T> annotationClass) {
-        long count = Arrays.stream(wrapperAnnotation)
-                .map(element -> apiVersion(element, annotationClass)).count();
+        long count = Arrays.stream(wrapperAnnotation).count();
 
         long distinctCount = Arrays.stream(wrapperAnnotation)
                 .map(element -> apiVersion(element, annotationClass)).distinct().count();
@@ -1090,7 +1046,7 @@ class CrdGenerator {
         return arrayNode;
     }
 
-    private String typeName(Class type) {
+    private String typeName(Class<?> type) {
         if (String.class.equals(type)) {
             return "string";
         } else if (int.class.equals(type)

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/CrdGenerator.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.strimzi.api.annotations.ApiVersion;
@@ -242,7 +243,9 @@ class CrdGenerator {
         }
     }
 
-
+    // Currently unused, but it might be hande in the future so it is not removed
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    @SuppressWarnings("unused")
     private final VersionRange<KubeVersion> targetKubeVersions;
     private final ObjectMapper mapper;
     private final JsonNodeFactory nf;

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/DocGenerator.java
@@ -37,7 +37,6 @@ import static io.strimzi.crdgenerator.Property.discriminator;
 import static io.strimzi.crdgenerator.Property.isPolymorphic;
 import static io.strimzi.crdgenerator.Property.properties;
 import static io.strimzi.crdgenerator.Property.subtypeMap;
-import static io.strimzi.crdgenerator.Property.subtypeNames;
 import static io.strimzi.crdgenerator.Property.subtypes;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -245,26 +244,6 @@ class DocGenerator {
         }
     }
 
-    /**
-     * Sets the external link to Kubernetes docs or the link for fields distinguished by `type`
-     *
-     * @param property  The property for which the description should be added
-     * @param kubeLink  The value of the KubeLink annotation or null if not set
-     * @param externalUrl   The URL to the Kubernetes documentation
-     *
-     * @throws IOException  Throws IOException when appending to the output fails
-     */
-    private void addExternalUrl(Property property, KubeLink kubeLink, String externalUrl) throws IOException {
-        if (externalUrl != null) {
-            out.append(" For more information, see the ").append(externalUrl)
-                    .append("[").append("external documentation for ").append(kubeLink.group()).append("/").append(kubeLink.version()).append(" ").append(kubeLink.kind()).append("].").append(NL).append(NL);
-        } else if (isPolymorphic(property.getType().getType())) {
-            out.append(" The type depends on the value of the `").append(property.getName()).append(".").append(discriminator(property.getType().getType()))
-                    .append("` property within the given object, which must be one of ")
-                    .append(subtypeNames(property.getType().getType()).toString()).append(".");
-        }
-    }
-
     private String getDeprecation(Property property, DeprecatedProperty deprecated) {
         String msg = String.format("**The `%s` property has been deprecated",
                 property.getName());
@@ -307,11 +286,9 @@ class DocGenerator {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void appendPropertyType(Crd crd, Appendable out, PropertyType propertyType, String externalUrl) throws IOException {
         Class<?> propertyClass = propertyType.isArray() ? propertyType.arrayBase() : propertyType.getType();
-        
-        
+
         out.append(NL);
         out.append("|");
         
@@ -333,7 +310,7 @@ class DocGenerator {
                 Set<String> strings = new HashSet<>();
                 Method valuesMethod = propertyType.arrayBase().getMethod("values");
 
-                for (JsonNode n : Schema.enumCases((Enum[]) valuesMethod.invoke(null))) {
+                for (JsonNode n : Schema.enumCases((Enum<?>[]) valuesMethod.invoke(null))) {
                     if (n.isTextual()) {
                         strings.add(n.asText());
                     } else {
@@ -357,7 +334,6 @@ class DocGenerator {
 
         out.append(NL);
         out.append("|");
-
     }
 
     private void appendTypeDeprecation(Crd crd, Class<?> cls) throws IOException {

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/PropertyType.java
@@ -31,9 +31,7 @@ class PropertyType {
     }
 
     public boolean isArray() {
-        //Class<?> propertyType = getType();
-        //return propertyType.isArray() || List.class.equals(propertyType);
-        boolean b = gType instanceof Class<?> && ((Class<?>) gType).equals(List.class)
+        boolean b = gType instanceof Class<?> && gType.equals(List.class)
                 || gType instanceof ParameterizedType && ((ParameterizedType) gType).getRawType().equals(List.class);
         return gType instanceof GenericArrayType
                 || gType instanceof Class<?> && ((Class<?>) gType).isArray()

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/CrdGeneratorTest.java
@@ -26,10 +26,6 @@ class CrdGeneratorTest {
 
     private final CrdGenerator.Reporter crdGeneratorReporter = new CrdGenerator.Reporter() {
         @Override
-        public void warn(String s) {
-        }
-
-        @Override
         public void err(String err) {
             if (err.contains("@JsonInclude") || err.contains("@JsonPropertyOrder")) {
                 // Currently we're only interested in testing @JsonInclude and @JsonPropertyOrder errors


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR does a minor clean-up of the CRD Generator. It mostly removes unused methods, unused code paths mainly related to `v1beta1` CRDs and some IDE warnings.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally