### PR TITLE
[ST] Configure number of messages per transaction into one more test

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/kafka/KafkaST.java
@@ -1080,6 +1080,8 @@ class KafkaST extends AbstractST {
         KafkaClients kafkaBasicClientJob = ClientUtils.getContinuousPlainClientBuilder(testStorage)
             .withMessageCount(continuousClientsMessageCount)
             .withAdditionalConfig(producerAdditionConfiguration)
+            // TODO: needed because of bug in test-clients - https://github.com/strimzi/test-clients/issues/119
+            .withMessagesPerTransaction("1")
             .build();
 
         resourceManager.createResourceWithWait(kafkaBasicClientJob.producerStrimzi(), kafkaBasicClientJob.consumerStrimzi());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds the `withMessagesPerTransaction` to one more test (`KafkaST#testResizeJbodVolumes`), which is flaky because of issue in test-clients.

### Checklist

- [ ] Make sure all tests pass
