### PR TITLE
Update Vert.x to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,8 @@
         <fasterxml.jackson-annotations.version>2.16.2</fasterxml.jackson-annotations.version>
         <fasterxml.jackson-datatype.version>2.16.2</fasterxml.jackson-datatype.version>
         <fasterxml.jackson-jaxrs.version>2.16.2</fasterxml.jackson-jaxrs.version>
-        <vertx.version>4.5.12</vertx.version>
-        <vertx-junit5.version>4.5.12</vertx-junit5.version>
+        <vertx.version>4.5.13</vertx.version>
+        <vertx-junit5.version>4.5.13</vertx-junit5.version>
         <kafka.version>3.9.0</kafka.version>
         <yammer-metrics.version>2.2.0</yammer-metrics.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -149,7 +149,7 @@
         <jetty.version>9.4.56.v20240826</jetty.version>
         <javax-servlet.version>3.1.0</javax-servlet.version>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
-        <netty.version>4.1.117.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <micrometer.version>1.12.13</micrometer.version>
         <jayway-jsonpath.version>2.9.0</jayway-jsonpath.version>
         <registry.version>1.3.2.Final</registry.version>


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR updates Vert.x to 4.5.13. This brings new Netty versions with some CVE fixes as well as various bugfixes.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally