### PR TITLE
Fix ACL Deny rules documentation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/user/acl/AclRule.java
@@ -52,8 +52,8 @@ public class AclRule implements UnknownPropertyPreserving {
     }
 
     @Description("The type of the rule. " +
-            "Currently the only supported type is `allow`. " +
             "ACL rules with type `allow` are used to allow user to execute the specified operations. " +
+            "ACL rules with type `deny` are used to deny user to execute the specified operations. " +
             "Default value is `allow`.")
     @JsonProperty(defaultValue = "allow")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -3442,7 +3442,7 @@ include::../api/io.strimzi.api.kafka.model.user.acl.AclRule.adoc[leveloffset=+1]
 |Property |Property type |Description
 |type
 |string (one of [allow, deny])
-|The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+|The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
 |resource
 |xref:type-AclRuleTopicResource-{context}[`AclRuleTopicResource`], xref:type-AclRuleGroupResource-{context}[`AclRuleGroupResource`], xref:type-AclRuleClusterResource-{context}[`AclRuleClusterResource`], xref:type-AclRuleTransactionalIdResource-{context}[`AclRuleTransactionalIdResource`]
 |Indicates the resource for which given ACL rule applies.

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
@@ -104,7 +104,7 @@ spec:
                             enum:
                               - allow
                               - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                            description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                           resource:
                             type: object
                             properties:
@@ -335,7 +335,7 @@ spec:
                             enum:
                               - allow
                               - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                            description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                           resource:
                             type: object
                             properties:
@@ -566,7 +566,7 @@ spec:
                             enum:
                               - allow
                               - deny
-                            description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                            description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                           resource:
                             type: object
                             properties:

--- a/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/packaging/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -103,7 +103,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:
@@ -334,7 +334,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:
@@ -565,7 +565,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:

--- a/packaging/install/user-operator/04-Crd-kafkauser.yaml
+++ b/packaging/install/user-operator/04-Crd-kafkauser.yaml
@@ -103,7 +103,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:
@@ -334,7 +334,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:
@@ -565,7 +565,7 @@ spec:
                           enum:
                           - allow
                           - deny
-                          description: The type of the rule. Currently the only supported type is `allow`. ACL rules with type `allow` are used to allow user to execute the specified operations. Default value is `allow`.
+                          description: The type of the rule. ACL rules with type `allow` are used to allow user to execute the specified operations. ACL rules with type `deny` are used to deny user to execute the specified operations. Default value is `allow`.
                         resource:
                           type: object
                           properties:


### PR DESCRIPTION
### Type of change

- Documentation

### Description

As raised in #11109, the documentation currently suggests that the User Operator does not support management of ACL Deny rules. But this does not seem to be correct -> deny rules are properly supported and handled by the User Operator. This PR updates the docs and fixes it.

This should resolve #11109.

### Checklist

- [x] Update documentation