### PR TITLE
Remove the Desired Kafka replicas column from the Kafka CRD

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/Kafka.java
@@ -47,11 +47,6 @@ import java.util.function.Predicate;
         ),
         additionalPrinterColumns = {
             @Crd.Spec.AdditionalPrinterColumn(
-                name = "Desired Kafka replicas",
-                description = "The desired number of Kafka replicas in the cluster",
-                jsonPath = ".spec.kafka.replicas",
-                type = "integer"),
-            @Crd.Spec.AdditionalPrinterColumn(
                 name = "Ready",
                 description = "The state of the custom resource",
                 jsonPath = ".status.conditions[?(@.type==\"Ready\")].status",

--- a/documentation/modules/managing/con-custom-resources-info.adoc
+++ b/documentation/modules/managing/con-custom-resources-info.adoc
@@ -22,8 +22,8 @@ The short name for `Kafka` is `k`, so you can also run `kubectl get k` to list a
 ----
 kubectl get k
 
-NAME         DESIRED KAFKA REPLICAS   DESIRED ZK REPLICAS
-my-cluster   3                        3
+NAME         READY   METADATA STATE   WARNINGS
+my-cluster   True    KRaft
 ----
 
 .Long and short names for each Strimzi resource
@@ -41,6 +41,7 @@ m|Strimzi resource      |Long name          |Short name
 | Kafka MirrorMaker 2   | kafkamirrormaker2 | kmm2
 | Kafka Bridge          | kafkabridge       | kb
 | Kafka Rebalance       | kafkarebalance    | kr
+| Strimzi Pod Set       | strimzipodset     | sps
 
 |===
 
@@ -57,8 +58,16 @@ For example, running `kubectl get strimzi` lists all Strimzi custom resources in
 ----
 kubectl get strimzi
 
-NAME                                   DESIRED KAFKA REPLICAS DESIRED ZK REPLICAS
-kafka.kafka.strimzi.io/my-cluster      3                      3
+NAME                                                   PODS   READY PODS   CURRENT PODS   AGE
+strimzipodset.core.strimzi.io/my-cluster-brokers       3      3            3              6h11m
+strimzipodset.core.strimzi.io/my-cluster-controllers   3      3            3              6h11m
+
+NAME                                         DESIRED REPLICAS   ROLES            NODEIDS
+kafkanodepool.kafka.strimzi.io/brokers       3                  ["broker"]       [3,4,5]
+kafkanodepool.kafka.strimzi.io/controllers   3                  ["controller"]   [0,1,2]
+
+NAME                                READY   METADATA STATE   WARNINGS
+kafka.kafka.strimzi.io/my-cluster   True    KRaft
 
 NAME                                   PARTITIONS REPLICATION FACTOR
 kafkatopic.kafka.strimzi.io/kafka-apps 3          3
@@ -75,6 +84,10 @@ The `-o name` option fetches the output in the _type/name_ format
 ----
 kubectl get strimzi -o name
 
+strimzipodset.core.strimzi.io/my-cluster-brokers
+strimzipodset.core.strimzi.io/my-cluster-controllers
+kafkanodepool.kafka.strimzi.io/brokers
+kafkanodepool.kafka.strimzi.io/controllers
 kafka.kafka.strimzi.io/my-cluster
 kafkatopic.kafka.strimzi.io/kafka-apps
 kafkauser.kafka.strimzi.io/my-user
@@ -88,6 +101,10 @@ For example, you can pass it into a `kubectl delete` command to delete all resou
 ----
 kubectl delete $(kubectl get strimzi -o name)
 
+strimzipodset.core.strimzi.io "my-cluster-brokers" deleted
+strimzipodset.core.strimzi.io "my-cluster-controllers" deleted
+kafkanodepool.kafka.strimzi.io "brokers" deleted
+kafkanodepool.kafka.strimzi.io "controllers" deleted
 kafka.kafka.strimzi.io "my-cluster" deleted
 kafkatopic.kafka.strimzi.io "kafka-apps" deleted
 kafkauser.kafka.strimzi.io "my-user" deleted

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
@@ -27,10 +27,6 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: Desired Kafka replicas
-          description: The desired number of Kafka replicas in the cluster
-          jsonPath: .spec.kafka.replicas
-          type: integer
         - name: Ready
           description: The state of the custom resource
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -26,10 +26,6 @@ spec:
     subresources:
       status: {}
     additionalPrinterColumns:
-    - name: Desired Kafka replicas
-      description: The desired number of Kafka replicas in the cluster
-      jsonPath: .spec.kafka.replicas
-      type: integer
     - name: Ready
       description: The state of the custom resource
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When removing ZooKeeper support, I removed the CRD column with number of ZooKeeper replicas. But I did not remove the column with Kafka replicas. But this is now empty for all up-to-date clusters. So this PR removes that as well.

I did not remove the metedata state field. While it will be always `KRaft` for up-to-date clusters, there might be old clusters with other states so it might raise awareness and also the column is at least not empty.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally